### PR TITLE
feat: split workers (uploader/substrate), range-aware downloader, pla…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ coverage.xml
 .pytest_cache/
 .e2e
 **/.claude/settings.local.json
+backup.git/
+artifacts/

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,7 +1,17 @@
 services:
+  base:
+    image: hippius-s3-base:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.base
+    profiles:
+      - build-base
   api:
+    build: .
     # Ensure CI does not depend on a local .env file
     env_file: []
+    ports:
+      - "8000:8000"
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/hippius?sslmode=disable
       - HIPPIUS_KEYSTORE_DATABASE_URL=postgresql://postgres:postgres@db:5432/hippius?sslmode=disable
@@ -23,12 +33,26 @@ services:
       - PORT=8000
       - HIPPIUS_SUBSTRATE_URL=wss://rpc.hippius.network
       - HIPPIUS_VALIDATOR_REGION=decentralized
+    depends_on:
+      db:
+        condition: service_healthy
+      ipfs:
+        condition: service_started
+      redis:
+        condition: service_healthy
+      redis-accounts:
+        condition: service_healthy
     volumes:
       - .:/app
       - ./.e2e/dlq:/tmp/hippius_dlq
       - ./.e2e/dlq_archive:/tmp/hippius_dlq_archive
+    networks:
+      - hippius_net
 
   uploader:
+    build:
+      context: .
+      dockerfile: workers/Dockerfile
     command: ["python", "workers/run_uploader_in_loop.py"]
     env_file: []
     environment:
@@ -47,12 +71,22 @@ services:
       - HIPPIUS_UPLOADER_MAX_ATTEMPTS=2
       - HIPPIUS_UPLOADER_BACKOFF_BASE_MS=100
       - HIPPIUS_UPLOADER_BACKOFF_MAX_MS=500
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
       - .:/app
       - ./.e2e/dlq:/tmp/hippius_dlq
       - ./.e2e/dlq_archive:/tmp/hippius_dlq_archive
+    networks:
+      - hippius_net
 
   substrate:
+    build:
+      context: .
+      dockerfile: workers/Dockerfile
     command: ["python", "workers/run_substrate_in_loop.py"]
     env_file: []
     environment:
@@ -80,10 +114,20 @@ services:
       - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
       - HIPPIUS_SUBSTRATE_BATCH_SIZE=1
       - HIPPIUS_SUBSTRATE_BATCH_MAX_AGE_SEC=1
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
       - .:/app
+    networks:
+      - hippius_net
 
   unpinner:
+    build:
+      context: .
+      dockerfile: workers/Dockerfile
     command: ["python", "workers/run_unpinner_in_loop.py"]
     env_file: []
     environment:
@@ -96,10 +140,20 @@ services:
       - HIPPIUS_IPFS_GET_URL=http://ipfs:8080
       - HIPPIUS_IPFS_STORE_URL=http://ipfs:5001
       - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
       - .:/app
+    networks:
+      - hippius_net
 
   downloader:
+    build:
+      context: .
+      dockerfile: workers/Dockerfile
     command: ["python", "workers/run_downloader_in_loop.py"]
     env_file: []
     environment:
@@ -113,8 +167,15 @@ services:
       - HIPPIUS_IPFS_GET_URL=http://ipfs:8080
       - HIPPIUS_IPFS_STORE_URL=http://ipfs:5001
       - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
       - .:/app
+    networks:
+      - hippius_net
 
   chain-pin-checker:
     build:
@@ -133,13 +194,20 @@ services:
       - HIPPIUS_IPFS_GET_URL=http://ipfs:8080
       - HIPPIUS_IPFS_STORE_URL=http://ipfs:5001
       - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
       - .:/app
+    networks:
+      - hippius_net
 
   toxiproxy:
     image: shopify/toxiproxy:latest
     ports:
-      - "8474:8474" # control API (for host-driven tests if needed)
+      - "8474:8474"
     depends_on:
       - ipfs
     networks:
@@ -162,10 +230,59 @@ services:
       - HIPPIUS_IPFS_GET_URL=http://ipfs:8080
       - HIPPIUS_IPFS_STORE_URL=http://ipfs:5001
       - RESUBMISSION_SEED_PHRASE=about acid actor absent action able actual abandon abstract above ability achieve
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     volumes:
       - .:/app
 
+  db:
+    image: postgres:15
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=hippius
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - hippius_net
+
+  ipfs:
+    image: ipfs/kubo:latest
+    # No host port bindings needed for CI; services use internal DNS
+    environment:
+      - IPFS_PROFILE=server
+    healthcheck:
+      test: ["CMD-SHELL", "ipfs id"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - hippius_net
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+    networks:
+      - hippius_net
+
+  redis-accounts:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+    networks:
+      - hippius_net
+
 networks:
   hippius_net:
-    external: true
     name: hippius_net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,16 +26,18 @@ services:
         condition: service_healthy
     volumes:
       - .:/app
+      - /var/lib/hippius/dlq:/tmp/hippius_dlq
+      - /var/lib/hippius/dlq_archive:/tmp/hippius_dlq_archive
     restart: unless-stopped
     environment:
       - PYTHONUNBUFFERED=1
       - UVICORN_LOG_LEVEL=debug
       - DEBUG=true
-      - HIPPIUS_IPFS_GET_URL=https://get.hippius.network
-      - HIPPIUS_IPFS_STORE_URL=https://store.hippius.network
       - REDIS_URL=redis://redis:6379/0
       - REDIS_ACCOUNTS_URL=redis://redis-accounts:6379/0
       - REDIS_CHAIN_URL=redis://redis-chain:6379/0
+      - HIPPIUS_DLQ_DIR=/tmp/hippius_dlq
+      - HIPPIUS_DLQ_ARCHIVE_DIR=/tmp/hippius_dlq_archive
     networks:
       - hippius_net
 
@@ -145,8 +147,12 @@ services:
       - PYTHONUNBUFFERED=1
       - REDIS_URL=redis://redis:6379/0
       - REDIS_ACCOUNTS_URL=redis://redis-accounts:6379/0
+      - HIPPIUS_DLQ_DIR=/tmp/hippius_dlq
+      - HIPPIUS_DLQ_ARCHIVE_DIR=/tmp/hippius_dlq_archive
     volumes:
       - .:/app
+      - /var/lib/hippius/dlq:/tmp/hippius_dlq
+      - /var/lib/hippius/dlq_archive:/tmp/hippius_dlq_archive
     networks:
       - hippius_net
 

--- a/hippius_s3/adapters/publish.py
+++ b/hippius_s3/adapters/publish.py
@@ -77,6 +77,8 @@ class ResilientPublishAdapter:
                     subaccount_id=account_address,
                     bucket_name=bucket_name,
                     store_node=self.config.ipfs_store_url,
+                    pin_node=self.config.ipfs_store_url,
+                    substrate_url=self.config.substrate_url,
                 )
                 tx_hash = getattr(pub, "tx_hash", None)
                 logger.info(f"SDK publish complete cid={pub.cid} tx={tx_hash}")

