### PR TITLE
Implement Chunked Encryption, Caching, and DLQ Enhancements for Private Buckets

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -15,6 +15,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - REDIS_ACCOUNTS_URL=redis://redis-accounts:6379/0
       - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
+      - HTTP_STREAM_INITIAL_TIMEOUT_SECONDS=0.5
       - LOG_LEVEL=DEBUG
     volumes:
       - .:/app

--- a/hippius_s3/api/middlewares/backend_hmac.py
+++ b/hippius_s3/api/middlewares/backend_hmac.py
@@ -61,7 +61,6 @@ class SigV4Verifier:
             raise AuthParsingError("Credentials not found")
 
         logger.debug("SUCCESS: Authorization header format valid")
-        logger.debug(f"Full authorization header: '{self.auth_header}'")
 
         credential_match = re.search(
             r"Credential=([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^,]+)",

--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -170,7 +170,7 @@ async def handle_get_object(
                 )
 
         with contextlib.suppress(Exception):
-            logger.info(
+            logger.debug(
                 f"GET manifest-built multipart={object_info.get('multipart')} parts={[c if isinstance(c, dict) else c for c in download_chunks]}"
             )
 

--- a/hippius_s3/cache/object_parts.py
+++ b/hippius_s3/cache/object_parts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json as _json
 from typing import Any
 from typing import Optional
 from typing import Protocol
@@ -13,6 +14,7 @@ DEFAULT_OBJ_PART_TTL_SECONDS = get_config().cache_ttl_seconds
 class ObjectPartsCache(Protocol):
     def build_key(self, object_id: str, part_number: int) -> str: ...
 
+    # Back-compat whole-part API
     async def get(self, object_id: str, part_number: int) -> Optional[bytes]: ...
     async def set(
         self, object_id: str, part_number: int, data: bytes, *, ttl: int = DEFAULT_OBJ_PART_TTL_SECONDS
@@ -20,6 +22,34 @@ class ObjectPartsCache(Protocol):
     async def exists(self, object_id: str, part_number: int) -> bool: ...
     async def strlen(self, object_id: str, part_number: int) -> int: ...
     async def expire(self, object_id: str, part_number: int, *, ttl: int = DEFAULT_OBJ_PART_TTL_SECONDS) -> None: ...
+
+    # New chunked API
+    def build_chunk_key(self, object_id: str, part_number: int, chunk_index: int) -> str: ...
+    async def get_chunk(self, object_id: str, part_number: int, chunk_index: int) -> Optional[bytes]: ...
+    async def set_chunk(
+        self,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+        data: bytes,
+        *,
+        ttl: int = DEFAULT_OBJ_PART_TTL_SECONDS,
+    ) -> None: ...
+    async def chunk_exists(self, object_id: str, part_number: int, chunk_index: int) -> bool: ...
+
+    # Metadata API
+    def build_meta_key(self, object_id: str, part_number: int) -> str: ...
+    async def set_meta(
+        self,
+        object_id: str,
+        part_number: int,
+        *,
+        chunk_size: int,
+        num_chunks: int,
+        size_bytes: int,
+        ttl: int = DEFAULT_OBJ_PART_TTL_SECONDS,
+    ) -> None: ...
+    async def get_meta(self, object_id: str, part_number: int) -> Optional[dict]: ...
 
 
 class RedisObjectPartsCache:
@@ -29,25 +59,126 @@ class RedisObjectPartsCache:
     def build_key(self, object_id: str, part_number: int) -> str:
         return f"obj:{object_id}:part:{int(part_number)}"
 
+    def build_chunk_key(self, object_id: str, part_number: int, chunk_index: int) -> str:
+        return f"obj:{object_id}:part:{int(part_number)}:chunk:{int(chunk_index)}"
+
+    def build_meta_key(self, object_id: str, part_number: int) -> str:
+        return f"obj:{object_id}:part:{int(part_number)}:meta"
+
     async def get(self, object_id: str, part_number: int) -> Optional[bytes]:
-        result = await self.redis.get(self.build_key(object_id, part_number))
-        return result if isinstance(result, bytes) else None
+        # Assemble from chunked entries using meta
+        try:
+            meta_raw = await self.redis.get(self.build_meta_key(object_id, part_number))
+            if not meta_raw:
+                return None
+            meta = _json.loads(meta_raw)
+            num_chunks = int(meta.get("num_chunks", 0))
+            if num_chunks <= 0:
+                return None
+            chunks: list[bytes] = []
+            for i in range(num_chunks):
+                c = await self.redis.get(self.build_chunk_key(object_id, part_number, i))
+                if not isinstance(c, bytes):
+                    return None
+                chunks.append(c)
+            return b"".join(chunks)
+        except Exception:
+            return None
 
     async def set(
         self, object_id: str, part_number: int, data: bytes, *, ttl: int = DEFAULT_OBJ_PART_TTL_SECONDS
     ) -> None:
-        await self.redis.setex(self.build_key(object_id, part_number), ttl, data)
+        # Split into fixed-size chunks and store meta first (for cheap readiness checks), then chunk keys
+        try:
+            chunk_size = int(get_config().object_chunk_size_bytes)
+        except Exception:
+            chunk_size = 4 * 1024 * 1024
+        total = len(data) if isinstance(data, (bytes, bytearray)) else 0
+        if total == 0:
+            # Still write empty meta with zero chunks for consistency
+            await self.set_meta(object_id, part_number, chunk_size=chunk_size, num_chunks=0, size_bytes=0, ttl=ttl)
+            return
+        num_chunks = (total + chunk_size - 1) // chunk_size
+        # Write meta first to signal readiness before chunks are fully written
+        await self.set_meta(
+            object_id, part_number, chunk_size=chunk_size, num_chunks=num_chunks, size_bytes=total, ttl=ttl
+        )
+        # Then write chunk data
+        for i in range(num_chunks):
+            start = i * chunk_size
+            end = min(start + chunk_size, total)
+            await self.set_chunk(object_id, part_number, i, data[start:end], ttl=ttl)
 
     async def exists(self, object_id: str, part_number: int) -> bool:
-        return bool(await self.redis.exists(self.build_key(object_id, part_number)))
+        return bool(await self.redis.exists(self.build_meta_key(object_id, part_number)))
 
     async def strlen(self, object_id: str, part_number: int) -> int:
-        return int(await self.redis.strlen(self.build_key(object_id, part_number)))
+        try:
+            meta_raw = await self.redis.get(self.build_meta_key(object_id, part_number))
+            if not meta_raw:
+                return 0
+            meta = _json.loads(meta_raw)
+            return int(meta.get("size_bytes", 0))
+        except Exception:
+            return 0
 
     async def expire(self, object_id: str, part_number: int, *, ttl: int = DEFAULT_OBJ_PART_TTL_SECONDS) -> None:
-        await self.redis.expire(self.build_key(object_id, part_number), ttl)
+        """Set TTL on meta and all chunk keys for this part to prevent orphaned chunk bytes."""
+        await self.redis.expire(self.build_meta_key(object_id, part_number), ttl)
+        # Also expire all chunk keys for this part (scan pattern to catch all indices)
+        pattern = f"obj:{object_id}:part:{int(part_number)}:chunk:*"
+        cursor = 0
+        while True:
+            cursor, keys = await self.redis.scan(cursor, match=pattern, count=100)
+            if keys:
+                # Expire all found chunk keys
+                for key in keys:
+                    await self.redis.expire(key, ttl)
+            if cursor == 0:
+                break
 
     # Note: base part policy is 1-based; callers should use get/set directly with part_number=1
+
+    # Chunked API
+    async def get_chunk(self, object_id: str, part_number: int, chunk_index: int) -> Optional[bytes]:
+        result = await self.redis.get(self.build_chunk_key(object_id, part_number, chunk_index))
+        return result if isinstance(result, bytes) else None
+
+    async def set_chunk(
+        self,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+        data: bytes,
+        *,
+        ttl: int = DEFAULT_OBJ_PART_TTL_SECONDS,
+    ) -> None:
+        await self.redis.setex(self.build_chunk_key(object_id, part_number, chunk_index), ttl, data)
+
+    async def chunk_exists(self, object_id: str, part_number: int, chunk_index: int) -> bool:
+        return bool(await self.redis.exists(self.build_chunk_key(object_id, part_number, chunk_index)))
+
+    async def set_meta(
+        self,
+        object_id: str,
+        part_number: int,
+        *,
+        chunk_size: int,
+        num_chunks: int,
+        size_bytes: int,
+        ttl: int = DEFAULT_OBJ_PART_TTL_SECONDS,
+    ) -> None:
+        payload = {"chunk_size": int(chunk_size), "num_chunks": int(num_chunks), "size_bytes": int(size_bytes)}
+        await self.redis.setex(self.build_meta_key(object_id, part_number), ttl, _json.dumps(payload))
+
+    async def get_meta(self, object_id: str, part_number: int) -> Optional[dict]:
+        raw = await self.redis.get(self.build_meta_key(object_id, part_number))
+        if not raw:
+            return None
+        try:
+            return dict(_json.loads(raw))  # type: ignore[arg-type]
+        except Exception:
+            return None
 
 
 class RedisUploadPartsCache:

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -104,6 +104,14 @@ class Config:
 
     # Cache TTL (shared across components)
     cache_ttl_seconds: int = env("HIPPIUS_CACHE_TTL:259200", convert=int)
+    # Unified object part chunk size (bytes) for cache and range math
+    object_chunk_size_bytes: int = env("HIPPIUS_CHUNK_SIZE_BYTES:4194304", convert=int)
+
+    # Crypto configuration
+    # Default encryption suite for new objects
+    # hip-enc/1: XSalsa20-Poly1305 with random nonces (current)
+    # hip-enc/legacy: Legacy whole-part encryption (SDK compatibility)
+    crypto_suite_id: str = env("HIPPIUS_CRYPTO_SUITE_ID:hip-enc/1")
 
     # endpoint chunk download settings, quite aggressive
     redis_read_chunk_timeout = 60

--- a/hippius_s3/dlq/storage.py
+++ b/hippius_s3/dlq/storage.py
@@ -4,9 +4,13 @@ DLQ Storage Module
 Handles filesystem operations for DLQ chunk persistence.
 """
 
+import contextlib
+import json
 import logging
+import re
 import shutil
 from pathlib import Path
+from typing import Dict
 from typing import List
 from typing import Optional
 from uuid import UUID
@@ -47,6 +51,111 @@ class DLQStorage:
             logger.error(f"Failed to save chunk to DLQ: {part_file}, error={e}")
             raise
 
+    def save_meta(self, object_id: str, part_number: int, meta: Dict) -> None:
+        """Save cache metadata (chunk_size, num_chunks, size_bytes) as JSON sidecar.
+
+        Enables exact Redis cache reconstruction without inferring chunk boundaries.
+        """
+        object_dir = self.dlq_dir / self._safe_id(object_id)
+        object_dir.mkdir(parents=True, exist_ok=True)
+
+        meta_file = object_dir / f"part_{part_number}.meta.json"
+        try:
+            with meta_file.open("w") as f:
+                json.dump(meta, f)
+            logger.debug(f"Saved meta to DLQ: {meta_file}")
+        except Exception as e:
+            logger.error(f"Failed to save meta to DLQ: {meta_file}, error={e}")
+            raise
+
+    def load_meta(self, object_id: str, part_number: int) -> Optional[Dict]:
+        """Load cache metadata from JSON sidecar."""
+        meta_file = self.dlq_dir / self._safe_id(object_id) / f"part_{part_number}.meta.json"
+        try:
+            with meta_file.open("r") as f:
+                result = json.load(f)
+                return dict(result) if isinstance(result, dict) else None
+        except FileNotFoundError:
+            logger.debug(f"Meta not found in DLQ: {meta_file}")
+            return None
+        except Exception as e:
+            logger.error(f"Failed to load meta from DLQ: {meta_file}, error={e}")
+            return None
+
+    def save_chunk_piece(self, object_id: str, part_number: int, chunk_index: int, data: bytes) -> None:
+        """Save a single chunk piece exactly as stored in Redis (ciphertext or plaintext)."""
+        object_dir = self.dlq_dir / self._safe_id(object_id)
+        object_dir.mkdir(parents=True, exist_ok=True)
+
+        piece_file = object_dir / f"part_{part_number}.chunk_{chunk_index}"
+        try:
+            with piece_file.open("wb") as f:
+                f.write(data)
+            logger.debug(f"Saved chunk piece to DLQ: {piece_file}, size={len(data)}")
+        except Exception as e:
+            logger.error(f"Failed to save chunk piece to DLQ: {piece_file}, error={e}")
+            raise
+
+    def load_chunk_piece(self, object_id: str, part_number: int, chunk_index: int) -> Optional[bytes]:
+        """Load a single chunk piece from DLQ, if present."""
+        piece_file = self.dlq_dir / self._safe_id(object_id) / f"part_{part_number}.chunk_{chunk_index}"
+        try:
+            with piece_file.open("rb") as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            logger.error(f"Failed to load chunk piece from DLQ: {piece_file}, error={e}")
+            raise
+
+    def list_chunk_piece_indices(self, object_id: str, part_number: int) -> List[int]:
+        """List available chunk piece indices for a given part in DLQ."""
+        object_dir = self.dlq_dir / self._safe_id(object_id)
+        if not object_dir.exists():
+            return []
+        indices: List[int] = []
+        prefix = f"part_{part_number}.chunk_"
+        try:
+            for item in object_dir.iterdir():
+                if item.is_file() and item.name.startswith(prefix):
+                    try:
+                        idx_str = item.name[len(prefix) :]
+                        indices.append(int(idx_str))
+                    except Exception:
+                        continue
+        except Exception as e:
+            logger.error(f"Failed to list chunk pieces for object {object_id} part {part_number}: {e}")
+            raise
+        return sorted(indices)
+
+    def part_size(self, object_id: str, part_number: int) -> int:
+        """Return total bytes for a part, using meta or summing piece sizes. Legacy fallback to whole file."""
+        # Prefer meta.size_bytes if present
+        meta = self.load_meta(object_id, part_number)
+        if isinstance(meta, dict):
+            try:
+                sb = int(meta.get("size_bytes", 0))
+                if sb > 0:
+                    return sb
+            except Exception:
+                pass
+        # Sum all piece files
+        indices = self.list_chunk_piece_indices(object_id, part_number)
+        if indices:
+            total = 0
+            object_dir = self.dlq_dir / self._safe_id(object_id)
+            for ci in indices:
+                piece_file = object_dir / f"part_{part_number}.chunk_{ci}"
+                try:
+                    total += piece_file.stat().st_size
+                except Exception:
+                    b = self.load_chunk_piece(object_id, part_number, ci)
+                    total += len(b) if isinstance(b, (bytes, bytearray)) else 0
+            return total
+        # Legacy whole file fallback
+        data = self.load_chunk(object_id, part_number)
+        return len(data) if isinstance(data, (bytes, bytearray)) else 0
+
     def load_chunk(self, object_id: str, part_number: int) -> Optional[bytes]:
         """Load chunk bytes from filesystem."""
         part_file = self.dlq_dir / self._safe_id(object_id) / f"part_{part_number}"
@@ -61,24 +170,26 @@ class DLQStorage:
             raise
 
     def list_chunks(self, object_id: str) -> List[int]:
-        """List available part numbers for an object in DLQ."""
+        """List available part numbers (supports meta/pieces-only layout)."""
         object_dir = self.dlq_dir / self._safe_id(object_id)
         if not object_dir.exists():
             return []
-
-        part_numbers = []
+        part_numbers: set = set()
+        re_meta = re.compile(r"^part_(\d+)\.meta\.json$")
+        re_piece = re.compile(r"^part_(\d+)\.chunk_\d+$")
+        re_whole = re.compile(r"^part_(\d+)$")  # legacy
         try:
             for item in object_dir.iterdir():
-                if item.is_file() and item.name.startswith("part_"):
-                    try:
-                        part_num = int(item.name.split("_", 1)[1])
-                        part_numbers.append(part_num)
-                    except ValueError:
-                        logger.warning(f"Invalid part filename: {item.name}")
+                if not item.is_file():
+                    continue
+                name = item.name
+                m = re_meta.match(name) or re_piece.match(name) or re_whole.match(name)
+                if m:
+                    with contextlib.suppress(Exception):
+                        part_numbers.add(int(m.group(1)))
         except Exception as e:
             logger.error(f"Failed to list chunks for object {object_id}: {e}")
             raise
-
         return sorted(part_numbers)
 
     def has_object(self, object_id: str) -> bool:

--- a/hippius_s3/services/crypto_service.py
+++ b/hippius_s3/services/crypto_service.py
@@ -1,0 +1,577 @@
+"""Crypto service with versioned adapters for chunked AEAD encryption/decryption.
+
+Supports:
+- Random per-chunk nonces (libsodium default, prevents nonce reuse)
+- Streaming encrypt/decrypt for memory-efficient range operations
+- Legacy decrypt for backward compatibility
+
+Note: AAD binding helpers exist but are not currently used. SecretBox does not expose
+native AAD support; future work could switch to a proper AEAD primitive (ChaCha20-Poly1305)
+or implement AAD via explicit MAC computation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import struct
+from abc import ABC
+from abc import abstractmethod
+from typing import AsyncIterator
+from typing import Callable
+from typing import Dict
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from nacl.exceptions import CryptoError  # type: ignore[import-not-found]
+from nacl.secret import SecretBox  # type: ignore[import-not-found]
+
+
+class CryptoAdapter(ABC):
+    """Base interface for encryption adapters."""
+
+    @property
+    @abstractmethod
+    def overhead_per_chunk(self) -> int:
+        """Bytes of overhead added per chunk (nonce + MAC)."""
+        ...
+
+    @abstractmethod
+    def encrypt_chunk(
+        self,
+        plaintext: bytes,
+        *,
+        key: bytes,
+        bucket_id: str,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+        upload_id: str,
+    ) -> bytes:
+        """Encrypt a single chunk with AEAD."""
+        pass
+
+    @abstractmethod
+    def decrypt_chunk(
+        self,
+        ciphertext: bytes,
+        *,
+        key: bytes,
+        bucket_id: str,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+        upload_id: str,
+    ) -> bytes:
+        """Decrypt a single chunk with AEAD."""
+        pass
+
+    @abstractmethod
+    def decrypt_chunk_legacy(
+        self,
+        ciphertext: bytes,
+        *,
+        key: bytes,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+    ) -> bytes:
+        """Legacy decrypt path for backward compatibility (no AAD)."""
+        pass
+
+
+class SecretBoxChunkedAdapter(CryptoAdapter):
+    """XSalsa20-Poly1305 adapter using PyNaCl SecretBox with random nonces.
+
+    Suite ID: hip-enc/1
+    - Nonce: 24 bytes random (libsodium default, prepended to ciphertext)
+    - MAC: 16 bytes Poly1305
+    - Total overhead: 40 bytes per chunk
+
+    Random nonces prevent nonce reuse on object rewrites without additional state.
+    HKDF/AAD helper methods remain for potential future use with proper AEAD.
+    """
+
+    @property
+    def overhead_per_chunk(self) -> int:
+        return int(SecretBox.NONCE_SIZE + SecretBox.MACBYTES)  # 24 + 16 = 40
+
+    def _derive_nonce_hkdf(
+        self,
+        key: bytes,
+        bucket_id: str,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+        upload_id: str,
+    ) -> bytes:
+        """Derive unique nonce via HKDF-like construction using HMAC-SHA256.
+
+        Info string includes all stable identifiers to ensure nonce uniqueness.
+        Uses simple HKDF-Expand-like construction: HMAC(key, info)[0:nonce_size]
+        """
+        info = (
+            f"hippius-chunk:"
+            f"bucket={bucket_id}:"
+            f"object={object_id}:"
+            f"upload={upload_id}:"
+            f"part={part_number}:"
+            f"chunk={chunk_index}"
+        ).encode("utf-8")
+
+        # Simple HKDF-Expand using HMAC-SHA256
+        # PRK=key, Info=info, expand to nonce_size bytes
+        return hmac.new(key, info, hashlib.sha256).digest()[: SecretBox.NONCE_SIZE]
+
+    def _derive_nonce_legacy(
+        self,
+        key: bytes,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+    ) -> bytes:
+        """Legacy nonce derivation for backward compatibility."""
+        msg = f"{object_id}:{int(part_number)}:{int(chunk_index)}".encode("utf-8")
+        digest = hmac.new(key, msg, hashlib.sha256).digest()
+        return digest[: SecretBox.NONCE_SIZE]
+
+    def _build_aad(
+        self,
+        bucket_id: str,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+        upload_id: str,
+    ) -> bytes:
+        """Build AAD (Additional Authenticated Data) for this chunk.
+
+        AAD is included in MAC computation but not encrypted.
+        Pack as: bucket_id_len | bucket_id | object_id_len | object_id |
+                 upload_id_len | upload_id | part_number (u32) | chunk_index (u32)
+        """
+        parts = []
+        for s in [bucket_id, object_id, upload_id]:
+            s_bytes = s.encode("utf-8")
+            parts.append(struct.pack("<H", len(s_bytes)))
+            parts.append(s_bytes)
+        parts.append(struct.pack("<II", part_number, chunk_index))
+        return b"".join(parts)
+
+    def encrypt_chunk(
+        self,
+        plaintext: bytes,
+        *,
+        key: bytes,
+        bucket_id: str,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+        upload_id: str,
+    ) -> bytes:
+        box = SecretBox(key)
+        # Random nonce (prepended to ciphertext automatically by SecretBox)
+        # Prevents nonce reuse on rewrites without any storage overhead
+        ct = box.encrypt(plaintext)
+        return bytes(ct)
+
+    def decrypt_chunk(
+        self,
+        ciphertext: bytes,
+        *,
+        key: bytes,
+        bucket_id: str,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+        upload_id: str,
+    ) -> bytes:
+        box = SecretBox(key)
+        # SecretBox.decrypt reads nonce from first 24 bytes, verifies MAC
+        pt = box.decrypt(ciphertext)
+        return bytes(pt)
+
+    def decrypt_chunk_legacy(
+        self,
+        ciphertext: bytes,
+        *,
+        key: bytes,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+    ) -> bytes:
+        """Legacy decrypt for data encrypted before HKDF nonces."""
+        box = SecretBox(key)
+        pt = box.decrypt(ciphertext)
+        return bytes(pt)
+
+
+class LegacySecretBoxAdapter(CryptoAdapter):
+    """Legacy whole-part SecretBox adapter.
+
+    Suite ID: hip-enc/legacy
+    - Used for objects encrypted before chunked AEAD
+    - No chunk-level granularity
+    """
+
+    @property
+    def overhead_per_chunk(self) -> int:
+        return int(SecretBox.NONCE_SIZE + SecretBox.MACBYTES)
+
+    def encrypt_chunk(
+        self,
+        plaintext: bytes,
+        *,
+        key: bytes,
+        bucket_id: str,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+        upload_id: str,
+    ) -> bytes:
+        # Not used for legacy (whole-part only)
+        raise NotImplementedError("Legacy adapter does not support chunked encrypt")
+
+    def decrypt_chunk(
+        self,
+        ciphertext: bytes,
+        *,
+        key: bytes,
+        bucket_id: str,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+        upload_id: str,
+    ) -> bytes:
+        box = SecretBox(key)
+        return bytes(box.decrypt(ciphertext))
+
+    def decrypt_chunk_legacy(
+        self,
+        ciphertext: bytes,
+        *,
+        key: bytes,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+    ) -> bytes:
+        return self.decrypt_chunk(
+            ciphertext,
+            key=key,
+            bucket_id="",
+            object_id=object_id,
+            part_number=part_number,
+            chunk_index=chunk_index,
+            upload_id="",
+        )
+
+
+class CryptoService:
+    """Unified crypto service with adapter-based encryption/decryption.
+
+    Key features:
+    - HKDF-derived nonces per chunk
+    - AAD binding via nonce derivation (object_id, part_number, chunk_index, upload_id, bucket_id)
+    - Streaming decrypt for memory-efficient range operations
+    - Legacy decrypt path for backward compatibility
+    """
+
+    # Adapter registry
+    _ADAPTERS: Dict[str, CryptoAdapter] = {
+        "hip-enc/legacy": LegacySecretBoxAdapter(),
+        "hip-enc/1": SecretBoxChunkedAdapter(),  # Legacy chunked (HMAC nonces)
+    }
+
+    # Default suite for new writes
+    DEFAULT_SUITE_ID = "hip-enc/1"
+
+    # Backward compat: exposed for existing code
+    OVERHEAD_PER_CHUNK = SecretBox.NONCE_SIZE + SecretBox.MACBYTES  # 40 bytes
+
+    @classmethod
+    def get_adapter(cls, suite_id: Optional[str] = None) -> CryptoAdapter:
+        """Get adapter for the given suite ID."""
+        if not suite_id or suite_id not in cls._ADAPTERS:
+            suite_id = cls.DEFAULT_SUITE_ID
+        return cls._ADAPTERS[suite_id]
+
+    @staticmethod
+    def derive_key_from_seed(seed_phrase: str) -> bytes:
+        """Derive 32-byte encryption key from seed phrase.
+
+        Uses SHA-256 for backward compatibility.
+        Future: use HKDF with salt from bucket/object context.
+        """
+        return hashlib.sha256(seed_phrase.encode("utf-8")).digest()
+
+    # Legacy aliases for backward compatibility
+    @staticmethod
+    def _derive_key(seed_phrase: str) -> bytes:
+        return CryptoService.derive_key_from_seed(seed_phrase)
+
+    @classmethod
+    def encrypt_part_to_chunks(
+        cls,
+        plaintext: bytes,
+        *,
+        object_id: str,
+        part_number: int,
+        seed_phrase: str,
+        chunk_size: int,
+        bucket_id: str = "",
+        upload_id: str = "",
+        suite_id: Optional[str] = None,
+    ) -> List[bytes]:
+        """Encrypt plaintext into fixed-size chunks.
+
+        Args:
+            plaintext: Data to encrypt
+            object_id: Object UUID
+            part_number: Part number (1-based)
+            seed_phrase: Seed phrase for key derivation
+            chunk_size: Plaintext bytes per chunk
+            bucket_id: Bucket UUID (for AAD)
+            upload_id: Upload UUID (for AAD)
+            suite_id: Encryption suite (defaults to hip-enc/1)
+
+        Returns:
+            List of ciphertext chunks (each chunk_size + overhead)
+        """
+        key = cls.derive_key_from_seed(seed_phrase)
+        adapter = cls.get_adapter(suite_id)
+
+        chunks: List[bytes] = []
+        total = len(plaintext)
+        if total == 0:
+            return []
+
+        num_chunks = (total + chunk_size - 1) // chunk_size
+        for i in range(num_chunks):
+            start = i * chunk_size
+            end = min(start + chunk_size, total)
+            ct = adapter.encrypt_chunk(
+                plaintext[start:end],
+                key=key,
+                bucket_id=bucket_id,
+                object_id=object_id,
+                part_number=part_number,
+                chunk_index=i,
+                upload_id=upload_id,
+            )
+            chunks.append(ct)
+        return chunks
+
+    @classmethod
+    def decrypt_chunk(
+        cls,
+        ciphertext_chunk: bytes,
+        *,
+        seed_phrase: str,
+        object_id: str,
+        part_number: int,
+        chunk_index: int,
+        bucket_id: str = "",
+        upload_id: str = "",
+        suite_id: Optional[str] = None,
+    ) -> bytes:
+        """Decrypt a single chunk.
+
+        Tries new HKDF path first, falls back to legacy if needed.
+        """
+        key = cls.derive_key_from_seed(seed_phrase)
+        adapter = cls.get_adapter(suite_id)
+
+        # Try new path first
+        try:
+            return adapter.decrypt_chunk(
+                ciphertext_chunk,
+                key=key,
+                bucket_id=bucket_id,
+                object_id=object_id,
+                part_number=part_number,
+                chunk_index=chunk_index,
+                upload_id=upload_id,
+            )
+        except Exception:
+            # Fall back to legacy path
+            try:
+                return adapter.decrypt_chunk_legacy(
+                    ciphertext_chunk,
+                    key=key,
+                    object_id=object_id,
+                    part_number=part_number,
+                    chunk_index=chunk_index,
+                )
+            except Exception as exc:
+                raise CryptoError("decrypt_failed") from exc
+
+    @classmethod
+    def decrypt_part_auto(
+        cls,
+        ciphertext: bytes,
+        *,
+        seed_phrase: str,
+        object_id: str,
+        part_number: int,
+        chunk_count: Optional[int] = None,
+        chunk_loader: Optional[Callable[[int], bytes]] = None,
+        bucket_id: str = "",
+        upload_id: str = "",
+        suite_id: Optional[str] = None,
+    ) -> bytes:
+        """Decrypt a part that may be whole-part or chunked.
+
+        Tries whole-part decrypt first (legacy), then per-chunk decrypt.
+        """
+        key = cls.derive_key_from_seed(seed_phrase)
+
+        # Try whole-part decrypt first (legacy sealed box)
+        try:
+            legacy_adapter = cls.get_adapter("hip-enc/legacy")
+            return legacy_adapter.decrypt_chunk(
+                ciphertext,
+                key=key,
+                bucket_id=bucket_id,
+                object_id=object_id,
+                part_number=part_number,
+                chunk_index=0,
+                upload_id=upload_id,
+            )
+        except Exception:
+            pass
+
+        # Fall back to per-chunk decrypt if loader provided
+        if chunk_count is not None and chunk_loader is not None:
+            out: list[bytes] = []
+            for ci in range(int(chunk_count)):
+                ct = chunk_loader(ci)
+                if not isinstance(ct, (bytes, bytearray)):
+                    raise CryptoError("missing_chunk")
+                pt = cls.decrypt_chunk(
+                    ct,
+                    seed_phrase=seed_phrase,
+                    object_id=object_id,
+                    part_number=part_number,
+                    chunk_index=ci,
+                    bucket_id=bucket_id,
+                    upload_id=upload_id,
+                    suite_id=suite_id,
+                )
+                out.append(pt)
+            return b"".join(out)
+
+        raise CryptoError("decrypt_failed")
+
+    @classmethod
+    def decrypt_stream(
+        cls,
+        chunk_iterator: Iterator[Tuple[int, bytes]],
+        *,
+        seed_phrase: str,
+        object_id: str,
+        part_number: int,
+        bucket_id: str = "",
+        upload_id: str = "",
+        suite_id: Optional[str] = None,
+        range_start: Optional[int] = None,
+        range_end: Optional[int] = None,
+        chunk_size: int = 4 * 1024 * 1024,
+    ) -> Iterator[bytes]:
+        """Streaming decrypt that yields plaintext slices.
+
+        Memory-efficient: decrypts one chunk at a time and yields only the requested range.
+
+        Args:
+            chunk_iterator: Iterator yielding (chunk_index, ciphertext) tuples
+            seed_phrase: Seed for key derivation
+            object_id: Object UUID
+            part_number: Part number
+            bucket_id: Bucket UUID (for AAD)
+            upload_id: Upload UUID (for AAD)
+            suite_id: Encryption suite
+            range_start: Starting byte offset (plaintext)
+            range_end: Ending byte offset inclusive (plaintext)
+            chunk_size: Plaintext size per chunk
+
+        Yields:
+            Plaintext byte slices covering the requested range
+        """
+        plaintext_offset = 0
+
+        for chunk_index, ct_chunk in chunk_iterator:
+            # Decrypt this chunk
+            pt_chunk = cls.decrypt_chunk(
+                ct_chunk,
+                seed_phrase=seed_phrase,
+                object_id=object_id,
+                part_number=part_number,
+                chunk_index=chunk_index,
+                bucket_id=bucket_id,
+                upload_id=upload_id,
+                suite_id=suite_id,
+            )
+
+            chunk_start = plaintext_offset
+            chunk_end = plaintext_offset + len(pt_chunk) - 1
+            plaintext_offset += len(pt_chunk)
+
+            # Determine slice within this chunk
+            if range_start is not None and range_end is not None:
+                # Check if this chunk intersects the range
+                if chunk_end < range_start or chunk_start > range_end:
+                    continue  # Skip this chunk
+
+                # Compute slice bounds within chunk
+                slice_start = max(0, range_start - chunk_start)
+                slice_end = min(len(pt_chunk), range_end - chunk_start + 1)
+                yield pt_chunk[slice_start:slice_end]
+            else:
+                # No range: yield entire chunk
+                yield pt_chunk
+
+    @classmethod
+    async def decrypt_stream_async(
+        cls,
+        chunk_iterator: AsyncIterator[Tuple[int, bytes]],
+        *,
+        seed_phrase: str,
+        object_id: str,
+        part_number: int,
+        bucket_id: str = "",
+        upload_id: str = "",
+        suite_id: Optional[str] = None,
+        range_start: Optional[int] = None,
+        range_end: Optional[int] = None,
+        chunk_size: int = 4 * 1024 * 1024,
+    ) -> AsyncIterator[bytes]:
+        """Async version of decrypt_stream for use in async contexts."""
+        plaintext_offset = 0
+
+        async for chunk_index, ct_chunk in chunk_iterator:
+            # Decrypt this chunk (CPU-bound, but fast enough for now)
+            pt_chunk = cls.decrypt_chunk(
+                ct_chunk,
+                seed_phrase=seed_phrase,
+                object_id=object_id,
+                part_number=part_number,
+                chunk_index=chunk_index,
+                bucket_id=bucket_id,
+                upload_id=upload_id,
+                suite_id=suite_id,
+            )
+
+            chunk_start = plaintext_offset
+            chunk_end = plaintext_offset + len(pt_chunk) - 1
+            plaintext_offset += len(pt_chunk)
+
+            # Determine slice within this chunk
+            if range_start is not None and range_end is not None:
+                if chunk_end < range_start or chunk_start > range_end:
+                    continue
+
+                slice_start = max(0, range_start - chunk_start)
+                slice_end = min(len(pt_chunk), range_end - chunk_start + 1)
+                yield pt_chunk[slice_start:slice_end]
+            else:
+                yield pt_chunk

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import hashlib
 import json
@@ -14,13 +15,15 @@ from fastapi.responses import StreamingResponse
 
 from hippius_s3.api.s3.common import build_headers
 from hippius_s3.api.s3.range_utils import calculate_chunks_for_range
-from hippius_s3.api.s3.range_utils import extract_range_from_chunks
 from hippius_s3.cache import ObjectPartsCache
 from hippius_s3.queue import ChunkToDownload
 from hippius_s3.queue import DownloadChainRequest
 from hippius_s3.queue import enqueue_download_request
+from hippius_s3.services.crypto_service import CryptoService
 from hippius_s3.services.manifest_service import ManifestService
 from hippius_s3.utils import get_query
+from hippius_s3.utils.timing import async_timing_context
+from hippius_s3.utils.timing import log_timing
 
 
 class DownloadNotReadyError(Exception):
@@ -41,6 +44,7 @@ class ObjectInfo:
     should_decrypt: bool
     simple_cid: str | None
     upload_id: str | None
+    enc_suite_id: str | None = None
 
 
 @dataclass
@@ -95,6 +99,7 @@ class ObjectReader:
             metadata=md,
             multipart=bool(row["multipart"]),
             should_decrypt=bool(row["should_decrypt"]),
+            enc_suite_id=row.get("enc_suite_id"),
             simple_cid=row.get("simple_cid"),
             upload_id=row.get("upload_id"),
         )
@@ -291,16 +296,71 @@ class ObjectReader:
         seed_phrase: str,
         range_was_invalid: bool = False,
     ) -> Response:
-        # Step 1: Build the full manifest of all parts (includes base 0 + appended parts)
-        full_parts = await self.build_manifest(db, info)
-        full_parts = sorted(full_parts, key=lambda p: p.part_number)
-        layout = [{"part_number": p.part_number, "size_bytes": p.size_bytes} for p in full_parts]
+        import time as _timing_time
 
-        # Step 2: Derive needed parts for the requested range
+        read_start = _timing_time.perf_counter()
+
+        # Step 1: Build the full manifest of all parts (includes base 0 + appended parts)
+        async with async_timing_context(
+            "object_reader.build_manifest", extra={"object_id": info.object_id, "parts_count": "TBD"}
+        ):
+            full_parts = await self.build_manifest(db, info)
+            full_parts = sorted(full_parts, key=lambda p: p.part_number)
+        with contextlib.suppress(Exception):
+            self._logger.info(
+                f"READER Step1: object_id={info.object_id} initial full_parts count={len(full_parts)} parts={[(p.part_number, p.size_bytes, p.cid) for p in full_parts]}"
+            )
+
+        # Plaintext size map for range computation (declared here, updated throughout)
+        plaintext_sizes: dict[int, int] = {}  # part_number -> plaintext size
+
+        # Step 2: For range requests, compute plaintext sizes and filter to needed parts only
         if rng is not None:
+            # Compute plaintext sizes from cache metadata
+            for p in full_parts:
+                pn = int(p.part_number)
+                try:
+                    meta = await obj_cache.get_meta(info.object_id, pn)
+                    if meta and not info.should_decrypt:
+                        # Public object: cache has plaintext, meta size_bytes is accurate
+                        plaintext_sizes[pn] = int(meta.get("size_bytes", p.size_bytes))
+                    elif meta and info.should_decrypt:
+                        # Encrypted object: compute plaintext size from ciphertext
+                        ct_size = int(meta.get("size_bytes", 0))
+                        num_chunks = int(meta.get("num_chunks", 0))
+                        if ct_size > 0 and num_chunks > 0:
+                            overhead = CryptoService.OVERHEAD_PER_CHUNK * num_chunks
+                            plaintext_sizes[pn] = max(0, ct_size - overhead)
+                        else:
+                            # No meta yet: use DB size minus estimated overhead
+                            if info.should_decrypt and p.size_bytes > CryptoService.OVERHEAD_PER_CHUNK:
+                                plaintext_sizes[pn] = int(p.size_bytes) - CryptoService.OVERHEAD_PER_CHUNK
+                            else:
+                                plaintext_sizes[pn] = int(p.size_bytes)
+                    else:
+                        # No meta: estimate from DB size
+                        if info.should_decrypt and p.size_bytes > CryptoService.OVERHEAD_PER_CHUNK:
+                            plaintext_sizes[pn] = int(p.size_bytes) - CryptoService.OVERHEAD_PER_CHUNK
+                        else:
+                            plaintext_sizes[pn] = int(p.size_bytes)
+                except Exception:
+                    plaintext_sizes[pn] = int(p.size_bytes)
+
+            # Build layout with plaintext sizes for range calculation
+            layout = [
+                {"part_number": p.part_number, "size_bytes": plaintext_sizes.get(p.part_number, p.size_bytes)}
+                for p in full_parts
+            ]
+            with contextlib.suppress(Exception):
+                self._logger.info(f"READER Step2: plaintext_sizes={plaintext_sizes} layout={layout}")
+
+            # Calculate which parts are actually needed for this range
             needed_part_numbers = calculate_chunks_for_range(rng.start, rng.end, layout)
             parts = [p for p in full_parts if p.part_number in needed_part_numbers]
+            with contextlib.suppress(Exception):
+                self._logger.info(f"READER Step2: range={rng.start}-{rng.end} needed_parts={needed_part_numbers}")
         else:
+            # Full object request: fetch all parts
             parts = full_parts
 
         parts = sorted(parts, key=lambda p: p.part_number)
@@ -349,17 +409,28 @@ class ObjectReader:
             )
 
         # Step 5: Pre-flight check to ensure the first part is available before sending headers
