### PR TITLE
Enhance Hippius S3 Reliability, Add Batch Delete Support, and Refactor Pinning Logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ pytest tests/e2e -v
 docker compose -f docker-compose.yml -f docker-compose.e2e.yml down -v
 ```
 
-Note: The e2e override may enable `HIPPIUS_BYPASS_CREDIT_CHECK=true` and `HIPPIUS_PUBLISH_MODE=ipfs_only` for faster runs without chain publishing.
+Note: The e2e override may enable `HIPPIUS_BYPASS_CREDIT_CHECK=true` and `PUBLISH_TO_CHAIN=false` for faster runs without chain publishing.
 
 ### Benchmarking
 

--- a/cacher/run_cacher.py
+++ b/cacher/run_cacher.py
@@ -2,7 +2,6 @@
 import asyncio
 import json
 import logging
-import os
 import sys
 from typing import Dict
 from typing import Optional
@@ -10,6 +9,8 @@ from typing import Optional
 import redis.asyncio as async_redis
 from dotenv import load_dotenv
 from hippius_sdk.substrate import SubstrateClient
+
+from hippius_s3.config import get_config
 
 
 logging.basicConfig(level=logging.INFO)
@@ -269,9 +270,10 @@ class SubstrateCacher:
 async def main():
     """Entry point for the cacher script."""
     try:
-        # Load environment variables directly
-        substrate_url = os.getenv("HIPPIUS_SUBSTRATE_URL")
-        redis_url = os.getenv("REDIS_ACCOUNTS_URL", "redis://127.0.0.1:6380/0")
+        # Load configuration
+        config = get_config()
+        substrate_url = config.substrate_url
+        redis_url = config.redis_accounts_url
 
         if not substrate_url:
             raise ValueError("HIPPIUS_SUBSTRATE_URL environment variable is required")

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -10,9 +10,10 @@ services:
       - ENABLE_REQUEST_PROFILING=false
       - ENABLE_BANHAMMER=false
       - RATE_LIMIT_PER_MINUTE=100000
+      - REDIS_URL=redis://redis:6379/0
       - HIPPIUS_IPFS_GET_URL=http://ipfs:8080
       - HIPPIUS_IPFS_STORE_URL=http://ipfs:5001
-      - RESUBMISSION_SEED_PHRASE=test twelve word seed phrase for e2e testing purposes only
+      - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
     volumes:
       - .:/app
 
@@ -25,10 +26,11 @@ services:
       - HIPPIUS_KEYSTORE_DATABASE_URL=postgresql://postgres:postgres@db:5432/hippius?sslmode=disable
       - ENVIRONMENT=dev
       - PUBLISH_TO_CHAIN=false
+      - REDIS_URL=redis://redis:6379/0
       - REDIS_ACCOUNTS_URL=redis://redis-accounts:6379/0
       - HIPPIUS_IPFS_GET_URL=http://ipfs:8080
       - HIPPIUS_IPFS_STORE_URL=http://ipfs:5001
-      - RESUBMISSION_SEED_PHRASE=test twelve word seed phrase for e2e testing purposes only
+      - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
     volumes:
       - .:/app
 
@@ -45,7 +47,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - HIPPIUS_IPFS_GET_URL=http://ipfs:8080
       - HIPPIUS_IPFS_STORE_URL=http://ipfs:5001
-      - RESUBMISSION_SEED_PHRASE=test twelve word seed phrase for e2e testing purposes only
+      - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
       - MANIFEST_BUILDER_ENABLED=true
       - MANIFEST_STABILIZATION_WINDOW_SEC=1
       - MANIFEST_SCAN_INTERVAL_SEC=1
@@ -66,7 +68,7 @@ services:
       - REDIS_ACCOUNTS_URL=redis://redis-accounts:6379/0
       - HIPPIUS_IPFS_GET_URL=http://ipfs:8080
       - HIPPIUS_IPFS_STORE_URL=http://ipfs:5001
-      - RESUBMISSION_SEED_PHRASE=test twelve word seed phrase for e2e testing purposes only
+      - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
     volumes:
       - .:/app
 
@@ -83,7 +85,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - HIPPIUS_IPFS_GET_URL=http://ipfs:8080
       - HIPPIUS_IPFS_STORE_URL=http://ipfs:5001
-      - RESUBMISSION_SEED_PHRASE=test twelve word seed phrase for e2e testing purposes only
+      - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
     volumes:
       - .:/app
 
@@ -103,7 +105,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - HIPPIUS_IPFS_GET_URL=http://ipfs:8080
       - HIPPIUS_IPFS_STORE_URL=http://ipfs:5001
-      - RESUBMISSION_SEED_PHRASE=test twelve word seed phrase for e2e testing purposes only
+      - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
     volumes:
       - .:/app
 
@@ -123,6 +125,6 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - HIPPIUS_IPFS_GET_URL=http://ipfs:8080
       - HIPPIUS_IPFS_STORE_URL=http://ipfs:5001
-      - RESUBMISSION_SEED_PHRASE=test twelve word seed phrase for e2e testing purposes only
+      - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
     volumes:
       - .:/app

--- a/hippius_s3/api/middlewares/backend_hmac.py
+++ b/hippius_s3/api/middlewares/backend_hmac.py
@@ -257,13 +257,11 @@ async def _check_public_read_bypass(request: Request) -> bool:
         return False
 
     bucket_name = path_parts[0]
-    object_key = "/".join(path_parts[1:])
 
     # Query param policy is enforced in public_router (whitelist). Middleware does not block by params.
 
     # Use helper to check public flag (cached)
     if not await is_public_bucket(request, bucket_name):
-        logger.debug(f"Anonymous read blocked: bucket {bucket_name} not found or not public")
         return False
 
     # Set up anonymous access state
@@ -285,7 +283,6 @@ async def _check_public_read_bypass(request: Request) -> bool:
     with contextlib.suppress(Exception):
         request.scope["raw_path"] = new_path.encode("utf-8")
 
-    logger.debug(f"Anonymous public read bypass: {bucket_name}/{object_key} -> {new_path}")
     return True
 
 

--- a/hippius_s3/api/middlewares/credit_check.py
+++ b/hippius_s3/api/middlewares/credit_check.py
@@ -4,7 +4,6 @@ import asyncio
 import base64
 import json
 import logging
-import os
 import re
 from typing import Callable
 
@@ -166,7 +165,7 @@ async def check_credit_for_all_operations(request: Request, call_next: Callable)
     path = request.url.path
 
     # Test bypass: short-circuit credit and substrate/redis access entirely
-    if os.getenv("HIPPIUS_BYPASS_CREDIT_CHECK", "false").lower() == "true":
+    if config.enable_bypass_credit_check:
         # Ensure downstream code has an account object
         from contextlib import suppress
 
@@ -203,7 +202,7 @@ async def check_credit_for_all_operations(request: Request, call_next: Callable)
                     raise BadAccount("This account does not have DELETE permissions")
 
                 # Bypass for testing if enabled
-                if os.getenv("HIPPIUS_BYPASS_CREDIT_CHECK", "false").lower() == "true":
+                if config.enable_bypass_credit_check:
                     logger.info("Credit check bypassed for testing")
                 elif not request.state.account.has_credits:
                     logger.warning(f"Account does not have credit for {request.method} operation: {path}")

--- a/hippius_s3/api/s3/buckets/delete_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/delete_objects_endpoint.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import Request
+from fastapi import Response
+from lxml import etree as ET
+
+from hippius_s3.api.s3 import errors
+from hippius_s3.config import get_config
+from hippius_s3.queue import UnpinChainRequest
+from hippius_s3.queue import enqueue_unpin_request
+from hippius_s3.repositories.buckets import BucketRepository
+from hippius_s3.repositories.users import UserRepository
+from hippius_s3.utils import get_query
+
+
+logger = logging.getLogger(__name__)
+config = get_config()
+
+
+async def handle_delete_objects(bucket_name: str, request: Request, db: Any, redis_client: Any) -> Response:
+    """Implements S3 DeleteObjects: POST /{bucket}?delete
+
+    - Accepts XML body with up to 1000 <Object><Key>...</Key></Object> entries
+    - "Quiet" flag suppresses <Deleted> entries when true
+    - Non-existent keys are treated as successfully deleted (idempotent)
+    - Versioning is not supported: keys with VersionId yield per-key <Error NotImplemented>
+    """
+    try:
+        # AuthN/AuthZ context
+        user = await UserRepository(db).ensure_by_main_account(request.state.account.main_account)
+        bucket = await BucketRepository(db).get_by_name_and_owner(bucket_name, user["main_account_id"])
+        if not bucket:
+            return errors.s3_error_response(
+                code="NoSuchBucket",
+                message=f"The specified bucket {bucket_name} does not exist",
+                status_code=404,
+                BucketName=bucket_name,
+            )
+
+        # Parse XML body
+        body = await request.body()
+        if not body:
+            return errors.s3_error_response(
+                "MalformedXML",
+                "The XML you provided was not well-formed or did not validate against our published schema.",
+                status_code=400,
+            )
+
+        try:
+            root = ET.fromstring(body)
+        except Exception:
+            logger.exception("Malformed XML for DeleteObjects")
+            return errors.s3_error_response(
+                "MalformedXML",
+                "The XML you provided was not well-formed or did not validate against our published schema.",
+                status_code=400,
+            )
+
+        ns = {"s3": "http://s3.amazonaws.com/doc/2006-03-01/"}
+
+        # Quiet flag
+        quiet_nodes = root.xpath("./s3:Quiet", namespaces=ns)  # type: ignore[attr-defined]
+        quiet = False
+        if quiet_nodes and quiet_nodes[0].text:
+            quiet = str(quiet_nodes[0].text).strip().lower() == "true"
+
+        # Collect objects
+        object_elems = root.xpath(".//s3:Object", namespaces=ns)  # type: ignore[attr-defined]
+        if len(object_elems) > 1000:
+            return errors.s3_error_response(
+                "MalformedXML",
+                "The XML you provided was not well-formed or did not validate against our published schema.",
+                status_code=400,
+            )
+
+        bucket_id = bucket["bucket_id"]
+        deleted_keys: list[str] = []
+        errors_list: list[dict[str, str]] = []
+
+        for obj in object_elems:
+            key_nodes = obj.xpath("./s3:Key", namespaces=ns)  # type: ignore[attr-defined]
+            version_nodes = obj.xpath("./s3:VersionId", namespaces=ns)  # type: ignore[attr-defined]
+            key = str(key_nodes[0].text) if key_nodes and key_nodes[0].text else ""
+            version_id = str(version_nodes[0].text) if version_nodes and version_nodes[0].text else ""
+
+            if not key:
+                # Skip invalid entries
+                errors_list.append({"Key": "", "Code": "MalformedXML", "Message": "Invalid Delete Object entry"})
+                continue
+
+            if version_id:
+                errors_list.append({"Key": key, "Code": "NotImplemented", "Message": "Versioning not supported"})
+                continue
+
+            # Perform permission-aware delete; non-existent counts as success
+            try:
+                deleted_object = await db.fetchrow(get_query("delete_object"), bucket_id, key, user["main_account_id"])
+            except Exception:
+                logger.exception("Delete query failed for key %s", key)
+                deleted_object = None
+
+            if deleted_object and (deleted_object.get("ipfs_cid") or "").strip():
+                # Enqueue unpin
+                try:
+                    await enqueue_unpin_request(
+                        payload=UnpinChainRequest(
+                            substrate_url=config.substrate_url,
+                            ipfs_node=config.ipfs_store_url,
+                            address=request.state.account.main_account,
+                            subaccount=request.state.account.main_account,
+                            subaccount_seed_phrase=request.state.seed_phrase,
+                            bucket_name=bucket_name,
+                            object_key=key,
+                            should_encrypt=not bucket["is_public"],
+                            cid=str(deleted_object["ipfs_cid"]),
+                            object_id=str(deleted_object["object_id"]) if deleted_object.get("object_id") else "",
+                        ),
+                        redis_client=redis_client,
+                    )
+                except Exception:
+                    logger.debug("Failed to enqueue unpin request for %s", key, exc_info=True)
+
+            # S3 semantics: even if not found, include as Deleted (unless Quiet)
+            deleted_keys.append(key)
+
+        # Build XML response
+        resp_root = ET.Element("DeleteResult", xmlns="http://s3.amazonaws.com/doc/2006-03-01/")
+
+        if not quiet:
+            for key in deleted_keys:
+                d = ET.SubElement(resp_root, "Deleted")
+                ET.SubElement(d, "Key").text = key
+
+        for err in errors_list:
+            e = ET.SubElement(resp_root, "Error")
+            ET.SubElement(e, "Key").text = err.get("Key", "")
+            ET.SubElement(e, "Code").text = err.get("Code", "")
+            ET.SubElement(e, "Message").text = err.get("Message", "")
+
+        xml_content = ET.tostring(resp_root, encoding="UTF-8", xml_declaration=True, pretty_print=True)
+        return Response(content=xml_content, media_type="application/xml", status_code=200)
+
+    except Exception:
+        logger.exception("Error in DeleteObjects")
+        return errors.s3_error_response(
+            "InternalError",
+            "We encountered an internal error. Please try again.",
+            status_code=500,
+        )

--- a/hippius_s3/api/s3/extensions/append.py
+++ b/hippius_s3/api/s3/extensions/append.py
@@ -307,8 +307,12 @@ async def handle_append(
         )
 
         # End of transactional phase; publish outside of the lock window
+
     # PHASE 2 (out-of-DB): enqueue background publish for the reserved part and return immediately
     # Write-through cache first for immediate reads
+
+    # Write-through cache: store appended bytes for immediate reads
+
     with contextlib.suppress(Exception):
         logger.info(f"APPEND cache write object_id={object_id} part={int(next_part)} bytes={len(incoming_bytes)}")
         await RedisObjectPartsCache(redis_client).set(object_id, int(next_part), incoming_bytes, ttl=1800)

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -28,8 +28,18 @@ async def _get_object_with_permissions_min(
     if main_account_id:
         # Ensure user exists (align with GET behavior)
         await UserRepository(db).ensure_by_main_account(main_account_id)
+
+    # Check if this is an anonymous request to a public bucket
+    account_id_for_query = main_account_id
+    if not main_account_id:
+        # Check if bucket is public
+        from hippius_s3.repositories.buckets import BucketRepository
+
+        bucket = await BucketRepository(db).get_by_name(bucket_name)
+        account_id_for_query = None if bucket and bucket.get("is_public") else main_account_id
+
     # Prefer the same query used by GET with permissions baked in
-    row = await ObjectRepository(db).get_for_download_with_permissions(bucket_name, object_key, main_account_id)
+    row = await ObjectRepository(db).get_for_download_with_permissions(bucket_name, object_key, account_id_for_query)
     if not row:
         raise errors.S3Error(
             code="NoSuchKey",
@@ -47,10 +57,31 @@ async def handle_head_object(
     *,
     object_reader: ObjectReader | None = None,
 ) -> Response:
+    # Compute anonymity before accessing request.state.account
+    is_anonymous = getattr(request.state, "access_mode", None) == "anon"
+    account = getattr(request.state, "account", None)
+
+    if (not is_anonymous) and (account is None):
+        # Check bucket publicity and switch to anon if public
+        from hippius_s3.repositories.buckets import BucketRepository
+
+        bucket = await BucketRepository(db).get_by_name(bucket_name)
+        if bucket and bucket.get("is_public"):
+            from hippius_s3.api.middlewares.credit_check import HippiusAccount
+
+            request.state.access_mode = "anon"
+            request.state.account = HippiusAccount(
+                seed="", id="anon", main_account="public", has_credits=True, upload=False, delete=False
+            )
+            is_anonymous = True
+            account = request.state.account
+
+    main_account_id = None if is_anonymous else (account.main_account if account else None)
+
     # Tagging HEAD: only verify existence
     if "tagging" in request.query_params:
         try:
-            await _get_object_with_permissions_min(bucket_name, object_key, db, request.state.account.main_account)
+            await _get_object_with_permissions_min(bucket_name, object_key, db, main_account_id)
             return Response(status_code=200)
         except errors.S3Error as e:
             return Response(status_code=e.status_code)
@@ -59,7 +90,7 @@ async def handle_head_object(
             return Response(status_code=500)
 
     try:
-        row = await _get_object_with_permissions_min(bucket_name, object_key, db, request.state.account.main_account)
+        row = await _get_object_with_permissions_min(bucket_name, object_key, db, main_account_id)
         # Build headers
         created_at = row["created_at"]
         size_bytes = int(row["size_bytes"]) if row.get("size_bytes") is not None else 0

--- a/hippius_s3/cache/object_parts.py
+++ b/hippius_s3/cache/object_parts.py
@@ -4,8 +4,10 @@ from typing import Any
 from typing import Optional
 from typing import Protocol
 
+from hippius_s3.config import get_config
 
-DEFAULT_OBJ_PART_TTL_SECONDS = 1800
+
+DEFAULT_OBJ_PART_TTL_SECONDS = get_config().cache_ttl_seconds
 
 
 class ObjectPartsCache(Protocol):

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -42,6 +42,7 @@ class Config:
     enable_banhammer: bool = env("ENABLE_BANHAMMER:true", convert=lambda x: x.lower() == "true")
     enable_public_read: bool = env("HIPPIUS_ENABLE_PUBLIC_READ:true", convert=lambda x: x.lower() == "true")
     public_bucket_cache_ttl_seconds: int = env("PUBLIC_BUCKET_CACHE_TTL_SECONDS:60", convert=int)
+    enable_bypass_credit_check: bool = env("HIPPIUS_BYPASS_CREDIT_CHECK:false", convert=lambda x: x.lower() == "true")
 
     # S3 Validation Limits
     min_bucket_name_length: int = env("MIN_BUCKET_NAME_LENGTH", convert=int)
@@ -58,6 +59,9 @@ class Config:
 
     # Redis for account caching (persistent)
     redis_accounts_url: str = env("REDIS_ACCOUNTS_URL")
+
+    # Redis for chain operations
+    redis_chain_url: str = env("REDIS_CHAIN_URL:redis://127.0.0.1:6381/0")
 
     # API signing key for pre-signed URLs
     # Generated on first run if not provided
@@ -77,6 +81,20 @@ class Config:
     # Resubmission settings
     resubmission_seed_phrase: str = env("RESUBMISSION_SEED_PHRASE")
 
+    # Publishing toggle (read directly from env; default true)
+    publish_to_chain: bool = env("PUBLISH_TO_CHAIN:true", convert=lambda x: x.lower() == "true")
+
+    # Pinner configuration
+    pinner_max_attempts: int = env("HIPPIUS_PINNER_MAX_ATTEMPTS:5", convert=int)
+    pinner_backoff_base_ms: int = env("HIPPIUS_PINNER_BACKOFF_BASE_MS:500", convert=int)
+    pinner_backoff_max_ms: int = env("HIPPIUS_PINNER_BACKOFF_MAX_MS:60000", convert=int)
+    pinner_batch_max_age_sec: int = env("HIPPIUS_PINNER_BATCH_MAX_AGE_SEC:10", convert=int)
+    pinner_batch_max_items: int = env("HIPPIUS_PINNER_BATCH_MAX_ITEMS:16", convert=int)
+    pinner_multipart_max_concurrency: int = env("HIPPIUS_PINNER_MULTIPART_MAX_CONCURRENCY:5", convert=int)
+
+    # Cache TTL (shared across components)
+    cache_ttl_seconds: int = env("HIPPIUS_CACHE_TTL:259200", convert=int)
+
     # endpoint chunk download settings, quite aggressive
     redis_read_chunk_timeout = 60
     http_download_sleep_loop = 0.1
@@ -90,9 +108,6 @@ class Config:
     manifest_stabilization_window_sec: int = env("MANIFEST_STABILIZATION_WINDOW_SEC:600", convert=int)
     manifest_scan_interval_sec: int = env("MANIFEST_SCAN_INTERVAL_SEC:120", convert=int)
     manifest_builder_max_concurrency: int = env("MANIFEST_BUILDER_MAX_CONCURRENCY:5", convert=int)
-
-    # Publishing toggle (read directly from env; default true)
-    publish_to_chain: bool = env("PUBLISH_TO_CHAIN:true", convert=lambda x: x.lower() == "true")
 
 
 def get_config() -> Config:

--- a/hippius_s3/main.py
+++ b/hippius_s3/main.py
@@ -230,8 +230,6 @@ Disallow: /"""
 
 
 app.include_router(user_router, prefix="/user")
-# Public router handles rewritten anonymous requests (more specific routes first)
-app.include_router(public_router, prefix="")
-# Replace old s3 router with new composed router
+app.include_router(public_router, prefix="")  # before the generic S3 routes
 app.include_router(s3_router_new, prefix="")
 app.include_router(multipart_router, prefix="")

--- a/hippius_s3/queue.py
+++ b/hippius_s3/queue.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import time
+import uuid
 from typing import Union
 
 import redis.asyncio as async_redis
@@ -30,6 +32,12 @@ class ChainRequest(BaseModel):
     object_key: str
     should_encrypt: bool
     object_id: str
+
+    # Retry & tracing metadata
+    request_id: str | None = None
+    attempts: int = 0
+    first_enqueued_at: float | None = None
+    last_error: str | None = None
 
     @property
     def name(self):
@@ -80,10 +88,15 @@ async def enqueue_upload_request(
     redis_client: async_redis.Redis,
 ) -> None:
     """Add an upload request to the Redis queue for processing by workers."""
-    await redis_client.lpush(
-        "upload_requests",
-        payload.model_dump_json(),
-    )
+    # Initialize tracing metadata if missing
+    if payload.request_id is None:
+        payload.request_id = uuid.uuid4().hex
+    if payload.first_enqueued_at is None:
+        payload.first_enqueued_at = time.time()
+    if payload.attempts is None:
+        payload.attempts = 0
+
+    await redis_client.lpush("upload_requests", payload.model_dump_json())
     logger.info(f"Enqueued upload request {payload.name=}")
 
 
@@ -104,6 +117,56 @@ async def dequeue_upload_request(
         return MultipartUploadChainRequest.model_validate(queue_data)
 
     return None
+
+
+# Retry handling (ZSET with score = next_attempt_unix_ts)
+RETRY_ZSET = "upload_retries"
+
+
+async def enqueue_retry_request(
+    payload: Union[
+        MultipartUploadChainRequest,
+        SimpleUploadChainRequest,
+    ],
+    redis_client: async_redis.Redis,
+    *,
+    delay_seconds: float,
+    last_error: str | None = None,
+) -> None:
+    if payload.request_id is None:
+        payload.request_id = uuid.uuid4().hex
+    payload.attempts = int((payload.attempts or 0) + 1)
+    payload.last_error = last_error
+    if payload.first_enqueued_at is None:
+        payload.first_enqueued_at = time.time()
+    next_ts = time.time() + max(0.0, float(delay_seconds))
+    member = payload.model_dump_json()
+    await redis_client.zadd(RETRY_ZSET, {member: next_ts})
+    logger.info(f"Scheduled retry for {payload.name=} attempts={payload.attempts} next_at={int(next_ts)}")
+
+
+async def move_due_retries_to_primary(
+    redis_client: async_redis.Redis,
+    *,
+    now_ts: float | None = None,
+    max_items: int = 64,
+) -> int:
+    """Move due retry items back to the primary queue. Returns number moved."""
+    now_ts = time.time() if now_ts is None else now_ts
+    # Fetch due items
+    members = await redis_client.zrangebyscore(RETRY_ZSET, min="-inf", max=now_ts, start=0, num=max_items)
+    moved = 0
+    for m in members:
+        try:
+            # Move atomically: remove from ZSET, push to primary
+            async with redis_client.pipeline(transaction=True) as pipe:
+                pipe.zrem(RETRY_ZSET, m)
+                pipe.lpush("upload_requests", m)
+                await pipe.execute()
+            moved += 1
+        except Exception:
+            logger.exception("Failed to move retry item back to primary queue")
+    return moved
 
 
 async def enqueue_unpin_request(

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -247,8 +247,9 @@ class ObjectReader:
             required_parts = {p.part_number for p in still_pending}
             if required_parts:
                 # Check if CIDs have become available for any pending parts
+                # Allow brief polling to account for pinner committing CIDs shortly after PUT
                 cid_updates = await ManifestService.wait_for_cids(
-                    db, info.object_id, required_parts, attempts=1, interval_sec=0
+                    db, info.object_id, required_parts, attempts=10, interval_sec=0.2
                 )
                 if cid_updates:
                     # Convert CID updates to parts and enqueue downloads

--- a/hippius_s3/workers/pinner.py
+++ b/hippius_s3/workers/pinner.py
@@ -1,0 +1,368 @@
+"""Pinner logic with retry handling and batch processing."""
+
+import asyncio
+import hashlib
+import logging
+import random
+from typing import Any
+from typing import List
+
+# FileInput is from hippius_sdk.substrate.FileInput but we define a simple alias for testing
+from typing import NamedTuple
+from typing import Tuple
+from typing import Union
+
+from hippius_s3.queue import Chunk
+from hippius_s3.queue import MultipartUploadChainRequest
+from hippius_s3.queue import SimpleUploadChainRequest
+from hippius_s3.queue import enqueue_retry_request
+from hippius_s3.utils import upsert_cid_and_get_id
+
+
+class FileInput(NamedTuple):
+    file_hash: str
+    file_name: str
+
+
+# Import heavy dependencies only when needed to avoid test import issues
+def _get_redis_cache() -> Any:
+    from hippius_s3.cache import RedisObjectPartsCache
+
+    return RedisObjectPartsCache
+
+
+logger = logging.getLogger(__name__)
+
+
+def classify_error(exc: Exception) -> bool:
+    """Classify exception as transient (retryable) or permanent (fail immediately).
+
+    Transient: timeouts, connection errors, 5xx HTTP, reset.
+    Permanent: 4xx validation errors, auth failures, etc.
+    """
+    # Type-based checks for common transient exceptions
+    if isinstance(exc, (asyncio.TimeoutError, asyncio.CancelledError, ConnectionError, OSError, BrokenPipeError)):
+        return True
+
+    # Try aiohttp-specific checks if available
+    try:
+        import aiohttp
+
+        if isinstance(exc, (aiohttp.ClientConnectorError, aiohttp.ServerTimeoutError, aiohttp.ClientError)):
+            return True
+    except ImportError:
+        pass
+
+    # String-based pattern matching for other cases
+    err_str = str(exc).lower()
+    transient_patterns = ["timeout", "temporarily", "connection", "reset", "503", "502", "504", "connect"]
+    return any(p in err_str for p in transient_patterns)
+
+
+def compute_backoff_ms(attempts: int, base_ms: int, max_ms: int) -> int:
+    """Compute exponential backoff with jitter.
+
+    Formula: min(max_ms, base_ms * 2^(attempts-1)) with ±20% jitter.
+    """
+    n = attempts
+    raw_delay = base_ms * (2 ** (n - 1))
+    jitter = int(0.2 * raw_delay)
+    jitter_offset = random.randint(-jitter, jitter)
+    delay_ms = max(0, raw_delay + jitter_offset)
+    delay_ms = min(max_ms, delay_ms)
+    return int(delay_ms)
+
+
+class Pinner:
+    """Handles per-item upload processing with retry logic."""
+
+    def __init__(self, db: Any, ipfs_service: Any, redis_client: Any, config: Any):
+        self.db = db
+        self.ipfs_service = ipfs_service
+        self.redis_client = redis_client
+        self.config = config
+
+    async def process_item(
+        self, payload: Union[SimpleUploadChainRequest, MultipartUploadChainRequest]
+    ) -> Tuple[List[FileInput], bool]:
+        """Process a single upload item.
+
+        Returns (files_to_publish, success).
+        On transient error: schedules retry and returns ([], False).
+        On permanent error: marks failed and returns ([], False).
+        On success: returns (files, True).
+        """
+        try:
+            if isinstance(payload, MultipartUploadChainRequest):  # Multipart
+                chunk_results = await self._process_multipart_upload(payload)
+                files = [result[0] for result in chunk_results]
+            else:  # Simple
+                result = await self._process_simple_upload(payload)
+                files = [result]
+            logger.info(
+                f"Pinner success: {payload.name} request_id={payload.request_id} attempts={payload.attempts} files={len(files)}"
+            )
+            return files, True
+        except Exception as e:
+            err_str = str(e)
+            transient = classify_error(e)
+            attempts_next = (payload.attempts or 0) + 1
+            if transient and attempts_next <= self.config.pinner_max_attempts:
+                delay_ms = compute_backoff_ms(
+                    attempts_next, self.config.pinner_backoff_base_ms, self.config.pinner_backoff_max_ms
+                )
+                await enqueue_retry_request(
+                    payload, self.redis_client, delay_seconds=delay_ms / 1000.0, last_error=err_str
+                )
+                logger.warning(
+                    f"Pinner transient failure (retry scheduled): {payload.name} request_id={payload.request_id} attempts={payload.attempts} error={err_str[:200]}"
+                )
+                return [], False
+            await self.db.execute("UPDATE objects SET status = 'failed' WHERE object_id = $1", payload.object_id)
+            logger.error(
+                f"Pinner permanent failure: {payload.name} request_id={payload.request_id} attempts={payload.attempts} error={err_str[:200]}"
+            )
+            return [], False
+
+    async def process_batch(
+        self, payloads: List[Union[SimpleUploadChainRequest, MultipartUploadChainRequest]]
+    ) -> Tuple[List[FileInput], List[Union[SimpleUploadChainRequest, MultipartUploadChainRequest]]]:
+        """Process a batch of items, isolating failures.
+
+        Returns (successful_files, succeeded_payloads) for substrate publish.
+        """
+        all_files = []
+        succeeded_payloads = []
+        for payload in payloads:
+            files, success = await self.process_item(payload)
+            if success:
+                all_files.extend(files)
+                succeeded_payloads.append(payload)
+        return all_files, succeeded_payloads
+
+    async def _process_simple_upload(self, payload: SimpleUploadChainRequest) -> FileInput:
+        """Process a simple upload."""
+        logger.info(f"Processing simple upload for object {payload.object_id}")
+        RedisObjectPartsCache = _get_redis_cache()
+        obj_cache = RedisObjectPartsCache(self.redis_client)
+        # For simple upload, the chunk id should be 0
+        chunk_data = await obj_cache.get(payload.object_id, int(payload.chunk.id))
+        logger.info(
+            f"Retrieved chunk data for object {payload.object_id}, size: {len(chunk_data) if chunk_data else 0}"
+        )
+
+        # Generate IPFS CID using s3_publish (pin, no chain publish)
+        # Keep filename as-is for unencrypted; hash for encrypted to avoid leaking names
+        file_name = payload.object_key
+        if payload.should_encrypt:
+            filename_hash = hashlib.md5(f"{payload.object_key}_md5".encode()).hexdigest()
+            file_name = f"{filename_hash}.chunk"
+
+        s3_result = await self.ipfs_service.client.s3_publish(
+            content=chunk_data,
+            encrypt=payload.should_encrypt,
+            seed_phrase=payload.subaccount_seed_phrase,
+            subaccount_id=payload.subaccount,
+            bucket_name=payload.bucket_name,
+            file_name=file_name,
+            store_node=payload.ipfs_node,
+            pin_node=payload.ipfs_node,
+            substrate_url=payload.substrate_url,
+            publish=False,
+        )
+        logger.info(
+            f"s3_publish result for object {payload.object_id}: cid={getattr(s3_result, 'cid', 'MISSING')}, type={type(s3_result)}"
+        )
+
+        # Backfill the base part CID for unified multipart reads
+        logger.info(f"Storing CID {s3_result.cid} for object {payload.object_id} in objects table")
+        await self.db.execute(
+            """
+            UPDATE objects
+            SET ipfs_cid = $2
+            WHERE object_id = $1 AND ipfs_cid IS NULL
+            """,
+            payload.object_id,
+            s3_result.cid,
+        )
+
+        # Ensure base (part 0) exists/updated with concrete ipfs_cid and cid_id for manifest/reads
+        try:
+            base_md5 = hashlib.md5(chunk_data).hexdigest()
+            cid_id = await upsert_cid_and_get_id(self.db, s3_result.cid)
+            logger.info(
+                f"Storing CID {s3_result.cid} (cid_id={cid_id}) for object {payload.object_id} part 0 in parts table"
+            )
+            # Try update-first; if no row was updated, insert a new one.
+            status = await self.db.execute(
+                """
+                UPDATE parts
+                SET ipfs_cid = $1, cid_id = $2, size_bytes = $3, etag = $4
+                WHERE object_id = $5 AND part_number = 0
+                """,
+                s3_result.cid,
+                cid_id,
+                len(chunk_data),
+                base_md5,
+                payload.object_id,
+            )
+            updated = False
+            try:
+                updated = isinstance(status, str) and status.split()[-1].isdigit() and int(status.split()[-1]) > 0
+            except Exception:
+                updated = False
+            if not updated:
+                await self.db.execute(
+                    """
+                    INSERT INTO parts (object_id, part_number, ipfs_cid, cid_id, size_bytes, etag)
+                    VALUES ($1, 0, $2, $3, $4, $5)
+                    """,
+                    payload.object_id,
+                    s3_result.cid,
+                    cid_id,
+                    len(chunk_data),
+                    base_md5,
+                )
+            logger.info(f"Successfully stored/updated part 0 in parts table for object {payload.object_id}")
+        except Exception:
+            logger.exception("Failed to write base part 0 into parts table")
+
+        # Keep cache for a while to ensure immediate consistency on reads (unified multipart)
+        RedisObjectPartsCache = _get_redis_cache()
+        await RedisObjectPartsCache(self.redis_client).expire(payload.object_id, 0, ttl=self.config.cache_ttl_seconds)
+
+        return FileInput(file_hash=s3_result.cid, file_name=file_name)
+
+    async def _process_multipart_chunk(
+        self, payload: MultipartUploadChainRequest, chunk: Chunk
+    ) -> Tuple[FileInput, Chunk]:
+        """Process a single multipart chunk."""
+        RedisObjectPartsCache = _get_redis_cache()
+        obj_cache = RedisObjectPartsCache(self.redis_client)
+        # Derive part_number from key to drive both read and DB updates
+
+        part_number_db = int(chunk.id)
+
+        # Get chunk data from cache
+        chunk_data = await obj_cache.get(payload.object_id, part_number_db)
+
+        # Generate IPFS CID for this chunk using s3_publish (no chain publish)
+        file_name = payload.object_key
+        if payload.should_encrypt:
+            filename_hash = hashlib.md5(f"{payload.object_key}_{chunk.id}".encode()).hexdigest()
+            file_name = f"{filename_hash}.chunk"
+
+        s3_result = await self.ipfs_service.client.s3_publish(
+            content=chunk_data,
+            encrypt=payload.should_encrypt,
+            seed_phrase=payload.subaccount_seed_phrase,
+            subaccount_id=payload.subaccount,
+            bucket_name=payload.bucket_name,
+            file_name=file_name,
+            store_node=payload.ipfs_node,
+            pin_node=payload.ipfs_node,
+            substrate_url=payload.substrate_url,
+            publish=False,
+        )
+
+        # Store part CID in database (update reserved placeholder row)
+        cid_id = await upsert_cid_and_get_id(self.db, s3_result.cid)
+        await self.db.execute(
+            """
+            UPDATE parts
+            SET ipfs_cid = $1, cid_id = $2, size_bytes = $3
+            WHERE object_id = $4 AND part_number = $5
+            """,
+            s3_result.cid,
+            cid_id,
+            len(chunk_data),
+            payload.object_id,
+            part_number_db,
+        )
+
+        return FileInput(file_hash=s3_result.cid, file_name=file_name), chunk
+
+    async def _process_multipart_upload(self, payload: MultipartUploadChainRequest) -> List[Tuple[FileInput, Chunk]]:
+        """Process multipart upload with concurrent chunk processing."""
+        # Concurrency for multipart processing is configurable
+        concurrency = int(getattr(self.config, "pinner_multipart_max_concurrency", 5) or 5)
+        semaphore = asyncio.Semaphore(concurrency)
+
+        # Ensure base part 0 has a concrete CID (simple PUT may still be pending)
+        try:
+            row = await self.db.fetchrow(
+                "SELECT ipfs_cid FROM parts WHERE object_id = $1 AND part_number = 0",
+                payload.object_id,
+            )
+            needs_base = True
+            if row is not None:
+                cid_raw = row[0]
+                if cid_raw is not None:
+                    cid_str = cid_raw if isinstance(cid_raw, str) else str(cid_raw)
+                    needs_base = cid_str.strip().lower() in {"", "none", "pending"}
+
+            if needs_base:
+                RedisObjectPartsCache = _get_redis_cache()
+                obj_cache = RedisObjectPartsCache(self.redis_client)
+                base_bytes = await obj_cache.get(payload.object_id, 0)
+                if base_bytes:
+                    file_name = payload.object_key
+                    if payload.should_encrypt:
+                        filename_hash = hashlib.md5(f"{payload.object_key}_md5".encode()).hexdigest()
+                        file_name = f"{filename_hash}.chunk"
+                    base_result = await self.ipfs_service.client.s3_publish(
+                        content=base_bytes,
+                        encrypt=payload.should_encrypt,
+                        seed_phrase=payload.subaccount_seed_phrase,
+                        subaccount_id=payload.subaccount,
+                        bucket_name=payload.bucket_name,
+                        file_name=file_name,
+                        store_node=payload.ipfs_node,
+                        pin_node=payload.ipfs_node,
+                        substrate_url=payload.substrate_url,
+                        publish=False,
+                    )
+                    cid_id = await upsert_cid_and_get_id(self.db, base_result.cid)
+                    base_md5 = hashlib.md5(base_bytes).hexdigest()
+                    await self.db.execute(
+                        """
+                        UPDATE parts
+                        SET ipfs_cid = $2, cid_id = $3, size_bytes = COALESCE(size_bytes, $4), etag = COALESCE(etag, $5)
+                        WHERE object_id = $1 AND part_number = 0
+                        """,
+                        payload.object_id,
+                        base_result.cid,
+                        cid_id,
+                        len(base_bytes),
+                        base_md5,
+                    )
+                    await obj_cache.expire(payload.object_id, 0, ttl=self.config.cache_ttl_seconds)
+        except Exception:
+            logger.debug("Failed ensuring base part(0) CID before multipart processing", exc_info=True)
+
+        async def process_chunk_with_semaphore(chunk: Chunk) -> Tuple[FileInput, Chunk]:
+            async with semaphore:
+                return await self._process_multipart_chunk(payload, chunk)
+
+        # Process first part synchronously to ensure encryption key is generated once,
+        # then parallelize the remaining parts to avoid key-generation races.
+        chunks_sorted = sorted(payload.chunks, key=lambda c: c.id)
+        first_result = await process_chunk_with_semaphore(chunks_sorted[0])
+
+        # Process remaining parts concurrently
+        if len(chunks_sorted) > 1:
+            remaining_results = await asyncio.gather(
+                *[process_chunk_with_semaphore(chunk) for chunk in chunks_sorted[1:]]
+            )
+            chunk_results = [first_result] + list(remaining_results)
+        else:
+            chunk_results = [first_result]
+
+        # Keep per-chunk caches for a while; GETs may still be assembling from cache
+        RedisObjectPartsCache = _get_redis_cache()
+        obj_cache = RedisObjectPartsCache(self.redis_client)
+        for _, chunk in chunk_results:
+            part_number_db = int(chunk.id)
+            await obj_cache.expire(payload.object_id, part_number_db, ttl=self.config.cache_ttl_seconds)
+
+        return chunk_results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "types-redis",
     "requests>=2.31.0",
     "psycopg[binary]>=3.1",
+    "fakeredis>=2.23.0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -192,6 +193,14 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "psycopg.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "fakeredis.aioredis"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "aiohttp.*"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -7,7 +7,7 @@ This directory contains end-to-end tests that verify the full Hippius S3 pipelin
 The tests currently use environment variable bypasses to skip credit checks and blockchain publishing:
 
 - `HIPPIUS_BYPASS_CREDIT_CHECK=true` - Skips credit verification for write operations
-- `HIPPIUS_PUBLISH_MODE=ipfs_only` - Uses IPFS-only mode instead of full blockchain publishing for single file uploads
+- `PUBLISH_TO_CHAIN=false` - Disables blockchain publishing for faster e2e runs
 
 These bypasses allow tests to run without:
 
@@ -59,15 +59,15 @@ services:
     environment:
       # delete these lines
       - HIPPIUS_BYPASS_CREDIT_CHECK=true
-      - HIPPIUS_PUBLISH_MODE=ipfs_only
+      - PUBLISH_TO_CHAIN=false
   pinner:
     environment:
       # delete this line
-      - HIPPIUS_PUBLISH_MODE=ipfs_only
+      - PUBLISH_TO_CHAIN=false
   unpinner:
     environment:
       # delete this line
-      - HIPPIUS_PUBLISH_MODE=ipfs_only
+      - PUBLISH_TO_CHAIN=false
 ```
 
 ### 2. Remove Bypass Code from Source

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -67,7 +67,7 @@ def test_run_id() -> str:
 def test_seed_phrase() -> str:
     """Generate a unique seed phrase for this test run."""
     # For now, use a fixed test seed. In production, generate or load from secure source.