--- a/hippius_s3/api/s3/extensions/append.py
+++ b/hippius_s3/api/s3/extensions/append.py
@@ -258,9 +258,7 @@ async def handle_append(
             part_number=int(next_part),
             size_bytes=int(delta_size),
             etag=delta_md5,
-            chunk_size_bytes=int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024))
-            if not bucket["is_public"]
-            else None,
+            chunk_size_bytes=int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024)),
         )
 
         # Recompute composite ETag from base object MD5 + all appended part etags

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -601,30 +601,32 @@ async def upload_part(
 
         # Store in Redis via chunked cache API (encrypt for private, meta-first for readiness)
         redis_start = time.time()
+        chunk_size = int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024))
         if should_encrypt:
-            chunk_size = int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024))
-            ct_chunks = CryptoService.encrypt_part_to_chunks(
+            chunks_bytes = CryptoService.encrypt_part_to_chunks(
                 file_data,
                 object_id=str(object_id),
                 part_number=int(part_number),
                 seed_phrase=request.state.seed_phrase,
                 chunk_size=chunk_size,
             )
-            total_ct = sum(len(ct) for ct in ct_chunks)
-            # Write meta first for cheap readiness check
-            await obj_cache.set_meta(
-                str(object_id),
-                int(part_number),
-                chunk_size=chunk_size,
-                num_chunks=len(ct_chunks),
-                size_bytes=total_ct,
-                ttl=1800,
-            )
-            # Then write chunk data
-            for i, ct in enumerate(ct_chunks):
-                await obj_cache.set_chunk(str(object_id), int(part_number), i, ct, ttl=1800)
         else:
-            await obj_cache.set(str(object_id), int(part_number), file_data, ttl=1800)
+            # Plaintext is chunked identically to ciphertext (no encryption)
+            chunks_bytes = [file_data[i : i + chunk_size] for i in range(0, len(file_data), chunk_size)]
+
+        total_size_bytes = sum(len(c) for c in chunks_bytes)
+        # Write meta first for readiness
+        await obj_cache.set_meta(
+            str(object_id),
+            int(part_number),
+            chunk_size=chunk_size,
+            num_chunks=len(chunks_bytes),
+            size_bytes=total_size_bytes,
+            ttl=1800,
+        )
+        # Then write chunk data
+        for i, piece in enumerate(chunks_bytes):
+            await obj_cache.set_chunk(str(object_id), int(part_number), i, piece, ttl=1800)
         redis_time = time.time() - redis_start
         logger.debug(
             f"Part {part_number}: Cached via RedisObjectPartsCache in {redis_time:.3f}s (object_id={object_id}, encrypted={should_encrypt})"
@@ -655,9 +657,8 @@ async def upload_part(
             part_number=int(part_number),
             size_bytes=int(file_size),
             etag=str(etag),
-            chunk_size_bytes=int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024))
-            if should_encrypt
-            else None,
+            # Treat plaintext and ciphertext identically for chunking
+            chunk_size_bytes=int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024)),
         )
         db_time = time.time() - db_start
         logger.debug(f"Part {part_number}: Database insert took {db_time:.3f}s")

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -31,6 +31,7 @@ from hippius_s3.queue import UploadChainRequest
 from hippius_s3.queue import enqueue_upload_request
 from hippius_s3.services.crypto_service import CryptoService
 from hippius_s3.services.object_reader import ObjectReader
+from hippius_s3.services.parts_service import upsert_part_placeholder
 from hippius_s3.utils import get_query
 
 
@@ -647,16 +648,16 @@ async def upload_part(
 
         # Save the part information in the database
         db_start = time.time()
-        await db.fetchrow(
-            get_query("upload_part"),
-            str(uuid.uuid4()),
-            upload_id,
-            part_number,
-            "",
-            # cid not yet available
-            part_result["size_bytes"],
-            part_result["etag"],
-            datetime.now(UTC),
+        await upsert_part_placeholder(
+            db,
+            object_id=str(object_id),
+            upload_id=str(upload_id),
+            part_number=int(part_number),
+            size_bytes=int(file_size),
+            etag=str(etag),
+            chunk_size_bytes=int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024))
+            if should_encrypt
+            else None,
         )
         db_time = time.time() - db_start
         logger.debug(f"Part {part_number}: Database insert took {db_time:.3f}s")
@@ -1072,12 +1073,14 @@ async def complete_multipart_upload(
             object_id,
         )
 