+        # Use meta-based check (cheap) instead of whole-part get (expensive assembly)
         import time as _time
 
         if parts:
+            pre_header_start = _time.perf_counter()
             first_part = parts[0]
             deadline = _time.time() + float(self.config.http_stream_initial_timeout_seconds)
             while True:
-                if (await obj_cache.get(info.object_id, int(first_part.part_number))) is not None:
+                meta = await obj_cache.get_meta(info.object_id, int(first_part.part_number))
+                if meta and int(meta.get("num_chunks", 0)) > 0:
                     break
                 if _time.time() > deadline:
                     raise DownloadNotReadyError("initial_stream_timeout")
                 await asyncio.sleep(self.config.http_download_sleep_loop)
+            pre_header_ms = (_time.perf_counter() - pre_header_start) * 1000.0
+            log_timing(
+                "object_reader.pre_header_wait",
+                pre_header_ms,
+                extra={"object_id": info.object_id, "part_number": first_part.part_number},
+            )
+
+        # No additional wait; caching/hydration handled earlier and falls back to pipeline
 
         # Step 6: Prepare and stream the response
         _md = info.metadata
@@ -369,22 +440,302 @@ class ObjectReader:
             except Exception:
                 _md = {}
 
+        # For range requests: do a bounded polling refresh to ensure we have all appended parts
+        # before computing the range. Appends commit to DB atomically but read may race.
+        # Update plaintext_sizes as we discover new parts or size changes.
+        if rng is not None:
+            import time as _tr
+
+            refresh_start = _tr.time()
+            refresh_deadline = refresh_start + 2.0  # up to 2s to observe appends in DB
+            initial_count = len(full_parts)
+            while _tr.time() < refresh_deadline:
+                try:
+                    latest_parts = await self.build_manifest(db, info)
+                    with contextlib.suppress(Exception):
+                        self._logger.debug(
+                            f"RANGE refresh: initial={initial_count} latest={len(latest_parts)} parts={[(p.part_number, p.size_bytes) for p in latest_parts]}"
+                        )
+                    # BUGFIX: Always update full_parts if we got new data, not just when count increases
+                    # Parts can have size updates (e.g., after pinner writes CID) without count changing
+                    if latest_parts and len(latest_parts) > len(full_parts):
+                        # New parts appeared: update full_parts AND recalculate needed parts for range
+                        full_parts = sorted(latest_parts, key=lambda p: p.part_number)
+                        # Recompute plaintext sizes for new parts
+                        for p in full_parts:
+                            pn = int(p.part_number)
+                            if pn not in plaintext_sizes:
+                                # Estimate plaintext size for new part
+                                if info.should_decrypt and p.size_bytes > CryptoService.OVERHEAD_PER_CHUNK:
+                                    plaintext_sizes[pn] = int(p.size_bytes) - CryptoService.OVERHEAD_PER_CHUNK
+                                else:
+                                    plaintext_sizes[pn] = int(p.size_bytes)
+                        # Note: we don't re-filter parts here; the initial filter was conservative
+                        # and gen_range will stream all available parts in the range dynamically
+                    # If we've extended and all known parts are in cache, we're done
+                    if latest_parts and len(latest_parts) >= initial_count:
+                        all_in_cache = True
+                        for lp in latest_parts:
+                            if not await obj_cache.exists(info.object_id, int(lp.part_number)):
+                                all_in_cache = False
+                                break
+                        if all_in_cache:
+                            with contextlib.suppress(Exception):
+                                self._logger.debug(f"RANGE refresh complete: all {len(full_parts)} parts in cache")
+                            break
+                except Exception:
+                    pass
+                await asyncio.sleep(0.05)
+
+            # Build plaintext size map from cache metadata
+            # For encrypted objects, cache meta stores ciphertext size; we need to probe actual decrypted size
+            # For public objects, cache stores plaintext directly
+            for p in full_parts:
+                pn = int(p.part_number)
+                try:
+                    # Try to get plaintext size by checking cache or reading the part
+                    meta = await obj_cache.get_meta(info.object_id, pn)
+                    if meta and not info.should_decrypt:
+                        # Public object: cache has plaintext, meta size_bytes is accurate
+                        plaintext_sizes[pn] = int(meta.get("size_bytes", p.size_bytes))
+                    elif meta and info.should_decrypt:
+                        # Encrypted object: need to compute plaintext size
+                        # Ciphertext size = plaintext_size + OVERHEAD_PER_CHUNK * num_chunks
+                        # So plaintext_size = ciphertext_size - OVERHEAD_PER_CHUNK * num_chunks
+                        ct_size = int(meta.get("size_bytes", 0))
+                        num_chunks = int(meta.get("num_chunks", 0))
+                        if ct_size > 0 and num_chunks > 0:
+                            overhead = CryptoService.OVERHEAD_PER_CHUNK * num_chunks
+                            plaintext_sizes[pn] = max(0, ct_size - overhead)
+                        else:
+                            # Fallback: use DB size (may be stale but better than nothing)
+                            plaintext_sizes[pn] = int(p.size_bytes)
+                    else:
+                        # No meta yet: use DB size as best guess
+                        # This may be ciphertext size if pinner ran, or plaintext if it hasn't
+                        # For now, assume it's ciphertext and subtract estimated overhead
+                        if info.should_decrypt and p.size_bytes > CryptoService.OVERHEAD_PER_CHUNK:
+                            # Estimate: assume single chunk per part for sizing
+                            plaintext_sizes[pn] = int(p.size_bytes) - CryptoService.OVERHEAD_PER_CHUNK
+                        else:
+                            plaintext_sizes[pn] = int(p.size_bytes)
+                except Exception:
+                    # Fallback to DB size
+                    plaintext_sizes[pn] = int(p.size_bytes)
+
+            with contextlib.suppress(Exception):
+                self._logger.info(f"RANGE plaintext_sizes computed: {plaintext_sizes}")
+
+        async def _read_part_bytes(part_number: int) -> bytes:
+            # Assemble ciphertext/plaintext chunks from cache; decrypt once as needed
+            import time as _ptime
+
+            part_start = _ptime.perf_counter()
+            meta = await obj_cache.get_meta(info.object_id, int(part_number))  # type: ignore[attr-defined]
+            with contextlib.suppress(Exception):
+                self._logger.debug(f"READER part={int(part_number)} should_decrypt={info.should_decrypt} meta={meta}")
+            if not meta:
+                # Best-effort short wait for meta to appear (hydration in progress)
+                import time as _t
+
+                deadline_meta = _t.time() + float(self.config.http_stream_initial_timeout_seconds)
+                while _t.time() < deadline_meta:
+                    m2 = await obj_cache.get_meta(info.object_id, int(part_number))  # type: ignore[attr-defined]
+                    if m2:
+                        meta = m2
+                        break
+                    await asyncio.sleep(self.config.http_download_sleep_loop)
+
+                if not meta:
+                    data = await obj_cache.get(info.object_id, int(part_number))
+                else:
+                    data = None
+                with contextlib.suppress(Exception):
+                    self._logger.debug(
+                        f"READER part={int(part_number)} fallback whole get size={0 if data is None else len(data)}"
+                    )
+                if data is not None:
+                    return data
+            # If meta is present but chunks are not yet written, wait briefly
+            num_chunks = int(meta.get("num_chunks", 0)) if meta else 0
+            if num_chunks <= 0:
+                import time as _tw
+
+                deadline_nc = _tw.time() + float(self.config.http_stream_initial_timeout_seconds)
+                while _tw.time() < deadline_nc:
+                    m3 = await obj_cache.get_meta(info.object_id, int(part_number))  # type: ignore[attr-defined]
+                    try:
+                        num_chunks = int(m3.get("num_chunks", 0)) if m3 else 0
+                    except Exception:
+                        num_chunks = 0
+                    if num_chunks > 0:
+                        meta = m3 or meta
+                        break
+                    await asyncio.sleep(self.config.http_download_sleep_loop)
+                if num_chunks <= 0:
+                    # Last fallback to whole-get if available
+                    data_fallback = await obj_cache.get(info.object_id, int(part_number))
+                    if data_fallback is not None:
+                        return data_fallback
+                    return b""
+            chunks: list[bytes] = []
+            for ci in range(num_chunks):
+                while True:
+                    chunk_bytes = await obj_cache.get_chunk(info.object_id, int(part_number), ci)  # type: ignore[attr-defined]
+                    if chunk_bytes is not None:
+                        break
+                    await asyncio.sleep(self.config.http_download_sleep_loop)
+                chunks.append(chunk_bytes)
+            with contextlib.suppress(Exception):
+                self._logger.debug(
+                    f"READER part={int(part_number)} num_chunks={num_chunks} first_chunk_len={len(chunks[0]) if chunks else -1}"
+                )
+
+            if info.should_decrypt:
+                # Try legacy whole-part decrypt first; fallback to per-chunk
+                ct_all = b"".join(chunks)
+                try:
+                    return CryptoService.decrypt_part_auto(
+                        ct_all,
+                        seed_phrase=seed_phrase,
+                        object_id=info.object_id,
+                        part_number=int(part_number),
+                        chunk_count=len(chunks),
+                        chunk_loader=lambda i: chunks[i],
+                    )
+                except Exception:
+                    try:
+                        pts: list[bytes] = []
+                        for ci, c in enumerate(chunks):
+                            pts.append(
+                                CryptoService.decrypt_chunk(
+                                    c,
+                                    seed_phrase=seed_phrase,
+                                    object_id=info.object_id,
+                                    part_number=int(part_number),
+                                    chunk_index=ci,
+                                )
+                            )
+                        return b"".join(pts)
+                    except Exception:
+                        # Fallback: data may be plaintext in cache despite should_decrypt flag
+                        with contextlib.suppress(Exception):
+                            self._logger.warning(
+                                f"READER decrypt failed; returning plaintext for part={int(part_number)}"
+                            )
+                        return b"".join(chunks)
+            # Public/plaintext or private-but-plaintext-cached
+            result = b"".join(chunks)
+            part_ms = (_ptime.perf_counter() - part_start) * 1000.0
+            log_timing(
+                "object_reader.read_part",
+                part_ms,
+                extra={
+                    "object_id": info.object_id,
+                    "part_number": int(part_number),
+                    "size_bytes": len(result),
+                    "decrypted": info.should_decrypt,
+                },
+            )
+            return result
+
         # Handle Range Request
         if rng is not None:
 
             async def gen_range() -> AsyncGenerator[bytes, None]:
