### PR TITLE
Add Test Coverage for Bucket Lifecycle Events

### DIFF
--- a/docs/s3-compatibility.md
+++ b/docs/s3-compatibility.md
@@ -9,116 +9,116 @@ Notes:
 
 ### All AWS S3 actions
 
-| Action                                          | Supported | Notes                                                     | Endpoint(s)                                   | Test                  |
-| ----------------------------------------------- | --------- | --------------------------------------------------------- | --------------------------------------------- | --------------------- |
-| AbortMultipartUpload                            | ✔         | Aborts upload and cleans up                               | DELETE /{bucket}/{key}?uploadId=...           |
-| CompleteMultipartUpload                         | ✔         | Computes combined ETag                                    | POST /{bucket}/{key}?uploadId=...             |
-| CopyObject                                      | ✔         | Via x-amz-copy-source header                              | PUT /{bucket}/{key}                           |
-| CreateBucket                                    | ✔         | Supports x-amz-acl: private/public-read/public-read-write | PUT /{bucket}                                 |
-| CreateBucketMetadataConfiguration               |           |                                                           |                                               |
-| CreateBucketMetadataTableConfiguration          |           |                                                           |                                               |
-| CreateMultipartUpload                           | ✔         | Initiate multipart upload                                 | POST /{bucket}/{key}?uploads                  |
-| CreateSession                                   |           |                                                           |                                               |
-| DeleteBucket                                    | ✔         | 404 if missing; 204 on success                            | DELETE /{bucket}                              |
-| DeleteBucketAnalyticsConfiguration              |           |                                                           |                                               |
-| DeleteBucketCors                                |           |                                                           |                                               |
-| DeleteBucketEncryption                          |           |                                                           |                                               |
-| DeleteBucketIntelligentTieringConfiguration     |           |                                                           |                                               |
-| DeleteBucketInventoryConfiguration              |           |                                                           |                                               |
-| DeleteBucketLifecycle                           |           |                                                           |                                               |
-| DeleteBucketMetadataConfiguration               |           |                                                           |                                               |
-| DeleteBucketMetadataTableConfiguration          |           |                                                           |                                               |
-| DeleteBucketMetricsConfiguration                |           |                                                           |                                               |
-| DeleteBucketOwnershipControls                   |           |                                                           |                                               |
-| DeleteBucketPolicy                              |           |                                                           |                                               |
-| DeleteBucketReplication                         |           |                                                           |                                               |
-| DeleteBucketTagging                             | ✔         | Deletes all tags                                          | DELETE /{bucket}?tagging                      | test_BucketTagging.py |
-| DeleteBucketWebsite                             |           |                                                           |                                               |
-| DeleteObject                                    | ✔         | Idempotent 204                                            | DELETE /{bucket}/{key}                        | test_DeleteObject.py  |
-| DeleteObjects                                   |           | Batch delete not supported                                |                                               |
-| DeleteObjectTagging                             | ✔         | Deletes all tags                                          | DELETE /{bucket}/{key}?tagging                | test_ObjectTagging.py |
-| DeletePublicAccessBlock                         |           |                                                           |                                               |
-| GetBucketAccelerateConfiguration                |           |                                                           |                                               |
-| GetBucketAcl                                    |           |                                                           |                                               |
-| GetBucketAnalyticsConfiguration                 |           |                                                           |                                               |
-| GetBucketCors                                   |           |                                                           |                                               |
-| GetBucketEncryption                             |           |                                                           |                                               |
-| GetBucketIntelligentTieringConfiguration        |           |                                                           |                                               |
-| GetBucketInventoryConfiguration                 |           |                                                           |                                               |
-| GetBucketLifecycle                              | ✔         | Minimal default lifecycle XML                             | GET /{bucket}?lifecycle                       |                       |
-| GetBucketLifecycleConfiguration                 | ✔         | Same as above (compat)                                    | GET /{bucket}?lifecycle                       |                       |
-| GetBucketLocation                               | ✔         | Always returns us-east-1 XML                              | GET /{bucket}?location                        |                       |
-| GetBucketLogging                                |           |                                                           |                                               |
-| GetBucketMetadataConfiguration                  |           |                                                           |                                               |
-| GetBucketMetadataTableConfiguration             |           |                                                           |                                               |
-| GetBucketMetricsConfiguration                   |           |                                                           |                                               |
-| GetBucketNotification                           |           |                                                           |                                               |
-| GetBucketNotificationConfiguration              |           |                                                           |                                               |
-| GetBucketOwnershipControls                      |           |                                                           |                                               |
-| GetBucketPolicy                                 | ✔         | Only for public buckets                                   | GET /{bucket}?policy                          |
-| GetBucketPolicyStatus                           |           |                                                           |                                               |
-| GetBucketReplication                            |           |                                                           |                                               |
-| GetBucketRequestPayment                         |           |                                                           |                                               |
-| GetBucketTagging                                | ✔         | XML response                                              | GET /{bucket}?tagging                         | test_BucketTagging.py |
-| GetBucketVersioning                             |           |                                                           |                                               |
-| GetBucketWebsite                                |           |                                                           |                                               |
-| GetObject                                       | ✔         | Supports Range; S3-like headers                           | GET /{bucket}/{key}                           | test_GetObject.py     |
-| GetObjectAcl                                    |           |                                                           |                                               |
-| GetObjectAttributes                             |           |                                                           |                                               |
-| GetObjectLegalHold                              |           |                                                           |                                               |
-| GetObjectLockConfiguration                      |           |                                                           |                                               |
-| GetObjectRetention                              |           |                                                           |                                               |
-| GetObjectTagging                                | ✔         | XML response                                              | GET /{bucket}/{key}?tagging                   | test_ObjectTagging.py |
-| GetObjectTorrent                                |           |                                                           |                                               |
-| GetPublicAccessBlock                            |           |                                                           |                                               |
-| HeadBucket                                      | ✔         | 200 if exists, 404 if not (empty body)                    | HEAD /{bucket}                                | test_CreateBucket.py  |
-| HeadObject                                      | ✔         | Returns metadata headers                                  | HEAD /{bucket}/{key}                          | test_HeadObject.py    |
-| ListBucketAnalyticsConfigurations               |           |                                                           |                                               |
-| ListBucketIntelligentTieringConfigurations      |           |                                                           |                                               |
-| ListBucketInventoryConfigurations               |           |                                                           |                                               |
-| ListBucketMetricsConfigurations                 |           |                                                           |                                               |
-| ListBuckets                                     | ✔         | Lists buckets owned by the authenticated account          | GET /                                         | test_CreateBucket.py  |
-| ListDirectoryBuckets                            |           |                                                           |                                               |
-| ListMultipartUploads                            | ✔         | Lists ongoing multipart uploads                           | GET /{bucket}?uploads                         |
-| ListObjects                                     | ✔         | Optional prefix filtering                                 | GET /{bucket}                                 | test_ListObjects.py   |
-| ListObjectsV2                                   |           |                                                           |                                               |
-| ListObjectVersions                              |           |                                                           |                                               |
-| ListParts                                       |           |                                                           |                                               |
-| PutBucketAccelerateConfiguration                |           |                                                           |                                               |
-| PutBucketAcl                                    |           |                                                           |                                               |
-| PutBucketAnalyticsConfiguration                 |           |                                                           |                                               |
-| PutBucketCors                                   |           |                                                           |                                               |
-| PutBucketEncryption                             |           |                                                           |                                               |
-| PutBucketIntelligentTieringConfiguration        |           |                                                           |                                               |
-| PutBucketInventoryConfiguration                 |           |                                                           |                                               |
-| PutBucketLifecycle                              | ✔         | Accepts XML, not persisted (ack only)                     | PUT /{bucket}?lifecycle                       |
-| PutBucketLifecycleConfiguration                 | ✔         | Accepts XML, not persisted (ack only)                     | PUT /{bucket}?lifecycle                       |
-| PutBucketLogging                                |           |                                                           |                                               |
-| PutBucketMetricsConfiguration                   |           |                                                           |                                               |
-| PutBucketNotification                           |           |                                                           |                                               |
-| PutBucketNotificationConfiguration              |           |                                                           |                                               |
-| PutBucketOwnershipControls                      |           |                                                           |                                               |
-| PutBucketPolicy                                 | ✔         | Public-read helper only                                   | PUT /{bucket}?policy                          |
-| PutBucketReplication                            |           |                                                           |                                               |
-| PutBucketRequestPayment                         |           |                                                           |                                               |
-| PutBucketTagging                                | ✔         | XML request                                               | PUT /{bucket}?tagging                         | test_BucketTagging.py |
-| PutBucketVersioning                             |           |                                                           |                                               |
-| PutBucketWebsite                                |           |                                                           |                                               |
-| PutObject                                       | ✔         | MD5 as ETag; x-amz-meta-\*                                | PUT /{bucket}/{key}                           | test_PutObject.py     |
-| PutObjectAcl                                    |           |                                                           |                                               |
-| PutObjectLegalHold                              |           |                                                           |                                               |
-| PutObjectLockConfiguration                      |           |                                                           |                                               |
-| PutObjectRetention                              |           |                                                           |                                               |
-| PutObjectTagging                                | ✔         | XML request                                               | PUT /{bucket}/{key}?tagging                   | test_ObjectTagging.py |
-| PutPublicAccessBlock                            |           |                                                           |                                               |
-| RenameObject                                    |           |                                                           |                                               |
-| RestoreObject                                   |           |                                                           |                                               |
-| SelectObjectContent                             |           |                                                           |                                               |
-| UpdateBucketMetadataInventoryTableConfiguration |           |                                                           |                                               |
-| UpdateBucketMetadataJournalTableConfiguration   |           |                                                           |                                               |
-| UploadPart                                      | ✔         | Returns part ETag                                         | PUT /{bucket}/{key}?uploadId=...&partNumber=N |
-| UploadPartCopy                                  |           |                                                           |                                               |
-| WriteGetObjectResponse                          |           |                                                           |                                               |
+| Action                                          | Supported | Notes                                                      | Endpoint(s)                                   | Test                    |
+| ----------------------------------------------- | --------- | ---------------------------------------------------------- | --------------------------------------------- | ----------------------- |
+| AbortMultipartUpload                            | ✔         | Aborts upload and cleans up                                | DELETE /{bucket}/{key}?uploadId=...           |
+| CompleteMultipartUpload                         | ✔         | Computes combined ETag                                     | POST /{bucket}/{key}?uploadId=...             |
+| CopyObject                                      | ✔         | Via x-amz-copy-source header                               | PUT /{bucket}/{key}                           |
+| CreateBucket                                    | ✔         | Rejects x-amz-acl with InvalidBucketAclWithObjectOwnership | PUT /{bucket}                                 | test_CreateBucket.py    |
+| CreateBucketMetadataConfiguration               |           |                                                            |                                               |
+| CreateBucketMetadataTableConfiguration          |           |                                                            |                                               |
+| CreateMultipartUpload                           | ✔         | Initiate multipart upload                                  | POST /{bucket}/{key}?uploads                  |
+| CreateSession                                   |           |                                                            |                                               |
+| DeleteBucket                                    | ✔         | 404 if missing; 204 on success                             | DELETE /{bucket}                              |
+| DeleteBucketAnalyticsConfiguration              |           |                                                            |                                               |
+| DeleteBucketCors                                |           |                                                            |                                               |
+| DeleteBucketEncryption                          |           |                                                            |                                               |
+| DeleteBucketIntelligentTieringConfiguration     |           |                                                            |                                               |
+| DeleteBucketInventoryConfiguration              |           |                                                            |                                               |
+| DeleteBucketLifecycle                           |           |                                                            |                                               |
+| DeleteBucketMetadataConfiguration               |           |                                                            |                                               |
+| DeleteBucketMetadataTableConfiguration          |           |                                                            |                                               |
+| DeleteBucketMetricsConfiguration                |           |                                                            |                                               |
+| DeleteBucketOwnershipControls                   |           |                                                            |                                               |
+| DeleteBucketPolicy                              |           |                                                            |                                               |
+| DeleteBucketReplication                         |           |                                                            |                                               |
+| DeleteBucketTagging                             | ✔         | Deletes all tags                                           | DELETE /{bucket}?tagging                      | test_BucketTagging.py   |
+| DeleteBucketWebsite                             |           |                                                            |                                               |
+| DeleteObject                                    | ✔         | Idempotent 204                                             | DELETE /{bucket}/{key}                        | test_DeleteObject.py    |
+| DeleteObjects                                   |           | Batch delete not supported                                 |                                               |
+| DeleteObjectTagging                             | ✔         | Deletes all tags                                           | DELETE /{bucket}/{key}?tagging                | test_ObjectTagging.py   |
+| DeletePublicAccessBlock                         |           |                                                            |                                               |
+| GetBucketAccelerateConfiguration                |           |                                                            |                                               |
+| GetBucketAcl                                    |           |                                                            |                                               |
+| GetBucketAnalyticsConfiguration                 |           |                                                            |                                               |
+| GetBucketCors                                   |           |                                                            |                                               |
+| GetBucketEncryption                             |           |                                                            |                                               |
+| GetBucketIntelligentTieringConfiguration        |           |                                                            |                                               |
+| GetBucketInventoryConfiguration                 |           |                                                            |                                               |
+| GetBucketLifecycle                              | ✔         | 404 NoSuchLifecycleConfiguration when not configured       | GET /{bucket}?lifecycle                       | test_BucketLifecycle.py |
+| GetBucketLifecycleConfiguration                 | ✔         | 404 NoSuchLifecycleConfiguration when not configured       | GET /{bucket}?lifecycle                       | test_BucketLifecycle.py |
+| GetBucketLocation                               | ✔         | Always returns us-east-1 XML                               | GET /{bucket}?location                        |                         |
+| GetBucketLogging                                |           |                                                            |                                               |
+| GetBucketMetadataConfiguration                  |           |                                                            |                                               |
+| GetBucketMetadataTableConfiguration             |           |                                                            |                                               |
+| GetBucketMetricsConfiguration                   |           |                                                            |                                               |
+| GetBucketNotification                           |           |                                                            |                                               |
+| GetBucketNotificationConfiguration              |           |                                                            |                                               |
+| GetBucketOwnershipControls                      |           |                                                            |                                               |
+| GetBucketPolicy                                 | ✔         | Only for public buckets                                    | GET /{bucket}?policy                          |
+| GetBucketPolicyStatus                           |           |                                                            |                                               |
+| GetBucketReplication                            |           |                                                            |                                               |
+| GetBucketRequestPayment                         |           |                                                            |                                               |
+| GetBucketTagging                                | ✔         | XML response                                               | GET /{bucket}?tagging                         | test_BucketTagging.py   |
+| GetBucketVersioning                             |           |                                                            |                                               |
+| GetBucketWebsite                                |           |                                                            |                                               |
+| GetObject                                       | ✔         | Supports Range; S3-like headers                            | GET /{bucket}/{key}                           | test_GetObject.py       |
+| GetObjectAcl                                    |           |                                                            |                                               |
+| GetObjectAttributes                             |           |                                                            |                                               |
+| GetObjectLegalHold                              |           |                                                            |                                               |
+| GetObjectLockConfiguration                      |           |                                                            |                                               |
+| GetObjectRetention                              |           |                                                            |                                               |
+| GetObjectTagging                                | ✔         | XML response                                               | GET /{bucket}/{key}?tagging                   | test_ObjectTagging.py   |
+| GetObjectTorrent                                |           |                                                            |                                               |
+| GetPublicAccessBlock                            |           |                                                            |                                               |
+| HeadBucket                                      | ✔         | 200 if exists, 404 if not (empty body)                     | HEAD /{bucket}                                | test_CreateBucket.py    |
+| HeadObject                                      | ✔         | Returns metadata headers                                   | HEAD /{bucket}/{key}                          | test_HeadObject.py      |
+| ListBucketAnalyticsConfigurations               |           |                                                            |                                               |
+| ListBucketIntelligentTieringConfigurations      |           |                                                            |                                               |
+| ListBucketInventoryConfigurations               |           |                                                            |                                               |
+| ListBucketMetricsConfigurations                 |           |                                                            |                                               |
+| ListBuckets                                     | ✔         | Lists buckets owned by the authenticated account           | GET /                                         | test_CreateBucket.py    |
+| ListDirectoryBuckets                            |           |                                                            |                                               |
+| ListMultipartUploads                            | ✔         | Lists ongoing multipart uploads                            | GET /{bucket}?uploads                         |
+| ListObjects                                     | ✔         | Optional prefix filtering                                  | GET /{bucket}                                 | test_ListObjects.py     |
+| ListObjectsV2                                   |           |                                                            |                                               |
+| ListObjectVersions                              |           |                                                            |                                               |
+| ListParts                                       |           |                                                            |                                               |
+| PutBucketAccelerateConfiguration                |           |                                                            |                                               |
+| PutBucketAcl                                    |           |                                                            |                                               |
+| PutBucketAnalyticsConfiguration                 |           |                                                            |                                               |
+| PutBucketCors                                   |           |                                                            |                                               |
+| PutBucketEncryption                             |           |                                                            |                                               |
+| PutBucketIntelligentTieringConfiguration        |           |                                                            |                                               |
+| PutBucketInventoryConfiguration                 |           |                                                            |                                               |
+| PutBucketLifecycle                              | ✔         | Accepts config; not persisted yet (ack only)               | PUT /{bucket}?lifecycle                       | test_BucketLifecycle.py |
+| PutBucketLifecycleConfiguration                 | ✔         | Accepts config; not persisted yet (ack only)               | PUT /{bucket}?lifecycle                       | test_BucketLifecycle.py |
+| PutBucketLogging                                |           |                                                            |                                               |
+| PutBucketMetricsConfiguration                   |           |                                                            |                                               |
+| PutBucketNotification                           |           |                                                            |                                               |
+| PutBucketNotificationConfiguration              |           |                                                            |                                               |
+| PutBucketOwnershipControls                      |           |                                                            |                                               |
+| PutBucketPolicy                                 | ✔         | Public-read helper only                                    | PUT /{bucket}?policy                          |
+| PutBucketReplication                            |           |                                                            |                                               |
+| PutBucketRequestPayment                         |           |                                                            |                                               |
+| PutBucketTagging                                | ✔         | XML request                                                | PUT /{bucket}?tagging                         | test_BucketTagging.py   |
+| PutBucketVersioning                             |           |                                                            |                                               |
+| PutBucketWebsite                                |           |                                                            |                                               |
+| PutObject                                       | ✔         | MD5 as ETag; x-amz-meta-\*                                 | PUT /{bucket}/{key}                           | test_PutObject.py       |
+| PutObjectAcl                                    |           |                                                            |                                               |
+| PutObjectLegalHold                              |           |                                                            |                                               |
+| PutObjectLockConfiguration                      |           |                                                            |                                               |
+| PutObjectRetention                              |           |                                                            |                                               |
+| PutObjectTagging                                | ✔         | XML request                                                | PUT /{bucket}/{key}?tagging                   | test_ObjectTagging.py   |
+| PutPublicAccessBlock                            |           |                                                            |                                               |
+| RenameObject                                    |           |                                                            |                                               |
+| RestoreObject                                   |           |                                                            |                                               |
+| SelectObjectContent                             |           |                                                            |                                               |
+| UpdateBucketMetadataInventoryTableConfiguration |           |                                                            |                                               |
+| UpdateBucketMetadataJournalTableConfiguration   |           |                                                            |                                               |
+| UploadPart                                      | ✔         | Returns part ETag                                          | PUT /{bucket}/{key}?uploadId=...&partNumber=N |
+| UploadPartCopy                                  |           |                                                            |                                               |
+| WriteGetObjectResponse                          |           |                                                            |                                               |
 
 ### Supported
 