-        # Mark multipart upload as completed
-        await db.execute(
-            "UPDATE multipart_uploads SET is_completed = TRUE WHERE upload_id = $1",
-            upload_id,
-        )
+        # Mark multipart upload as completed and only enqueue after DB commit
+        async with db.transaction():
+            await db.execute(
+                "UPDATE multipart_uploads SET is_completed = TRUE WHERE upload_id = $1",
+                upload_id,
+            )
 
+        # After commit, enqueue background publish
         await enqueue_upload_request(
             UploadChainRequest(
                 object_key=object_key,

--- a/hippius_s3/api/s3/objects/put_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/put_object_endpoint.py
@@ -13,7 +13,6 @@ from fastapi import Response
 
 from hippius_s3 import utils
 from hippius_s3.api.s3 import errors
-from hippius_s3.api.s3.extensions.append import _upsert_cid
 from hippius_s3.api.s3.extensions.append import handle_append
 from hippius_s3.cache import RedisObjectPartsCache
 from hippius_s3.config import get_config
@@ -21,6 +20,7 @@ from hippius_s3.queue import Chunk
 from hippius_s3.queue import UploadChainRequest
 from hippius_s3.queue import enqueue_upload_request
 from hippius_s3.services.crypto_service import CryptoService
+from hippius_s3.services.parts_service import upsert_part_placeholder
 from hippius_s3.utils import get_query
 
 
@@ -159,50 +159,42 @@ async def handle_put_object(
             except Exception:
                 logger.debug("Failed to cleanup previous parts on overwrite", exc_info=True)
 
-        # Ensure a multipart_uploads row exists to satisfy parts.upload_id FK
-        try:
-            upload_row = await db.fetchrow(
-                get_query("create_multipart_upload"),
-                uuid.UUID(object_id),
-                bucket_id,
-                object_key,
-                created_at,
-                content_type,
-                json.dumps(metadata),
-                created_at,
-                uuid.UUID(object_id),
-            )
-            upload_id = upload_row["upload_id"] if upload_row else uuid.UUID(object_id)
-        except Exception:
-            # Best effort: reuse existing upload row if it already exists
-            upload_row = await db.fetchrow(
-                "SELECT upload_id FROM multipart_uploads WHERE bucket_id = $1 AND object_key = $2 ORDER BY initiated_at DESC LIMIT 1",
-                bucket_id,
-                object_key,
-            )
-            upload_id = upload_row["upload_id"] if upload_row else uuid.UUID(object_id)
+        # Ensure upload row and parts(1) placeholder exist atomically before enqueueing
+        async with db.transaction():
+            # Ensure a multipart_uploads row exists to satisfy parts.upload_id FK
+            try:
+                upload_row = await db.fetchrow(
+                    get_query("create_multipart_upload"),
+                    uuid.UUID(object_id),
+                    bucket_id,
+                    object_key,
+                    created_at,
+                    content_type,
+                    json.dumps(metadata),
+                    created_at,
+                    uuid.UUID(object_id),
+                )
+                upload_id = upload_row["upload_id"] if upload_row else uuid.UUID(object_id)
+            except Exception:
+                upload_row = await db.fetchrow(
+                    "SELECT upload_id FROM multipart_uploads WHERE bucket_id = $1 AND object_key = $2 ORDER BY initiated_at DESC LIMIT 1",
+                    bucket_id,
+                    object_key,
+                )
+                upload_id = upload_row["upload_id"] if upload_row else uuid.UUID(object_id)
 
-        # Insert parts(1) for simple objects - all objects are represented by parts (1-based)
-        placeholder_cid = "pending"
-        placeholder_cid_id = await _upsert_cid(db, placeholder_cid)
-
-        # Insert part 1 representing the base object (placeholder)
-        await db.execute(
-            """
-            INSERT INTO parts (part_id, upload_id, part_number, ipfs_cid, size_bytes, etag, uploaded_at, object_id, cid_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-            ON CONFLICT (object_id, part_number) DO NOTHING
-            """,
-            str(uuid.uuid4()),
-            upload_id,
-            1,
-            placeholder_cid,
-            int(file_size),
-            md5_hash,
-            created_at,
-            object_id,
-            placeholder_cid_id,
-        )
+            # Insert parts(1) placeholder for simple objects (1-based indexing)
+            await upsert_part_placeholder(
+                db,
+                object_id=object_id,
+                upload_id=str(upload_id),
+                part_number=1,
+                size_bytes=int(file_size),
+                etag=md5_hash,
+                chunk_size_bytes=int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024))
+                if should_encrypt
+                else None,
+            )
 
         # Only enqueue after DB state (object, upload row, and part 1) is persisted to avoid race with pinner
         await enqueue_upload_request(

--- a/hippius_s3/api/s3/objects/put_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/put_object_endpoint.py
@@ -191,9 +191,7 @@ async def handle_put_object(
                 part_number=1,
                 size_bytes=int(file_size),
                 etag=md5_hash,
-                chunk_size_bytes=int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024))
-                if should_encrypt
-                else None,
+                chunk_size_bytes=int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024)),
             )
 
         # Only enqueue after DB state (object, upload row, and part 1) is persisted to avoid race with pinner

--- a/hippius_s3/metadata/__init__.py
+++ b/hippius_s3/metadata/__init__.py
@@ -1,0 +1,1 @@
+"""Metadata reading utilities."""

