### PR TITLE
perf(downloader): multi-DCR inflight pool + chunk batching

### DIFF
--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -180,6 +180,12 @@ class Config:
     downloader_retry_base_seconds: float = env("DOWNLOADER_RETRY_BASE_SECONDS:0.1", convert=float)
     downloader_retry_jitter_seconds: float = env("DOWNLOADER_RETRY_JITTER_SECONDS:0.1", convert=float)
     downloader_semaphore: int = env("DOWNLOADER_SEMAPHORE:20", convert=int)
+    # Max concurrent DownloadChainRequests a single downloader pod processes.
+    # The main loop dequeues and spawns tasks up to this cap; the semaphore
+    # above still bounds total concurrent chunk fetches across all tasks.
+    # Range-heavy read patterns produce many 1-part DCRs, so parallelising
+    # DCRs is what delivers real backend throughput.
+    downloader_max_inflight: int = env("DOWNLOADER_MAX_INFLIGHT:10", convert=int)
     # When multiple streamers hit a cache miss on the same part concurrently,
     # only one enqueues a DownloadChainRequest; the others wait via pub/sub.
     # The Redis lock that enforces this is cleared by the downloader on

--- a/hippius_s3/workers/downloader.py
+++ b/hippius_s3/workers/downloader.py
@@ -413,19 +413,47 @@ async def run_downloader_loop(
 
     max_inflight = max(1, config.downloader_max_inflight)
     inflight: set[asyncio.Task[None]] = set()
+    # Flags set by _reap when an inflight task died on an infra error. The
+    # main loop picks these up and rebuilds the affected client before
+    # dequeuing the next request, so subsequent tasks don't keep failing
+    # against a stale connection.
+    needs_redis_reconnect = False
+    needs_db_reconnect = False
 
     def _reap(tasks: set[asyncio.Task[None]]) -> None:
+        nonlocal needs_redis_reconnect, needs_db_reconnect
         for t in tasks:
             inflight.discard(t)
             err = t.exception()
-            if err is not None and not isinstance(err, asyncio.CancelledError):
-                logger.error(f"[{backend_name}] inflight task error: {err}")
+            if err is None or isinstance(err, asyncio.CancelledError):
+                continue
+            logger.error(f"[{backend_name}] inflight task error: {err}")
+            if isinstance(err, (BusyLoadingError, RedisConnectionError, RedisTimeoutError)):
+                needs_redis_reconnect = True
+            elif isinstance(err, asyncpg.InterfaceError):
+                needs_db_reconnect = True
 
     logger.info(f"[{backend_name}] Inflight pool size: {max_inflight}")
 
     try:
         while True:
             _reap({t for t in inflight if t.done()})
+
+            if needs_redis_reconnect:
+                logger.warning(f"[{backend_name}] Rebuilding cache redis client after task error")
+                with contextlib.suppress(Exception):
+                    await redis_client.aclose()  # ty: ignore[unresolved-attribute]
+                redis_client = create_redis_client(config.redis_url)  # ty: ignore[invalid-assignment]
+                initialize_cache_client(redis_client)
+                obj_cache = RedisObjectPartsCache(redis_client, queues_client=redis_queues_client, fs_store=fs_store)
+                needs_redis_reconnect = False
+
+            if needs_db_reconnect:
+                logger.warning(f"[{backend_name}] Recreating DB pool after task error")
+                with contextlib.suppress(Exception):
+                    await db_pool.close()
+                db_pool = await asyncpg.create_pool(config.database_url, min_size=2, max_size=20)
+                needs_db_reconnect = False
 
             if len(inflight) >= max_inflight:
                 done_wait, _ = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)

