### PR TITLE
fix: echo Origin header for presigned URLs

### DIFF
--- a/gateway/middlewares/cors.py
+++ b/gateway/middlewares/cors.py
@@ -26,7 +26,9 @@ async def cors_middleware(
         response = await call_next(request)
 
     # Add CORS headers to ALL responses (including OPTIONS)
-    response.headers["Access-Control-Allow-Origin"] = "*"
+    origin = request.headers.get("origin")
+    response.headers["Access-Control-Allow-Origin"] = origin if origin else "*"
+    response.headers["Access-Control-Allow-Credentials"] = "true"
     response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, HEAD, OPTIONS"
     response.headers["Access-Control-Allow-Headers"] = "*"
     response.headers["Access-Control-Expose-Headers"] = "*"


### PR DESCRIPTION
Replaces hardcoded `*` with dynamic Origin echo in CORS middleware to support presigned URL uploads from browser clients like localhost:3000. Also adds Access-Control-Allow-Credentials: true.