-    return "test twelve word seed phrase for e2e testing purposes only"
+    return "about acid actor absent action able actual abandon abstract above ability achieve"
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/test_DeleteObjects.py
+++ b/tests/e2e/test_DeleteObjects.py
@@ -1,0 +1,106 @@
+"""E2E tests for DeleteObjects (POST /{bucket}?delete)."""
+
+from typing import Any
+from typing import Callable
+
+from botocore.exceptions import ClientError
+
+
+def _xml_delete_body(keys: list[str], quiet: bool = False) -> str:
+    ns = "http://s3.amazonaws.com/doc/2006-03-01/"
+    quiet_xml = "<Quiet>true</Quiet>" if quiet else ""
+    objects_xml = "".join([f"<Object><Key>{k}</Key></Object>" for k in keys])
+    return f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<Delete xmlns=\"{ns}\">{quiet_xml}{objects_xml}</Delete>"""
+
+
+def test_delete_objects_happy_path(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket_name = unique_bucket_name("del-objects")
+    cleanup_buckets(bucket_name)
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    # Put two keys
+    boto3_client.put_object(Bucket=bucket_name, Key="a.txt", Body=b"aaa", ContentType="text/plain")
+    boto3_client.put_object(Bucket=bucket_name, Key="b.txt", Body=b"bbb", ContentType="text/plain")
+
+    # Delete both
+    # Use boto3's native delete_objects call
+    resp = boto3_client.delete_objects(
+        Bucket=bucket_name,
+        Delete={
+            "Objects": [{"Key": "a.txt"}, {"Key": "b.txt"}],
+            "Quiet": False,
+        },
+    )
+
+    assert "Deleted" in resp
+    deleted_keys = sorted([d["Key"] for d in resp.get("Deleted", [])])
+    assert deleted_keys == ["a.txt", "b.txt"]
+    assert "Errors" not in resp or not resp["Errors"]
+
+    # Confirm deletion
+    for key in ["a.txt", "b.txt"]:
+        try:
+            boto3_client.head_object(Bucket=bucket_name, Key=key)
+            raise AssertionError("Expected 404 after delete")
+        except ClientError as e:
+            assert e.response["ResponseMetadata"]["HTTPStatusCode"] in (404,)
+
+
+def test_delete_objects_idempotent_and_missing(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket_name = unique_bucket_name("del-objects-idem")
+    cleanup_buckets(bucket_name)
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+    boto3_client.put_object(Bucket=bucket_name, Key="x.txt", Body=b"x", ContentType="text/plain")
+
+    # First delete existing and non-existing
+    resp1 = boto3_client.delete_objects(
+        Bucket=bucket_name, Delete={"Objects": [{"Key": "x.txt"}, {"Key": "missing.txt"}], "Quiet": False}
+    )
+    assert sorted([d["Key"] for d in resp1.get("Deleted", [])]) == ["missing.txt", "x.txt"]
+    assert not resp1.get("Errors")
+
+    # Second delete again should still show Deleted for both (idempotent)
+    resp2 = boto3_client.delete_objects(
+        Bucket=bucket_name, Delete={"Objects": [{"Key": "x.txt"}, {"Key": "missing.txt"}], "Quiet": False}
+    )
+    assert sorted([d["Key"] for d in resp2.get("Deleted", [])]) == ["missing.txt", "x.txt"]
+    assert not resp2.get("Errors")
+
+
+def test_delete_objects_quiet_mode(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket_name = unique_bucket_name("del-objects-quiet")
+    cleanup_buckets(bucket_name)
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+    boto3_client.put_object(Bucket=bucket_name, Key="q.txt", Body=b"q", ContentType="text/plain")
+
+    resp = boto3_client.delete_objects(
+        Bucket=bucket_name, Delete={"Objects": [{"Key": "q.txt"}, {"Key": "missing.txt"}], "Quiet": True}
+    )
+    # In quiet mode, boto3's parsing returns potentially empty Deleted list
+    assert "Errors" not in resp or not resp["Errors"]
+
+    # Ensure object gone
+    try:
+        boto3_client.head_object(Bucket=bucket_name, Key="q.txt")
+        raise AssertionError("Expected 404")
+    except ClientError as e:
+        assert e.response["ResponseMetadata"]["HTTPStatusCode"] in (404,)

--- a/tests/unit/test_pinner.py
+++ b/tests/unit/test_pinner.py
@@ -1,0 +1,208 @@
+"""Unit tests for pinner logic."""
+
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+
+from hippius_s3.config import Config
+from hippius_s3.queue import Chunk
+from hippius_s3.queue import SimpleUploadChainRequest
+from hippius_s3.workers.pinner import Pinner
+from hippius_s3.workers.pinner import classify_error
+from hippius_s3.workers.pinner import compute_backoff_ms
+
+
+@pytest.fixture
+def mock_config() -> Mock:
+    """Mock config for testing."""
+    config = Mock(spec=Config)
+    config.pinner_max_attempts = 3
+    config.pinner_backoff_base_ms = 100
+    config.pinner_backoff_max_ms = 1000
+    config.cache_ttl_seconds = 86400
+    return config
+
+
+@pytest.fixture
+def pinner(mock_config: Mock) -> Pinner:
+    """Pinner instance with mocked dependencies."""
+    db = AsyncMock()
+    ipfs_service = AsyncMock()
+    redis_client = AsyncMock()
+    return Pinner(db, ipfs_service, redis_client, mock_config)
+
+
+def test_classify_error_transient() -> None:
+    """Test error classification for transient errors."""
+    assert classify_error(ConnectionError("timeout"))
+    assert classify_error(ValueError("503 Service Unavailable"))
+    assert classify_error(Exception("connection reset"))
+
+
+def test_classify_error_permanent() -> None:
+    """Test error classification for permanent errors."""
+    assert not classify_error(ValueError("invalid input"))
+    assert not classify_error(RuntimeError("auth failed"))
+    assert not classify_error(Exception("normal error"))
+
+
+def test_compute_backoff_ms() -> None:
+    """Test backoff computation with jitter."""
+    # First attempt (attempts=1 means first retry after initial failure)
+    delay1 = compute_backoff_ms(attempts=1, base_ms=100, max_ms=10000)
+    assert 80 <= delay1 <= 120  # 100ms ±20%
+
+    # Second attempt
+    delay2 = compute_backoff_ms(attempts=2, base_ms=100, max_ms=10000)
+    assert 160 <= delay2 <= 240  # 200ms ±20%
+
+    # Test max cap
+    delay_max = compute_backoff_ms(attempts=10, base_ms=100, max_ms=500)
+    assert delay_max <= 500
+
+
+@pytest.mark.asyncio
+async def test_process_item_success_simple(pinner: Pinner) -> None:
+    """Test successful processing of simple upload."""
+    payload = SimpleUploadChainRequest(
+        substrate_url="http://test",
+        ipfs_node="http://test",
+        address="user1",
+        subaccount="user1",
+        subaccount_seed_phrase="test-seed",
+        bucket_name="test-bucket",
+        object_key="test-key",
+        should_encrypt=False,
+        object_id="obj-123",
+        chunk=Chunk(id=0),
+        attempts=0,
+        request_id="req-456",
+    )
+
+    # Mock successful processing
+    mock_result = Mock()
+    mock_result.file_hash = "bafkreid"
+    mock_result.cid = "bafkreid"
+
+    with patch.object(pinner, "_process_simple_upload", return_value=mock_result):
+        files, success = await pinner.process_item(payload)
+
+    assert success
+    assert len(files) == 1
+    assert files[0].file_hash == "bafkreid"
+
+    # Should not call retry enqueue or DB failure update
+    pinner.redis_client.zadd.assert_not_called()
+    pinner.db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_item_transient_error_retry(pinner: Pinner) -> None:
+    """Test transient error triggers retry."""
+    payload = SimpleUploadChainRequest(
+        substrate_url="http://test",
+        ipfs_node="http://test",
+        address="user1",
+        subaccount="user1",
+        subaccount_seed_phrase="test-seed",
+        bucket_name="test-bucket",
+        object_key="test-key",
+        should_encrypt=False,
+        object_id="obj-123",
+        chunk=Chunk(id=0),
+        attempts=1,  # Already tried once
+        request_id="req-456",
+    )
+
+    with patch.object(pinner, "_process_simple_upload", side_effect=ConnectionError("timeout")):
+        files, success = await pinner.process_item(payload)
+
+    assert not success
+    assert files == []
+
+    # Should enqueue retry
+    pinner.redis_client.zadd.assert_called_once()
+    # Should not mark as failed
+    pinner.db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_item_permanent_error_fail(pinner: Pinner) -> None:
+    """Test permanent error marks object as failed."""
+    payload = SimpleUploadChainRequest(
+        substrate_url="http://test",
+        ipfs_node="http://test",
+        address="user1",
+        subaccount="user1",
+        subaccount_seed_phrase="test-seed",
+        bucket_name="test-bucket",
+        object_key="test-key",
+        should_encrypt=False,
+        object_id="obj-123",
+        chunk=Chunk(id=0),
+        attempts=5,  # Max attempts exceeded
+        request_id="req-456",
+    )
+
+    with patch.object(pinner, "_process_simple_upload", side_effect=ValueError("invalid data")):
+        files, success = await pinner.process_item(payload)
+
+    assert not success
+    assert files == []
+
+    # Should mark as failed in DB
+    pinner.db.execute.assert_called_once_with("UPDATE objects SET status = 'failed' WHERE object_id = $1", "obj-123")
+    # Should not enqueue retry
+    pinner.redis_client.zadd.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_batch_mixed_results(pinner: Pinner) -> None:
+    """Test batch processing isolates failures."""
+    payload1 = SimpleUploadChainRequest(
+        substrate_url="http://test",
+        ipfs_node="http://test",
+        address="user1",
+        subaccount="user1",
+        subaccount_seed_phrase="test-seed",
+        bucket_name="test-bucket",
+        object_key="test-key-1",
+        should_encrypt=False,
+        object_id="obj-1",
+        chunk=Chunk(id=0),
+        attempts=0,
+        request_id="req-1",
+    )
+
+    payload2 = SimpleUploadChainRequest(
+        substrate_url="http://test",
+        ipfs_node="http://test",
+        address="user1",
+        subaccount="user1",
+        subaccount_seed_phrase="test-seed",
+        bucket_name="test-bucket",
+        object_key="test-key-2",
+        should_encrypt=False,
+        object_id="obj-2",
+        chunk=Chunk(id=0),
+        attempts=0,
+        request_id="req-2",
+    )
+
+    # Mock: first succeeds, second fails and retries
+    mock_result1 = Mock()
+    mock_result1.file_hash = "bafkreid1"
+    mock_result1.cid = "bafkreid1"
+
+    with patch.object(pinner, "_process_simple_upload", side_effect=[mock_result1, ConnectionError("timeout")]):
+        files, succeeded_payloads = await pinner.process_batch([payload1, payload2])
+
+    # Only successful file returned
+    assert len(files) == 1
+    assert files[0].file_hash == "bafkreid1"
+
+    # Only successful payload returned
+    assert len(succeeded_payloads) == 1
+    assert succeeded_payloads[0].object_id == "obj-1"

--- a/tests/unit/test_queue_retry.py
+++ b/tests/unit/test_queue_retry.py
@@ -1,0 +1,110 @@
+"""Unit tests for queue retry functionality."""
+
+import json
+import time
+
+import pytest
+from fakeredis.aioredis import FakeRedis
+
+from hippius_s3.queue import Chunk
+from hippius_s3.queue import SimpleUploadChainRequest
+from hippius_s3.queue import enqueue_retry_request
+from hippius_s3.queue import move_due_retries_to_primary
+
+
+@pytest.mark.asyncio
+async def test_enqueue_retry_request_sets_attempts_and_schedules() -> None:
+    """Test that enqueue_retry_request increments attempts and schedules with delay."""
+    redis = FakeRedis()
+    payload = SimpleUploadChainRequest(
+        substrate_url="http://test",
+        ipfs_node="http://test",
+        address="user1",
+        subaccount="user1",
+        subaccount_seed_phrase="test-seed",
+        bucket_name="test-bucket",
+        object_key="test-key",
+        should_encrypt=False,
+        object_id="obj-123",
+        chunk=Chunk(id=0),
+        attempts=1,
+        first_enqueued_at=time.time(),
+        request_id="req-456",
+    )
+
+    await enqueue_retry_request(payload, redis, delay_seconds=10.0, last_error="test error")
+
+    # Check ZSET has the item
+    members = await redis.zrange("upload_retries", 0, -1, withscores=True)
+    assert len(members) == 1
+
+    stored_payload = members[0][0]
+    score = members[0][1]
+
+    # Should be scheduled for future
+    assert score > time.time()
+
+    # Parse and verify payload
+    import json
+
+    data = json.loads(stored_payload)
+    assert data["attempts"] == 2  # incremented
+    assert data["last_error"] == "test error"
+    assert data["request_id"] == "req-456"
+
+
+@pytest.mark.asyncio
+async def test_move_due_retries_to_primary() -> None:
+    """Test that due retries are moved to primary queue."""
+    redis = FakeRedis()
+
+    # Add a due retry (score = past time)
+    past_time = time.time() - 10
+    payload_data = {"test": "data", "attempts": 1}
+    await redis.zadd("upload_retries", {json.dumps(payload_data): past_time})
+
+    # Add a not-due retry (score = future time)
+    future_time = time.time() + 100
+    await redis.zadd("upload_retries", {json.dumps({"not_due": True}): future_time})
+
+    moved = await move_due_retries_to_primary(redis, now_ts=time.time())
+
+    assert moved == 1  # Only the due one moved
+
+    # Check primary queue has the item
+    primary_item = await redis.lpop("upload_requests")
+    assert json.loads(primary_item) == payload_data
+
+    # Check ZSET still has the not-due item
+    remaining = await redis.zcard("upload_retries")
+    assert remaining == 1
+
+
+@pytest.mark.asyncio
+async def test_move_due_retries_respects_max_items() -> None:
+    """Test that move_due_retries_to_primary respects max_items limit."""
+    redis = FakeRedis()
+
+    # Add multiple due retries
+    past_time = time.time() - 10
+    for i in range(5):
+        payload_data = {"item": i}
+        await redis.zadd("upload_retries", {json.dumps(payload_data): past_time})
+
+    # Move with limit
+    moved = await move_due_retries_to_primary(redis, max_items=2)
+
+    assert moved == 2
+
+    # Check primary queue has exactly 2 items
+    primary_items = []
+    for _ in range(3):  # Try to pop 3, but only 2 should exist
+        item = await redis.lpop("upload_requests")
+        if item:
+            primary_items.append(item)
+
+    assert len(primary_items) == 2
+
+    # Check ZSET has remaining items
+    remaining = await redis.zcard("upload_retries")
+    assert remaining == 3

--- a/workers/chain_pin_checker.py
+++ b/workers/chain_pin_checker.py
@@ -2,7 +2,6 @@
 import asyncio
 import json
 import logging
-import os
 import sys
 import time
 from pathlib import Path
@@ -171,7 +170,7 @@ async def run_chain_pin_checker_loop():
     db = await asyncpg.connect(config.database_url)
 
     # Connect to redis-chain (identical to redis-accounts)
-    redis_chain_url = os.getenv("REDIS_CHAIN_URL", "redis://127.0.0.1:6381/0")
+    redis_chain_url = config.redis_chain_url
     redis_chain = async_redis.from_url(redis_chain_url)
 
     logger.info("Starting chain pin checker service...")

--- a/workers/chain_profile_cacher.py
+++ b/workers/chain_profile_cacher.py
@@ -2,7 +2,6 @@
 import asyncio
 import json
 import logging
-import os
 import sys
 import time
 from pathlib import Path
@@ -151,7 +150,7 @@ async def run_chain_profile_cacher_loop():
     db = await asyncpg.connect(config.database_url)
 
     # Connect to redis-chain
-    redis_chain_url = os.getenv("REDIS_CHAIN_URL", "redis://127.0.0.1:6381/0")
+    redis_chain_url = config.redis_chain_url
     redis_chain = async_redis.from_url(redis_chain_url)
 
     # Create HTTP client for profile downloads

--- a/workers/run_pinner_in_loop.py
+++ b/workers/run_pinner_in_loop.py
@@ -1,30 +1,38 @@
 #!/usr/bin/env python3
 import asyncio  # noqa: I001
-import hashlib
-import json
+import contextlib
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import Union
+import time
 
 import asyncpg
 import redis.asyncio as async_redis
-from hippius_sdk.ipfs import S3PublishPin
-from hippius_sdk.substrate import FileInput
 
 # Add parent directory to path to import hippius_s3 modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hippius_s3.cache import RedisObjectPartsCache
 from hippius_s3.config import get_config
 from hippius_s3.ipfs_service import IPFSService
-from hippius_s3.queue import Chunk
 from hippius_s3.queue import MultipartUploadChainRequest
 from hippius_s3.queue import SimpleUploadChainRequest
 from hippius_s3.queue import dequeue_upload_request
-from hippius_s3.utils import upsert_cid_and_get_id
+from hippius_s3.queue import move_due_retries_to_primary
+from hippius_s3.workers.pinner import Pinner
 from workers.substrate import submit_storage_request
+
+
+def _get_batch_context(upload_requests):
+    """Extract aggregate context from batch of upload requests for logging."""
+    if not upload_requests:
+        return "no_requests"
+
+    request_ids = [req.request_id for req in upload_requests if req.request_id]
+    attempts = [req.attempts or 0 for req in upload_requests]
+    object_ids = [req.object_id for req in upload_requests]
+
+    return f"requests={len(upload_requests)} request_ids={request_ids[:3]}{'...' if len(request_ids) > 3 else ''} attempts={attempts[:3]}{'...' if len(attempts) > 3 else ''} objects={object_ids[:3]}{'...' if len(object_ids) > 3 else ''}"
 
 
 config = get_config()
@@ -32,268 +40,24 @@ config = get_config()
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-# Keep Redis caches warm after pin by expiring instead of deleting
-_CACHE_TTL_SECONDS = int(os.getenv("HIPPIUS_CACHE_TTL", "1800"))
+# Config is loaded globally, no module-level constants needed
 
 
-async def _process_simple_upload(
-    payload: SimpleUploadChainRequest,
-    db: asyncpg.Connection,
-    ipfs_service: IPFSService,
-    redis_client: async_redis.Redis,
-) -> S3PublishPin:
-    from hippius_s3.cache import RedisObjectPartsCache
-
-    obj_cache = RedisObjectPartsCache(redis_client)
-    # For simple upload, the chunk id should be 0
-    chunk_data = await obj_cache.get(payload.object_id, int(payload.chunk.id))
-    if not chunk_data:
-        raise ValueError(f"Simple upload chunk not found: object_id={payload.object_id} part={int(payload.chunk.id)}")
-
-    # Mangle filename if encrypting
-    file_name = payload.object_key
-    if payload.should_encrypt:
-        filename_hash = hashlib.md5(f"{payload.object_key}_md5".encode()).hexdigest()
-        file_name = f"{filename_hash}.chunk"
-
-    # Encrypt chunk using s3_publish
-    s3_result = await ipfs_service.client.s3_publish(
-        content=chunk_data,
-        encrypt=payload.should_encrypt,
-        seed_phrase=payload.subaccount_seed_phrase,
-        subaccount_id=payload.subaccount,
-        bucket_name=payload.bucket_name,
-        file_name=file_name,
-        store_node=payload.ipfs_node,
-        pin_node=payload.ipfs_node,
-        substrate_url=payload.substrate_url,
-        publish=False,
-    )
-
-    encryption_status = "encrypted" if payload.should_encrypt else "unencrypted"
-    logger.info(f"Processed {encryption_status} simple upload -> CID: {s3_result.cid}")
-
-    # Update objects table with CID
-    await db.execute(
-        "UPDATE objects SET cid_id = $1, multipart = FALSE WHERE object_id = $2",
-        await upsert_cid_and_get_id(
-            db,
-            s3_result.cid,
-        ),
-        payload.object_id,
-    )
-
-    # If there is a provisional multipart part 0 row with missing or placeholder CID, backfill it
-    try:
-        base_cid_id = await upsert_cid_and_get_id(db, s3_result.cid)
-        base_md5 = hashlib.md5(chunk_data).hexdigest()
-        await db.execute(
-            """
-            UPDATE parts
-            SET ipfs_cid = $1,
-                cid_id = $2,
-                size_bytes = COALESCE(size_bytes, $3),
-                etag = COALESCE(etag, $4)
-            WHERE object_id = $5
-              AND part_number = 0
-              AND (
-                    ipfs_cid IS NULL OR ipfs_cid = '' OR ipfs_cid = 'pending' OR ipfs_cid = 'None'
-                  )
-            """,
-            s3_result.cid,
-            base_cid_id,
-            len(chunk_data),
-            base_md5,
-            payload.object_id,
-        )
-        logger.info(f"Backfilled base part(0) CID for object_id={payload.object_id} cid={s3_result.cid}")
-    except Exception as e:
-        logger.debug(
-            f"Failed to backfill base part CID for object_id={payload.object_id}: {e}",
-            exc_info=True,
-        )
-
-    # Keep cache for a while to ensure immediate consistency on reads (unified multipart)
-    await redis_client.expire(f"obj:{payload.object_id}:part:0", _CACHE_TTL_SECONDS)
-
-    return s3_result
+"""Processing helpers are implemented in hippius_s3.workers.pinner.Pinner"""
 
 
-async def _process_multipart_chunk(
-    payload: SimpleUploadChainRequest,
-    chunk: Chunk,
-    db: asyncpg.Connection,
-    ipfs_service: IPFSService,
-    redis_client: async_redis.Redis,
-) -> tuple[S3PublishPin, Chunk]:
-    obj_cache = RedisObjectPartsCache(redis_client)
-    # Derive part_number from key to drive both read and DB updates
-
-    part_number_db = int(chunk.id)
-
-    chunk_data = await obj_cache.get(payload.object_id, part_number_db)
-    if not chunk_data:
-        raise ValueError(f"Multipart chunk not found for object_id={payload.object_id} part={part_number_db}")
-
-    # Debug: compute md5 and show first/last bytes for validation
-    import hashlib as _hashlib
-
-    md5_pre = _hashlib.md5(chunk_data).hexdigest()
-    head_hex = chunk_data[:8].hex() if chunk_data else ""
-    tail_hex = chunk_data[-8:].hex() if len(chunk_data) >= 8 else head_hex
-    # part_number_db already computed above
-    logger.debug(
-        f"Multipart read: part={part_number_db} len={len(chunk_data)} md5={md5_pre} head8={head_hex} tail8={tail_hex}"
-    )
-
-    # Mangle filename if encrypting
-    file_name = payload.object_key
-    if payload.should_encrypt:
-        filename_hash = hashlib.md5(f"{payload.object_key}_{chunk.id}".encode()).hexdigest()
-        file_name = f"{filename_hash}.chunk"
-
-    # Encrypt chunk using s3_publish
-    s3_result = await ipfs_service.client.s3_publish(
-        content=chunk_data,
-        encrypt=payload.should_encrypt,
-        seed_phrase=payload.subaccount_seed_phrase,
-        subaccount_id=payload.subaccount,
-        bucket_name=payload.bucket_name,
-        file_name=file_name,
-        store_node=payload.ipfs_node,
-        pin_node=payload.ipfs_node,
-        substrate_url=payload.substrate_url,
-        publish=False,
-    )
-
-    import hashlib as _hashlib
-
-    encryption_status = "encrypted" if payload.should_encrypt else "unencrypted"
-    md5_post = _hashlib.md5(chunk_data).hexdigest()
-    head_hex_post = chunk_data[:8].hex() if chunk_data else ""
-    tail_hex_post = chunk_data[-8:].hex() if len(chunk_data) >= 8 else head_hex_post
-    logger.debug(
-        f"After encrypt/publish: part={part_number_db} status={encryption_status} cid={s3_result.cid} "
-        f"md5={md5_post} head8={head_hex_post} tail8={tail_hex_post}"
-    )
-
-    return s3_result, chunk
-
-
-async def _process_multipart_upload(
-    payload: SimpleUploadChainRequest,
-    db: asyncpg.Connection,
-    ipfs_service: IPFSService,
-    redis_client: async_redis.Redis,
-) -> tuple[list[S3PublishPin], S3PublishPin]:
-    semaphore = asyncio.Semaphore(5)
-
-    async def process_chunk_with_semaphore(chunk: Chunk) -> tuple[S3PublishPin, Chunk]:
-        async with semaphore:
-            return await _process_multipart_chunk(
-                payload=payload,
-                db=db,
-                chunk=chunk,
-                ipfs_service=ipfs_service,
-                redis_client=redis_client,
-            )
-
-    # Process first part synchronously to ensure encryption key is generated once,
-    # then parallelize the remaining parts to avoid key-generation races.
-    chunks_sorted = sorted(payload.chunks, key=lambda c: c.id)
-    first_result = await process_chunk_with_semaphore(chunks_sorted[0])
-    logger.info(f"Primed encryption key by processing first part synchronously: part={chunks_sorted[0].id}")
-    tasks = [process_chunk_with_semaphore(chunk) for chunk in chunks_sorted[1:]]
-    other_results = await asyncio.gather(*tasks) if tasks else []
-    chunk_results = [first_result] + other_results
-
-    # Update parts table with CIDs for all chunks
-
-    for s3_result, chunk in chunk_results:
-        part_number_db = int(chunk.id)
-        if part_number_db != chunk.id:
-            logger.warning(f"Part number mismatch detected: chunk.id={chunk.id} -> using {part_number_db}")
-        cid_id = await upsert_cid_and_get_id(db, s3_result.cid)
-        # Set both cid_id and ipfs_cid so tests that check ipfs_cid != 'pending' pass,
-        # and pipeline assembly can reference a concrete CID immediately.
-        await db.execute(
-            "UPDATE parts SET cid_id = $1, ipfs_cid = $2 WHERE object_id = $3 AND part_number = $4",
-            cid_id,
-            s3_result.cid,
-            payload.object_id,
-            part_number_db,
-        )
-        # Update last_append_at timestamp for manifest builder scheduling
-        await db.execute(
-            "UPDATE objects SET last_append_at = NOW() WHERE object_id = $1",
-            payload.object_id,
-        )
-        logger.debug(
-            f"Updated parts mapping: object_id={payload.object_id} part_number={part_number_db} cid={s3_result.cid}"
-        )
-
-    # Create manifest with chunk indices and CIDs
-    manifest = []
-    for s3_result, chunk in chunk_results:
-        part_number_db = int(chunk.id)
-        manifest.append([part_number_db, s3_result.cid])
-
-    # Sort manifest by chunk index to ensure proper order
-    manifest.sort(key=lambda x: x[0])
-
-    # Create filename_manifest.json and publish it
-    manifest_filename = f"{payload.object_key}_manifest.json"
-    manifest_data = json.dumps(manifest).encode()
-
-    # Publish the manifest to IPFS
-    manifest_result = await ipfs_service.client.s3_publish(
-        content=manifest_data,
-        encrypt=False,
-        seed_phrase=payload.subaccount_seed_phrase,
-        subaccount_id=payload.subaccount,
-        bucket_name=payload.bucket_name,
-        file_name=manifest_filename,
-        store_node=payload.ipfs_node,
-        pin_node=payload.ipfs_node,
-        substrate_url=payload.substrate_url,
-        publish=False,
-    )
-
-    logger.info(f"Created manifest for multipart upload -> Main CID: {manifest_result.cid}")
-
-    # Save the main object CID
-    main_cid_id = await upsert_cid_and_get_id(db, manifest_result.cid)
-
-    # Update objects table with main CID and mark as multipart
-    await db.execute(
-        "UPDATE objects SET cid_id = $1, multipart = TRUE WHERE object_id = $2",
-        main_cid_id,
-        payload.object_id,
-    )
-
-    # Keep per-chunk caches for a while; GETs may still be assembling from cache
-    obj_cache = RedisObjectPartsCache(redis_client)
-    for _, chunk in chunk_results:
-        part_number_db = int(chunk.id)
-        await obj_cache.expire(payload.object_id, part_number_db, ttl=_CACHE_TTL_SECONDS)
-
-    return [result[0] for result in chunk_results], manifest_result
+"""Deprecated multipart chunk handler removed in favor of Pinner._process_multipart_chunk"""
 
 
 async def process_upload_request(
-    upload_requests: list[
-        Union[
-            SimpleUploadChainRequest,
-            MultipartUploadChainRequest,
-        ]
-    ],
+    upload_requests: list[Union[SimpleUploadChainRequest, MultipartUploadChainRequest]],
     db: asyncpg.Connection,
     redis_client: async_redis.Redis,
 ) -> bool:
     """Process upload requests by processing chunks, encrypting, and updating database."""
     ipfs_service = IPFSService(config, redis_client)
+    pinner = Pinner(db, ipfs_service, redis_client, config)
     seed_phrase = upload_requests[0].subaccount_seed_phrase  # All requests for same user have same seed phrase
-    files = []
 
     # Update all objects status to 'pinning' when processing starts
     for payload in upload_requests:
@@ -303,80 +67,13 @@ async def process_upload_request(
         )
         logger.info(f"Updated object {payload.object_id} status to 'pinning'")
 
-    for payload in upload_requests:
-        logger.info(
-            f"Processing upload request for object_key={payload.object_key}, object_id={payload.object_id}, "
-            f"should_encrypt={payload.should_encrypt}, chunks={len(getattr(payload, 'chunks', [])) or 1}"
-        )
+    # Process batch with per-item isolation
+    files, succeeded_payloads = await pinner.process_batch(upload_requests)
 
-        if hasattr(payload, "chunks"):  # Multipart upload
-            try:
-                chunk_results, manifest_result = await _process_multipart_upload(
-                    payload=payload,
-                    db=db,
-                    ipfs_service=ipfs_service,
-                    redis_client=redis_client,
-                )
-
-                # Add individual chunk CIDs
-                files.extend(
-                    [
-                        FileInput(
-                            file_hash=result.cid,
-                            file_name=result.file_name,
-                        )
-                        for result in chunk_results
-                    ]
-                )
-
-                # Add manifest CID
-                files.append(
-                    FileInput(
-                        file_hash=manifest_result.cid,
-                        file_name=manifest_result.file_name,
-                    )
-                )
-            except Exception as e:
-                logger.error(
-                    f"Failed to process multipart upload for object_id={payload.object_id}, object_key={payload.object_key}: {e}"
-                )
-                # Mark all objects in this batch as failed
-                for req in upload_requests:
-                    await db.execute(
-                        "UPDATE objects SET status = 'failed' WHERE object_id = $1",
-                        req.object_id,
-                    )
-                return False
-        else:  # Simple upload
-            try:
-                result = await _process_simple_upload(
-                    payload=payload,
-                    db=db,
-                    ipfs_service=ipfs_service,
-                    redis_client=redis_client,
-                )
-                files.append(
-                    FileInput(
-                        file_hash=result.cid,
-                        file_name=result.file_name,
-                    )
-                )
-            except Exception as e:
-                logger.error(
-                    f"Failed to process simple upload for object_id={payload.object_id}, object_key={payload.object_key}: {e}"
-                )
-                # Mark all objects in this batch as failed
-                for req in upload_requests:
-                    await db.execute(
-                        "UPDATE objects SET status = 'failed' WHERE object_id = $1",
-                        req.object_id,
-                    )
-                return False
-
-    # Optionally skip substrate publish when not publishing to chain
+    # Optionally skip substrate publish if disabled
     if not config.publish_to_chain:
-        logger.info("Skipping substrate publish because publish_to_chain is disabled; marking objects as uploaded")
-        for payload in upload_requests:
+        logger.info("Skipping substrate publish because publish_to_chain=false; marking objects as uploaded")
+        for payload in succeeded_payloads:
             await db.execute(
                 "UPDATE objects SET status = 'uploaded' WHERE object_id = $1",
                 payload.object_id,
@@ -386,12 +83,19 @@ async def process_upload_request(
 
     # Submit storage request to substrate
     cids = [file.file_hash for file in files]
+    if not cids:
+        logger.info(
+            f"No successful items to publish; skipping substrate submission for this batch ({_get_batch_context(upload_requests)})"
+        )
+        return True
     tx_hash = await submit_storage_request(cids=cids, seed_phrase=seed_phrase, substrate_url=config.substrate_url)
 
-    logger.info(f"Processed {len(upload_requests)} upload requests with transaction: {tx_hash}")
+    logger.info(
+        f"Processed {len(succeeded_payloads)} upload requests with transaction: {tx_hash} ({_get_batch_context(succeeded_payloads)})"
+    )
 
     # Update all processed objects status to 'uploaded'
-    for payload in upload_requests:
+    for payload in succeeded_payloads:
         await db.execute(
             "UPDATE objects SET status = 'uploaded' WHERE object_id = $1",
             payload.object_id,
@@ -402,70 +106,92 @@ async def process_upload_request(
 
 
 async def run_pinner_loop():
-    """Main loop that monitors the Redis queue and processes upload requests."""
-    redis_client = async_redis.from_url(config.redis_url)
+    # Connect to database and Redis
     db = await asyncpg.connect(config.database_url)
+    redis_client = async_redis.from_url(config.redis_url)
 
     logger.info("Starting workers service...")
     logger.info(f"Redis URL: {config.redis_url}")
     logger.info(f"Database connected: {config.database_url}")
-    user_upload_requests = {}
+    # user -> { 'items': [ChainRequest...], 'first_at': epoch_seconds }
+    user_upload_requests: dict[str, dict[str, object]] = {}
 
     try:
-        # Batch policy: flush per user when 10 items or 500ms elapsed since first item
-        BATCH_MAX_ITEMS = int(os.getenv("PINNER_BATCH_MAX_ITEMS", "10"))
-        BATCH_MAX_AGE_SEC = float(os.getenv("PINNER_BATCH_MAX_AGE_SEC", "0.5"))
-        batch_first_seen: dict[str, float] = {}
-
         while True:
+            # Pull due retries
+            try:
+                moved = await move_due_retries_to_primary(redis_client, now_ts=time.time(), max_items=64)
+                if moved:
+                    logger.info(f"Moved {moved} due retry requests back to primary queue")
+            except Exception:
+                logger.debug("Failed moving due retries", exc_info=True)
+
             upload_request = await dequeue_upload_request(redis_client)
 
-            now = asyncio.get_event_loop().time()
+            now = time.time()
 
             if upload_request:
-                addr = upload_request.address
-                try:
-                    user_upload_requests[addr].append(upload_request)
-                except KeyError:
-                    user_upload_requests[addr] = [upload_request]
-                    batch_first_seen[addr] = now
+                entry = user_upload_requests.get(upload_request.address)
+                if entry is None:
+                    user_upload_requests[upload_request.address] = {"items": [upload_request], "first_at": now}
+                else:
+                    items = entry.get("items")
+                    if isinstance(items, list):
+                        items.append(upload_request)
+                    else:
+                        entry["items"] = [upload_request]
+                    # Preserve first_at
 
-                # Flush conditions: size >= max or age >= max
-                for user, items in list(user_upload_requests.items()):
-                    age = now - batch_first_seen.get(user, now)
-                    if len(items) >= BATCH_MAX_ITEMS or age >= BATCH_MAX_AGE_SEC:
-                        success = await process_upload_request(items, db, redis_client)
-                        if success:
-                            logger.info(f"Processed batch for user {user} with {len(items)} items (age={age:.3f}s)")
-                        else:
-                            logger.info(f"Failed to process batch with {len(items)} items for user {user}")
-                        user_upload_requests.pop(user, None)
-                        batch_first_seen.pop(user, None)
-
-            else:
-                # No items popped: flush any aged batches
-                for user, items in list(user_upload_requests.items()):
-                    age = now - batch_first_seen.get(user, now)
-                    if items and age >= BATCH_MAX_AGE_SEC:
-                        success = await process_upload_request(items, db, redis_client)
+                # Flush immediately if batch exceeds thresholds
+                entry = user_upload_requests.get(upload_request.address)
+                if entry is not None:
+                    items = entry.get("items")
+                    first_at = entry.get("first_at", now)
+                    size_ok = isinstance(items, list) and len(items) >= config.pinner_batch_max_items
+                    age_ok = isinstance(first_at, (int, float)) and (
+                        now - float(first_at) >= config.pinner_batch_max_age_sec
+                    )
+                    if size_ok or age_ok:
+                        batch = list(items) if isinstance(items, list) else []
+                        success = await process_upload_request(batch, db, redis_client)
                         if success:
                             logger.info(
-                                f"Processed aged batch for user {user} with {len(items)} items (age={age:.3f}s)"
+                                f"Processed user's {upload_request.address} with {len(batch)} files (flush reason: {'size' if size_ok else 'age'})"
                             )
                         else:
-                            logger.info(f"Failed to process aged batch with {len(items)} items for user {user}")
+                            logger.info(
+                                f"Failed to process {len(batch)} pin requests for user {upload_request.address} (flush reason: {'size' if size_ok else 'age'})"
+                            )
+                        # Reset entry for user
+                        user_upload_requests.pop(upload_request.address, None)
+
+            else:
+                # No items in queue: flush all pending batches
+                if user_upload_requests:
+                    for user, entry in list(user_upload_requests.items()):
+                        items = entry.get("items")
+                        batch = list(items) if isinstance(items, list) else []
+                        if not batch:
+                            user_upload_requests.pop(user, None)
+                            continue
+                        success = await process_upload_request(batch, db, redis_client)
+                        if success:
+                            logger.info(f"SUCCESSFULLY processed user's {user} with {len(batch)} files")
+                        else:
+                            logger.info(f"Failed to batch and serve {len(batch)} pin requests for user {user}")
                         user_upload_requests.pop(user, None)
-                        batch_first_seen.pop(user, None)
+                await asyncio.sleep(0.1)
 
     except KeyboardInterrupt:
         logger.info("Pinner service stopping...")
     except Exception as e:
-        logger.exception(f"Error in workers loop: {e}")
-        # Log and continue instead of exiting
-        await asyncio.sleep(5)  # Brief pause before retrying
+        logger.error(f"Error in pinner loop: {e}")
     finally:
-        await redis_client.aclose()
-        await db.close()
+        with contextlib.suppress(Exception):
+            await redis_client.close()
+            logger.info("Redis client closed")
+        with contextlib.suppress(Exception):
+            await db.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Enhance Hippius S3 Reliability, Add Batch Delete Support, and Refactor Pinning Logic

## Overview

This pull request introduces significant enhancements to the Hippius S3 project, aimed at improving system reliability through retry mechanisms, adding S3-compatible batch delete functionality, centralizing configuration management, and refining public access controls. It also refactors the pinning worker for better maintainability and adds comprehensive unit and end-to-end (E2E) tests to ensure robustness. These changes make the system more resilient to transient failures (e.g., network issues with IPFS or Substrate), extend API compatibility, and streamline development/testing workflows.

The updates are backward-compatible where possible, but note breaking changes to environment variables (e.g., `HIPPIUS_PUBLISH_MODE` renamed to `PUBLISH_TO_CHAIN`)—update your setups accordingly. No database migrations are required, but review the new config options in `config.py`.

## Motivation

- **Reliability**: Transient errors in pinning/uploads (e.g., timeouts) previously led to failures; retries with backoff address this.
- **Feature Parity**: Added `DeleteObjects` to support S3 batch deletes, improving usability for clients.
- **Maintainability**: Scattered env var accesses were error-prone; centralization fixes this. Worker refactor isolates concerns.
- **Testing**: Expanded coverage for retries, batch operations, and public access to catch regressions early.
- **Performance**: Batch processing in pinning with configurable limits optimizes throughput.

## Key Changes

### Configuration and Environment
- Centralised config loading in `hippius_s3/config.py` using `get_config()`. Removed direct `os.getenv` calls in favor of this (e.g., in `cacher/run_cacher.py`, `hippius_s3/api/middlewares/credit_check.py`).
- New config options: `enable_bypass_credit_check`, `redis_chain_url`, `publish_to_chain` (replaces old modes), `pinner_*` (e.g., `max_attempts=5`, backoff params), `cache_ttl_seconds=259200`.
- Updated E2E overrides in `docker-compose.e2e.yml` and docs to use `PUBLISH_TO_CHAIN=false` for faster tests without blockchain.

### Reliability Improvements
- Introduced retry logic in `hippius_s3/queue.py` and new `hippius_s3/workers/pinner.py`:
  - Uses Redis ZSET for scheduled retries with exponential backoff + jitter (e.g., base 500ms, max 60s).
  - Classifies errors as transient (e.g., timeouts, 5xx) vs. permanent (e.g., 4xx validation).
  - Moves due retries to primary queue in the pinner loop.
- Refactored `workers/run_pinner_in_loop.py` to use `Pinner` class for item/batch processing, isolating failures.
- Increased polling for CIDs in `hippius_s3/services/object_reader.py` (10 attempts @ 0.2s) for better pending handling.

### New Features
- Implemented S3 `DeleteObjects` (batch delete via XML) in `hippius_s3/api/s3/buckets/delete_objects_endpoint.py`:
  - Supports up to 1000 keys, quiet mode, idempotency (non-existent keys succeed).
  - Enqueues unpin requests; handles versioning as not supported.
  - Integrated into router with 501 for unsupported subresources.
- Enhanced append semantics docs and caching in `hippius_s3/api/s3/extensions/append.py`.
- Improved anonymous/public access in `get_object_endpoint.py` and `head_object_endpoint.py`:
  - Switches to anon mode if bucket is public, even for authenticated requests.
- Updated object status headers (e.g., `uploaded`, `publishing`) and added `x-hippius-source` diagnostic.

### Documentation and Compatibility
- Updated `docs/s3-compatibility.md` with `DeleteObjects` details, append extensions, and status enums.
- Aligned README and E2E docs with new config (e.g., `PUBLISH_TO_CHAIN=false`).

### Testing
- New E2E tests in `tests/e2e/test_DeleteObjects.py`: Covers happy path, idempotency, quiet mode, missing keys.
- New unit tests:
  - `tests/unit/test_pinner.py`: Success/failure paths, error classification, backoff, batch isolation.
  - `tests/unit/test_queue_retry.py`: Enqueue/move retries, metadata updates, limits.
- Updated `pyproject.toml` with `fakeredis` for Redis mocking in units; mypy overrides for deps.

### Other Fixes and Refactors
- Removed deprecated code (e.g., old multipart handlers) in favor of `Pinner`.
- Cache TTLs now configurable and applied consistently (e.g., in `hippius_s3/cache/object_parts.py`).