--- a/hippius_s3/workers/downloader.py
+++ b/hippius_s3/workers/downloader.py
@@ -270,9 +270,17 @@ async def process_download_request(
                     except Exception as meta_exc:
                         logger.warning(f"[{backend_name}] Failed to write eager meta part={part_number}: {meta_exc}")
 
-                chunk_results = await asyncio.gather(
-                    *[_fetch_chunk(part_number, spec, part_span) for spec in part.chunks]
-                )
+                # Batch chunks so a pathological single-part (up to ~1280
+                # chunks for a 5 GiB part at 4 MiB chunk size) doesn't create
+                # thousands of tasks parked on the semaphore. Matches the
+                # part-batching budget so the worst case per part is capped.
+                chunk_batch_size = max(1, config.downloader_semaphore)
+                chunk_results: list[bool] = []
+                for i in range(0, len(part.chunks), chunk_batch_size):
+                    batch = part.chunks[i : i + chunk_batch_size]
+                    chunk_results.extend(
+                        await asyncio.gather(*[_fetch_chunk(part_number, spec, part_span) for spec in batch])
+                    )
 
                 # Release the coalescing lock (set by build_stream_context on
                 # enqueue). Key format must match that callsite exactly.
@@ -369,8 +377,61 @@ async def run_downloader_loop(
         backend_info = f" base_url={config.arion_base_url} verify_ssl={config.arion_verify_ssl}"
         logger.info(f"[{backend_name}] Starting downloader, queue={queue_name}{backend_info}")
 
+    async def _run_job(request: DownloadChainRequest) -> None:
+        ray_id = request.ray_id or "no-ray-id"
+        ray_id_context.set(ray_id)
+        worker_logger = get_logger_with_ray_id(__name__, ray_id)
+
+        with tracer.start_as_current_span(
+            "downloader.job",
+            attributes={
+                "object_id": request.object_id,
+                "hippius.ray_id": ray_id,
+                "backend": backend_name,
+                "hippius.account.main": request.address,
+            },
+        ) as job_span:
+            try:
+                ok = await process_download_request(
+                    request,
+                    backend_name=backend_name,
+                    fetch_fn=fetch_fn,
+                    db_pool=db_pool,
+                    obj_cache=obj_cache,
+                    fs_store=fs_store,
+                )
+                if ok:
+                    worker_logger.info(f"[{backend_name}] Done: {request.bucket_name}/{request.object_key}")
+                else:
+                    job_span.set_status(trace.StatusCode.ERROR, "partial failure")
+                    worker_logger.error(f"[{backend_name}] Failed: {request.bucket_name}/{request.object_key}")
+            except Exception as exc:
+                job_span.record_exception(exc)
+                job_span.set_status(trace.StatusCode.ERROR, str(exc))
+                worker_logger.error(f"[{backend_name}] job error: {exc}", exc_info=True)
+                raise
+
+    max_inflight = max(1, config.downloader_max_inflight)
+    inflight: set[asyncio.Task[None]] = set()
+
+    def _reap(tasks: set[asyncio.Task[None]]) -> None:
+        for t in tasks:
+            inflight.discard(t)
+            err = t.exception()
+            if err is not None and not isinstance(err, asyncio.CancelledError):
+                logger.error(f"[{backend_name}] inflight task error: {err}")
+
+    logger.info(f"[{backend_name}] Inflight pool size: {max_inflight}")
+
     try:
         while True:
+            _reap({t for t in inflight if t.done()})
+
+            if len(inflight) >= max_inflight:
+                done_wait, _ = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
+                _reap(done_wait)
+                continue
+
             try:
                 request = await dequeue_download_request(queue_name)
             except (BusyLoadingError, RedisConnectionError, RedisTimeoutError) as exc:
@@ -386,61 +447,30 @@ async def run_downloader_loop(
                 continue
 
             if request is None:
-                await asyncio.sleep(config.downloader_sleep_loop)
+                # Nothing to pick up. If we have inflight work, wait on it
+                # instead of sleeping — keeps the loop responsive to task
+                # completions without an idle poll.
+                if inflight:
+                    done_wait, _ = await asyncio.wait(
+                        inflight, return_when=asyncio.FIRST_COMPLETED, timeout=config.downloader_sleep_loop
+                    )
+                    _reap(done_wait)
+                else:
+                    await asyncio.sleep(config.downloader_sleep_loop)
                 continue
 
             if request.expire_at and time.time() > request.expire_at:
                 logger.warning(f"[{backend_name}] Discarding expired request {request.name}")
                 continue
 
-            ray_id = request.ray_id or "no-ray-id"
-            ray_id_context.set(ray_id)
-            worker_logger = get_logger_with_ray_id(__name__, ray_id)
-
-            with tracer.start_as_current_span(
-                "downloader.job",
-                attributes={
-                    "object_id": request.object_id,
-                    "hippius.ray_id": ray_id,
-                    "backend": backend_name,
-                    "hippius.account.main": request.address,
-                },
-            ) as job_span:
-                try:
-                    ok = await process_download_request(
-                        request,
-                        backend_name=backend_name,
-                        fetch_fn=fetch_fn,
-                        db_pool=db_pool,
-                        obj_cache=obj_cache,
-                        fs_store=fs_store,
-                    )
-                    if ok:
-                        worker_logger.info(f"[{backend_name}] Done: {request.bucket_name}/{request.object_key}")
-                    else:
-                        job_span.set_status(trace.StatusCode.ERROR, "partial failure")
-                        worker_logger.error(f"[{backend_name}] Failed: {request.bucket_name}/{request.object_key}")
-                except (RedisConnectionError, RedisTimeoutError, BusyLoadingError) as exc:
-                    job_span.record_exception(exc)
-                    job_span.set_status(trace.StatusCode.ERROR, str(exc))
-                    logger.warning(f"[{backend_name}] Redis issue during processing: {exc}. Reconnecting…")
-                    with contextlib.suppress(Exception):
-                        await redis_client.aclose()  # ty: ignore[unresolved-attribute]
-                    redis_client = create_redis_client(config.redis_url)  # ty: ignore[invalid-assignment]
-                    initialize_cache_client(redis_client)
-                    obj_cache = RedisObjectPartsCache(
-                        redis_client, queues_client=redis_queues_client, fs_store=fs_store
-                    )
-                except asyncpg.InterfaceError as exc:
-                    job_span.record_exception(exc)
-                    job_span.set_status(trace.StatusCode.ERROR, str(exc))
-                    logger.warning(f"[{backend_name}] DB pool issue, recreating…")
-                    with contextlib.suppress(Exception):
-                        await db_pool.close()
-                    db_pool = await asyncpg.create_pool(config.database_url, min_size=2, max_size=20)
+            inflight.add(asyncio.create_task(_run_job(request)))
 
     except KeyboardInterrupt:
         logger.info(f"[{backend_name}] Downloader stopping…")
+        for t in inflight:
+            t.cancel()
+        if inflight:
+            await asyncio.gather(*inflight, return_exceptions=True)
     except Exception as exc:
         logger.error(f"[{backend_name}] Fatal loop error: {exc}", exc_info=True)
         raise

--- a/tests/unit/test_downloader_batching.py
+++ b/tests/unit/test_downloader_batching.py
@@ -444,3 +444,61 @@ async def test_in_progress_flag_cleared_per_part(mock_metrics, mock_config, fs_s
     )
 
     assert obj_cache.redis.delete.await_count == num_parts
+
+
+@pytest.mark.asyncio
+@patch("hippius_s3.workers.downloader.get_config")
+@patch("hippius_s3.workers.downloader.get_metrics_collector")
+async def test_chunk_batching_caps_concurrent_fetches_per_part(mock_metrics, mock_config, fs_store):
+    """A single part with many chunks must not fire all chunk fetches at once.
+
+    Protects against the pathological case of a 5 GiB part at 4 MiB chunk size
+    (~1280 chunks) creating thousands of tasks parked on the semaphore. The
+    chunk batch size is bound to downloader_semaphore so worst-case in-flight
+    tasks per part is capped.
+    """
+    import asyncio
+
+    semaphore_value = 8
+    chunks_per_part = 50  # Simulate a large single-part DCR
+    config = _make_mock_config(semaphore=semaphore_value)
+    mock_config.return_value = config
+    mock_metrics.return_value = MagicMock()
+
+    concurrent_fetches = 0
+    max_concurrent = 0
+    lock = asyncio.Lock()
+
+    async def tracking_fetch(identifier, account):
+        nonlocal concurrent_fetches, max_concurrent
+        async with lock:
+            concurrent_fetches += 1
+            if concurrent_fetches > max_concurrent:
+                max_concurrent = concurrent_fetches
+        # Give the event loop a chance to schedule more if we weren't capped
+        await asyncio.sleep(0.001)
+        async with lock:
+            concurrent_fetches -= 1
+        return b"x" * 4096
+
+    db_pool = _make_mock_db_pool()
+    obj_cache = _make_mock_obj_cache()
+    request = _make_request(1, chunks_per_part=chunks_per_part)
+
+    result = await process_download_request(
+        request,
+        backend_name="arion",
+        fetch_fn=tracking_fetch,
+        db_pool=db_pool,
+        obj_cache=obj_cache,
+        fs_store=fs_store,
+    )
+
+    assert result is True
+    # All chunks eventually processed
+    for ci in range(chunks_per_part):
+        assert await fs_store.chunk_exists(OBJ, 1, 1, ci)
+    # Concurrent fetches never exceed the batch ceiling (= downloader_semaphore)
+    assert max_concurrent <= semaphore_value, (
+        f"Chunk batching breached: {max_concurrent} concurrent > {semaphore_value} cap"
+    )

--- a/tests/unit/test_downloader_loop.py
+++ b/tests/unit/test_downloader_loop.py
@@ -1,0 +1,303 @@
+"""Tests for run_downloader_loop's inflight pool and reconnect paths.
+
+Verifies:
+- Multiple DownloadChainRequests are processed concurrently (up to max_inflight).
+- The loop waits when at max_inflight capacity before dequeuing more.
+- Redis connection errors from a spawned task trigger redis_client rebuild.
+- asyncpg.InterfaceError from a spawned task triggers DB pool recreation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import asyncpg
+import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from hippius_s3.queue import DownloadChainRequest
+from hippius_s3.queue import PartChunkSpec
+from hippius_s3.queue import PartToDownload
+from hippius_s3.workers.downloader import run_downloader_loop
+
+
+OBJ = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def _make_request(name: str = "req") -> DownloadChainRequest:
+    parts = [PartToDownload(part_number=1, chunks=[PartChunkSpec(index=0, cid=f"cid-{name}")])]
+    return DownloadChainRequest(
+        object_id=OBJ,
+        object_version=1,
+        object_key=f"test/{name}.bin",
+        bucket_name="test-bucket",
+        object_storage_version=5,
+        address="5TestAddr",
+        subaccount="5TestAddr",
+        subaccount_seed_phrase="",
+        substrate_url="http://test",
+        size=4096,
+        multipart=False,
+        chunks=parts,
+    )
+
+
+def _make_loop_config(*, max_inflight: int = 10, semaphore: int = 4, sleep_loop: float = 0.01) -> MagicMock:
+    cfg = MagicMock()
+    cfg.downloader_max_inflight = max_inflight
+    cfg.downloader_semaphore = semaphore
+    cfg.downloader_chunk_retries = 1
+    cfg.downloader_retry_base_seconds = 0.0
+    cfg.downloader_retry_jitter_seconds = 0.0
+    cfg.downloader_sleep_loop = sleep_loop
+    cfg.redis_url = "redis://localhost:6379"
+    cfg.redis_queues_url = "redis://localhost:6382"
+    cfg.database_url = "postgresql://localhost/test"
+    cfg.arion_base_url = "https://arion.test"
+    cfg.arion_verify_ssl = True
+    cfg.object_cache_dir = "/tmp/object_cache_test"
+    cfg.fs_cache_hot_retention_seconds = 3600
+    return cfg
+
+
+class _LoopHarness:
+    """Mocks every external dep run_downloader_loop touches.
+
+    Lets a test script the dequeue sequence, observe spawned tasks, and
+    inspect whether the main loop rebuilt its redis/db clients after task
+    errors. Tests stop the loop by raising KeyboardInterrupt inside
+    dequeue once the test scenario is complete.
+    """
+
+    def __init__(self, *, max_inflight: int = 10, semaphore: int = 4) -> None:
+        self.config = _make_loop_config(max_inflight=max_inflight, semaphore=semaphore)
+        self.dequeue_sequence: list = []  # items: DownloadChainRequest | None | Exception
+        self.process_calls: list[DownloadChainRequest] = []
+        self.process_fn = None  # type: ignore[var-annotated]
+
+        # Track redis/db client rebuild counts
+        self.redis_create_count = 0
+        self.redis_queues_create_count = 0
+        self.db_pool_create_count = 0
+
+    async def _dequeue(self, queue_name: str):
+        # Yield the event loop so spawned _run_job tasks get scheduled.
+        # Real BRPOP always yields; a no-op coroutine would not, and tasks
+        # created via asyncio.create_task inside the main loop would never
+        # run their bodies until the loop terminates.
+        await asyncio.sleep(0)
+        if not self.dequeue_sequence:
+            raise KeyboardInterrupt()
+        item = self.dequeue_sequence.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def _process_download_request(self, request, **_kwargs):
+        self.process_calls.append(request)
+        assert self.process_fn is not None, "Test must set process_fn"
+        return await self.process_fn(request)
+
+    def _create_redis_client(self, *args, **kwargs):
+        self.redis_create_count += 1
+        client = MagicMock()
+        client.aclose = AsyncMock()
+        return client
+
+    def _async_redis_from_url(self, *args, **kwargs):
+        self.redis_queues_create_count += 1
+        client = MagicMock()
+        client.aclose = AsyncMock()
+        return client
+
+    async def _asyncpg_create_pool(self, *args, **kwargs):
+        self.db_pool_create_count += 1
+        pool = MagicMock()
+        pool.close = AsyncMock()
+        return pool
+
+    async def run(self) -> None:
+        """Execute run_downloader_loop under the harness' patches."""
+        with (
+            patch("hippius_s3.workers.downloader.get_config", return_value=self.config),
+            patch("hippius_s3.workers.downloader.create_redis_client", side_effect=self._create_redis_client),
+            patch(
+                "hippius_s3.workers.downloader.async_redis.from_url",
+                side_effect=self._async_redis_from_url,
+            ),
+            patch(
+                "hippius_s3.workers.downloader.asyncpg.create_pool",
+                side_effect=self._asyncpg_create_pool,
+            ),
+            patch("hippius_s3.workers.downloader.create_fs_store", return_value=MagicMock()),
+            patch("hippius_s3.workers.downloader.RedisObjectPartsCache", return_value=MagicMock()),
+            patch("hippius_s3.workers.downloader.process_download_request", side_effect=self._process_download_request),
+            patch("hippius_s3.queue.dequeue_download_request", side_effect=self._dequeue),
+            patch("hippius_s3.queue.initialize_queue_client"),
+            patch("hippius_s3.redis_cache.initialize_cache_client"),
+            patch("hippius_s3.monitoring.initialize_metrics_collector"),
+            patch("hippius_s3.services.ray_id_service.get_logger_with_ray_id", return_value=MagicMock()),
+        ):
+            await run_downloader_loop(
+                backend_name="arion",
+                queue_name="arion_download_requests",
+                fetch_fn=AsyncMock(),
+            )
+
+
+@pytest.mark.asyncio
+async def test_loop_processes_multiple_dcrs_concurrently():
+    """With max_inflight>1, several DCRs should be in process_download_request
+    at the same moment (not serialized)."""
+    harness = _LoopHarness(max_inflight=5)
+
+    # Enqueue 3 requests then stop
+    harness.dequeue_sequence = [_make_request("a"), _make_request("b"), _make_request("c")]
+
+    concurrent_count = 0
+    max_concurrent = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_process(_req):
+        nonlocal concurrent_count, max_concurrent
+        concurrent_count += 1
+        max_concurrent = max(max_concurrent, concurrent_count)
+        if max_concurrent >= 3:
+            started.set()
+        # Hold open until release
+        await release.wait()
+        concurrent_count -= 1
+        return True
+
+    harness.process_fn = _slow_process
+
+    # Race the loop against a controller that waits until all 3 tasks are
+    # concurrently active, then releases them and lets the loop stop.
+    async def controller():
+        await asyncio.wait_for(started.wait(), timeout=2.0)
+        release.set()
+
+    await asyncio.gather(harness.run(), controller())
+
+    assert max_concurrent == 3, f"expected 3 concurrent DCRs, saw {max_concurrent}"
+    assert len(harness.process_calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_loop_respects_max_inflight_capacity():
+    """When inflight == max_inflight, the loop waits before spawning more."""
+    harness = _LoopHarness(max_inflight=2)
+
+    # 4 requests, but cap at 2 concurrent
+    harness.dequeue_sequence = [_make_request(f"r{i}") for i in range(4)]
+
+    concurrent_count = 0
+    max_concurrent = 0
+    gate = asyncio.Event()
+
+    async def _slow_process(_req):
+        nonlocal concurrent_count, max_concurrent
+        concurrent_count += 1
+        max_concurrent = max(max_concurrent, concurrent_count)
+        await asyncio.sleep(0.05)  # Hold briefly so next dequeue must wait
+        concurrent_count -= 1
+        return True
+
+    harness.process_fn = _slow_process
+
+    async def releaser():
+        # Let the loop run to completion under its own momentum
+        await asyncio.sleep(1.0)
+        gate.set()
+
+    # The loop will stop on its own when the sequence is exhausted (KeyboardInterrupt)
+    await asyncio.gather(harness.run(), releaser())
+
+    assert max_concurrent <= 2, f"inflight cap breached: saw {max_concurrent} concurrent"
+    assert len(harness.process_calls) == 4
+
+
+@pytest.mark.asyncio
+async def test_loop_rebuilds_redis_on_task_redis_error():
+    """RedisConnectionError raised by a spawned task must trigger the main
+    loop to rebuild redis_client + obj_cache before the next dequeue."""
+    harness = _LoopHarness(max_inflight=2)
+
+    # First request fails with redis error, second should succeed after rebuild
+    harness.dequeue_sequence = [_make_request("bad"), _make_request("good")]
+
+    second_call_redis_count = None
+
+    async def _process(req):
+        nonlocal second_call_redis_count
+        if req.object_key.endswith("bad.bin"):
+            raise RedisConnectionError("connection reset")
+        second_call_redis_count = harness.redis_create_count
+        return True
+
+    harness.process_fn = _process
+
+    await harness.run()
+
+    # Initial setup creates 1 redis_client; after task's RedisConnectionError,
+    # the main loop rebuilds it → 2 total create calls.
+    assert harness.redis_create_count >= 2, (
+        f"redis_client was not rebuilt after task RedisConnectionError (create_count={harness.redis_create_count})"
+    )
+    # The second DCR was processed AFTER the rebuild occurred
+    assert second_call_redis_count is not None and second_call_redis_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_loop_recreates_db_pool_on_task_interface_error():
+    """asyncpg.InterfaceError raised by a spawned task must trigger the main
+    loop to recreate db_pool before the next dequeue."""
+    harness = _LoopHarness(max_inflight=2)
+
+    harness.dequeue_sequence = [_make_request("bad"), _make_request("good")]
+
+    second_call_pool_count = None
+
+    async def _process(req):
+        nonlocal second_call_pool_count
+        if req.object_key.endswith("bad.bin"):
+            raise asyncpg.InterfaceError("pool closed")
+        second_call_pool_count = harness.db_pool_create_count
+        return True
+
+    harness.process_fn = _process
+
+    await harness.run()
+
+    # Initial setup creates 1 pool; after InterfaceError, main loop creates a
+    # second one.
+    assert harness.db_pool_create_count >= 2, (
+        f"db_pool was not recreated after InterfaceError (create_count={harness.db_pool_create_count})"
+    )
+    assert second_call_pool_count is not None and second_call_pool_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_loop_ignores_generic_task_exceptions_without_reconnect():
+    """A generic Exception from a task is logged but must NOT cause redis/db
+    reconnects — those are reserved for specific infra error classes."""
+    harness = _LoopHarness(max_inflight=2)
+    harness.dequeue_sequence = [_make_request("boom"), _make_request("ok")]
+
+    async def _process(req):
+        if req.object_key.endswith("boom.bin"):
+            raise ValueError("not an infra error")
+        return True
+
+    harness.process_fn = _process
+
+    await harness.run()
+
+    # Only the initial setup should have created clients — 1 each.
+    assert harness.redis_create_count == 1
+    assert harness.db_pool_create_count == 1
+    assert len(harness.process_calls) == 2


### PR DESCRIPTION
## Summary

Removes two bottlenecks in the arion-downloader worker that surfaced after the FS-cache migration (#146):

1. **Serial DCR processing** — the loop awaited each `DownloadChainRequest` to completion before dequeuing the next. With range-heavy reads (aws-cli style) each DCR is only 1 part ≈ 4 chunks, so backend throughput was capped at ~0.7 DCRs/sec per pod.
2. **Unbounded chunk task creation inside a part** — `_process_part` did `asyncio.gather(*[_fetch_chunk(...) for spec in part.chunks])`. A pathological 5 GiB single-part upload (~1280 chunks at 4 MiB) would spawn ~1280 asyncio tasks parked on the semaphore. Scaled across 10 inflight DCRs that's ~1 GB of task state — OOM surface.

## Changes

- `hippius_s3/workers/downloader.py` — refactor `run_downloader_loop` to maintain an inflight set of spawned `_run_job` tasks, bounded by `DOWNLOADER_MAX_INFLIGHT` (new config, default `10`). The main loop reaps completed tasks, reconnects redis/DB on infra errors via `_reap`-set flags, and responsively waits on task completions when the queue is empty.
- `_process_part` — batch chunks within a part by `downloader_semaphore` so worst-case tasks-per-part is bounded (`~4000` total = bounded memory).
- Restored the infra-reconnect paths (`RedisConnectionError` / `RedisTimeoutError` / `BusyLoadingError` → `redis_client` rebuild; `asyncpg.InterfaceError` → `db_pool` recreation) that the refactor initially dropped.
- `hippius_s3/config.py` — new `DOWNLOADER_MAX_INFLIGHT` env var.

## Tests

6 new unit tests in `tests/unit/`:

- `test_chunk_batching_caps_concurrent_fetches_per_part` — instruments `fetch_fn` to measure real concurrency; asserts 50-chunk single-part DCR never exceeds semaphore ceiling.
- `test_loop_processes_multiple_dcrs_concurrently` — verifies multiple DCRs simultaneously in-flight.
- `test_loop_respects_max_inflight_capacity` — asserts the pool blocks at cap.
- `test_loop_rebuilds_redis_on_task_redis_error` — regression guard for the redis reconnect path.
- `test_loop_recreates_db_pool_on_task_interface_error` — regression guard for the DB pool recreation path.
- `test_loop_ignores_generic_task_exceptions_without_reconnect` — generic exceptions must NOT trigger infra reconnects.

Full unit suite: 539 passed, 6 skipped.

## Staging verification

- `[arion] Inflight pool size: 10` confirmed at startup.
- Multi-DCR overlap visible in logs: `Processing part=40` / `Processing part=41` before either PERFs.
- 6 concurrent client downloads drained without queue buildup, zero 5xx, per-client throughput improved.
- Janitor ran through cycles during active load with `parts_cleaned=0` (replication-gated GC holds).

## Deployment notes

- **No k8s changes in this PR.** Existing `k8s/production/local-cache-patch.yaml` pins `api`, `arion-uploader`, `arion-downloader`, `janitor` to `k8s-v3-node6-cache` with `local-cache-pvc` mounted at `/var/lib/hippius/local_object_cache`. Sister-repo (s3-backup) pins its hydrator + backup pods to the same node with the same mount. Already aligned.
- `DOWNLOADER_MAX_INFLIGHT` is **not set** in any configmap → picks up the `10` default. Tunable via ConfigMap + rollout restart if arion backend rate-limits.
- No memory-limit bump required — inflight task state is ~100 KB even at cap.
- No DB migration, no new env secrets, no new k8s resources.

## Conclusion

Performance fix for the FS-cache migration landed in #146: **range-read workloads were downloader-bound**; now they're bounded by reader enqueue rate (upstream coalescing), which is the correct shape. OOM risk from pathological multipart uploads closed as part of the same change.