--- a/hippius_s3/metadata/meta_reader.py
+++ b/hippius_s3/metadata/meta_reader.py
@@ -1,0 +1,101 @@
+"""Explicit meta readers for DB and cache.
+
+Separates authoritative DB reads from cache-only readiness checks.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import TypedDict
+
+from asyncpg import Connection
+
+
+class DBMeta(TypedDict):
+    plain_size: int
+    chunk_size_bytes: int | None
+    num_chunks_db: int
+
+
+class CacheMeta(TypedDict):
+    chunk_size: int
+    num_chunks: int
+    size_bytes: int
+
+
+async def read_db_meta(
+    db: Connection,
+    object_id: str,
+    part_number: int,
+) -> DBMeta | None:
+    """Read authoritative part metadata from DB.
+
+    Args:
+        db: asyncpg connection.
+        object_id: Object UUID.
+        part_number: Part number (1-based).
+
+    Returns:
+        {plain_size, chunk_size_bytes, num_chunks_db} or None if part doesn't exist.
+    """
+    # Get part metadata
+    part_row = await db.fetchrow(
+        """
+        SELECT part_id, size_bytes, chunk_size_bytes
+        FROM parts
+        WHERE object_id = $1 AND part_number = $2
+        """,
+        object_id,
+        part_number,
+    )
+    if not part_row:
+        return None
+
+    part_id = part_row["part_id"]
+    plain_size = int(part_row["size_bytes"])
+    chunk_size_bytes = part_row["chunk_size_bytes"]
+
+    # Count chunks from part_chunks table
+    num_chunks_row = await db.fetchrow(
+        """
+        SELECT COUNT(*) as cnt
+        FROM part_chunks
+        WHERE part_id = $1
+        """,
+        part_id,
+    )
+    num_chunks_db = int(num_chunks_row["cnt"]) if num_chunks_row else 0
+
+    return {
+        "plain_size": plain_size,
+        "chunk_size_bytes": chunk_size_bytes,
+        "num_chunks_db": num_chunks_db,
+    }
+
+
+async def read_cache_meta(
+    obj_cache: Any,
+    object_id: str,
+    part_number: int,
+) -> CacheMeta | None:
+    """Read cache meta if present; for readiness checks only.
+
+    Args:
+        obj_cache: RedisObjectPartsCache instance.
+        object_id: Object UUID.
+        part_number: Part number (1-based).
+
+    Returns:
+        {chunk_size, num_chunks, size_bytes} or None if not cached.
+    """
+    try:
+        raw = await obj_cache.get_meta(object_id, part_number)
+        if isinstance(raw, dict):
+            return {
+                "chunk_size": int(raw.get("chunk_size", 4 * 1024 * 1024)),
+                "num_chunks": int(raw.get("num_chunks", 0)),
+                "size_bytes": int(raw.get("size_bytes", 0)),
+            }
+    except Exception:
+        pass
+    return None

--- a/hippius_s3/planning/__init__.py
+++ b/hippius_s3/planning/__init__.py
@@ -1,0 +1,1 @@
+"""Range request planning utilities."""

--- a/hippius_s3/planning/range_planner.py
+++ b/hippius_s3/planning/range_planner.py
@@ -1,0 +1,84 @@
+"""Pure planning logic for range requests.
+
+No IO; deterministic mapping from part sizes and chunk size to minimal chunk indices.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class PartOffset(TypedDict):
+    part_number: int
+    offset: int
+    plain_size: int
+
+
+class PartInput(TypedDict):
+    part_number: int
+    plain_size: int
+
+
+def build_part_offsets(parts: list[PartInput]) -> list[PartOffset]:
+    """Build plaintext offset map for each part.
+
+    Args:
+        parts: List of {part_number, plain_size} from DB, ordered by part_number.
+
+    Returns:
+        List of {part_number, offset, plain_size} with cumulative offsets.
+    """
+    result: list[PartOffset] = []
+    cumulative = 0
+    for p in sorted(parts, key=lambda x: x["part_number"]):
+        result.append(
+            {
+                "part_number": p["part_number"],
+                "offset": cumulative,
+                "plain_size": p["plain_size"],
+            }
+        )
+        cumulative += p["plain_size"]
+    return result
+
+
+def plan_indices_for_range(
+    offsets: list[PartOffset],
+    range_start: int,
+    range_end: int,
+    chunk_size: int,
+) -> dict[int, list[int]]:
+    """Compute minimal per-part chunk indices for a plaintext range.
+
+    Args:
+        offsets: Part offset map from build_part_offsets.
+        range_start: Inclusive start byte (plaintext, 0-based).
+        range_end: Inclusive end byte (plaintext, 0-based).
+        chunk_size: Chunk size in bytes (from DB or config).
+
+    Returns:
+        dict[part_number, list[chunk_index]] for chunks overlapping the range.
+    """
+    result: dict[int, list[int]] = {}
+    for part in offsets:
+        pn = part["part_number"]
+        part_start = part["offset"]
+        part_end = part_start + part["plain_size"] - 1
+
+        # Skip if part doesn't overlap range
+        if part_end < range_start or part_start > range_end:
+            continue
+
+        # Compute local range within this part
+        local_start = max(0, range_start - part_start)
+        local_end = min(part["plain_size"] - 1, range_end - part_start)
+
+        # Map to chunk indices
+        if chunk_size <= 0:
+            raise ValueError(f"Invalid chunk_size={chunk_size} for part {pn}; cannot plan range")
+        start_chunk = local_start // chunk_size
+        end_chunk = local_end // chunk_size
+
+        result[pn] = list(range(start_chunk, end_chunk + 1))
+
+    return result

--- a/hippius_s3/queue.py
+++ b/hippius_s3/queue.py
@@ -23,6 +23,8 @@ class ChunkToDownload(BaseModel):
     part_id: int
     # Temporary backward-compat: accept legacy payloads that include or expect a redis_key
     redis_key: str | None = None
+    # Optional subset of chunk indices to hydrate for this part (minimal range fetch)
+    chunk_indices: list[int] | None = None
 
 
 class ChainRequest(BaseModel):