-                data_chunks: list[bytes] = []
-                for p in parts:
+                # Stream parts needed for range: use full_parts (already refreshed above for range requests)
+                # and compute offsets using PLAINTEXT sizes (not ciphertext DB sizes)
+                import time as _t
+
+                cursor = int(rng.start)
+                end_inclusive = int(rng.end)
+
+                # Use the already-refreshed full_parts as the source of truth
+                ordered_parts = sorted(full_parts, key=lambda x: x.part_number)
+                with contextlib.suppress(Exception):
+                    self._logger.info(
+                        f"RANGE gen_range: start={cursor} end={end_inclusive} full_parts_count={len(full_parts)} ordered_parts={[(p.part_number, p.size_bytes) for p in ordered_parts]}"
+                    )
+                # BUGFIX: Use plaintext sizes for range computation (user requested range is in plaintext bytes)
+                layout_full = [
+                    {"part_number": p.part_number, "size_bytes": plaintext_sizes.get(p.part_number, p.size_bytes)}
+                    for p in ordered_parts
+                ]
+                with contextlib.suppress(Exception):
+                    self._logger.info(
+                        f"RANGE gen_range: layout_full (plaintext)={[(e['part_number'], e['size_bytes']) for e in layout_full]}"
+                    )
+                # Compute offsets once upfront
+                offsets: dict[int, int] = {}
+                acc = 0
+                for e in layout_full:
+                    pn_tmp = int(e["part_number"])
+                    offsets[pn_tmp] = acc
+                    acc += int(e["size_bytes"])
+
+                total_plain = acc
+                with contextlib.suppress(Exception):
+                    self._logger.info(f"RANGE gen_range: total_plain={total_plain} offsets={offsets}")
+
+                while cursor <= end_inclusive:
+                    # Identify part covering current cursor
+                    target_pn = None
+                    part_start = 0
+                    size_bytes = 0
+                    for e in layout_full:
+                        pn_candidate = int(e["part_number"])
+                        start_candidate = int(offsets[pn_candidate])
+                        end_candidate = start_candidate + int(e["size_bytes"]) - 1
+                        if start_candidate <= cursor <= end_candidate:
+                            target_pn = pn_candidate
+                            part_start = start_candidate
+                            size_bytes = int(e["size_bytes"])
+                            break
+                    if target_pn is None:
+                        with contextlib.suppress(Exception):
+                            self._logger.warning(
+                                f"RANGE gen_range: No part covers cursor={cursor}, breaking. total_plain={total_plain} end_inclusive={end_inclusive}"
+                            )
+                        break
+
+                    with contextlib.suppress(Exception):
+                        self._logger.info(
+                            f"RANGE gen_range: target_pn={target_pn} part_start={part_start} size_bytes={size_bytes} cursor={cursor}"
+                        )
+
+                    # Per-part readiness wait (bounded) before reading
+                    wait_deadline = _t.time() + float(self.config.http_stream_initial_timeout_seconds)
                     while True:
