### PR TITLE
Hippius S4: Atomic Append Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ All endpoints support standard S3 headers and return S3-compatible XML responses
 
 See the compatibility list of supported S3 features in [docs/s3-compatibility.md](docs/s3-compatibility.md).
 
+### S4 Extensions (Because Hippius is more than S3)
+
+See the features beyond the scope of S3 in [docs/s4.md](docs/s4.md).
+
 ## Architecture
 
 ```

--- a/docs/s4.md
+++ b/docs/s4.md
@@ -1,0 +1,116 @@
+# Hippius S4: Atomic Append Extensions
+
+Status: Experimental (opt-in via metadata)
+
+Overview
+
+Hippius S4 enables atomic, O(delta) appends to an existing object while keeping standard S3 clients unchanged. Writers use PutObject with x-amz-meta-\* hints; readers use normal GET/HEAD.
+
+Writer API (PutObject with metadata)
+
+- x-amz-meta-append: true (required)
+- x-amz-meta-append-if-version: <int> (required CAS)
+- x-amz-meta-append-id: <uuid> (optional idempotency for retries)
+
+Server behavior
+
+- Treats body as append delta; publishes only the new chunk to IPFS.
+- Atomically appends a new part to the object manifest and updates size and composite ETag (multipart-style) in a single transaction.
+- Validates `append-if-version` against the current `append_version`; on mismatch, returns 412 PreconditionFailed.
+- On success, increments `append_version`; HEAD/GET reflect new content, new ETag, and the updated version immediately.
+
+Reader API (unchanged)
+
+- GET streams the entire object from its parts (supports Range across chunks).
+- HEAD returns Content-Length, Content-Type, ETag, user metadata, and `x-amz-meta-append-version: <int>` to support version-based CAS from S3 clients.
+
+Concurrency and atomicity
+
+- Per-object serialization using row locks (SELECT ... FOR UPDATE).
+- Version-based CAS provides linearizable append visibility. Readers see old or new, never partial.
+- Optional append-id enables idempotent retries for a fixed window (server caches the successful result).
+
+ETag semantics
+
+- ETag is opaque; we use multipart-style ETag (MD5 over concatenated per-part MD5s with `-N` suffix). Do not use ETag for CAS.
+
+Error codes
+
+- 412 PreconditionFailed (XML S3 error) when `append-if-version` mismatches current version.
+- 400 InvalidRequest when `append-if-version` is missing or malformed.
+- 503 ServiceUnavailable when temporarily not appendable.
+
+Readiness requirement (important)
+
+- Writers MUST wait until the object is readable (HEAD returns 200) before attempting an append.
+- While a new object (or overwrite) is being published, HEAD may return 202 with `x-amz-object-status` (e.g. `pending` or `pinning`) and `Retry-After`.
+- Appending before readiness may return 503 ServiceUnavailable. Recommended flow:
+  1. HEAD until status 200, then 2) read `x-amz-meta-append-version`, then 3) PUT with `append=true` and `append-if-version`.
+
+Examples
+
+AWS CLI
+
+```bash
+# Fetch current append version for CAS
+VER=$(aws s3api head-object \
+  --bucket my-bucket \
+  --key path/to/file.log \
+  --endpoint-url http://localhost:8000 \
+  --query 'ResponseMetadata.HTTPHeaders.x-amz-meta-append-version' --output text)
+
+# Append new bytes from delta.bin
+aws s3api put-object \
+  --bucket my-bucket \
+  --key path/to/file.log \
+  --body delta.bin \
+  --metadata append=true,append-if-version=$VER,append-id=$(uuidgen) \
+  --content-type application/octet-stream \
+  --endpoint-url http://localhost:8000
+```
+
+Python (boto3)
+
+```python
+import uuid
+import boto3
+from botocore.config import Config
+
+s3 = boto3.client(
+    "s3",
+    endpoint_url="http://localhost:8000",
+    aws_access_key_id="base64-encoded-seed",
+    aws_secret_access_key="seed-phrase",
+    region_name="decentralized",
+    config=Config(signature_version="s3v4"),
+)
+
+bucket = "my-bucket"
+key = "path/to/file.log"
+
+head = s3.head_object(Bucket=bucket, Key=key)
+append_version = head["ResponseMetadata"]["HTTPHeaders"].get("x-amz-meta-append-version", "0")
+
+with open("delta.bin", "rb") as f:
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=f,
+        ContentType="application/octet-stream",
+        Metadata={
+            "append": "true",
+            "append-if-version": append_version,
+            "append-id": str(uuid.uuid4()),
+        },
+    )
+```
+
+Performance
+
+- Each append is O(delta) (publish the new chunk and append to manifest); no rewrite of prior bytes.
+- GET remains proportional to total size; Range GETs avoid unnecessary transfer.
+
+Limitations
+
+- Provide CAS (append-if-version) for safe multi-writer operation.
+- Idempotency via append-id is supported for retry safety (short-term cache window).

--- a/hippius_s3/api/s3/errors.py
+++ b/hippius_s3/api/s3/errors.py
@@ -76,6 +76,9 @@ def s3_error_response(code: str, message: str, request_id: str = "", status_code
         "Content-Type": "application/xml; charset=utf-8",
         "x-amz-request-id": request_id,
         "Content-Length": str(len(xml_content)),
+        # Help SDKs parse error type/message even when they don't parse XML body
+        "x-amz-error-code": code,
+        "x-amz-error-message": message,
     }
 
     return Response(content=xml_content, media_type="application/xml", status_code=status_code, headers=headers)

--- a/hippius_s3/api/s3/extensions/append.py
+++ b/hippius_s3/api/s3/extensions/append.py
@@ -1,0 +1,305 @@
+"""S4 Append extension: version-CAS append for S3-compatible PUT requests.
+
+This module contains the append implementation extracted from the monolithic
+endpoints file. It appends new bytes to the existing object atomically using a
+DB row lock and updates the object state while keeping S3 client compatibility.
+
+Concurrency control uses version-based CAS via ``x-amz-meta-append-if-version``
+and the current value exposed on HEAD as ``x-amz-meta-append-version``. ETag is
+maintained for clients, but is not used for CAS.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import uuid
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+from typing import cast
+
+from fastapi import Request
+from fastapi import Response
+
+from hippius_s3.api.s3 import errors
+from hippius_s3.config import get_config
+from hippius_s3.utils import get_query
+
+
+logger = logging.getLogger(__name__)
+config = get_config()
+
+
+async def handle_append(
+    request: Request,
+    db: Any,
+    ipfs_service: Any,
+    redis_client: Any,
+    *,
+    bucket: dict,
+    bucket_id: str,
+    bucket_name: str,
+    object_key: str,
+    incoming_bytes: bytes,
+) -> Response:
+    """Handle append PUT with ETag CAS and atomic update.
+
+    Args:
+        request: FastAPI request (contains headers and state)
+        db: asyncpg connection
+        ipfs_service: IPFS service dependency
+        redis_client: Redis async client
+        bucket: bucket row dict
+        bucket_id: bucket ID
+        bucket_name: bucket name
+        object_key: object key within bucket
+    Returns:
+        Response compatible with S3 clients
+    """
+
+    # Version-based CAS for append
+    expected_version_header = request.headers.get("x-amz-meta-append-if-version")
+    append_id = request.headers.get("x-amz-meta-append-id")
+    content_type = request.headers.get("Content-Type", "application/octet-stream")
+
+    # Reject empty append deltas to avoid bloating manifests
+    if not incoming_bytes:
+        return errors.s3_error_response(
+            code="InvalidRequest",
+            message="Empty append not allowed",
+            status_code=400,
+        )
+
+    # Idempotency: if append-id is provided and we've seen it for this object, return stored result
+    if append_id and append_id.strip():
+        id_key = f"append_id:{bucket_id}:{object_key}:{append_id}"
+        try:
+            cached = await redis_client.get(id_key)
+            if cached:
+                try:
+                    payload = json.loads(cached)
+                    etag = payload.get("etag")
+                    if etag:
+                        return Response(status_code=200, headers={"ETag": f'"{etag}"'})
+                except Exception:
+                    pass
+        except Exception:
+            # On Redis issues, proceed without idempotency
+            pass
+
+    # Atomic read-modify-write guarded by row lock
+    async with db.transaction():
+        current = await db.fetchrow(
+            "SELECT * FROM objects WHERE bucket_id = $1 AND object_key = $2 FOR UPDATE",
+            bucket_id,
+            object_key,
+        )
+
+        if not current:
+            return errors.s3_error_response(
+                code="NoSuchKey",
+                message=f"The specified key {object_key} does not exist",
+                status_code=404,
+                Key=object_key,
+            )
+
+        # Validate CAS version
+        if expected_version_header is None:
+            return errors.s3_error_response(
+                code="InvalidRequest",
+                message="Missing append-if-version",
+                status_code=400,
+            )
+        try:
+            expected_version = int(expected_version_header)
+        except ValueError:
+            return errors.s3_error_response(
+                code="InvalidRequest",
+                message="append-if-version must be an integer",
+                status_code=400,
+            )
+        current_version = int(current.get("append_version") or 0)
+        if expected_version != current_version:
+            return errors.s3_error_response(
+                code="PreconditionFailed",
+                message="Version precondition failed",
+                status_code=412,
+            )
+
+        # Enforce readiness: object must be fully uploaded before allowing append
+        current_status = str(current.get("status") or "").lower()
+        if current_status not in {"uploaded"}:
+            return errors.s3_error_response(
+                code="ServiceUnavailable",
+                message="Object is not yet ready for append. Wait for HEAD 200 (readable) before appending.",
+                status_code=503,
+            )
+
+        object_id = str(current["object_id"]) if current.get("object_id") else None
+        if object_id is None:
+            # Fallback: fetch object_id via get_object_by_path
+            row = await db.fetchrow(get_query("get_object_by_path"), bucket_id, object_key)
+            if row:
+                object_id = str(row["object_id"])  # type: ignore[index]
+        if object_id is None:
+            return errors.s3_error_response(
+                code="InternalError",
+                message="Could not resolve object id",
+                status_code=500,
+            )
+
+        # If object is not yet multipart, create an initial part from existing simple CID
+        # Ensure there is a backing multipart_uploads row to satisfy parts.upload_id NOT NULL
+        upload_row = await db.fetchrow(
+            "SELECT upload_id FROM multipart_uploads WHERE object_id = $1 ORDER BY initiated_at DESC LIMIT 1",
+            object_id,
+        )
+        if upload_row:
+            upload_id = str(upload_row["upload_id"])  # type: ignore[index]
+        else:
+            upload_id = str(uuid.uuid4())
+            await db.execute(
+                """
+                INSERT INTO multipart_uploads (upload_id, bucket_id, object_key, initiated_at, is_completed, content_type, metadata, object_id)
+                VALUES ($1, $2, $3, $4, TRUE, $5, $6, $7)
+                ON CONFLICT (upload_id) DO NOTHING
+                """,
+                upload_id,
+                bucket_id,
+                object_key,
+                datetime.now(timezone.utc),
+                content_type,
+                json.dumps(current.get("metadata") or {}),
+                object_id,
+            )
+
+        if not current.get("multipart"):
+            row = await db.fetchrow(get_query("get_object_by_path"), bucket_id, object_key)
+            simple_cid = (row.get("ipfs_cid") or "").strip() if row else ""
+            if not simple_cid:
+                return errors.s3_error_response(
+                    code="ServiceUnavailable",
+                    message="Object publish is in progress. Please retry shortly.",
+                    status_code=503,
+                )
+            # Upsert CID and create part 1 referencing existing content
+            cid_id = await _upsert_cid(db, simple_cid)
+            await db.execute(
+                """
+                INSERT INTO parts (part_id, upload_id, part_number, ipfs_cid, size_bytes, etag, uploaded_at, object_id, cid_id)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                ON CONFLICT (upload_id, part_number) DO NOTHING
+                """,
+                str(uuid.uuid4()),
+                upload_id,
+                1,
+                simple_cid,
+                int(current["size_bytes"]),
+                str(current.get("md5_hash") or ""),
+                datetime.now(timezone.utc),
+                object_id,
+                cid_id,
+            )
+            # Mark object as multipart
+            await db.execute(
+                "UPDATE objects SET multipart = TRUE WHERE object_id = $1",
+                object_id,
+            )
+
+        # Determine next part number
+        next_part = await db.fetchval(
+            "SELECT COALESCE(MAX(part_number), 0) + 1 FROM parts WHERE object_id = $1",
+            object_id,
+        )
+
+        # Publish delta chunk synchronously and create a part row
+        should_encrypt = not bucket["is_public"]
+        s3_result = await ipfs_service.client.s3_publish(
+            content=incoming_bytes,
+            encrypt=should_encrypt,
+            seed_phrase=request.state.seed_phrase,
+            subaccount_id=request.state.account.main_account,
+            bucket_name=bucket_name,
+            file_name=object_key,
+            store_node=config.ipfs_store_url,
+            pin_node=config.ipfs_store_url,
+            substrate_url=config.substrate_url,
+            publish=(os.getenv("HIPPIUS_PUBLISH_MODE", "full") != "ipfs_only"),
+        )
+        delta_cid = s3_result.cid
+        delta_md5 = hashlib.md5(incoming_bytes).hexdigest()
+        delta_size = len(incoming_bytes)
+
+        cid_id = await _upsert_cid(db, delta_cid)
+        await db.execute(
+            """
+            INSERT INTO parts (part_id, upload_id, part_number, ipfs_cid, size_bytes, etag, uploaded_at, object_id, cid_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (upload_id, part_number) DO UPDATE SET
+                ipfs_cid = EXCLUDED.ipfs_cid,
+                cid_id = EXCLUDED.cid_id,
+                size_bytes = EXCLUDED.size_bytes,
+                etag = EXCLUDED.etag,
+                uploaded_at = EXCLUDED.uploaded_at
+            """,
+            str(uuid.uuid4()),
+            upload_id,
+            int(next_part),
+            delta_cid,
+            int(delta_size),
+            delta_md5,
+            datetime.now(timezone.utc),
+            object_id,
+            cid_id,
+        )
+
+        # Recompute composite ETag from all part etags
+        parts = await db.fetch(
+            "SELECT part_number, etag FROM parts WHERE object_id = $1 ORDER BY part_number",
+            object_id,
+        )
+        md5s = []
+        for p in parts:
+            e = str(p["etag"]).strip('"')
+            e = e.split("-")[0]
+            if len(e) == 32:
+                md5s.append(bytes.fromhex(e))
+        combined_md5 = hashlib.md5(b"".join(md5s)).hexdigest()
+        composite_etag = f"{combined_md5}-{len(md5s)}"
+
+        # Update object size, etag, and append_version
+        await db.execute(
+            """
+            UPDATE objects
+            SET size_bytes = size_bytes + $2,
+                md5_hash = $3,
+                append_version = append_version + 1
+            WHERE object_id = $1
+            """,
+            object_id,
+            int(delta_size),
+            composite_etag,
+        )
+
+        resp = Response(
+            status_code=200,
+            headers={
+                "ETag": f'"{composite_etag}"',
+            },
+        )
+
+        # Record idempotency result for future retries (best-effort)
+        if append_id and append_id.strip():
+            id_key = f"append_id:{bucket_id}:{object_key}:{append_id}"
+            from contextlib import suppress
+
+            with suppress(Exception):
+                await redis_client.setex(id_key, 3600, json.dumps({"etag": composite_etag}))
+
+        return resp
+
+
+async def _upsert_cid(db: Any, cid: str) -> uuid.UUID:
+    row = await db.fetchrow(get_query("upsert_cid"), cid)
+    return cast(uuid.UUID, row["id"])  # uuid UUID value is acceptable to asyncpg

--- a/hippius_s3/api/s3/range_utils.py
+++ b/hippius_s3/api/s3/range_utils.py
@@ -1,0 +1,79 @@
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+
+def parse_range_header(range_header: str, total_size: int) -> Tuple[int, int]:
+    header = range_header.lower().strip()
+    if not header.startswith("bytes="):
+        raise ValueError(f"Invalid range format: {range_header}")
+
+    spec = header[len("bytes=") :]
+
+    if spec.startswith("-"):
+        try:
+            suffix = int(spec[1:])
+        except ValueError as e:
+            raise ValueError(f"Invalid range suffix: {range_header}") from e
+        if suffix <= 0:
+            raise ValueError(f"Invalid range suffix: {range_header}")
+        end = total_size - 1
+        start = max(0, total_size - suffix)
+        return start, end
+
+    parts = spec.split("-", 1)
+    if len(parts) != 2 or not parts[0].isdigit():
+        raise ValueError(f"Invalid range format: {range_header}")
+
+    start = int(parts[0])
+    if start >= total_size:
+        raise ValueError("Range start beyond file size")
+
+    if parts[1]:
+        if not parts[1].isdigit():
+            raise ValueError(f"Invalid range end: {range_header}")
+        end = int(parts[1])
+        if end < start:
+            raise ValueError("Range end before start")
+        end = min(end, total_size - 1)
+        return start, end
+
+    return start, total_size - 1
+
+
+def calculate_chunks_for_range(start_byte: int, end_byte: int, parts_info: List[Dict]) -> List[int]:
+    needed_parts: List[int] = []
+    current_offset = 0
+    for part in parts_info:
+        part_start = current_offset
+        # part_end is not needed directly; inline comparison for clarity
+        if (current_offset + part["size_bytes"] - 1) >= start_byte and part_start <= end_byte:
+            needed_parts.append(part["part_number"])
+        current_offset += part["size_bytes"]
+        if part_start > end_byte:
+            break
+    return needed_parts
+
+
+def extract_range_from_chunks(
+    chunks_data: List[bytes],
+    start_byte: int,
+    end_byte: int,
+    parts_info: List[Dict],
+    needed_parts: List[int],
+) -> bytes:
+    current_offset = 0
+    range_data = b""
+    chunk_idx = 0
+    for part in parts_info:
+        part_start = current_offset
+        if part["part_number"] in needed_parts:
+            chunk_data = chunks_data[chunk_idx]
+            slice_start = max(0, start_byte - part_start)
+            slice_end = min(part["size_bytes"], end_byte - part_start + 1)
+            range_data += chunk_data[slice_start:slice_end]
+            chunk_idx += 1
+        current_offset += part["size_bytes"]
+        if current_offset > end_byte:
+            break
+    return range_data

--- a/hippius_s3/sql/migrations/20250903000004_add_append_version_to_objects.sql
+++ b/hippius_s3/sql/migrations/20250903000004_add_append_version_to_objects.sql
@@ -1,0 +1,8 @@
+-- migrate:up
+-- Add append_version to objects for version-based CAS on appends
+ALTER TABLE objects
+    ADD COLUMN IF NOT EXISTS append_version INTEGER NOT NULL DEFAULT 0;
+
+-- migrate:down
+ALTER TABLE objects
+    DROP COLUMN IF EXISTS append_version;

--- a/hippius_s3/sql/queries/get_object_by_path.sql
+++ b/hippius_s3/sql/queries/get_object_by_path.sql
@@ -3,6 +3,7 @@
 SELECT o.object_id, o.bucket_id, o.object_key,
        COALESCE(c.cid, o.ipfs_cid, '') as ipfs_cid,
        o.size_bytes, o.content_type, o.created_at, o.metadata, o.md5_hash,
+       o.append_version,
        b.bucket_name
 FROM objects o
 JOIN buckets b ON o.bucket_id = b.bucket_id

--- a/hippius_s3/sql/queries/get_object_for_download_with_permissions.sql
+++ b/hippius_s3/sql/queries/get_object_for_download_with_permissions.sql
@@ -11,6 +11,7 @@ WITH object_info AS (
         o.metadata,
         o.created_at,
         o.md5_hash,
+        o.append_version,
         b.bucket_name,
         b.is_public,
         b.main_account_id as bucket_owner_id,

--- a/tests/e2e/test_AppendObject.py
+++ b/tests/e2e/test_AppendObject.py
@@ -1,0 +1,290 @@
+import base64
+import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
+from typing import Any
+
+import pytest
+from botocore.exceptions import ClientError
+
+
+def _put_object(boto3_client: Any, bucket: str, key: str, data: bytes, metadata: dict[str, str] | None = None) -> None:
+    boto3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=data,
+        ContentType="application/octet-stream",
+        Metadata=metadata or {},
+    )
+
+
+@pytest.mark.s4
+def test_append_single_writer(
+    boto3_client: Any, unique_bucket_name: Any, cleanup_buckets: Any, wait_until_readable: Any
+) -> None:
+    bucket = unique_bucket_name("append-single")
+    boto3_client.create_bucket(Bucket=bucket)
+    cleanup_buckets(bucket)
+
+    key = "log/append.txt"
+
+    # Seed object
+    initial = b"hello\n"
+    _put_object(boto3_client, bucket, key, initial)
+
+    # Wait until initial object is readable, then read append version for CAS
+    wait_until_readable(bucket, key, 60)
+    head = boto3_client.head_object(Bucket=bucket, Key=key)
+    version = head["ResponseMetadata"]["HTTPHeaders"].get("x-amz-meta-append-version", "0")
+
+    # Append delta
+    delta = b"world\n"
+    _put_object(
+        boto3_client,
+        bucket,
+        key,
+        delta,
+        metadata={
+            "append": "true",
+            "append-if-version": version,
+            "append-id": "single-writer-test",
+        },
+    )
+
+    # Verify full content
+    obj = boto3_client.get_object(Bucket=bucket, Key=key)
+    data = obj["Body"].read()
+    assert data == initial + delta
+
+
+@pytest.mark.s4
+def test_append_multi_writer_concurrent(
+    boto3_client: Any, unique_bucket_name: Any, cleanup_buckets: Any, wait_until_readable: Any
+) -> None:
+    bucket = unique_bucket_name("append-concurrent")
+    boto3_client.create_bucket(Bucket=bucket)
+    cleanup_buckets(bucket)
+
+    key = "log/append.txt"
+
+    # Seed object
+    initial = b"A\n"
+    _put_object(boto3_client, bucket, key, initial)
+
+    # Ensure seed object is readable before concurrent appends
+    wait_until_readable(bucket, key, 60)
+    # Prepare concurrent appends
+    deltas = [f"line-{i}\n".encode() for i in range(20)]
+
+    # Simple helper to attempt CAS append with retry on 412
+    def append_with_retry(delta: bytes) -> bool:
+        for attempt in range(100):
+            head = boto3_client.head_object(Bucket=bucket, Key=key)
+            version = head["ResponseMetadata"]["HTTPHeaders"].get("x-amz-meta-append-version", "0")
+            try:
+                _put_object(
+                    boto3_client,
+                    bucket,
+                    key,
+                    delta,
+                    metadata={
+                        "append": "true",
+                        "append-if-version": version,
+                        "append-id": base64.b64encode(delta).decode(),
+                    },
+                )
+                return True
+            except ClientError as e:  # noqa: PERF203
+                # Expect a 412 on CAS failure (PreconditionFailed). Retry.
+                status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+                code = e.response.get("Error", {}).get("Code")
+                if status == 412 or code in {"PreconditionFailed", "412"}:
+                    time.sleep(min(0.05 * (attempt + 1), 2.0))
+                    continue
+                # If server does not support append, skip test gracefully
+                if code in {"InvalidRequest", "NotImplemented"}:
+                    pytest.skip("Append extension not supported by server")
+                raise
+            except Exception as e:  # noqa: PERF203
+                msg = str(e)
+                if "412" in msg or "PreconditionFailed" in msg:
+                    time.sleep(min(0.05 * (attempt + 1), 2.0))
+                    continue
+                if "InvalidRequest" in msg or "NotImplemented" in msg:
+                    pytest.skip("Append extension not supported by server")
+                raise
+        return False
+
+    # Run appends concurrently
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        futs = [ex.submit(append_with_retry, d) for d in deltas]
+        results = [f.result() for f in as_completed(futs)]
+        assert all(results), "Some appends failed after retries"
+
+    # Verify content contains all lines in some order following initial prefix.
+    # Exact ordering depends on commit order under contention; we accept any order.
+    obj = boto3_client.get_object(Bucket=bucket, Key=key)
+    data = obj["Body"].read()
+    text = data.decode()
+    assert text.startswith(initial.decode())
+    for d in deltas:
+        assert d.decode() in text
+
+
+@pytest.mark.s4
+def test_append_stale_version_412(
+    boto3_client: Any, unique_bucket_name: Any, cleanup_buckets: Any, wait_until_readable: Any
+) -> None:
+    bucket = unique_bucket_name("append-412")
+    boto3_client.create_bucket(Bucket=bucket)
+    cleanup_buckets(bucket)
+
+    key = "log/append.txt"
+    _put_object(boto3_client, bucket, key, b"X\n")
+
+    # Ensure object is readable; then take an initial append-version snapshot
+    wait_until_readable(bucket, key, 60)
+    ver0 = boto3_client.head_object(Bucket=bucket, Key=key)["ResponseMetadata"]["HTTPHeaders"].get(
+        "x-amz-meta-append-version", "0"
+    )
+
+    # Advance the object (valid append)
+    _put_object(
+        boto3_client,
+        bucket,
+        key,
+        b"Y\n",
+        metadata={"append": "true", "append-if-version": ver0},
+    )
+
+    # Try to append again using the stale version -> expect 412 and no change
+    with pytest.raises(ClientError) as exc:
+        _put_object(
+            boto3_client,
+            bucket,
+            key,
+            b"Z\n",
+            metadata={"append": "true", "append-if-version": ver0},
+        )
+    status = exc.value.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    code = exc.value.response.get("Error", {}).get("Code")
+    assert status == 412 or code in {"PreconditionFailed", "412"}
+
+    body = boto3_client.get_object(Bucket=bucket, Key=key)["Body"].read()
+    assert body == b"X\nY\n"
+
+
+@pytest.mark.s4
+def test_append_preserves_user_metadata(
+    boto3_client: Any, unique_bucket_name: Any, cleanup_buckets: Any, wait_until_readable: Any
+) -> None:
+    bucket = unique_bucket_name("append-meta")
+    boto3_client.create_bucket(Bucket=bucket)
+    cleanup_buckets(bucket)
+
+    key = "log/append.txt"
+    _put_object(
+        boto3_client,
+        bucket,
+        key,
+        b"A",
+        metadata={"foo": "bar", "append": "false"},
+    )
+
+    wait_until_readable(bucket, key, 60)
+    head = boto3_client.head_object(Bucket=bucket, Key=key)
+    version = head["ResponseMetadata"]["HTTPHeaders"].get("x-amz-meta-append-version", "0")
+
+    # Append with control metadata; control keys should not persist as user metadata
+    _put_object(
+        boto3_client,
+        bucket,
+        key,
+        b"B",
+        metadata={"append": "true", "append-if-version": version, "append-id": "t1"},
+    )
+
+    head = boto3_client.head_object(Bucket=bucket, Key=key)
+    # Boto surfaces user metadata under 'Metadata'
+    md = {k.lower(): v for k, v in (head.get("Metadata") or {}).items()}
+    assert md.get("foo") == "bar"
+    assert "append" not in md and "append-if-etag" not in md and "append-id" not in md
+
+
+@pytest.mark.s4
+def test_append_missing_key_404(boto3_client: Any, unique_bucket_name: Any, cleanup_buckets: Any) -> None:
+    bucket = unique_bucket_name("append-404")
+    boto3_client.create_bucket(Bucket=bucket)
+    cleanup_buckets(bucket)
+
+    key = "log/missing.txt"
+    # Append request on missing key should return NoSuchKey (404)
+    with pytest.raises(ClientError) as exc:
+        _put_object(
+            boto3_client,
+            bucket,
+            key,
+            b"X",
+            metadata={"append": "true", "append-if-version": "0"},
+        )
+    status = exc.value.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    code = exc.value.response.get("Error", {}).get("Code")
+    assert status == 404 or code == "NoSuchKey"
+
+
+@pytest.mark.s4
+def test_range_get_across_append_boundary(boto3_client: Any, unique_bucket_name: Any, cleanup_buckets: Any) -> None:
+    bucket = unique_bucket_name("append-range")
+    boto3_client.create_bucket(Bucket=bucket)
+    cleanup_buckets(bucket)
+
+    key = "log/range.txt"
+    _put_object(boto3_client, bucket, key, b"abc")
+    ver = boto3_client.head_object(Bucket=bucket, Key=key)["ResponseMetadata"]["HTTPHeaders"].get(
+        "x-amz-meta-append-version", "0"
+    )
+    _put_object(boto3_client, bucket, key, b"defghi", metadata={"append": "true", "append-if-version": ver})
+
+    # Request a range that spans both original and appended bytes: bytes=2-5 -> "cdef"
+    obj = boto3_client.get_object(Bucket=bucket, Key=key, Range="bytes=2-5")
+    data = obj["Body"].read()
+    assert data == b"cdef"
+
+
+@pytest.mark.s4
+def test_append_idempotency_append_id(
+    boto3_client: Any, unique_bucket_name: Any, cleanup_buckets: Any, wait_until_readable: Any
+) -> None:
+    bucket = unique_bucket_name("append-idemp")
+    boto3_client.create_bucket(Bucket=bucket)
+    cleanup_buckets(bucket)
+
+    key = "log/idem.txt"
+    _put_object(boto3_client, bucket, key, b"base")
+
+    # Ensure seed object is readable before taking version snapshot
+    wait_until_readable(bucket, key, 60)
+    ver = boto3_client.head_object(Bucket=bucket, Key=key)["ResponseMetadata"]["HTTPHeaders"].get(
+        "x-amz-meta-append-version", "0"
+    )
+
+    # Use a fixed append-id and send the same append twice
+    append_id = "fixed-id-123"
+    delta = b"-delta"
+    for _ in range(2):
+        _put_object(
+            boto3_client,
+            bucket,
+            key,
+            delta,
+            metadata={
+                "append": "true",
+                "append-if-version": ver,
+                "append-id": append_id,
+            },
+        )
+        # Do not refresh etag to simulate exact retry of the same request
+
+    # Validate only one append was applied
+    body = boto3_client.get_object(Bucket=bucket, Key=key)["Body"].read()
+    assert body == b"base" + delta

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,4 +1,7 @@
-[tool:pytest]
+[pytest]
 testpaths = ["."]
 python_files = "test_*.py"
-addopts = ""
+# Run all tests by default; s4 tests are auto-skipped when RUN_REAL_AWS/AWS is set
+addopts =
+markers =
+    s4: marks tests that require Hippius S4 extensions (skipped on real AWS)


### PR DESCRIPTION
This PR adds append object, an experimental S3 extension for atomic, efficient appends to objects using `x-amz-meta-*` headers on PutObject. Enables O(delta) updates without full rewrites, with version-based CAS for concurrency and idempotency support.

## Key Features
- Atomic appends: Publish delta to IPFS, update manifest atomically.
- Compatibility: Unchanged GET/HEAD for readers; opt-in metadata for writers.
- Concurrency: Row locks + CAS (`append-if-version`); exposes `append-version` on HEAD.
- ETag: Composite multipart-style.
- Errors: 412 on CAS fail, 503 if not ready, etc.
- Docs: New [docs/s4.md](docs/s4.md) with API, examples (CLI/boto3), semantics.

## Changes
- **API**: Detect append in `endpoints.py`, handle in new `extensions/append.py`. Range utils to `range_utils.py`.
- **DB**: Add `append_version` column; update queries.
- **Errors**: Add headers for better parsing.
- **Tests**: New E2E suite in `test_AppendObject.py` (single/multi-writer, 412, metadata, range, idempotency). Skip S4 tests on real AWS via marker.

## Testing
- Local: Use docs examples.
- E2E: `pytest tests/e2e/test_AppendObject.py`.
- Edge: Concurrency, readiness, overwrites.
