### PR TITLE
Add PgBouncer connection proxy (staging only)

### DIFF
--- a/.github/workflows/k8s-deploy.yaml
+++ b/.github/workflows/k8s-deploy.yaml
@@ -189,10 +189,9 @@ jobs:
         run: |
           PG_MD5=$(echo -n "${{ secrets.DATABASE_PASSWORD }}postgres" | md5sum | cut -d' ' -f1)
           ADMIN_MD5=$(echo -n "${{ secrets.DATABASE_PASSWORD }}pgbouncer_admin" | md5sum | cut -d' ' -f1)
-          USERLIST="\"postgres\" \"md5${PG_MD5}\"
-          \"pgbouncer_admin\" \"md5${ADMIN_MD5}\""
+          printf '"postgres" "md5%s"\n"pgbouncer_admin" "md5%s"\n' "${PG_MD5}" "${ADMIN_MD5}" > /tmp/userlist.txt
           kubectl create secret generic pgbouncer-userlist \
-            --from-literal=userlist.txt="${USERLIST}" \
+            --from-file=userlist.txt=/tmp/userlist.txt \
             --namespace=hippius-s3-staging \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/.github/workflows/k8s-deploy.yaml
+++ b/.github/workflows/k8s-deploy.yaml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Update secrets
         run: |
-          DATABASE_URL="postgresql://postgres:${{ secrets.DATABASE_PASSWORD }}@postgres-rw:5432/hippius?sslmode=disable"
+          DATABASE_URL="postgresql://postgres:${{ secrets.DATABASE_PASSWORD }}@pgbouncer:5432/hippius?sslmode=disable"
 
           kubectl create secret generic hippius-s3-secrets \
             --from-literal=DATABASE_PASSWORD='${{ secrets.DATABASE_PASSWORD }}' \
@@ -182,6 +182,17 @@ jobs:
           kubectl create secret generic postgres-backup-creds \
             --from-literal=ACCESS_KEY_ID='${{ secrets.OVH_BACKUP_ACCESS_KEY_ID }}' \
             --from-literal=ACCESS_KEY_SECRET='${{ secrets.OVH_BACKUP_SECRET_ACCESS_KEY }}' \
+            --namespace=hippius-s3-staging \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create pgbouncer userlist secret
+        run: |
+          PG_MD5=$(echo -n "${{ secrets.DATABASE_PASSWORD }}postgres" | md5sum | cut -d' ' -f1)
+          ADMIN_MD5=$(echo -n "${{ secrets.DATABASE_PASSWORD }}pgbouncer_admin" | md5sum | cut -d' ' -f1)
+          USERLIST="\"postgres\" \"md5${PG_MD5}\"
+          \"pgbouncer_admin\" \"md5${ADMIN_MD5}\""
+          kubectl create secret generic pgbouncer-userlist \
+            --from-literal=userlist.txt="${USERLIST}" \
             --namespace=hippius-s3-staging \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -15,8 +15,6 @@ resources:
   - api-deployment.yaml
   - gateway-deployment.yaml
   - workers-deployments.yaml
-  - pgbouncer-configmap.yaml
-  - pgbouncer-deployment.yaml
   - services.yaml
   - ingress.yaml
   - networkpolicy.yaml

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -15,6 +15,8 @@ resources:
   - api-deployment.yaml
   - gateway-deployment.yaml
   - workers-deployments.yaml
+  - pgbouncer-configmap.yaml
+  - pgbouncer-deployment.yaml
   - services.yaml
   - ingress.yaml
   - networkpolicy.yaml

--- a/k8s/base/pgbouncer-configmap.yaml
+++ b/k8s/base/pgbouncer-configmap.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pgbouncer-config
+data:
+  pgbouncer.ini: |
+    [databases]
+    hippius = host=postgres-rw port=5432 dbname=hippius
+
+    [pgbouncer]
+    listen_addr = 0.0.0.0
+    listen_port = 5432
+    auth_type = md5
+    auth_file = /etc/pgbouncer/userlist.txt
+
+    ; Pool mode: transaction releases backend connections after each transaction.
+    ; Critical for PAUSE/RESUME to complete quickly during switchovers.
+    pool_mode = transaction
+
+    ; Connection limits
+    max_client_conn = 300
+    default_pool_size = 20
+    min_pool_size = 5
+    reserve_pool_size = 5
+    reserve_pool_timeout = 3
+    max_db_connections = 150
+
+    ; asyncpg uses prepared statements by default (cache size 100).
+    ; PgBouncer 1.22+ tracks and replays prepared statements across
+    ; backend connections in transaction mode.
+    max_prepared_statements = 100
+
+    ; Reset session state when a backend connection is returned to the pool.
+    server_reset_query = DISCARD ALL
+
+    ; Health check on idle backend connections
+    server_check_query = SELECT 1
+    server_check_delay = 10
+
+    ; Timeouts
+    server_connect_timeout = 15
+    server_idle_timeout = 600
+    server_lifetime = 3600
+    server_login_retry = 5
+    client_idle_timeout = 0
+    query_wait_timeout = 180
+
+    ; Short DNS TTL for fast backend hostname resolution after RELOAD
+    dns_max_ttl = 15
+
+    ; Admin access for PAUSE/RESUME/RELOAD commands
+    admin_users = pgbouncer_admin
+    stats_users = pgbouncer_admin
+
+    ; Logging
+    log_connections = 0
+    log_disconnections = 0
+    log_pooler_errors = 1
+    stats_period = 60
+    verbose = 0