-                        data = await obj_cache.get(info.object_id, int(p.part_number))
-                        if data is not None:
-                            data_chunks.append(data)
+                        meta = await obj_cache.get_meta(info.object_id, target_pn)  # type: ignore[attr-defined]
+                        ready = bool(meta and int(meta.get("num_chunks", 0)) > 0)
+                        if not ready:
+                            whole = await obj_cache.get(info.object_id, target_pn)
+                            ready = isinstance(whole, (bytes, bytearray)) and len(whole) > 0
+                        if ready or _t.time() > wait_deadline:
                             break
                         await asyncio.sleep(self.config.http_download_sleep_loop)
-                data = extract_range_from_chunks(
-                    data_chunks, rng.start, rng.end, layout, [p.part_number for p in parts]
-                )
-                yield data
+
+                    # Read this part and yield the required slice
+                    data = await _read_part_bytes(target_pn)
+                    with contextlib.suppress(Exception):
+                        self._logger.debug(
+                            f"RANGE read pn={target_pn} part_start={part_start} size={len(data) if data else 0} cursor={cursor}"
+                        )
+                    if not data:
+                        # Part not ready yet despite readiness check; retry within the same deadline
+                        if _t.time() <= wait_deadline:
+                            await asyncio.sleep(self.config.http_download_sleep_loop)
+                            continue
+                        break
+                    slice_start = max(0, cursor - part_start)
+                    desired_end_exclusive = (end_inclusive - part_start) + 1
+                    capped_end_exclusive = min(size_bytes, max(slice_start, desired_end_exclusive))
+                    if capped_end_exclusive > slice_start:
+                        yield data[slice_start:capped_end_exclusive]
+                        cursor = part_start + capped_end_exclusive
+                    else:
+                        # Nothing to yield for this part; advance to next
+                        cursor = part_start + size_bytes
 
             headers = build_headers(
                 dataclasses.asdict(info),
@@ -401,12 +752,16 @@ class ObjectReader:
         # Handle Full Request
         async def gen_full() -> AsyncGenerator[bytes, None]:
             for p in parts:
-                while True:
-                    data = await obj_cache.get(info.object_id, int(p.part_number))
-                    if data is not None:
-                        yield data
-                        break
-                    await asyncio.sleep(self.config.http_download_sleep_loop)
+                data = await _read_part_bytes(int(p.part_number))
+                yield data
+
+        # Log total read_response time
+        total_read_ms = (_timing_time.perf_counter() - read_start) * 1000.0
+        log_timing(
+            "object_reader.read_response_total",
+            total_read_ms,
+            extra={"object_id": info.object_id, "range": bool(rng), "source": source_header},
+        )
 
         headers = build_headers(dataclasses.asdict(info), source=source_header, metadata=_md)
         return StreamingResponse(gen_full(), media_type=info.content_type, headers=headers)

--- a/hippius_s3/sql/migrations/20251003000000_create_part_chunks.sql
+++ b/hippius_s3/sql/migrations/20251003000000_create_part_chunks.sql
@@ -1,0 +1,39 @@
+-- Create part_chunks table to store one CID per ciphertext chunk
+-- Forward-compatible with EC where data shards align to ciphertext chunks
+
+-- migrate:up
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS part_chunks (
+  id BIGSERIAL PRIMARY KEY,
+  part_id UUID NOT NULL REFERENCES parts(part_id) ON DELETE CASCADE,
+  chunk_index INT NOT NULL CHECK (chunk_index >= 0),
+  cid TEXT,
+  cipher_size_bytes BIGINT NOT NULL CHECK (cipher_size_bytes >= 0),
+  plain_size_bytes BIGINT CHECK (plain_size_bytes >= 0),
+  checksum BYTEA,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(part_id, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS part_chunks_part_idx ON part_chunks(part_id);
+
+-- Backfill existing part-level CIDs into chunk index 0
+-- We cannot know exact ciphertext boundaries historically; store as a single chunk per part
+-- Note: cipher_size_bytes here is parts.size_bytes which may be plaintext (public) or ciphertext (private) depending on bucket
+INSERT INTO part_chunks (part_id, chunk_index, cid, cipher_size_bytes)
+SELECT p.part_id, 0 AS chunk_index, COALESCE(c.cid, p.ipfs_cid) AS cid, p.size_bytes
+FROM parts p
+LEFT JOIN cids c ON p.cid_id = c.id
+WHERE (p.ipfs_cid IS NOT NULL AND p.ipfs_cid <> '') OR p.cid_id IS NOT NULL
+ON CONFLICT (part_id, chunk_index) DO NOTHING;
+
+COMMIT;
+
+-- migrate:down
+
+BEGIN;
+DROP INDEX IF EXISTS part_chunks_part_idx;
+DROP TABLE IF EXISTS part_chunks;
+COMMIT;

--- a/hippius_s3/sql/queries/get_part_chunks_by_object_and_number.sql
+++ b/hippius_s3/sql/queries/get_part_chunks_by_object_and_number.sql
@@ -1,0 +1,6 @@
+-- Parameters: $1: object_id (UUID), $2: part_number (INT)
+SELECT pc.chunk_index, pc.cid, pc.cipher_size_bytes, pc.plain_size_bytes
+FROM parts p
+JOIN part_chunks pc ON pc.part_id = p.part_id
+WHERE p.object_id = $1 AND p.part_number = $2
+ORDER BY pc.chunk_index ASC;

--- a/hippius_s3/sql/queries/get_part_chunks_by_part_id.sql
+++ b/hippius_s3/sql/queries/get_part_chunks_by_part_id.sql
@@ -1,0 +1,5 @@
+-- Parameters: $1: part_id (UUID)
+SELECT chunk_index, cid, cipher_size_bytes, plain_size_bytes
+FROM part_chunks
+WHERE part_id = $1
+ORDER BY chunk_index ASC;

--- a/hippius_s3/sql/queries/get_part_id_by_object_and_number.sql
+++ b/hippius_s3/sql/queries/get_part_id_by_object_and_number.sql
@@ -1,0 +1,5 @@
+-- Parameters: $1: object_id (UUID), $2: part_number (INT)
+SELECT part_id
+FROM parts
+WHERE object_id = $1 AND part_number = $2
+LIMIT 1;

--- a/hippius_s3/sql/queries/upsert_part_chunk.sql
+++ b/hippius_s3/sql/queries/upsert_part_chunk.sql
@@ -1,0 +1,9 @@
+-- Parameters: $1 part_id (UUID), $2 chunk_index (INT), $3 cid (TEXT), $4 cipher_size_bytes (INT), $5 plain_size_bytes (INT), $6 checksum (BYTEA)
+INSERT INTO part_chunks (part_id, chunk_index, cid, cipher_size_bytes, plain_size_bytes, checksum)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (part_id, chunk_index)
+DO UPDATE SET
+  cid = EXCLUDED.cid,
+  cipher_size_bytes = EXCLUDED.cipher_size_bytes,
+  plain_size_bytes = COALESCE(EXCLUDED.plain_size_bytes, part_chunks.plain_size_bytes),
+  checksum = COALESCE(EXCLUDED.checksum, part_chunks.checksum);

--- a/hippius_s3/utils/__init__.py
+++ b/hippius_s3/utils/__init__.py
@@ -1,0 +1,30 @@
+"""Utility modules and functions for hippius_s3.
+
+This package combines utility functions from utils_core.py with new timing utilities.
+"""
+
+# Explicit imports only - no star imports to avoid namespace pollution
+from hippius_s3.utils.timing import async_timing_context  # noqa: F401
+from hippius_s3.utils.timing import log_timing  # noqa: F401
+from hippius_s3.utils.timing import timing_context  # noqa: F401
+from hippius_s3.utils_core import env  # noqa: F401
+from hippius_s3.utils_core import get_object_download_info  # noqa: F401
+from hippius_s3.utils_core import get_query  # noqa: F401
+from hippius_s3.utils_core import get_request_body  # noqa: F401
+from hippius_s3.utils_core import is_public_bucket  # noqa: F401
+from hippius_s3.utils_core import upsert_cid_and_get_id  # noqa: F401
+
+
+__all__ = [
+    # From utils_core.py
+    "env",
+    "get_request_body",
+    "get_query",
+    "get_object_download_info",
+    "is_public_bucket",
+    "upsert_cid_and_get_id",
+    # From timing.py
+    "async_timing_context",
+    "log_timing",
+    "timing_context",
+]

--- a/hippius_s3/utils/timing.py
+++ b/hippius_s3/utils/timing.py
@@ -1,0 +1,99 @@
+"""Timing instrumentation utilities for performance monitoring."""
+
+from __future__ import annotations
+
+import logging
+import time
+from contextlib import asynccontextmanager
+from contextlib import contextmanager
+from typing import Any
+from typing import AsyncGenerator
+from typing import Generator
+
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def timing_context(
+    operation: str, *, log_threshold_ms: float = 0.0, extra: dict[str, Any] | None = None
+) -> Generator[dict[str, Any], None, None]:
+    """Context manager for timing synchronous operations.
+
+    Args:
+        operation: Name of the operation being timed
+        log_threshold_ms: Only log if duration exceeds this threshold (ms). 0 = always log.
+        extra: Additional context to include in log
+
+    Yields:
+        Timing dict with 'start' field, will have 'duration_ms' on exit
+
+    Example:
+        with timing_context("download_chunk", log_threshold_ms=100, extra={"cid": cid}) as t:
+            data = download(cid)
+        # Logs: "TIMING download_chunk duration_ms=150.5 cid=abc123"
+    """
+    ctx: dict[str, Any] = {"start": time.perf_counter()}
+    if extra:
+        ctx.update(extra)
+
+    try:
+        yield ctx
+    finally:
+        duration_ms = (time.perf_counter() - ctx["start"]) * 1000.0
+        ctx["duration_ms"] = duration_ms
+
+        if duration_ms >= log_threshold_ms:
+            extra_str = " ".join(f"{k}={v}" for k, v in (extra or {}).items())
+            logger.info(f"TIMING {operation} duration_ms={duration_ms:.2f} {extra_str}".strip())
+
+
+@asynccontextmanager
+async def async_timing_context(
+    operation: str, *, log_threshold_ms: float = 0.0, extra: dict[str, Any] | None = None
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Async context manager for timing async operations.
+
+    Args:
+        operation: Name of the operation being timed
+        log_threshold_ms: Only log if duration exceeds this threshold (ms). 0 = always log.
+        extra: Additional context to include in log
+
+    Yields:
+        Timing dict with 'start' field, will have 'duration_ms' on exit
+
+    Example:
+        async with async_timing_context("fetch_manifest", extra={"object_id": oid}) as t:
+            manifest = await build_manifest(db, oid)
+        # Logs: "TIMING fetch_manifest duration_ms=42.3 object_id=abc-123"
+    """
+    ctx: dict[str, Any] = {"start": time.perf_counter()}
+    if extra:
+        ctx.update(extra)
+
+    try:
+        yield ctx
+    finally:
+        duration_ms = (time.perf_counter() - ctx["start"]) * 1000.0
+        ctx["duration_ms"] = duration_ms
+
+        if duration_ms >= log_threshold_ms:
+            extra_str = " ".join(f"{k}={v}" for k, v in (extra or {}).items())
+            logger.info(f"TIMING {operation} duration_ms={duration_ms:.2f} {extra_str}".strip())
+
+
+def log_timing(operation: str, duration_ms: float, *, extra: dict[str, Any] | None = None) -> None:
+    """Direct timing log helper for manual timing.
+
+    Args:
+        operation: Name of the operation
+        duration_ms: Duration in milliseconds
+        extra: Additional context
+
+    Example:
+        start = time.perf_counter()
+        do_work()
+        log_timing("work", (time.perf_counter() - start) * 1000, extra={"items": 5})
+    """
+    extra_str = " ".join(f"{k}={v}" for k, v in (extra or {}).items())
+    logger.info(f"TIMING {operation} duration_ms={duration_ms:.2f} {extra_str}".strip())

--- a/scripts/bench_multipart.py
+++ b/scripts/bench_multipart.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+import argparse
+import concurrent.futures
+import contextlib
+import csv
+import io
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+from typing import List
+from typing import Tuple
+
+import boto3
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import ClientError
+
+
+@dataclass
+class UploadResult:
+    size_mb: int
+    run: int
+    key: str
+    seconds: float
+    etag: str
+
+
+@dataclass
+class DownloadResult:
+    size_mb: int
+    run: int
+    key: str
+    ttfb_ms: float
+    seconds: float
+    status: str
+
+
+def _generate_part_bytes(part_size_mb: int, seed_byte: int) -> bytes:
+    """Generate deterministic bytes for a part without allocating massive buffers repeatedly."""
+    size = part_size_mb * 1024 * 1024
+    # Use a repeating pattern; memory copy is acceptable for <= 64MB parts
+    pattern = bytes([seed_byte % 256]) * 1024 * 1024  # 1MB block
+    blocks, rem = divmod(size, len(pattern))
+    return pattern * blocks + pattern[:rem]
+
+
+def _multipart_upload(
+    s3,
+    bucket: str,
+    key: str,
+    total_size_mb: int,
+    part_size_mb: int,
+    max_workers: int,
+) -> str:
+    if total_size_mb % part_size_mb != 0:
+        raise ValueError("total_size_mb must be divisible by part_size_mb")
+
+    num_parts = total_size_mb // part_size_mb
+    create = s3.create_multipart_upload(Bucket=bucket, Key=key)
+    upload_id = create["UploadId"]
+
+    uploaded: List[Tuple[int, str]] = []
+
+    def _upload_one(part_number: int) -> Tuple[int, str]:
+        data = _generate_part_bytes(part_size_mb, seed_byte=part_number)
+        resp = s3.upload_part(
+            Bucket=bucket,
+            Key=key,
+            PartNumber=part_number,
+            UploadId=upload_id,
+            Body=io.BytesIO(data),
+        )
+        return part_number, resp["ETag"]
+
+    try:
+        if max_workers <= 1:
+            uploaded.extend(_upload_one(pn) for pn in range(1, num_parts + 1))
+        else:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+                for pn, etag in pool.map(_upload_one, range(1, num_parts + 1)):
+                    uploaded.append((pn, etag))
+
+        parts = [{"PartNumber": pn, "ETag": etag} for pn, etag in sorted(uploaded)]
+        comp = s3.complete_multipart_upload(
+            Bucket=bucket,
+            Key=key,
+            UploadId=upload_id,
+            MultipartUpload={"Parts": parts},
+        )
+        return comp.get("ETag", "")
+    except Exception:
+        with contextlib.suppress(Exception):
+            s3.abort_multipart_upload(Bucket=bucket, Key=key, UploadId=upload_id)
+        raise
+
+
+def benchmark_upload(
+    s3,
+    bucket: str,
+    prefix: str,
+    sizes_mb: Iterable[int],
+    runs: int,
+    total_size_mb: int,
+    max_workers: int,
+) -> List[UploadResult]:
+    results: List[UploadResult] = []
+    for size_mb in sizes_mb:
+        for run in range(1, runs + 1):
+            key = f"{prefix.rstrip('/')}/testfile-{size_mb}-run{run}.bin"
+            t0 = time.monotonic()
+            etag = _multipart_upload(
+                s3=s3,
+                bucket=bucket,
+                key=key,
+                total_size_mb=total_size_mb,
+                part_size_mb=size_mb,
+                max_workers=max_workers,
+            )
+            dt = time.monotonic() - t0
+            results.append(UploadResult(size_mb=size_mb, run=run, key=key, seconds=dt, etag=etag))
+    return results
+
+
+def benchmark_download(
+    s3,
+    bucket: str,
+    keys: List[Tuple[int, int, str]],
+) -> List[DownloadResult]:
+    results: List[DownloadResult] = []
+    for size_mb, run, key in keys:
+        t0 = time.monotonic()
+        ttfb_ms: float = float("nan")
+        status: str = ""
+        total_seconds: float = 0.0
+        try:
+            obj = s3.get_object(Bucket=bucket, Key=key)
+            body = obj["Body"]
+            # Time to first chunk
+            ttfb_start = time.monotonic()
+            chunk = next(body.iter_chunks(chunk_size=8192))
+            ttfb_ms = (time.monotonic() - ttfb_start) * 1000.0
+            # Drain the rest
+            total_bytes = len(chunk)
+            for c in body.iter_chunks(chunk_size=1024 * 1024):
+                total_bytes += len(c)
+            total_seconds = time.monotonic() - t0
+            status = f"ok:{total_bytes}"
+        except Exception as e:
+            total_seconds = time.monotonic() - t0
+            if isinstance(e, ClientError):
+                http_status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+                error_code = e.response.get("Error", {}).get("Code")
+                status = f"error:{http_status or error_code}"
+            else:
+                status = f"error:{e.__class__.__name__}"
+        results.append(
+            DownloadResult(
+                size_mb=size_mb,
+                run=run,
+                key=key,
+                ttfb_ms=ttfb_ms,
+                seconds=total_seconds,
+                status=status,
+            )
+        )
+    return results
+
+
+def _parse_sizes(s: str) -> List[int]:
+    return [int(x.strip()) for x in s.split(",") if x.strip()]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Benchmark multipart upload/download at different part sizes")
+    ap.add_argument("--bucket", required=True, help="S3 bucket name")
+    ap.add_argument("--prefix", default="bench-multipart", help="Key prefix to write under")
+    ap.add_argument("--endpoint-url", default=os.environ.get("S3_ENDPOINT_URL", ""), help="S3 endpoint URL")
+    ap.add_argument("--sizes", default="8,16,32", help="Comma-separated part sizes in MB")
+    ap.add_argument("--runs", type=int, default=3, help="Number of runs per size")
+    ap.add_argument("--total-size-mb", type=int, default=96, help="Total object size per test (MB)")
+    ap.add_argument("--workers", type=int, default=4, help="Concurrent upload workers for parts")
+    ap.add_argument("--csv", default="", help="Optional CSV output file path")
+    ap.add_argument("--mode", choices=["upload", "download", "both"], default="both")
+    ap.add_argument(
+        "--confirm-after-upload",
+        action="store_true",
+        help="Prompt for Enter after all uploads complete (to manually clear Redis)",
+    )
+    ap.add_argument("--no-cleanup", action="store_true", help="Don't delete uploaded files after testing")
+    args = ap.parse_args()
+
+    sizes_mb = _parse_sizes(args.sizes)
+    for s in sizes_mb:
+        if args.total_size_mb % s != 0:
+            sys.exit(2)
+
+    boto_cfg = BotoConfig(retries={"max_attempts": 5, "mode": "standard"})
+    session = boto3.session.Session()
+    s3 = session.client("s3", endpoint_url=(args.endpoint_url or None), config=boto_cfg)
+
+    upload_rows: List[UploadResult] = []
+    download_rows: List[DownloadResult] = []
+
+    if args.mode in ("upload", "both"):
+        upload_rows = benchmark_upload(
+            s3=s3,
+            bucket=args.bucket,
+            prefix=args.prefix,
+            sizes_mb=sizes_mb,
+            runs=args.runs,
+            total_size_mb=args.total_size_mb,
+            max_workers=args.workers,
+        )
+
+        # Single confirmation after all uploads complete
+        if args.confirm_after_upload and upload_rows:
+            with contextlib.suppress(EOFError):
+                input(f"All uploads complete ({len(upload_rows)} files). Clear Redis, then press Enter to continue...")
+
+    if args.mode in ("download", "both"):
+        # Use keys from prior upload set if available; otherwise derive names
+        keys: List[Tuple[int, int, str]] = []
+        if upload_rows:
+            keys = [(r.size_mb, r.run, r.key) for r in upload_rows]
+        else:
+            for size_mb in sizes_mb:
+                for run in range(1, args.runs + 1):
+                    key = f"{args.prefix.rstrip('/')}/testfile-{size_mb}-run{run}.bin"
+                    keys.append((size_mb, run, key))
+        download_rows = benchmark_download(
+            s3=s3,
+            bucket=args.bucket,
+            keys=keys,
+        )
+
+    # Cleanup: delete uploaded files
+    if upload_rows and not args.no_cleanup:
+        for result in upload_rows:
+            try:
+                s3.delete_object(Bucket=args.bucket, Key=result.key)
+            except ClientError:
+                pass
+            except Exception:
+                pass
+
+    if args.csv:
+        with Path(args.csv).open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                ["phase", "size_mb", "run", "key", "upload_seconds", "ttfb_ms", "download_seconds", "status", "etag"]
+            )
+            for r in upload_rows:
+                writer.writerow(["upload", r.size_mb, r.run, r.key, f"{r.seconds:.3f}", "", "", "", r.etag])
+            for r in download_rows:
+                writer.writerow(
+                    ["download", r.size_mb, r.run, r.key, "", f"{r.ttfb_ms:.1f}", f"{r.seconds:.3f}", r.status, ""]
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/test_GetObject.py
+++ b/tests/e2e/test_GetObject.py
@@ -124,9 +124,9 @@ def test_get_object_eventual_consistency(
     # Step 3: Get object_id and verify cache exists
     object_id = get_object_id(bucket_name, key)
 
-    # Verify Redis has cached parts (obj:{object_id}:part:{n})
+    # Verify Redis has cached part chunk meta
     redis_client = redis.Redis.from_url("redis://localhost:6379/0")
-    cache_keys = cast(list[bytes], redis_client.keys(f"obj:{object_id}:part:*"))
+    cache_keys = cast(list[bytes], redis_client.keys(f"obj:{object_id}:part:*:meta"))
     assert len(cache_keys) >= 2, f"Expected at least 2 cached parts, found {len(cache_keys)}"
 
     # Step 4: Simulate eventual consistency issue - force all CIDs to 'pending'

--- a/tests/e2e/test_GetObject_Range.py
+++ b/tests/e2e/test_GetObject_Range.py
@@ -1,5 +1,6 @@
 """E2E tests for GetObject with Range requests."""
 
+import time
 from typing import Any
 from typing import Callable
 
@@ -216,6 +217,7 @@ def test_get_object_range_large_spanning_many_parts(
         boto3_client.put_object(
             Bucket=bucket, Key=key, Body=part_data, Metadata={"append": "true", "append-if-version": ver}
         )
+
         ver = boto3_client.head_object(Bucket=bucket, Key=key)["ResponseMetadata"]["HTTPHeaders"].get(
             "x-amz-meta-append-version", "0"
         )
@@ -474,7 +476,6 @@ def test_get_object_range_concurrent_appends(
 ) -> None:
     """Test range requests when object is being appended to concurrently."""
     import threading
-    import time
 
     bucket = unique_bucket_name("range-concurrent")
     cleanup_buckets(bucket)

--- a/tests/e2e/test_Public_GetObject.py
+++ b/tests/e2e/test_Public_GetObject.py
@@ -61,6 +61,8 @@ def test_public_get_object_anonymous(
     url = f"{s3_base_url}/{bucket_name}/{key}"
     response = requests.get(url, timeout=10)
 
+    print(f"response: {response.content!r}, {url}")
+
     assert response.status_code == 200
     assert response.content == body
     assert response.headers.get("content-type") == "text/plain"

--- a/uv.lock
+++ b/uv.lock
@@ -751,7 +751,7 @@ wheels = [
 
 [[package]]
 name = "hippius"
-version = "0.2.59"
+version = "0.2.63"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "base58" },
@@ -766,9 +766,9 @@ dependencies = [
     { name = "substrate-interface" },
     { name = "zfec" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/18/9f3c82fd8b3f39e6f4995837aa8595b0b3fd38cfe35a90d3fc8710d06c01/hippius-0.2.59.tar.gz", hash = "sha256:ce500a3cfce0b382a3e668f07b899330e79aa02209e47c972b086e6e52457bd3", size = 108531, upload-time = "2025-09-16T18:23:53.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/cb/039a4f880135f1f0c4861081eb2b581ba5d3aa494b3453201a12250006be/hippius-0.2.63.tar.gz", hash = "sha256:efd3830524d42d84013c31ae2ea95791776201e3c9c9c564a2a27eff3f562afe", size = 108681, upload-time = "2025-10-02T06:53:24.627Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/43/bc31912882ae8a1fdb34b5fcda2b6b313cbb3264291bb4c259e4256153a5/hippius-0.2.59-py3-none-any.whl", hash = "sha256:66626083e8784931638f650359c70b612591c4cea4c2defcf0dfdd1ff52fb0b3", size = 110559, upload-time = "2025-09-16T18:23:52.226Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cd/cc3a3caf0a37a803d6c9ab216370c4aa0114c56f6962d5378abdfed06310/hippius-0.2.63-py3-none-any.whl", hash = "sha256:84a0bee9221725cfe4baab21c64cac93425522ac53c41ad6dc1a02aa4767e828", size = 110764, upload-time = "2025-10-02T06:53:22.988Z" },
 ]
 
 [package.optional-dependencies]
@@ -828,7 +828,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "gunicorn", specifier = ">=21.2.0" },
     { name = "hippius" },
-    { name = "hippius", extras = ["key-storage"], specifier = ">=0.2.59" },
+    { name = "hippius", extras = ["key-storage"], specifier = ">=0.2.61" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "lxml", specifier = ">=4.9.3" },
     { name = "minio", marker = "extra == 'dev'", specifier = ">=7.1.15" },

--- a/workers/run_downloader_in_loop.py
+++ b/workers/run_downloader_in_loop.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import asyncio
+import contextlib
 import logging
 import sys
 from pathlib import Path
@@ -11,10 +12,14 @@ from hippius_sdk.client import HippiusClient
 # Add parent directory to path to import hippius_s3 modules
 sys.path.insert(0, str(Path(__file__).parent))
 
+import asyncpg
+
 from hippius_s3.cache import RedisObjectPartsCache
 from hippius_s3.config import get_config
 from hippius_s3.queue import DownloadChainRequest
 from hippius_s3.queue import dequeue_download_request
+from hippius_s3.utils import get_query
+from hippius_s3.utils.timing import log_timing
 
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -45,22 +50,44 @@ async def process_download_request(
         f"Download request ids: object_id={download_request.object_id} request_id={download_request.request_id} parts={[c.part_id for c in download_request.chunks]}"
     )
 
-    # Process all chunks concurrently with higher concurrency for better IPFS utilization
-    semaphore = asyncio.Semaphore(10)  # Increased for better parallel downloads
+    # DB connection required for part_chunks lookup
+    db = await asyncpg.connect(config.database_url)
 
-    async def download_chunk(chunk):
-        chunk_logger = logging.getLogger(__name__)
-        async with semaphore:
-            # Guard invalid/placeholder CIDs
-            cid_str = str(chunk.cid or "").strip().lower()
-            if cid_str in {"", "none", "pending"}:
-                chunk_logger.error(f"Skipping download for chunk {chunk.part_id}: invalid CID '{chunk.cid}'")
-                # Clear in-progress flag so future attempts aren't blocked by TTL
+    try:
+        # Process all chunks concurrently with higher concurrency for better IPFS utilization
+        semaphore = asyncio.Semaphore(10)  # Increased for better parallel downloads
+
+        async def download_chunk(chunk):
+            chunk_logger = logging.getLogger(__name__)
+            async with semaphore:
+                # Build per-part download plan from DB
+                cid_plan: list[tuple[int, str, int | None]] = []
                 try:
-                    await redis_client.delete(f"download_in_progress:{download_request.object_id}:{int(chunk.part_id)}")
+                    rows = await db.fetch(
+                        get_query("get_part_chunks_by_object_and_number"),
+                        download_request.object_id,
+                        int(chunk.part_id),
+                    )
+                    cid_plan.extend((int(r[0]), str(r[1]), int(r[2]) if r[2] is not None else None) for r in rows or [])
                 except Exception:
-                    chunk_logger.debug("Failed to delete in-progress flag for invalid CID", exc_info=True)
-                return False
+                    cid_plan = []
+
+            # Fallback to single CID if no part_chunks in DB
+            if not cid_plan:
+                cid_str = str(chunk.cid or "").strip().lower()
+                if cid_str in {"", "none", "pending"}:
+                    chunk_logger.error(
+                        f"Skipping download for part {chunk.part_id}: invalid CID '{chunk.cid}' and no part_chunks"
+                    )
+                    # Clear in-progress flag so future attempts aren't blocked by TTL
+                    try:
+                        await redis_client.delete(
+                            f"download_in_progress:{download_request.object_id}:{int(chunk.part_id)}"
+                        )
+                    except Exception:
+                        chunk_logger.debug("Failed to delete in-progress flag for invalid CID", exc_info=True)
+                    return False
+                cid_plan = [(0, str(chunk.cid), None)]
 
             max_attempts = getattr(config, "downloader_chunk_retries", 5)
             base_sleep = getattr(config, "downloader_retry_base_seconds", 0.25)
@@ -71,19 +98,33 @@ async def process_download_request(
 
             for attempt in range(1, max_attempts + 1):
                 try:
+                    import time as _dtime
+
+                    chunk_start = _dtime.perf_counter()
                     chunk_logger.debug(
                         f"Downloading chunk {chunk.part_id} attempt={attempt}/{max_attempts} CID: {chunk.cid}"
                     )
 
-                    # Download the chunk using hippius_sdk
-                    chunk_data = await hippius_client.s3_download(
-                        cid=chunk.cid,
-                        subaccount_id=download_request.subaccount,
-                        bucket_name=download_request.bucket_name,
-                        auto_decrypt=download_request.should_decrypt,
-                        download_node=download_request.ipfs_node,
-                        return_bytes=True,
-                    )
+                    # Download per plan entry (DB-driven chunk layout if available)
+                    assembled: list[bytes] = []
+                    for ci, cid_val, expected_len in cid_plan:
+                        chunk_logger.debug(
+                            f"Downloading part {chunk.part_id} ci={ci} CID={cid_val[:10]}... expected={expected_len}"
+                        )
+                        data_i = await hippius_client.s3_download(
+                            cid=cid_val,
+                            subaccount_id=download_request.subaccount,
+                            bucket_name=download_request.bucket_name,
+                            auto_decrypt=False,
+                            download_node=download_request.ipfs_node,
+                            return_bytes=True,
+                        )
+                        if expected_len is not None and len(data_i) != int(expected_len):
+                            chunk_logger.warning(
+                                f"Cipher len mismatch for part {chunk.part_id} ci={ci}: got={len(data_i)} expected={expected_len}"
+                            )
+                        assembled.append(data_i)
+                    chunk_data = b"".join(assembled)
 
                     md5 = _hashlib.md5(chunk_data).hexdigest()
                     head_hex = chunk_data[:8].hex() if chunk_data else ""
@@ -93,13 +134,47 @@ async def process_download_request(
                         f"head8={head_hex} tail8={tail_hex}"
                     )
 
-                    # Store the chunk data in Redis object parts cache
-                    chunk_logger.info(
-                        f"OBJ-CACHE write object_id={download_request.object_id} part={int(chunk.part_id)} bytes={len(chunk_data)}"
-                    )
-                    await obj_cache.set(download_request.object_id, int(chunk.part_id), chunk_data)
-                    chunk_logger.info(
-                        f"OBJ-CACHE stored object_id={download_request.object_id} part={int(chunk.part_id)}"
+                    # Store bytes in Redis cache with meta-first write order (readiness signal before chunks)
+                    part_num = int(chunk.part_id)
+                    if cid_plan and len(cid_plan) > 1:
+                        # Multiple chunks in DB: write meta first, then chunk keys
+                        await obj_cache.set_meta(
+                            download_request.object_id,
+                            part_num,
+                            chunk_size=getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024),
+                            num_chunks=len(cid_plan),
+                            size_bytes=len(chunk_data),
+                        )
+                        for idx, (ci, _cid, _exp) in enumerate(cid_plan):
+                            data_i = assembled[idx] if idx < len(assembled) else b""
+                            await obj_cache.set_chunk(download_request.object_id, part_num, int(ci), data_i)
+                        chunk_logger.info(
+                            f"OBJ-CACHE stored (DB layout) object_id={download_request.object_id} part={part_num} ct_chunks={len(cid_plan)} total_bytes={len(chunk_data)}"
+                        )
+                    else:
+                        # Single-chunk case: write meta first, then chunk at index 0
+                        await obj_cache.set_meta(
+                            download_request.object_id,
+                            part_num,
+                            chunk_size=getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024),
+                            num_chunks=1,
+                            size_bytes=len(chunk_data),
+                        )
+                        await obj_cache.set_chunk(download_request.object_id, part_num, 0, chunk_data)
+                        chunk_logger.info(
+                            f"OBJ-CACHE stored (single) object_id={download_request.object_id} part={part_num} bytes={len(chunk_data)}"
+                        )
+                    # Log download timing
+                    chunk_ms = (_dtime.perf_counter() - chunk_start) * 1000.0
+                    log_timing(
+                        "downloader.chunk_download_and_store",
+                        chunk_ms,
+                        extra={
+                            "object_id": download_request.object_id,
+                            "part_id": chunk.part_id,
+                            "size_bytes": len(chunk_data),
+                            "num_cids": len(cid_plan),
+                        },
                     )
                     # Clear in-progress flag on success
                     try:
@@ -128,22 +203,26 @@ async def process_download_request(
                         f"Download error for chunk {chunk.part_id} (CID: {chunk.cid}) attempt {attempt}/{max_attempts}: {e}. Retrying in {sleep_for:.2f}s"
                     )
                     await asyncio.sleep(sleep_for)
-        return None
+            return None
 
-    # Download all chunks concurrently
-    results = await asyncio.gather(*[download_chunk(chunk) for chunk in download_request.chunks])
+        # Download all chunks concurrently
+        results = await asyncio.gather(*[download_chunk(chunk) for chunk in download_request.chunks])
 
-    success_count = sum(results)
-    total_chunks = len(download_request.chunks)
+        success_count = sum(results)
+        total_chunks = len(download_request.chunks)
 
-    if success_count == total_chunks:
-        logger.info(f"Successfully downloaded all {total_chunks} chunks for {short_id}")
-        return True
+        if success_count == total_chunks:
+            logger.info(f"Successfully downloaded all {total_chunks} chunks for {short_id}")
+            return True
 
-    logger.error(f"Only downloaded {success_count}/{total_chunks} chunks for {short_id}")
-    # Don't delete existing chunks as they might be in use by ongoing downloads
-    # Let Redis TTL handle cleanup naturally
-    return False
+        logger.error(f"Only downloaded {success_count}/{total_chunks} chunks for {short_id}")
+        # Don't delete existing chunks as they might be in use by ongoing downloads
+        # Let Redis TTL handle cleanup naturally
+        return False
+    finally:
+        # Clean up DB connection created for this request
+        with contextlib.suppress(Exception):
+            await db.close()
 
 
 async def run_downloader_loop():

--- a/workers/substrate.py
+++ b/workers/substrate.py
@@ -219,7 +219,9 @@ async def get_all_storage_requests(
                                     f"Failed to fetch storage request {storage_request_cid} for {account} from {url}: HTTP {response.status_code}"
                                 )
                         except Exception as e:
-                            logger.warning(f"Error fetching storage request {storage_request_cid} for {account} from {url}: {e}")
+                            logger.warning(
+                                f"Error fetching storage request {storage_request_cid} for {account} from {url}: {e}"
+                            )
 
             except Exception as e:
                 logger.warning(f"Error processing storage request key {key}: {e}")


### PR DESCRIPTION
This PR introduces significant improvements to the Hippius S3 storage system, focusing on security (via per-chunk encryption for private buckets), performance (through chunked Redis caching with metadata for readiness checks), and reliability (enhanced DLQ persistence and downloader logic). These changes enable more efficient handling of large objects, better encryption granularity, and streamlined recovery from failures. The updates are backward-compatible where possible, with fallbacks for legacy whole-part encryption and caching.

Key motivations:
- **Security**: Encrypt data before caching in Redis for private buckets, using a new `CryptoService` with XSalsa20-Poly1305 (via PyNaCl) and random nonces to prevent reuse issues.
- **Performance**: Split large parts into fixed-size chunks (default 4MB) for parallel processing, reduced memory usage during ranges/decrypts, and meta-first writes for cheap readiness signals.
- **Reliability**: Persist DLQ as meta + per-chunk pieces (no inferred boundaries), allowing exact Redis reconstruction. Downloader now uses DB-driven `part_chunks` for per-CID downloads.
- **Observability**: Added timing utilities (`timing_context`, `async_timing_context`, `log_timing`) for logging operation durations with thresholds.
- **Database**: New `part_chunks` table to store per-chunk CIDs, sizes, and checksums (forward-compatible with erasure coding). Migration backfills existing parts as single-chunk entries.

## Major Changes
- **Encryption & CryptoService** (new module `services/crypto_service.py`):
  - Adapter-based AEAD encryption/decryption with support for chunked layouts.
  - Default suite: `hip-enc/1` (random nonces, no AAD yet; future-proofed for ChaCha20-Poly1305).
  - Legacy fallback (`hip-enc/legacy`) for whole-part compatibility.
  - Streaming decrypt for range requests to minimize memory usage.
  - Integrated into upload (PUT/Append/Multipart) and download paths; only encrypts for private buckets.

- **Chunked Redis Caching** (`cache/object_parts.py`):
  - Extended `RedisObjectPartsCache` with chunked API: `set_meta` (written first for readiness), `set_chunk`/`get_chunk`.
  - Backward-compatible: `get`/`set` assemble/split chunks transparently.
  - Meta includes `chunk_size`, `num_chunks`, `size_bytes` for quick checks without full assembly.
  - TTL handling: Expire meta + all chunks via SCAN to prevent orphans.
  - Updated all endpoints (PUT, Append, Multipart, Copy) to use chunked cache for private buckets.

- **DLQ Enhancements** (`dlq/storage.py`, `dlq/logic.py`, `dlq_requeue.py`):
  - Persist meta as JSON sidecar + exact chunk pieces (no whole-part files or inferred slicing).
  - Hydration reconstructs Redis exactly from pieces (meta-first).
  - `part_size` sums pieces or uses meta; fallback to legacy whole-file if needed.
  - Requeue script: Fallback to Redis SCAN for parts if DLQ empty; consistent "0" output on errors.

- **Object Reader & Downloader** (`services/object_reader.py`, `run_downloader_in_loop.py`):
  - Use chunked cache for assembly/decrypt; fallback to whole-part.
  - Range requests: Compute plaintext sizes from meta (subtract overhead for encrypted); bounded polling for appends.
  - Downloader: Fetch per-chunk CIDs from DB (`part_chunks`); assemble before cache store.
  - Pre-header waits use meta checks; `_read_part_bytes` waits briefly for meta/chunks.

- **Database Schema & Queries** (new migration `20251003000000_create_part_chunks.sql` + queries):
  - `part_chunks` table: `part_id`, `chunk_index`, `cid`, `cipher_size_bytes`, etc.
  - Backfill: Existing parts as chunk 0 with whole size/CID.
  - New queries: `get_part_chunks_by_object_and_number`, `upsert_part_chunk`, etc.
  - Pinner: Uploads per-chunk CIDs to DB after part-level (for future EC).

- **Utils & Observability** (new `utils/timing.py`, `__init__.py`; renamed `utils.py` to `utils_core.py`):
  - Timing contexts for logging durations (e.g., downloads, manifest builds) with extras/thresholds.
  - Applied to critical paths (e.g., chunk downloads, part reads).

- **Benchmarks & Tests** (new `scripts/bench_multipart.py`; updated E2E tests):
  - Script: Benchmark multipart upload/download at varying part sizes; CSV output; concurrent workers.
  - Tests: Updated for chunked cache (e.g., check meta keys); added sleeps for append consistency; handled encrypted size overheads.

- **Config & Misc**:
  - New `object_chunk_size_bytes` (default 4MB), `crypto_suite_id` (default `hip-enc/1`).
  - Docker: Added `HTTP_STREAM_INITIAL_TIMEOUT_SECONDS=0.5` for faster timeouts.
  - Multipart: Resolved upload_id in queries; cleaned up chunk keys on errors/aborts.
  - Pinner: Ensured non-null upload_id; uploaded per-chunk CIDs.

## Impact & Migration
- **Breaking?** Mostly non-breaking; legacy fallbacks ensure compatibility. Run the new migration for `part_chunks`.
- **Performance Gains**: Chunking reduces memory for large parts; parallel downloads via per-chunk CIDs.
- **Security**: Private data now encrypted in Redis (previously plaintext cache).