--- a/hippius_s3/services/parts_service.py
+++ b/hippius_s3/services/parts_service.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from hippius_s3.utils import get_query
+
+
+async def upsert_part_placeholder(
+    db: Any,
+    *,
+    object_id: str,
+    upload_id: str,
+    part_number: int,
+    size_bytes: int,
+    etag: str,
+    placeholder_cid: str = "pending",
+    chunk_size_bytes: int | None = None,
+) -> None:
+    """Ensure a parts row exists with NOT NULL fields before uploader runs.
+
+    Creates or updates a parts row with placeholder CID and provided metadata.
+    Safe to call multiple times (idempotent on (object_id, part_number)).
+    """
+    # Resolve CID ID for placeholder (e.g., "pending")
+    cid_row = await db.fetchrow(get_query("upsert_cid"), placeholder_cid)
+    cid_id = cid_row["id"] if cid_row else None
+
+    now = datetime.now(timezone.utc)
+
+    if chunk_size_bytes is None:
+        await db.execute(
+            """
+            INSERT INTO parts (part_id, upload_id, part_number, ipfs_cid, size_bytes, etag, uploaded_at, object_id, cid_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (object_id, part_number) DO UPDATE SET
+                ipfs_cid = EXCLUDED.ipfs_cid,
+                size_bytes = EXCLUDED.size_bytes,
+                etag = EXCLUDED.etag,
+                uploaded_at = EXCLUDED.uploaded_at,
+                cid_id = EXCLUDED.cid_id
+            """,
+            str(uuid.uuid4()),
+            upload_id,
+            int(part_number),
+            placeholder_cid,
+            int(size_bytes),
+            etag,
+            now,
+            object_id,
+            cid_id,
+        )
+        return
+
+    await db.execute(
+        """
+        INSERT INTO parts (part_id, upload_id, part_number, ipfs_cid, size_bytes, etag, uploaded_at, object_id, cid_id, chunk_size_bytes)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        ON CONFLICT (object_id, part_number) DO UPDATE SET
+            ipfs_cid = EXCLUDED.ipfs_cid,
+            size_bytes = EXCLUDED.size_bytes,
+            etag = EXCLUDED.etag,
+            uploaded_at = EXCLUDED.uploaded_at,
+            cid_id = EXCLUDED.cid_id,
+            chunk_size_bytes = EXCLUDED.chunk_size_bytes
+        """,
+        str(uuid.uuid4()),
+        upload_id,
+        int(part_number),
+        placeholder_cid,
+        int(size_bytes),
+        etag,
+        now,
+        object_id,
+        cid_id,
+        int(chunk_size_bytes),
+    )

--- a/hippius_s3/sql/migrations/20251003000000_create_part_chunks.sql
+++ b/hippius_s3/sql/migrations/20251003000000_create_part_chunks.sql
@@ -3,8 +3,6 @@
 
 -- migrate:up
 