--- a/k8s/base/pgbouncer-deployment.yaml
+++ b/k8s/base/pgbouncer-deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgbouncer
+  labels:
+    app: pgbouncer
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pgbouncer
+  template:
+    metadata:
+      labels:
+        app: pgbouncer
+    spec:
+      containers:
+        - name: pgbouncer
+          image: bitnami/pgbouncer:1.25.0
+          ports:
+            - containerPort: 5432
+              name: pgbouncer
+          env:
+            - name: PGBOUNCER_CONF_FILE
+              value: /etc/pgbouncer/pgbouncer.ini
+            - name: PGBOUNCER_AUTH_FILE
+              value: /etc/pgbouncer/userlist.txt
+          volumeMounts:
+            - name: pgbouncer-config
+              mountPath: /etc/pgbouncer/pgbouncer.ini
+              subPath: pgbouncer.ini
+              readOnly: true
+            - name: pgbouncer-userlist
+              mountPath: /etc/pgbouncer/userlist.txt
+              subPath: userlist.txt
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          readinessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 5432
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 3
+      volumes:
+        - name: pgbouncer-config
+          configMap:
+            name: pgbouncer-config
+        - name: pgbouncer-userlist
+          secret:
+            secretName: pgbouncer-userlist
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgbouncer
+  labels:
+    app: pgbouncer
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+      name: pgbouncer
+  selector:
+    app: pgbouncer

--- a/k8s/base/pgbouncer-deployment.yaml
+++ b/k8s/base/pgbouncer-deployment.yaml
@@ -16,15 +16,10 @@ spec:
     spec:
       containers:
         - name: pgbouncer
-          image: bitnami/pgbouncer:1.25.0
+          image: edoburu/pgbouncer:1.25.0-p0
           ports:
             - containerPort: 5432
               name: pgbouncer
-          env:
-            - name: PGBOUNCER_CONF_FILE
-              value: /etc/pgbouncer/pgbouncer.ini
-            - name: PGBOUNCER_AUTH_FILE
-              value: /etc/pgbouncer/userlist.txt
           volumeMounts:
             - name: pgbouncer-config
               mountPath: /etc/pgbouncer/pgbouncer.ini

--- a/k8s/staging/kustomization.yaml
+++ b/k8s/staging/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - ../base
   - gateway-nodeport.yaml
   - postgres-objectstore.yaml
+  - ../base/pgbouncer-configmap.yaml
+  - ../base/pgbouncer-deployment.yaml
 
 patches:
   - path: namespace-patch.yaml


### PR DESCRIPTION
## Summary

Deploys PgBouncer as a connection proxy between application pods and PostgreSQL on staging. This enables zero-downtime database switchovers via PAUSE/RESUME — critical for the upcoming CephFS-to-NVMe PostgreSQL migration.

## Changes

- Add PgBouncer deployment (2 replicas) with ClusterIP service on port 5432
- Add PgBouncer configuration: transaction pool mode, prepared statement support for asyncpg, admin access for PAUSE/RESUME/RELOAD
- Route staging DATABASE_URL through PgBouncer (`pgbouncer:5432` instead of `postgres-rw:5432`)
- Add CI/CD step to create `pgbouncer-userlist` secret with md5 password hashes
- PgBouncer resources scoped to staging kustomization only — production is untouched

## Configuration highlights

- `pool_mode = transaction` — server connections released after each transaction, enables fast PAUSE/RESUME
- `max_prepared_statements = 100` — asyncpg prepared statement compatibility in transaction mode
- `query_wait_timeout = 180` — clients wait up to 3 min during PAUSE before error
- `max_client_conn = 300`, `max_db_connections = 150` — sized for staging load
- `server_reset_query = DISCARD ALL` — clean session state on connection return

## Switchover workflow (after validation)

```
PAUSE hippius → change backend in ConfigMap → RELOAD → RESUME hippius
```

Total client-visible impact: ~10-30 second pause, no errors, no retries.

## What's next

After staging validation, replicate to production, then use PgBouncer to perform the zero-downtime CephFS → NVMe PostgreSQL switchover.