--- a/tests/e2e/test_BucketLifecycle.py
+++ b/tests/e2e/test_BucketLifecycle.py
@@ -1,0 +1,106 @@
+"""E2E tests for Bucket Lifecycle using boto3 where possible.
+
+Local server uses path-style + SigV4 via our custom setup; boto3 will handle signing.
+"""
+
+from typing import Any
+from typing import Callable
+
+import pytest
+from botocore.awsrequest import AWSRequest  # type: ignore[import-untyped]
+from botocore.exceptions import ClientError  # type: ignore[import-untyped]
+
+
+def test_get_bucket_lifecycle_not_configured_returns_404(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket_name = unique_bucket_name("lifecycle-get")
+    cleanup_buckets(bucket_name)
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    # Use boto3; AWS and our server both raise NoSuchLifecycleConfiguration when not set
+    from botocore.exceptions import ClientError
+
+    with pytest.raises(ClientError) as excinfo:
+        boto3_client.get_bucket_lifecycle_configuration(Bucket=bucket_name)
+    code = excinfo.value.response.get("Error", {}).get("Code") or excinfo.value.response.get("Code")
+    assert code == "NoSuchLifecycleConfiguration"
+
+
+def test_put_bucket_lifecycle_accepts_configuration(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket_name = unique_bucket_name("lifecycle-put")
+    cleanup_buckets(bucket_name)
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    # PUT lifecycle via boto3 (it will serialize to XML)
+    lc = {
+        "Rules": [
+            {
+                "ID": "default-rule",
+                "Status": "Enabled",
+                "Filter": {"Prefix": "tmp/"},
+                "Expiration": {"Days": 7},
+            }
+        ]
+    }
+    resp = boto3_client.put_bucket_lifecycle_configuration(Bucket=bucket_name, LifecycleConfiguration=lc)
+    status = resp.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    assert status in (200, 204)
+
+
+def test_put_bucket_lifecycle_malformed_xml(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket_name = unique_bucket_name("lifecycle-malformed")
+    cleanup_buckets(bucket_name)
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    # Use a botocore before-sign hook to replace the serialized body with malformed XML
+    bad_xml = "<LifecycleConfiguration><Rule><ID>no-end"
+
+    def _malform_body(request: AWSRequest, **kwargs: Any) -> None:
+        request.headers["Content-Type"] = "application/xml"
+        request.data = bad_xml
+        request.headers["Content-Length"] = str(len(bad_xml))
+
+    boto3_client.meta.events.register(
+        "before-sign.s3.PutBucketLifecycleConfiguration",
+        _malform_body,
+    )
+
+    try:
+        with pytest.raises(ClientError) as excinfo:
+            # Provide any valid shape; the hook will replace the body after serialization
+            boto3_client.put_bucket_lifecycle_configuration(
+                Bucket=bucket_name,
+                LifecycleConfiguration={
+                    "Rules": [
+                        {
+                            "ID": "x",
+                            "Status": "Enabled",
+                            "Filter": {"Prefix": ""},
+                            "Expiration": {"Days": 1},
+                        }
+                    ]
+                },
+            )
+        assert excinfo.value.response.get("ResponseMetadata", {}).get("HTTPStatusCode") == 400
+    finally:
+        boto3_client.meta.events.unregister(
+            "before-sign.s3.PutBucketLifecycleConfiguration",
+            _malform_body,
+        )


### PR DESCRIPTION
This PR adds E2E test coverage for S3 bucket lifecycle configuration endpoints, updates the stub implementation for better compatibility (e.g., proper 404 errors), and syncs the compatibility matrix.

## Key Changes
- **New Tests** in `tests/e2e/test_BucketLifecycle.py`:
  - GET lifecycle returns 404 (NoSuchLifecycleConfiguration) when not configured.
  - PUT lifecycle accepts valid XML configs (200/204 response).
  - PUT rejects malformed XML (400 error), using a boto3 before-sign hook for testing.
- **Endpoint Updates** in `hippius_s3/api/s3/endpoints.py`:
  - `get_bucket_lifecycle`: Returns 404 instead of hardcoded default config.
  - `put_bucket_lifecycle`: Improves XML parsing with XPath for robustness; logs rules but doesn't persist (stub).
- **Docs**: Updated `docs/s3-compatibility.md` with accurate notes (e.g., "404 when not configured" for GET, "not persisted yet" for PUT) and test links. Also notes ACL rejection in CreateBucket.

## Motivation
Improves S3 compatibility for lifecycle ops (common in clients like MinIO/boto3) and adds tests to prevent regressions.

## Testing
- Ran `pytest tests/e2e/` locally—all pass.
- Verified against real AWS (via `RUN_REAL_AWS=1`) for error code matching.