-BEGIN;
-
 CREATE TABLE IF NOT EXISTS part_chunks (
   id BIGSERIAL PRIMARY KEY,
   part_id UUID NOT NULL REFERENCES parts(part_id) ON DELETE CASCADE,
@@ -29,11 +27,7 @@ LEFT JOIN cids c ON p.cid_id = c.id
 WHERE (p.ipfs_cid IS NOT NULL AND p.ipfs_cid <> '') OR p.cid_id IS NOT NULL
 ON CONFLICT (part_id, chunk_index) DO NOTHING;
 
-COMMIT;
-
 -- migrate:down
 
-BEGIN;
 DROP INDEX IF EXISTS part_chunks_part_idx;
 DROP TABLE IF EXISTS part_chunks;
-COMMIT;

--- a/hippius_s3/sql/migrations/20251006000000_add_chunk_size_to_parts.sql
+++ b/hippius_s3/sql/migrations/20251006000000_add_chunk_size_to_parts.sql
@@ -1,0 +1,37 @@
+-- migrate:up
+
+ALTER TABLE parts ADD COLUMN chunk_size_bytes INTEGER;
+
+-- Backfill chunk_size_bytes for existing parts
+-- For parts with exactly 1 chunk, set chunk_size_bytes = size_bytes (migrated single-chunk parts)
+UPDATE parts p
+SET chunk_size_bytes = p.size_bytes
+WHERE chunk_size_bytes IS NULL
+  AND EXISTS (
+    SELECT 1 FROM part_chunks pc
+    WHERE pc.part_id = p.part_id
+    GROUP BY pc.part_id
+    HAVING COUNT(*) = 1
+  );
+
+-- For parts with multiple chunks, calculate chunk_size from plaintext size and chunk count
+-- We use GREATEST to ensure we get at least 1 to avoid division issues
+UPDATE parts p
+SET chunk_size_bytes = CEIL(p.size_bytes::numeric / GREATEST(
+  (SELECT COUNT(*) FROM part_chunks WHERE part_id = p.part_id),
+  1
+))::integer
+WHERE chunk_size_bytes IS NULL
+  AND EXISTS (
+    SELECT 1 FROM part_chunks pc
+    WHERE pc.part_id = p.part_id
+    GROUP BY pc.part_id
+    HAVING COUNT(*) > 1
+  );
+
+-- For any remaining parts without part_chunks (edge case), leave NULL
+-- The reader will fall back to config value
+
+-- migrate:down
+
+ALTER TABLE parts DROP COLUMN chunk_size_bytes;

--- a/tests/e2e/test_GetObject_Range.py
+++ b/tests/e2e/test_GetObject_Range.py
@@ -7,6 +7,8 @@ from typing import Callable
 import pytest
 from botocore.exceptions import ClientError
 
+from .support.cache import clear_object_cache
+from .support.cache import get_object_id
 from .support.cache import wait_for_parts_cids
 
 
@@ -46,6 +48,71 @@ def test_get_object_range_valid(
     resp3 = boto3_client.get_object(Bucket=bucket, Key=key, Range="bytes=-5")
     assert resp3["ResponseMetadata"]["HTTPStatusCode"] == 206
     assert resp3["Body"].read() == data[-5:]
+
+
+@pytest.mark.local
+def test_range_downloads_only_needed_chunks(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+    signed_http_get: Any,
+) -> None:
+    """After clearing cache, a small range should only materialize the in-range chunk(s)."""
+    try:
+        import redis  # type: ignore[import-untyped]
+    except Exception:
+        pytest.skip("redis client unavailable")
+
+    bucket = unique_bucket_name("range-chunk-only")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+
+    # Create a single large part (>= 2 chunks with default 4MiB chunk_size)
+    part_size = 4 * 1024 * 1024
+    key = "large/single-part.bin"
+    body = b"A" * (part_size * 2 + 123)  # a bit over 2 chunks
+    boto3_client.put_object(Bucket=bucket, Key=key, Body=body, ContentType="application/octet-stream")
+
+    # Ensure server processed it
+    assert wait_for_parts_cids(bucket, key, min_count=1, timeout_seconds=20.0)
+
+    # Clear all cache for this object
+    object_id = get_object_id(bucket, key)
+    clear_object_cache(object_id)
+
+    # Request a small range within the first chunk
+    r = signed_http_get(bucket, key, {"Range": "bytes=0-1048575"})
+    assert r.status_code == 206
+    assert r.headers.get("x-hippius-source") in {"pipeline", "cache"}
+
+    # Inspect Redis for which chunk keys were created
+    rcli = redis.Redis.from_url("redis://localhost:6379/0")
+    keys = sorted(
+        [
+            k.decode()
+            for k in rcli.scan_iter(match=f"obj:{object_id}:part:1:chunk:*", count=1000)  # 1-based part number
+        ]
+    )
+    # Expect at minimum chunk:0 exists for the first-range request
+    # (downloader may prefetch additional chunks, but the in-range chunk must be present)
+    expected_chunk = f"obj:{object_id}:part:1:chunk:0"
+    assert expected_chunk in keys, f"expected chunk {expected_chunk} not found in {keys}"
+    # Verify minimal hydration: should not have fetched chunks far outside the range
+    # (allow adjacent chunks due to prefetch, but not all chunks)
+    assert len(keys) <= 3, f"too many chunks hydrated: {keys}"
+
+    # Clear cache again and request middle of the second chunk
+    clear_object_cache(object_id)
+    start = part_size + 256 * 1024
+    end = start + 128 * 1024 - 1
+    r2 = signed_http_get(bucket, key, {"Range": f"bytes={start}-{end}"})
+    assert r2.status_code == 206
+    keys2 = sorted([k.decode() for k in rcli.scan_iter(match=f"obj:{object_id}:part:1:chunk:*", count=1000)])
+    expected_chunk2 = f"obj:{object_id}:part:1:chunk:1"
+    assert expected_chunk2 in keys2, f"expected chunk {expected_chunk2} not found in {keys2}"
+    # Verify minimal hydration: should not have fetched all chunks
+    assert len(keys2) <= 3, f"too many chunks hydrated: {keys2}"
 
 
 def test_get_object_range_invalid(

--- a/uv.lock
+++ b/uv.lock
@@ -828,7 +828,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "gunicorn", specifier = ">=21.2.0" },
     { name = "hippius" },
-    { name = "hippius", extras = ["key-storage"], specifier = ">=0.2.61" },
+    { name = "hippius", extras = ["key-storage"], specifier = ">=0.2.62" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "lxml", specifier = ">=4.9.3" },
     { name = "minio", marker = "extra == 'dev'", specifier = ">=7.1.15" },

--- a/workers/run_downloader_in_loop.py
+++ b/workers/run_downloader_in_loop.py
@@ -63,7 +63,7 @@ async def process_download_request(
         async def download_chunk(chunk):
             chunk_logger = logging.getLogger(__name__)
             async with semaphore:
-                # Build per-part download plan from DB
+                # Build per-part download plan from DB; optionally restrict to in-range chunk indices
                 cid_plan: list[tuple[int, str, int | None]] = []
                 try:
                     rows = await db.fetch(
@@ -71,26 +71,65 @@ async def process_download_request(
                         download_request.object_id,
                         int(chunk.part_id),
                     )
-                    cid_plan.extend((int(r[0]), str(r[1]), int(r[2]) if r[2] is not None else None) for r in rows or [])
+                    all_entries = [(int(r[0]), str(r[1]), int(r[2]) if r[2] is not None else None) for r in rows or []]
+                    # Restrict to requested indices if provided
+                    if getattr(chunk, "chunk_indices", None):
+                        idx_set = set(int(i) for i in chunk.chunk_indices or [])
+                        cid_plan.extend([e for e in all_entries if e[0] in idx_set])
+                        # Check for missing indices; do NOT backfill unless flag allows
+                        if idx_set:
+                            found_indices = {e[0] for e in cid_plan}
+                            missing_indices = idx_set - found_indices
+                            if missing_indices and chunk.cid:
+                                if getattr(config, "downloader_allow_part_backfill", False):
+                                    chunk_logger.warning(
+                                        f"ALLOW_BACKFILL enabled: attempting to backfill missing indices {sorted(missing_indices)} from part CID for part {chunk.part_id}"
+                                    )
+                                    try:
+                                        from hippius_s3.metadata.meta_reader import read_db_meta
+
+                                        db_meta = await read_db_meta(db, download_request.object_id, int(chunk.part_id))
+                                        chunk_size = (
+                                            int(db_meta["chunk_size_bytes"])
+                                            if db_meta and db_meta["chunk_size_bytes"]
+                                            else 0
+                                        )
+                                    except Exception:
+                                        chunk_size = 0
+                                    if chunk_size <= 0:
+                                        # Cannot backfill without authoritative chunk size
+                                        raise RuntimeError("chunk_size_bytes_missing")
+                                    for mi in sorted(missing_indices):
+                                        # Plan entries will be fetched as full CID; client lacks range
+                                        cid_plan.append((mi, str(chunk.cid), None))
+                                else:
+                                    # Strict mode: don't guess/backfill; let caller retry later
+                                    raise RuntimeError("missing_requested_chunk_indices")
+                    else:
+                        cid_plan.extend(all_entries)
                 except Exception:
                     cid_plan = []
 
-            # Fallback to single CID if no part_chunks in DB
-            if not cid_plan:
-                cid_str = str(chunk.cid or "").strip().lower()
-                if cid_str in {"", "none", "pending"}:
-                    chunk_logger.error(
-                        f"Skipping download for part {chunk.part_id}: invalid CID '{chunk.cid}' and no part_chunks"
-                    )
-                    # Clear in-progress flag so future attempts aren't blocked by TTL
-                    try:
-                        await redis_client.delete(
-                            f"download_in_progress:{download_request.object_id}:{int(chunk.part_id)}"
+                # Fallback if no part_chunks rows in DB: honor requested indices if provided, else default to index 0
+                if not cid_plan:
+                    cid_str = str(chunk.cid or "").strip().lower()
+                    if cid_str in {"", "none", "pending"}:
+                        chunk_logger.error(
+                            f"Skipping download for part {chunk.part_id}: invalid CID '{chunk.cid}' and no part_chunks"
                         )
-                    except Exception:
-                        chunk_logger.debug("Failed to delete in-progress flag for invalid CID", exc_info=True)
-                    return False
-                cid_plan = [(0, str(chunk.cid), None)]
+                        # Clear in-progress flag so future attempts aren't blocked by TTL
+                        try:
+                            await redis_client.delete(
+                                f"download_in_progress:{download_request.object_id}:{int(chunk.part_id)}"
+                            )
+                        except Exception:
+                            chunk_logger.debug("Failed to delete in-progress flag for invalid CID", exc_info=True)
+                        return False
+                    requested = list(getattr(chunk, "chunk_indices", []) or [])
+                    if requested:
+                        cid_plan = [(int(i), str(chunk.cid), None) for i in requested]
+                    else:
+                        cid_plan = [(0, str(chunk.cid), None)]
 
             max_attempts = getattr(config, "downloader_chunk_retries", 5)
             base_sleep = getattr(config, "downloader_retry_base_seconds", 0.25)
@@ -109,25 +148,49 @@ async def process_download_request(
                     )
 
                     # Download per plan entry (DB-driven chunk layout if available)
-                    assembled: list[bytes] = []
+                    # Deduplicate CID fetches to avoid redundant IPFS downloads
+                    cid_cache: dict[str, bytes] = {}
+                    assembled: list[tuple[int, bytes]] = []  # (chunk_index, data)
+
+                    # Derive authoritative chunk_size from DB plan if provided (third column)
+                    auth_chunk_size = 0
+                    try:
+                        for _ci, _cidv, _exp in cid_plan:
+                            if _exp is not None and int(_exp) > 0:
+                                auth_chunk_size = int(_exp)
+                                break
+                    except Exception:
+                        auth_chunk_size = 0
+
                     for ci, cid_val, expected_len in cid_plan:
                         chunk_logger.debug(
                             f"Downloading part {chunk.part_id} ci={ci} CID={cid_val[:10]}... expected={expected_len}"
                         )
-                        data_i = await hippius_client.s3_download(
-                            cid=cid_val,
-                            subaccount_id=download_request.subaccount,
-                            bucket_name=download_request.bucket_name,
-                            auto_decrypt=False,
-                            download_node=download_request.ipfs_node,
-                            return_bytes=True,
-                        )
+                        # Check if we already fetched this CID
+                        if cid_val in cid_cache:
+                            data_i = cid_cache[cid_val]
+                            chunk_logger.debug(f"Using cached CID data for ci={ci}")
+                        else:
+                            data_i = await hippius_client.s3_download(
+                                cid=cid_val,
+                                subaccount_id=download_request.subaccount,
+                                bucket_name=download_request.bucket_name,
+                                auto_decrypt=False,
+                                download_node=download_request.ipfs_node,
+                                return_bytes=True,
+                            )
+                            cid_cache[cid_val] = data_i
+
                         if expected_len is not None and len(data_i) != int(expected_len):
                             chunk_logger.warning(
                                 f"Cipher len mismatch for part {chunk.part_id} ci={ci}: got={len(data_i)} expected={expected_len}"
                             )
-                        assembled.append(data_i)
-                    chunk_data = b"".join(assembled)
+                        assembled.append((ci, data_i))
+
+                    # Sort by chunk index and concatenate; also map by index for targeted writes
+                    assembled.sort(key=lambda x: x[0])
+                    by_index: dict[int, bytes] = {int(i): bytes(d) for i, d in assembled}
+                    chunk_data = b"".join([data for _, data in assembled])
 
                     md5 = _hashlib.md5(chunk_data).hexdigest()
                     head_hex = chunk_data[:8].hex()
@@ -140,32 +203,70 @@ async def process_download_request(
                     # Store bytes in Redis cache with meta-first write order (readiness signal before chunks)
                     part_num = int(chunk.part_id)
                     if cid_plan and len(cid_plan) > 1:
-                        # Multiple chunks in DB: write meta first, then chunk keys
+                        # Multiple chunks in DB: ensure non-zero chunk_size and prefer DB count
+                        eff_chunk_size = auth_chunk_size
+                        db_chunks = 0
+                        if eff_chunk_size <= 0:
+                            try:
+                                from hippius_s3.metadata.meta_reader import read_db_meta  # local import
+
+                                db_meta = await read_db_meta(db, download_request.object_id, part_num)
+                                if db_meta:
+                                    eff_chunk_size = int(db_meta.get("chunk_size_bytes") or 0)
+                                    db_chunks = int(db_meta.get("num_chunks_db") or 0)
+                            except Exception:
+                                eff_chunk_size = 0
+                        if eff_chunk_size <= 0:
+                            eff_chunk_size = int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024))
+
                         await obj_cache.set_meta(
                             download_request.object_id,
                             part_num,
-                            chunk_size=getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024),
-                            num_chunks=len(cid_plan),
+                            chunk_size=eff_chunk_size,
+                            # Prefer DB total; if unknown, keep 0 (reader polls per-chunk)
+                            num_chunks=db_chunks,
                             size_bytes=len(chunk_data),
                         )
-                        for idx, (ci, _cid, _exp) in enumerate(cid_plan):
-                            data_i = assembled[idx] if idx < len(assembled) else b""
+                        for ci, _cid, _exp in cid_plan:
+                            data_i = by_index.get(int(ci), b"")
                             await obj_cache.set_chunk(download_request.object_id, part_num, int(ci), data_i)
                         chunk_logger.info(
                             f"OBJ-CACHE stored (DB layout) object_id={download_request.object_id} part={part_num} ct_chunks={len(cid_plan)} total_bytes={len(chunk_data)}"
                         )
                     else:
-                        # Single-chunk case: write meta first, then chunk at index 0
+                        # Single-chunk case: write meta first, then chunk at the requested index (default 0)
+                        # Ensure meta reflects at least the requested index (e.g., idx=1 => num_chunks >= 2)
+                        target_index = int(cid_plan[0][0]) if cid_plan else 0
+
+                        # If chunk_size not known from DB plan, try to read authoritative value from DB meta
+                        eff_chunk_size = auth_chunk_size
+                        if eff_chunk_size <= 0:
+                            try:
+                                from hippius_s3.metadata.meta_reader import read_db_meta  # local import to avoid cycles
+
+                                db_meta = await read_db_meta(db, download_request.object_id, int(chunk.part_id))
+                                eff_chunk_size = (
+                                    int(db_meta["chunk_size_bytes"])
+                                    if db_meta and db_meta.get("chunk_size_bytes")
+                                    else 0
+                                )
+                            except Exception:
+                                eff_chunk_size = 0
+                        if eff_chunk_size <= 0:
+                            # Final fallback to configured chunk size to avoid stalling range math
+                            eff_chunk_size = int(getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024))
+
                         await obj_cache.set_meta(
                             download_request.object_id,
                             part_num,
-                            chunk_size=getattr(config, "object_chunk_size_bytes", 4 * 1024 * 1024),
-                            num_chunks=1,
+                            chunk_size=eff_chunk_size,
+                            num_chunks=max(1, target_index + 1),
                             size_bytes=len(chunk_data),
                         )
-                        await obj_cache.set_chunk(download_request.object_id, part_num, 0, chunk_data)
+                        data_i = by_index.get(target_index, chunk_data)
+                        await obj_cache.set_chunk(download_request.object_id, part_num, target_index, data_i)
                         chunk_logger.info(
-                            f"OBJ-CACHE stored (single) object_id={download_request.object_id} part={part_num} bytes={len(chunk_data)}"
+                            f"OBJ-CACHE stored (single) object_id={download_request.object_id} part={part_num} idx={target_index} bytes={len(data_i)}"
                         )
                     # Log download timing
                     chunk_ms = (_dtime.perf_counter() - chunk_start) * 1000.0

--- a/workers/run_downloader_in_loop.py
+++ b/workers/run_downloader_in_loop.py
@@ -74,7 +74,7 @@ async def process_download_request(
                     all_entries = [(int(r[0]), str(r[1]), int(r[2]) if r[2] is not None else None) for r in rows or []]
                     # Restrict to requested indices if provided
                     if getattr(chunk, "chunk_indices", None):
-                        idx_set = set(int(i) for i in chunk.chunk_indices or [])
+                        idx_set = {int(i) for i in chunk.chunk_indices or []}
                         cid_plan.extend([e for e in all_entries if e[0] in idx_set])
                         # Check for missing indices; do NOT backfill unless flag allows
                         if idx_set:
@@ -99,9 +99,7 @@ async def process_download_request(
                                     if chunk_size <= 0:
                                         # Cannot backfill without authoritative chunk size
                                         raise RuntimeError("chunk_size_bytes_missing")
-                                    for mi in sorted(missing_indices):
-                                        # Plan entries will be fetched as full CID; client lacks range
-                                        cid_plan.append((mi, str(chunk.cid), None))
+                                    cid_plan.extend((mi, str(chunk.cid), None) for mi in sorted(missing_indices))
                                 else:
                                     # Strict mode: don't guess/backfill; let caller retry later
                                     raise RuntimeError("missing_requested_chunk_indices")


### PR DESCRIPTION
Range-aware downloader: minimal per-part chunk hydration for Range requests; bounded polling; chunk-level decrypt; no overfetch
Parts placeholder service: central upsert_part_placeholder; API PUT/multipart/append create part rows atomically before enqueue
Manifest: defer build until all parts have concrete CIDs
Object reader: computes plaintext sizes safely, plans per-range indices, streams with chunk-ready checks
Config hardening: runtime fallback for HIPPIUS_KEYSTORE_DATABASE_URL; publish_to_chain preserved; sane defaults
Compose (e2e): auto-create hippius_net, proper depends_on, optional toxiproxy port, DLQ mounts
Migrations: part_chunks support and chunk_size_bytes on parts with backfill
Tests: add range-download minimal hydration test
Operational notes:
PUBLISH_TO_CHAIN=false respected by substrate worker in e2e