### PR TITLE
fix(db-pool): release Postgres conns during long-running PUT/GET work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ tests/e2e/certs/*.srl
 # Node
 node_modules/
 package-lock.json
+CLAUDE.md

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any
 
+import asyncpg
 from fastapi import Response
 from lxml import etree as ET  # ty: ignore[unresolved-import]
 
@@ -22,12 +22,12 @@ def _format_s3_timestamp(dt: datetime) -> str:
 async def handle_list_objects(
     bucket_name: str,
     ctx: RequestContext,
-    db: Any,
+    pool: asyncpg.Pool,
     prefix: str | None,
 ) -> Response:
     try:
         logger.error(f"bucket name {bucket_name}")
-        bucket = await db.fetchrow(
+        bucket = await pool.fetchrow(
             get_query("get_bucket_by_name"),
             bucket_name,
         )
@@ -42,7 +42,7 @@ async def handle_list_objects(
         bucket_id = bucket["bucket_id"]
         # list-objects supports optional Prefix filtering
 
-        results = await db.fetch(get_query("list_objects"), bucket_id, prefix)
+        results = await pool.fetch(get_query("list_objects"), bucket_id, prefix)
         # Defensive filter if backend query ignored prefix
         if prefix:
             results = [r for r in results if str(r["object_key"]).startswith(prefix)]

--- a/hippius_s3/api/s3/buckets/router.py
+++ b/hippius_s3/api/s3/buckets/router.py
@@ -31,9 +31,10 @@ router = APIRouter()
 @router.get("/", status_code=200)
 async def list_buckets(
     ctx: RequestContext = Depends(get_request_context),
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
 ) -> Response:
-    return await handle_list_buckets(ctx, db)
+    async with pool.acquire() as conn:
+        return await handle_list_buckets(ctx, conn)
 
 
 @router.get("/{bucket_name}", status_code=200)
@@ -67,34 +68,38 @@ async def get_bucket(
 async def create_or_modify_bucket(
     bucket_name: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
 ) -> Response:
     # Delegate to the new comprehensive handler (supports create/tagging/lifecycle/policy)
-    return await handle_create_bucket(bucket_name, request, db)
+    async with pool.acquire() as conn:
+        return await handle_create_bucket(bucket_name, request, conn)
 
 
 @router.delete("/{bucket_name}")
 async def delete_bucket_tags_route(
     bucket_name: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
     redis_client: Any = Depends(dependencies.get_redis),
 ) -> Response:
     if "tagging" in request.query_params:
-        return await tags_delete_bucket_tags(bucket_name, db, request.state.account.main_account)
-    return await handle_delete_bucket(bucket_name, request, db, redis_client)
+        async with pool.acquire() as conn:
+            return await tags_delete_bucket_tags(bucket_name, conn, request.state.account.main_account)
+    async with pool.acquire() as conn:
+        return await handle_delete_bucket(bucket_name, request, conn, redis_client)
 
 
 @router.post("/{bucket_name}")
 async def post_bucket_subresources(
     bucket_name: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
     redis_client: Any = Depends(dependencies.get_redis),
 ) -> Response:
     # Only subresource supported here is ?delete
     if "delete" in request.query_params:
-        return await handle_delete_objects(bucket_name, request, db, redis_client)
+        async with pool.acquire() as conn:
+            return await handle_delete_objects(bucket_name, request, conn, redis_client)
     return errors.s3_error_response(
         "NotImplemented",
         "The specified operation is not supported.",
@@ -106,6 +111,7 @@ async def post_bucket_subresources(
 async def head_bucket(
     bucket_name: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
 ) -> Response:
-    return await handle_head_bucket(bucket_name, request, db)
+    async with pool.acquire() as conn:
+        return await handle_head_bucket(bucket_name, request, conn)

--- a/hippius_s3/api/s3/buckets/router.py
+++ b/hippius_s3/api/s3/buckets/router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import asyncpg
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import Request
@@ -39,23 +40,27 @@ async def list_buckets(
 async def get_bucket(
     bucket_name: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
 ) -> Response:
     if "location" in request.query_params:
         return await handle_get_bucket_location(bucket_name)
     if "tagging" in request.query_params:
-        return await tags_get_bucket_tags(bucket_name, db, request.state.account.main_account)
+        async with pool.acquire() as conn:
+            return await tags_get_bucket_tags(bucket_name, conn, request.state.account.main_account)
     if "lifecycle" in request.query_params:
-        return await handle_get_bucket_lifecycle(bucket_name, db, request.state.account.main_account)
+        async with pool.acquire() as conn:
+            return await handle_get_bucket_lifecycle(bucket_name, conn, request.state.account.main_account)
     if "uploads" in request.query_params:
         from hippius_s3.api.s3.multipart import list_multipart_uploads
 
-        return await list_multipart_uploads(bucket_name, request, db)
+        async with pool.acquire() as conn:
+            return await list_multipart_uploads(bucket_name, request, conn)
     if "policy" in request.query_params:
-        return await policy_get_bucket_policy(bucket_name, db, request.state.account.main_account)
-    # list objects
+        async with pool.acquire() as conn:
+            return await policy_get_bucket_policy(bucket_name, conn, request.state.account.main_account)
+    # list objects — uses the pool directly so each query auto-releases its conn
     ctx = get_request_context(request)
-    return await handle_list_objects(bucket_name, ctx, db, request.query_params.get("prefix"))
+    return await handle_list_objects(bucket_name, ctx, pool, request.query_params.get("prefix"))
 
 
 @router.put("/{bucket_name}")

--- a/hippius_s3/api/s3/buckets/router.py
+++ b/hippius_s3/api/s3/buckets/router.py
@@ -59,7 +59,6 @@ async def get_bucket(
     if "policy" in request.query_params:
         async with pool.acquire() as conn:
             return await policy_get_bucket_policy(bucket_name, conn, request.state.account.main_account)
-    # list objects — uses the pool directly so each query auto-releases its conn
     ctx = get_request_context(request)
     return await handle_list_objects(bucket_name, ctx, pool, request.query_params.get("prefix"))
 

--- a/hippius_s3/api/s3/copy_helpers.py
+++ b/hippius_s3/api/s3/copy_helpers.py
@@ -206,7 +206,9 @@ async def handle_streaming_copy(
     )
 
     content_type = str(source_object["content_type"])
-    ow = ObjectWriter(db=db, redis_client=redis_client, fs_store=request.app.state.fs_store)
+    ow = ObjectWriter(
+        pool=request.app.state.postgres_pool, redis_client=redis_client, fs_store=request.app.state.fs_store
+    )
     put_res = await ow.put_simple_stream_full(
         bucket_id=str(dest_bucket["bucket_id"]),
         bucket_name=dest_bucket["bucket_name"],

--- a/hippius_s3/api/s3/copy_helpers.py
+++ b/hippius_s3/api/s3/copy_helpers.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any
 from urllib.parse import unquote
 
+import asyncpg
 from fastapi import Request
 from fastapi import Response
 from lxml import etree as ET  # ty: ignore[unresolved-import]
@@ -156,7 +157,7 @@ def build_copy_success_response(etag: str, last_modified: datetime) -> Response:
 
 
 async def handle_streaming_copy(
-    db: Any,
+    pool: asyncpg.Pool,
     redis_client: Any,
     request: Request,
     source_bucket: dict,
@@ -181,7 +182,7 @@ async def handle_streaming_copy(
     source_object_key = source_object["object_key"]
 
     chunks_iter = await stream_object(
-        db,
+        pool,
         redis_client,
         obj_cache,
         {
@@ -206,7 +207,7 @@ async def handle_streaming_copy(
     )
 
     content_type = str(source_object["content_type"])
-    ow = ObjectWriter(pool=db, redis_client=redis_client, fs_store=request.app.state.fs_store)
+    ow = ObjectWriter(pool=pool, redis_client=redis_client, fs_store=request.app.state.fs_store)
     put_res = await ow.put_simple_stream_full(
         bucket_id=str(dest_bucket["bucket_id"]),
         bucket_name=dest_bucket["bucket_name"],

--- a/hippius_s3/api/s3/copy_helpers.py
+++ b/hippius_s3/api/s3/copy_helpers.py
@@ -206,9 +206,7 @@ async def handle_streaming_copy(
     )
 
     content_type = str(source_object["content_type"])
-    ow = ObjectWriter(
-        pool=request.app.state.postgres_pool, redis_client=redis_client, fs_store=request.app.state.fs_store
-    )
+    ow = ObjectWriter(pool=db, redis_client=redis_client, fs_store=request.app.state.fs_store)
     put_res = await ow.put_simple_stream_full(
         bucket_id=str(dest_bucket["bucket_id"]),
         bucket_name=dest_bucket["bucket_name"],

--- a/hippius_s3/api/s3/extensions/append.py
+++ b/hippius_s3/api/s3/extensions/append.py
@@ -100,7 +100,9 @@ async def handle_append(
     # Endpoint delegates CAS and locking to writer.append
 
     # PHASE 2 (out-of-DB): delegate to ObjectWriter to append, cache, and update version
-    writer = ObjectWriter(db=db, redis_client=redis_client, fs_store=request.app.state.fs_store)
+    writer = ObjectWriter(
+        pool=request.app.state.postgres_pool, redis_client=redis_client, fs_store=request.app.state.fs_store
+    )
     try:
         result = await writer.append_stream(
             bucket_id=bucket_id,

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -13,6 +13,7 @@ from datetime import timezone
 from typing import Any
 from urllib.parse import unquote
 
+import asyncpg
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import Request
@@ -66,7 +67,7 @@ async def handle_post_object(
     bucket_name: str,
     object_key: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
 ) -> Response:
     """
     Handle POST requests for objects:
@@ -78,12 +79,13 @@ async def handle_post_object(
     # Check for uploads parameter (Initiate Multipart Upload)
     if "uploads" in request.query_params:
         with tracer.start_as_current_span("multipart.route_initiate"):
-            return await initiate_multipart_upload(
-                bucket_name,
-                object_key,
-                request,
-                db,
-            )
+            async with pool.acquire() as conn:
+                return await initiate_multipart_upload(
+                    bucket_name,
+                    object_key,
+                    request,
+                    conn,
+                )
 
     # Check for uploadId parameter (Complete Multipart Upload)
     if "uploadId" in request.query_params:
@@ -93,13 +95,14 @@ async def handle_post_object(
                 "multipart.route_complete",
                 attributes={"upload_id": upload_id, "has_upload_id": True},
             ):
-                return await complete_multipart_upload(
-                    bucket_name,
-                    object_key,
-                    upload_id,
-                    request,
-                    db,
-                )
+                async with pool.acquire() as conn:
+                    return await complete_multipart_upload(
+                        bucket_name,
+                        object_key,
+                        upload_id,
+                        request,
+                        conn,
+                    )
 
     # Not a multipart operation we handle
     return s3_error_response("InvalidRequest", "Unsupported multipart POST request", status_code=400)

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -341,7 +341,7 @@ async def get_all_cached_chunks(
 
 async def upload_part(
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool,
 ) -> Response:
     """Upload a part for a multipart upload (PUT with partNumber & uploadId)."""
     # These two parameters are required for multipart upload parts
@@ -372,7 +372,7 @@ async def upload_part(
         )
 
     # Check if the multipart upload exists
-    ongoing_multipart_upload = await db.fetchrow(
+    ongoing_multipart_upload = await pool.fetchrow(
         get_query("get_multipart_upload"),
         upload_id,
     )
@@ -422,16 +422,16 @@ async def upload_part(
             range_end = int(m.group(2))
 
         # Resolve source object and fetch bytes from IPFS (require CID available)
-        _ = await db.fetchrow(
+        _ = await pool.fetchrow(
             get_query("get_or_create_user_by_main_account"),
             request.state.account.main_account,
             datetime.now(timezone.utc),
         )
-        source_bucket = await db.fetchrow(get_query("get_bucket_by_name"), source_bucket_name)
+        source_bucket = await pool.fetchrow(get_query("get_bucket_by_name"), source_bucket_name)
         if not source_bucket:
             return s3_error_response("NoSuchBucket", f"Bucket {source_bucket_name} does not exist", status_code=404)
 
-        source_obj = await db.fetchrow(get_query("get_object_by_path"), source_bucket["bucket_id"], source_object_key)
+        source_obj = await pool.fetchrow(get_query("get_object_by_path"), source_bucket["bucket_id"], source_object_key)
         if not source_obj:
             return s3_error_response("NoSuchKey", f"Key {source_object_key} not found", status_code=404)
 
@@ -449,7 +449,7 @@ async def upload_part(
 
         object_id_str = str(source_obj["object_id"])
         src_ver = int(source_obj.get("object_version") or 1)
-        parts = await read_parts_list(db, object_id_str, src_ver)
+        parts = await read_parts_list(pool, object_id_str, src_ver)
         rng = None
         source_size = int(source_obj.get("size_bytes") or 0)
         if range_start is not None and range_end is not None:
@@ -460,7 +460,7 @@ async def upload_part(
             from hippius_s3.reader.types import RangeRequest  # local import
 
             rng = RangeRequest(start=int(range_start), end=int(range_end))
-        plan = await build_chunk_plan(db, object_id_str, parts, rng, object_version=src_ver)
+        plan = await build_chunk_plan(pool, object_id_str, parts, rng, object_version=src_ver)
 
         # Enqueue downloader for any missing chunk indices in cache
         obj_cache = RedisObjectPartsCache(request.app.state.redis_client)
@@ -474,7 +474,7 @@ async def upload_part(
             dl_parts: list[PartToDownload] = []
             for pn, idxs in indices_by_part.items():
                 try:
-                    rows = await db.fetch(
+                    rows = await pool.fetch(
                         get_query("get_part_chunks_by_object_and_number"),
                         object_id_str,
                         src_ver,
@@ -578,7 +578,7 @@ async def upload_part(
         # Store in Redis via chunked cache API (encrypt for private, meta-first for readiness)
         # Resolve destination bucket name for key lookup
         try:
-            row = await db.fetchrow(
+            row = await pool.fetchrow(
                 """
                 SELECT b.bucket_name
                 FROM multipart_uploads mu
@@ -597,7 +597,7 @@ async def upload_part(
 
         redis_start = time.time()
         # Route through ObjectWriter for standardized behavior
-        writer = ObjectWriter(db=db, redis_client=redis_client, fs_store=request.app.state.fs_store)
+        writer = ObjectWriter(pool=pool, redis_client=redis_client, fs_store=request.app.state.fs_store)
         try:
             part_res = await writer.mpu_upload_part_stream(
                 upload_id=str(upload_id),
@@ -1017,7 +1017,11 @@ async def complete_multipart_upload(
                 status_code=400,
             )
 
-        writer = ObjectWriter(db=db, redis_client=request.app.state.redis_client, fs_store=request.app.state.fs_store)
+        writer = ObjectWriter(
+            pool=request.app.state.postgres_pool,
+            redis_client=request.app.state.redis_client,
+            fs_store=request.app.state.fs_store,
+        )
         complete_res = await writer.mpu_complete(
             bucket_name=bucket_name,
             object_id=str(object_id),

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -711,12 +711,11 @@ async def upload_part(
         raise
 
 
-@router.delete("/{bucket_name}/{object_key:path}", status_code=204)
 async def abort_multipart_upload(
     _: str,
     __: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    db: Any,
 ) -> Response:
     """Abort a multipart upload (DELETE with uploadId)."""
     upload_id = request.query_params.get("uploadId")

--- a/hippius_s3/api/s3/objects/CLAUDE.md
+++ b/hippius_s3/api/s3/objects/CLAUDE.md
@@ -105,4 +105,13 @@ Full spec: [docs/s4.md](../../../../docs/s4.md).
 | #2411 | 10:53 PM | 🔵 | GetObject endpoint retrieves objects via get_object_for_download_with_permissions queries | ~343 |
 | #2410 | " | 🔵 | HeadObject endpoint implementation and database queries | ~331 |
 | #2409 | " | 🔵 | S3 object router implementation using FastAPI | ~304 |
+
+### Apr 23, 2026
+
+| ID | Time | T | Title | Read |
+|----|------|---|-------|------|
+| #6914 | 12:20 PM | 🔄 | Migrated put_object and delete_object routes to scoped connection acquisition | ~571 |
+| #6912 | 12:13 PM | 🔄 | HEAD object endpoint refactored to use connection pool with scoped acquisition | ~549 |
+| #6911 | 12:11 PM | 🔄 | Migrated head_object and get_object routes to pool-based connection lifecycle | ~503 |
+| #6902 | 11:55 AM | 🔵 | S3 object router shows all operations including MPU parts acquire database connections | ~555 |
 </claude-mem-context>

--- a/hippius_s3/api/s3/objects/copy_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/copy_object_endpoint.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from datetime import timezone
 from typing import Any
 
+import asyncpg
 from fastapi import Request
 from fastapi import Response
 
@@ -29,21 +30,21 @@ async def handle_copy_object(
     bucket_name: str,
     object_key: str,
     request: Request,
-    db: Any,
+    pool: asyncpg.Pool,
     redis_client: Any,
 ) -> Response:
     try:
         source_bucket_name, source_object_key = parse_copy_source(request.headers.get("x-amz-copy-source"))
 
         user, source_bucket, dest_bucket, source_object = await resolve_copy_resources(
-            db=db,
+            db=pool,
             main_account=request.state.account.main_account,
             source_bucket_name=source_bucket_name,
             source_object_key=source_object_key,
             dest_bucket_name=bucket_name,
         )
 
-        existing_dest = await ObjectRepository(db).get_by_path(dest_bucket["bucket_id"], object_key)
+        existing_dest = await ObjectRepository(pool).get_by_path(dest_bucket["bucket_id"], object_key)
         object_id = str(existing_dest["object_id"]) if existing_dest else str(uuid.uuid4())
         copy_created_at = datetime.now(timezone.utc)
 
@@ -65,7 +66,7 @@ async def handle_copy_object(
         if src_multipart:
             logger.info("CopyObject multipart source: forcing streaming fallback")
             return await handle_streaming_copy(
-                db=db,
+                db=pool,
                 redis_client=redis_client,
                 request=request,
                 source_bucket=source_bucket,
@@ -79,7 +80,7 @@ async def handle_copy_object(
             )
 
         eligible, chunk_rows, reason = await should_use_v5_fast_path(
-            db=db,
+            db=pool,
             src_obj_row=src_obj_row,
             existing_dest=existing_dest,
             src_storage_version=src_storage_version,
@@ -90,7 +91,7 @@ async def handle_copy_object(
             assert chunk_rows is not None
             logger.info("CopyObject using v5 fast path (envelope rewrap + CID reuse)")
             return await execute_v5_fast_path_copy(
-                db=db,
+                db=pool,
                 source_bucket=source_bucket,
                 dest_bucket=dest_bucket,
                 source_object=source_object,
@@ -104,7 +105,7 @@ async def handle_copy_object(
 
         logger.info(f"CopyObject using streaming fallback: {reason}")
         return await handle_streaming_copy(
-            db=db,
+            db=pool,
             redis_client=redis_client,
             request=request,
             source_bucket=source_bucket,

--- a/hippius_s3/api/s3/objects/copy_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/copy_object_endpoint.py
@@ -66,7 +66,7 @@ async def handle_copy_object(
         if src_multipart:
             logger.info("CopyObject multipart source: forcing streaming fallback")
             return await handle_streaming_copy(
-                db=pool,
+                pool=pool,
                 redis_client=redis_client,
                 request=request,
                 source_bucket=source_bucket,
@@ -105,7 +105,7 @@ async def handle_copy_object(
 
         logger.info(f"CopyObject using streaming fallback: {reason}")
         return await handle_streaming_copy(
-            db=pool,
+            pool=pool,
             redis_client=redis_client,
             request=request,
             source_bucket=source_bucket,

--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -94,8 +94,6 @@ async def handle_get_object(
             f"GET start {bucket_name}/{object_key} read_mode={hdr_mode or 'auto'} range={bool(range_header)} version={version_id or 'current'}"
         )
 
-    # Acquire only for the metadata phase; release before the StreamingResponse
-    # begins so the conn isn't held across the body write.
     db = await pool.acquire()
     try:
         # Gateway now handles all ACL/permission checks

--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from datetime import timezone
 from typing import Any
 
+import asyncpg
 from fastapi import Request
 from fastapi import Response
 from opentelemetry import trace
@@ -33,7 +34,7 @@ async def handle_get_object(
     bucket_name: str,
     object_key: str,
     request: Request,
-    db: Any,
+    pool: asyncpg.Pool,
     redis_client: Any,
 ) -> Response:
     """Isolated GET object endpoint handler."""
@@ -43,13 +44,14 @@ async def handle_get_object(
             from hippius_s3.api.s3.objects.tagging_endpoint import get_object_tags  # local import to avoid cycles
 
             account = getattr(request.state, "account", None)
-            return await get_object_tags(
-                bucket_name,
-                object_key,
-                db,
-                getattr(request.state, "seed_phrase", ""),
-                account.main_account if account else "",
-            )
+            async with pool.acquire() as conn:
+                return await get_object_tags(
+                    bucket_name,
+                    object_key,
+                    conn,
+                    getattr(request.state, "seed_phrase", ""),
+                    account.main_account if account else "",
+                )
 
     # List parts for an ongoing multipart upload
     if "uploadId" in request.query_params:
@@ -60,7 +62,8 @@ async def handle_get_object(
         ):
             from hippius_s3.api.s3.multipart import list_parts_internal
 
-            return await list_parts_internal(bucket_name, object_key, request, db)
+            async with pool.acquire() as conn:
+                return await list_parts_internal(bucket_name, object_key, request, conn)
 
     # Parse versionId query parameter
     version_id = None
@@ -91,6 +94,9 @@ async def handle_get_object(
             f"GET start {bucket_name}/{object_key} read_mode={hdr_mode or 'auto'} range={bool(range_header)} version={version_id or 'current'}"
         )
 
+    # Acquire only for the metadata phase; release before the StreamingResponse
+    # begins so the conn isn't held across the body write.
+    db = await pool.acquire()
     try:
         # Gateway now handles all ACL/permission checks
         # Backend trusts the account information from gateway
@@ -391,3 +397,6 @@ async def handle_get_object(
             message=f"We encountered an internal error: {str(e)}. Please try again.",
             status_code=500,
         )
+
+    finally:
+        await pool.release(db)

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 from typing import Optional
 
+import asyncpg
 from fastapi import Request
 from fastapi import Response
 from opentelemetry import trace
@@ -73,7 +74,7 @@ async def handle_head_object(
     bucket_name: str,
     object_key: str,
     request: Request,
-    db: Any,
+    pool: asyncpg.Pool,
 ) -> Response:
     # Gateway now handles all ACL/permission checks
     # Backend trusts the account information from gateway
@@ -101,7 +102,8 @@ async def handle_head_object(
     if "tagging" in request.query_params:
         with tracer.start_as_current_span("head_object.check_tagging_request"):
             try:
-                await _get_object_with_permissions_min(bucket_name, object_key, db, main_account_id, version_id)
+                async with pool.acquire() as conn:
+                    await _get_object_with_permissions_min(bucket_name, object_key, conn, main_account_id, version_id)
                 return Response(status_code=200)
             except errors.S3Error as e:
                 return Response(
@@ -115,6 +117,7 @@ async def handle_head_object(
                 logger.exception("Error in HEAD tagging request")
                 return Response(status_code=500)
 
+    db = await pool.acquire()
     try:
         with tracer.start_as_current_span("head_object.get_object_metadata") as span:
             row = await _get_object_with_permissions_min(bucket_name, object_key, db, main_account_id, version_id)
@@ -234,3 +237,6 @@ async def handle_head_object(
     except Exception as e:
         logger.exception(f"Error getting object metadata: {e}")
         return Response(status_code=500)
+
+    finally:
+        await pool.release(db)

--- a/hippius_s3/api/s3/objects/put_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/put_object_endpoint.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from datetime import timezone
 from typing import Any
 
+import asyncpg
 from fastapi import Request
 from fastapi import Response
 from opentelemetry import trace
@@ -30,7 +31,7 @@ async def handle_put_object(
     bucket_name: str,
     object_key: str,
     request: Request,
-    db: Any,
+    pool: asyncpg.Pool,
     redis_client: Any,
 ) -> Response:
     try:
@@ -40,14 +41,14 @@ async def handle_put_object(
         with tracer.start_as_current_span(
             "put_object.get_or_create_user", attributes={"hippius.account.main": main_account_id}
         ):
-            await db.fetchrow(
+            await pool.fetchrow(
                 get_query("get_or_create_user_by_main_account"),
                 main_account_id,
                 datetime.now(timezone.utc),
             )
 
         with tracer.start_as_current_span("put_object.get_bucket", attributes={"bucket_name": bucket_name}):
-            bucket = await db.fetchrow(
+            bucket = await pool.fetchrow(
                 get_query("get_bucket_by_name"),
                 bucket_name,
             )
@@ -69,7 +70,7 @@ async def handle_put_object(
         if meta_append:
             return await handle_append(
                 request,
-                db,
+                pool,
                 redis_client,
                 bucket=bucket,
                 bucket_id=bucket_id,
@@ -95,7 +96,7 @@ async def handle_put_object(
 
         # Capture previous object (to clean up multipart parts if overwriting)
         with tracer.start_as_current_span("put_object.check_existing_object") as span:
-            prev = await db.fetchrow(
+            prev = await pool.fetchrow(
                 get_query("get_object_by_path"),
                 bucket_id,
                 object_key,
@@ -127,7 +128,7 @@ async def handle_put_object(
                 "storage_version": config.target_storage_version,
             },
         ) as span:
-            writer = ObjectWriter(db=db, redis_client=redis_client, fs_store=request.app.state.fs_store)
+            writer = ObjectWriter(pool=pool, redis_client=redis_client, fs_store=request.app.state.fs_store)
 
             put_res = await writer.put_simple_stream_full(
                 bucket_id=bucket_id,
@@ -172,7 +173,7 @@ async def handle_put_object(
 
         # Mark upload completed to prevent CASCADE deletion of chunk_backend on DELETE
         # Maintains parity with append (sets TRUE immediately) and multipart (sets TRUE in mpu_complete)
-        await db.execute(
+        await pool.execute(
             "UPDATE multipart_uploads SET is_completed = TRUE WHERE upload_id = $1",
             put_res.upload_id,
         )

--- a/hippius_s3/api/s3/objects/router.py
+++ b/hippius_s3/api/s3/objects/router.py
@@ -67,8 +67,7 @@ async def put_object(
     upload_id = request.query_params.get("uploadId")
     part_number = request.query_params.get("partNumber")
     if upload_id and part_number:
-        async with pool.acquire() as conn:
-            return await upload_part(request, conn)
+        return await upload_part(request, pool)
     if "tagging" in request.query_params:
         async with pool.acquire() as conn:
             return await tags_set_object_tags(
@@ -77,8 +76,7 @@ async def put_object(
     if request.headers.get("x-amz-copy-source"):
         async with pool.acquire() as conn:
             return await handle_copy_object(bucket_name, object_key, request, conn, redis_client)
-    async with pool.acquire() as conn:
-        return await handle_put_object(bucket_name, object_key, request, conn, redis_client)
+    return await handle_put_object(bucket_name, object_key, request, pool, redis_client)
 
 
 @router.delete("/{bucket_name}/{object_key:path}", status_code=204)

--- a/hippius_s3/api/s3/objects/router.py
+++ b/hippius_s3/api/s3/objects/router.py
@@ -74,8 +74,7 @@ async def put_object(
                 bucket_name, object_key, request, conn, request.state.seed_phrase, request.state.account.main_account
             )
     if request.headers.get("x-amz-copy-source"):
-        async with pool.acquire() as conn:
-            return await handle_copy_object(bucket_name, object_key, request, conn, redis_client)
+        return await handle_copy_object(bucket_name, object_key, request, pool, redis_client)
     return await handle_put_object(bucket_name, object_key, request, pool, redis_client)
 
 

--- a/hippius_s3/api/s3/objects/router.py
+++ b/hippius_s3/api/s3/objects/router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import asyncpg
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import Request
@@ -29,9 +30,9 @@ async def head_object(
     bucket_name: str,
     object_key: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
 ) -> Response:
-    return await handle_head_object(bucket_name, object_key, request, db)
+    return await handle_head_object(bucket_name, object_key, request, pool)
 
 
 @router.get("/{bucket_name}/{object_key:path}", status_code=200)
@@ -39,17 +40,19 @@ async def get_object(
     bucket_name: str,
     object_key: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
     redis_client: Any = Depends(dependencies.get_redis),
 ) -> Response:
     # Handle query variants by delegation
     if "tagging" in request.query_params:
-        return await tags_get_object_tags(
-            bucket_name, object_key, db, request.state.seed_phrase, request.state.account.main_account
-        )
+        async with pool.acquire() as conn:
+            return await tags_get_object_tags(
+                bucket_name, object_key, conn, request.state.seed_phrase, request.state.account.main_account
+            )
     if "uploadId" in request.query_params:
-        return await list_parts_internal(bucket_name, object_key, request, db)
-    return await handle_get_object(bucket_name, object_key, request, db, redis_client)
+        async with pool.acquire() as conn:
+            return await list_parts_internal(bucket_name, object_key, request, conn)
+    return await handle_get_object(bucket_name, object_key, request, pool, redis_client)
 
 
 @router.put("/{bucket_name}/{object_key:path}/", status_code=200, include_in_schema=False)
@@ -58,20 +61,24 @@ async def put_object(
     bucket_name: str,
     object_key: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
     redis_client: Any = Depends(dependencies.get_redis),
 ) -> Response:
     upload_id = request.query_params.get("uploadId")
     part_number = request.query_params.get("partNumber")
     if upload_id and part_number:
-        return await upload_part(request, db)
+        async with pool.acquire() as conn:
+            return await upload_part(request, conn)
     if "tagging" in request.query_params:
-        return await tags_set_object_tags(
-            bucket_name, object_key, request, db, request.state.seed_phrase, request.state.account.main_account
-        )
+        async with pool.acquire() as conn:
+            return await tags_set_object_tags(
+                bucket_name, object_key, request, conn, request.state.seed_phrase, request.state.account.main_account
+            )
     if request.headers.get("x-amz-copy-source"):
-        return await handle_copy_object(bucket_name, object_key, request, db, redis_client)
-    return await handle_put_object(bucket_name, object_key, request, db, redis_client)
+        async with pool.acquire() as conn:
+            return await handle_copy_object(bucket_name, object_key, request, conn, redis_client)
+    async with pool.acquire() as conn:
+        return await handle_put_object(bucket_name, object_key, request, conn, redis_client)
 
 
 @router.delete("/{bucket_name}/{object_key:path}", status_code=204)
@@ -79,13 +86,16 @@ async def delete_object(
     bucket_name: str,
     object_key: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
     redis_client: Any = Depends(dependencies.get_redis),
 ) -> Response:
     if "uploadId" in request.query_params:
-        return await abort_multipart_upload(bucket_name, object_key, request, db)
+        async with pool.acquire() as conn:
+            return await abort_multipart_upload(bucket_name, object_key, request, conn)
     if "tagging" in request.query_params:
-        return await tags_delete_object_tags(
-            bucket_name, object_key, db, request.state.seed_phrase, request.state.account.main_account
-        )
-    return await handle_delete_object(bucket_name, object_key, request, db, redis_client)
+        async with pool.acquire() as conn:
+            return await tags_delete_object_tags(
+                bucket_name, object_key, conn, request.state.seed_phrase, request.state.account.main_account
+            )
+    async with pool.acquire() as conn:
+        return await handle_delete_object(bucket_name, object_key, request, conn, redis_client)

--- a/hippius_s3/api/s3/public_router.py
+++ b/hippius_s3/api/s3/public_router.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import asyncpg
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import Request
@@ -24,7 +25,7 @@ async def get_public_object(
     bucket_name: str,
     object_key: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
     redis_client: Any = Depends(dependencies.get_redis),
 ) -> Response:
     """Anonymous GET object endpoint for public buckets."""
@@ -37,7 +38,7 @@ async def get_public_object(
             status_code=403,
         )
     # Call the regular get_object handler with anonymous account
-    response = await handle_get_object(bucket_name, object_key, request, db, redis_client)
+    response = await handle_get_object(bucket_name, object_key, request, pool, redis_client)
 
     # Add anonymous access header
     response.headers["x-hippius-access-mode"] = "anon"
@@ -49,7 +50,7 @@ async def head_public_object(
     bucket_name: str,
     object_key: str,
     request: Request,
-    db: dependencies.DBConnection = Depends(dependencies.get_postgres),
+    pool: asyncpg.Pool = Depends(dependencies.get_db_pool),
 ) -> Response:
     """Anonymous HEAD object endpoint for public buckets."""
     # Whitelist: only allow HEAD with no special query parameters
@@ -60,7 +61,7 @@ async def head_public_object(
             status_code=403,
         )
     # Call the regular head_object handler with anonymous account
-    response = await handle_head_object(bucket_name, object_key, request, db)
+    response = await handle_head_object(bucket_name, object_key, request, pool)
 
     # Add anonymous access header
     response.headers["x-hippius-access-mode"] = "anon"

--- a/hippius_s3/dependencies.py
+++ b/hippius_s3/dependencies.py
@@ -58,16 +58,9 @@ async def get_postgres(request: Request) -> AsyncGenerator["DBConnection", None]
 
 
 def get_db_pool(request: Request) -> asyncpg.Pool:
-    """
-    Dependency that returns the shared Postgres pool itself, without acquiring
-    a connection. Endpoints should call `pool.fetch(...)` / `pool.fetchrow(...)` /
-    `pool.execute(...)` (asyncpg auto-acquires + releases per call), or use
-    `async with pool.acquire() as conn:` for multi-statement / transactional work.
-
-    Prefer this over `get_postgres` for endpoints with long-running non-DB work
-    (streaming responses, slow client reads, FS/Arion operations) so a Postgres
-    connection isn't held idle for the entire request.
-    """
+    """Return the pool directly. Use for endpoints with long-running non-DB
+    work (streaming, slow client reads, FS/Arion I/O) so a connection isn't
+    held idle across the entire request."""
     pool: asyncpg.Pool = request.app.state.postgres_pool
     return pool
 

--- a/hippius_s3/dependencies.py
+++ b/hippius_s3/dependencies.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing import AsyncGenerator
 from typing import Union
 
+import asyncpg
 from fastapi import HTTPException
 from fastapi import Request
 from redis.asyncio import Redis
@@ -54,6 +55,21 @@ async def get_postgres(request: Request) -> AsyncGenerator["DBConnection", None]
         yield db
     finally:
         await db.close()
+
+
+def get_db_pool(request: Request) -> asyncpg.Pool:
+    """
+    Dependency that returns the shared Postgres pool itself, without acquiring
+    a connection. Endpoints should call `pool.fetch(...)` / `pool.fetchrow(...)` /
+    `pool.execute(...)` (asyncpg auto-acquires + releases per call), or use
+    `async with pool.acquire() as conn:` for multi-statement / transactional work.
+
+    Prefer this over `get_postgres` for endpoints with long-running non-DB work
+    (streaming responses, slow client reads, FS/Arion operations) so a Postgres
+    connection isn't held idle for the entire request.
+    """
+    pool: asyncpg.Pool = request.app.state.postgres_pool
+    return pool
 
 
 def get_config(request: Request) -> Config:

--- a/hippius_s3/scripts/migrate_objects.py
+++ b/hippius_s3/scripts/migrate_objects.py
@@ -606,9 +606,9 @@ async def main_async(args: argparse.Namespace) -> int:
                     work_item["attempts"] = int(work_item.get("attempts") or 0) + 1
                     state_dirty.set()
 
-            task_db: Any | None = None
+            task_pool: Any | None = None
             try:
-                task_db = await asyncpg.create_pool(config.database_url, min_size=1, max_size=2)
+                task_pool = await asyncpg.create_pool(config.database_url, min_size=1, max_size=2)
                 address = str(o.get("main_account_id", ""))
 
                 if args.dry_run:
@@ -627,7 +627,7 @@ async def main_async(args: argparse.Namespace) -> int:
                 ok = False
                 try:
                     coro = migrate_one(
-                        db=task_db,
+                        db=task_pool,
                         redis_client=redis_client,
                         object_id=o["object_id"],
                         bucket_id=o["bucket_id"],
@@ -689,9 +689,9 @@ async def main_async(args: argparse.Namespace) -> int:
                         work_item["finished_at"] = _now_ts()
                         state_dirty.set()
             finally:
-                if task_db is not None:
+                if task_pool is not None:
                     with suppress(Exception):
-                        await task_db.close()
+                        await task_pool.close()
 
         queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue(maxsize=max(1, concurrency * 2))
 

--- a/hippius_s3/scripts/migrate_objects.py
+++ b/hippius_s3/scripts/migrate_objects.py
@@ -224,7 +224,7 @@ async def migrate_one(
     from hippius_s3.cache import FileSystemPartsStore  # local import
 
     fs_store = FileSystemPartsStore(config.object_cache_dir)
-    writer = ObjectWriter(db=db, redis_client=redis_client, fs_store=fs_store)
+    writer = ObjectWriter(pool=db, redis_client=redis_client, fs_store=fs_store)
     new_version = await writer.create_version_for_migration(
         object_id=object_id,
         content_type=content_type,
@@ -608,7 +608,7 @@ async def main_async(args: argparse.Namespace) -> int:
 
             task_db: Any | None = None
             try:
-                task_db = await asyncpg.connect(config.database_url)
+                task_db = await asyncpg.create_pool(config.database_url, min_size=1, max_size=2)
                 address = str(o.get("main_account_id", ""))
 
                 if args.dry_run:

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -11,6 +11,7 @@ from datetime import timezone
 from typing import Any
 from typing import AsyncIterator
 
+import asyncpg
 from opentelemetry import trace
 
 from hippius_s3.api.middlewares.tracing import set_span_attributes
@@ -38,8 +39,8 @@ logger = logging.getLogger(__name__)
 
 
 class ObjectWriter:
-    def __init__(self, *, db: Any, redis_client: Any, fs_store: FileSystemPartsStore | None = None) -> None:
-        self.db = db
+    def __init__(self, *, pool: asyncpg.Pool, redis_client: Any, fs_store: FileSystemPartsStore | None = None) -> None:
+        self.pool = pool
         self.redis_client = redis_client
         self.config = get_config()
         self.obj_cache = RedisObjectPartsCache(redis_client)
@@ -55,7 +56,7 @@ class ObjectWriter:
         storage_version_target: int,
         upload_backends: list[str],
     ) -> int:
-        row = await self.db.fetchrow(
+        row = await self.pool.fetchrow(
             get_query("create_migration_version"),
             object_id,
             content_type,
@@ -74,7 +75,7 @@ class ObjectWriter:
         expected_old_version: int,
         new_version: int,
     ) -> bool:
-        row = await self.db.fetchrow(
+        row = await self.pool.fetchrow(
             get_query("swap_current_version_cas"),
             object_id,
             int(expected_old_version),
@@ -139,7 +140,7 @@ class ObjectWriter:
 
         # Ensure upload row and insert part placeholder
         upload_id = await ensure_upload_row(
-            self.db,
+            self.pool,
             object_id=object_id,
             bucket_id=bucket_id,
             object_key=object_key,
@@ -147,7 +148,7 @@ class ObjectWriter:
             metadata=metadata,
         )
         await upsert_part_placeholder(
-            self.db,
+            self.pool,
             object_id=object_id,
             upload_id=str(upload_id),
             part_number=1,
@@ -208,7 +209,7 @@ class ObjectWriter:
             },
         ):
             reserve_row = await upsert_object_basic(
-                self.db,
+                self.pool,
                 object_id=object_id,
                 bucket_id=bucket_id,
                 object_key=object_key,
@@ -242,7 +243,7 @@ class ObjectWriter:
         # Write envelope to DB immediately so concurrent GETs never see NULL kek_id/wrapped_dek.
         # Without this, a GET between the upsert (which bumps current_object_version) and this
         # UPDATE would hit v5_missing_envelope_metadata → 500.
-        await self.db.execute(
+        await self.pool.execute(
             """
             UPDATE object_versions
                SET encryption_version = 5,
@@ -439,7 +440,7 @@ class ObjectWriter:
                 "storage_version": resolved_storage_version,
             },
         ):
-            await self.db.execute(
+            await self.pool.execute(
                 get_query("update_object_version_metadata"),
                 int(total_size),
                 md5_hash,
@@ -453,7 +454,7 @@ class ObjectWriter:
             # the upsert to prevent the read-race on concurrent overwrites.
 
         upload_id = await ensure_upload_row(
-            self.db,
+            self.pool,
             object_id=object_id,
             bucket_id=bucket_id,
             object_key=object_key,
@@ -462,7 +463,7 @@ class ObjectWriter:
         )
 
         await upsert_part_placeholder(
-            self.db,
+            self.pool,
             object_id=object_id,
             upload_id=str(upload_id),
             part_number=int(part_number),
@@ -511,8 +512,8 @@ class ObjectWriter:
         from hippius_s3.services.kek_service import get_bucket_kek_bytes
         from hippius_s3.services.kek_service import get_or_create_active_bucket_kek
 
-        async with self.db.transaction():
-            row = await self.db.fetchrow(
+        async with self.pool.acquire() as conn, conn.transaction():
+            row = await conn.fetchrow(
                 """
                 SELECT storage_version, kek_id, wrapped_dek
                   FROM object_versions
@@ -539,7 +540,7 @@ class ObjectWriter:
             kek_id_new, kek_bytes = await get_or_create_active_bucket_kek(bucket_id=bucket_id)
             aad = f"hippius-dek:{bucket_id}:{object_id}:{int(object_version)}".encode("utf-8")
             wrapped_new = wrap_dek(kek=kek_bytes, dek=dek, aad=aad)
-            await self.db.execute(
+            await conn.execute(
                 """
                 UPDATE object_versions
                    SET encryption_version = 5,
@@ -576,7 +577,7 @@ class ObjectWriter:
 
         chunk_size = self.config.object_chunk_size_bytes
         # Resolve bucket_id for this version
-        meta = await self.db.fetchrow(
+        meta = await self.pool.fetchrow(
             """
             SELECT o.bucket_id, ov.storage_version
               FROM objects o
@@ -626,7 +627,7 @@ class ObjectWriter:
         md5_hash = await loop.run_in_executor(None, lambda: hashlib.md5(body_bytes).hexdigest())
 
         await upsert_part_placeholder(
-            self.db,
+            self.pool,
             object_id=str(object_id),
             upload_id=str(upload_id),
             part_number=int(part_number),
@@ -661,7 +662,7 @@ class ObjectWriter:
             max_size = 0
 
         # Resolve bucket_id for this version
-        meta = await self.db.fetchrow(
+        meta = await self.pool.fetchrow(
             """
             SELECT o.bucket_id, ov.storage_version
               FROM objects o
@@ -881,7 +882,7 @@ class ObjectWriter:
 
         perf_post_start = time.monotonic()
         await upsert_part_placeholder(
-            self.db,
+            self.pool,
             object_id=str(object_id),
             upload_id=str(upload_id),
             part_number=int(part_number),
@@ -916,7 +917,7 @@ class ObjectWriter:
         seed_phrase: str,
     ) -> CompleteResult:
         # Compute combined ETag from part etags for this version
-        parts = await self.db.fetch(
+        parts = await self.pool.fetch(
             get_query("get_parts_etags_for_version"),
             object_id,
             int(object_version),
@@ -926,16 +927,16 @@ class ObjectWriter:
         final_md5 = hashlib.md5(binary).hexdigest() + f"-{len(etags)}"
 
         # Total size
-        all_parts = await self.db.fetch(
+        all_parts = await self.pool.fetch(
             get_query("list_parts_for_version"),
             object_id,
             int(object_version),
         )
         total_size = sum(int(p["size_bytes"]) for p in all_parts)
 
-        async with self.db.transaction():
+        async with self.pool.acquire() as conn, conn.transaction():
             # Update object_versions
-            await self.db.execute(
+            await conn.execute(
                 """
                 UPDATE object_versions ov
                 SET md5_hash = $1,
@@ -951,7 +952,7 @@ class ObjectWriter:
             )
 
             # Mark MPU completed
-            await self.db.execute(
+            await conn.execute(
                 "UPDATE multipart_uploads SET is_completed = TRUE WHERE upload_id = $1",
                 upload_id,
             )
@@ -970,7 +971,7 @@ class ObjectWriter:
         body_iter: AsyncIterator[bytes],
     ) -> dict:
         """Append bytes with CAS, cache write-through, and enqueue (streaming)."""
-        row = await self.db.fetchrow(
+        row = await self.pool.fetchrow(
             """
             SELECT o.object_id, o.current_object_version AS cov
             FROM objects o
@@ -989,8 +990,8 @@ class ObjectWriter:
         next_part = None
         upload_id = None
 
-        async with self.db.transaction():
-            locked = await self.db.fetchrow(
+        async with self.pool.acquire() as conn, conn.transaction():
+            locked = await conn.fetchrow(
                 """
                 SELECT append_version
                   FROM object_versions
@@ -1006,7 +1007,7 @@ class ObjectWriter:
             if expected_version != current_version:
                 raise AppendPreconditionFailed(current_version)
 
-            next_part = await self.db.fetchval(
+            next_part = await conn.fetchval(
                 """
                 SELECT COALESCE(MAX(part_number), 0) + 1
                   FROM parts
@@ -1015,7 +1016,7 @@ class ObjectWriter:
                 object_id,
                 cov,
             )
-            upload_row = await self.db.fetchrow(
+            upload_row = await conn.fetchrow(
                 "SELECT upload_id FROM multipart_uploads WHERE object_id = $1 ORDER BY initiated_at DESC LIMIT 1",
                 object_id,
             )
@@ -1023,7 +1024,7 @@ class ObjectWriter:
                 upload_id = str(upload_row["upload_id"])
             else:
                 upload_id = str(uuid.uuid4())
-                await self.db.execute(
+                await conn.execute(
                     """
                     INSERT INTO multipart_uploads (upload_id, bucket_id, object_key, initiated_at, is_completed, content_type, metadata, object_id)
                     VALUES ($1, (SELECT bucket_id FROM buckets WHERE bucket_name = $2 LIMIT 1), $3, NOW(), TRUE, 'application/octet-stream', '{}', $4)
@@ -1035,7 +1036,7 @@ class ObjectWriter:
                     object_id,
                 )
 
-            await self.db.execute(
+            await conn.execute(
                 """
                 INSERT INTO parts (part_id, upload_id, part_number, ipfs_cid, size_bytes, etag, uploaded_at, object_id, object_version, chunk_size_bytes)
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
@@ -1057,7 +1058,7 @@ class ObjectWriter:
             raise RuntimeError("append_reservation_failed")
 
         async def _delete_part_row() -> None:
-            await self.db.execute(
+            await self.pool.execute(
                 "DELETE FROM parts WHERE object_id = $1 AND object_version = $2 AND part_number = $3",
                 object_id,
                 int(cov),
@@ -1129,8 +1130,8 @@ class ObjectWriter:
         num_chunks = int(meta.get("num_chunks", 0)) if meta else None
 
         try:
-            async with self.db.transaction():
-                locked = await self.db.fetchrow(
+            async with self.pool.acquire() as conn, conn.transaction():
+                locked = await conn.fetchrow(
                     """
                     SELECT append_version,
                            md5_hash,
@@ -1150,7 +1151,7 @@ class ObjectWriter:
 
                 seed_md5s = b""
                 if not bool(locked.get("has_etag_md5s")):
-                    parts = await self.db.fetch(
+                    parts = await conn.fetch(
                         "SELECT part_number, etag FROM parts WHERE object_id = $1 AND object_version = $2 ORDER BY part_number",
                         object_id,
                         cov,
@@ -1171,7 +1172,7 @@ class ObjectWriter:
                             md5s.append(bytes.fromhex(e))
                     seed_md5s = b"".join(md5s)
 
-                updated = await self.db.fetchrow(
+                updated = await conn.fetchrow(
                     """
                     UPDATE object_versions
                        SET size_bytes     = size_bytes + $3,
@@ -1212,7 +1213,7 @@ class ObjectWriter:
                     str(part_res.etag),
                 )
                 if not updated:
-                    fresh = await self.db.fetchval(
+                    fresh = await conn.fetchval(
                         "SELECT append_version FROM object_versions WHERE object_id = $1 AND object_version = $2",
                         object_id,
                         cov,

--- a/tests/unit/api/test_bucket_create_validation.py
+++ b/tests/unit/api/test_bucket_create_validation.py
@@ -11,8 +11,27 @@ from httpx import ASGITransport
 from httpx import AsyncClient
 
 from hippius_s3.api.s3.buckets.router import router
-from hippius_s3.dependencies import get_postgres
+from hippius_s3.dependencies import get_db_pool
 from hippius_s3.models.account import HippiusAccount
+
+
+def _make_mock_pool() -> Any:
+    mock_db = AsyncMock()
+
+    @asynccontextmanager
+    async def dummy_transaction() -> Any:
+        yield
+
+    mock_db.transaction = dummy_transaction
+    mock_db.fetchrow = AsyncMock()
+
+    @asynccontextmanager
+    async def acquire() -> Any:
+        yield mock_db
+
+    mock_pool = AsyncMock()
+    mock_pool.acquire = acquire
+    return mock_pool
 
 
 @pytest.fixture
@@ -31,17 +50,7 @@ def bucket_app() -> Any:
         )
         return await call_next(request)
 
-    @asynccontextmanager
-    async def dummy_transaction() -> Any:
-        yield
-
-    async def override_get_postgres() -> Any:
-        mock_db = AsyncMock()
-        mock_db.transaction = dummy_transaction
-        mock_db.fetchrow = AsyncMock()
-        yield mock_db
-
-    app.dependency_overrides[get_postgres] = override_get_postgres
+    app.dependency_overrides[get_db_pool] = _make_mock_pool
 
     return app
 
@@ -76,17 +85,7 @@ async def test_create_bucket_allows_own_ss58_address() -> None:
         )
         return await call_next(request)
 
-    @asynccontextmanager
-    async def dummy_transaction() -> Any:
-        yield
-
-    async def override_get_postgres() -> Any:
-        mock_db = AsyncMock()
-        mock_db.transaction = dummy_transaction
-        mock_db.fetchrow = AsyncMock()
-        yield mock_db
-
-    app.dependency_overrides[get_postgres] = override_get_postgres
+    app.dependency_overrides[get_db_pool] = _make_mock_pool
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.put(f"/{ss58_bucket}")

--- a/tests/unit/test_mpu_upload_part_stream_cleanup.py
+++ b/tests/unit/test_mpu_upload_part_stream_cleanup.py
@@ -28,7 +28,7 @@ async def test_mpu_upload_part_stream_cleans_up_on_oversize(tmp_path, monkeypatc
     object_id = str(uuid.uuid4())
     fs_store = FileSystemPartsStore(str(tmp_path))
 
-    class DummyDB:
+    class DummyPool:
         async def fetchrow(self, *_args, **_kwargs):
             return {"bucket_id": "bucket", "storage_version": 5, "kek_id": "kek-1", "wrapped_dek": b"\x00" * 48}
 
@@ -49,7 +49,7 @@ async def test_mpu_upload_part_stream_cleans_up_on_oversize(tmp_path, monkeypatc
         yield b"abcd"
         yield b"ef"
 
-    writer = ObjectWriter(db=DummyDB(), redis_client=DummyRedis(), fs_store=fs_store)
+    writer = ObjectWriter(pool=DummyPool(), redis_client=DummyRedis(), fs_store=fs_store)
     monkeypatch.setattr(writer, "_ensure_and_get_v5_dek", fake_ensure_dek)
 
     try:


### PR DESCRIPTION
## Summary

Resolves the connection-pool exhaustion observed in prod on 2026-04-23 (DB pool spiked from a baseline of ~70 to **660 conns at 07:00 UTC**, sustained 200+ for hours). Root cause: the `get_postgres` FastAPI dependency acquired a Postgres connection at the start of every request and held it via `yield` until FastAPI fully sent the response — including throughout the multi-minute body-streaming phase of `PUT /pi-backup/*` MPU parts (avg `Tr` 240 s, max 5.5 min) and the entire `GET /<bucket>/<2GB-file>` stream.

This PR introduces a parallel `get_db_pool` dependency that returns the pool itself; handlers acquire conns only for their actual DB phases and release them before any long non-DB work (streaming response bodies, FS/Arion I/O, slow client reads).

## Changes

### New dependency
- `hippius_s3/dependencies.py` — adds `get_db_pool(request) -> asyncpg.Pool` alongside the existing `get_postgres`. Same shape as the corcel pattern. `get_postgres` and the `DBConnection` wrapper are unchanged so nothing existing breaks.

### `ObjectWriter` redesigned to take a pool
- `hippius_s3/writer/object_writer.py` — `__init__` now takes `pool: asyncpg.Pool`. `self.db` → `self.pool`. The 4 transaction blocks (`_ensure_and_get_v5_dek`, `mpu_complete`, two in `append_stream`) were rewritten as `async with self.pool.acquire() as conn, conn.transaction(): ... conn.X(...)` — the pool itself doesn't expose `.transaction()`, only acquired connections do. All other 23 callsites use `self.pool.X(...)` directly (asyncpg auto-acquires + releases per call). Helpers (`upsert_object_basic`, `ensure_upload_row`, `upsert_part_placeholder`) work unchanged because asyncpg.Pool exposes the same `fetchrow`/`fetchval`/`execute` interface as Connection.

### S3 object handlers (high-impact paths)
- **`get_object`** — `handle_get_object` acquires a conn for the metadata phase only and releases via `finally` before returning the `StreamingResponse`. The returned `stream_plan` generator doesn't capture `db`, so the conn is back in the pool the moment FastAPI starts streaming bytes. For a 2 GB GET that streams for minutes, this frees a slot that was previously held idle the whole time.
- **`head_object`** — same pattern, smaller surface.
- **`put_object`** — `handle_put_object` takes `pool` directly, all `db.X` → `pool.X`, passes pool to `ObjectWriter` and `handle_append`. The PUT body-streaming phase now holds zero DB connections: phase 1 (user upsert, bucket lookup, prev-object lookup) acquires per call and releases each immediately; the `ObjectWriter.put_simple_stream_full` streaming loop runs with no DB acquires; phase 2 (final size update + multipart_uploads completion) acquires fresh conns. For a 240 s pi-backup MPU part, conn-hold drops from ~240 s to a few ms across the request.
- **`copy_object`** — `handle_copy_object` and `handle_streaming_copy` migrated to pool. Removes the dual-conn-hold (router conn + writer conn) that existed during the multi-minute byte copy.
- **`upload_part`** (MPU) — same shape: takes `pool` directly, all `db.X` → `pool.X` (8 sites), passes pool to ObjectWriter.
- **`public_router.py`** — public GET/HEAD migrated to pool.

### Bucket router
- `list_objects` uses `pool.fetchrow`/`pool.fetch` directly (auto-release per query).
- All other bucket routes (`list_buckets`, `create_or_modify_bucket`, `delete_bucket_tags_route`, `post_bucket_subresources`, `head_bucket`) switched to inject pool with scoped `async with pool.acquire()` per branch — bounds conn lifetime to the handler instead of the FastAPI request.

### Multipart
- `handle_post_object` (POST: InitiateMPU + CompleteMPU) injects pool, wraps each branch in `async with`.
- Dropped the dead `@router.delete` decorator on `abort_multipart_upload` (shadowed by `objects/router.py:delete_object` since both routers mount at the same prefix).
- Lower-impact callsites (`copy_helpers`, `append`, multipart `initiate`/`complete`) use the pragmatic pattern: ObjectWriter receives `pool=request.app.state.postgres_pool` directly while the handler still takes a conn.

### Script + test
- `migrate_objects.py` — per-task `asyncpg.connect(...)` swapped for `asyncpg.create_pool(min_size=1, max_size=2)`. `task_db` renamed to `task_pool` for accuracy.
- `tests/unit/test_mpu_upload_part_stream_cleanup.py` — `DummyDB` → `DummyPool`, `db=` → `pool=`.
- `tests/unit/api/test_bucket_create_validation.py` — fixture overrides `get_db_pool` (the migrated route no longer injects `get_postgres`).

## Test plan

- [x] `ruff check` and `ruff format --check` pass on all 14 PR-scope `.py` files
- [x] `mypy` shows only pre-existing missing-stub warnings (asyncpg/lxml) and the pre-existing `multipart.py:497` `PartChunkSpec` type issue (unchanged by this PR)
- [x] `pytest tests/unit` (excluding gateway): **276 passed, 1 skipped**
- [x] Targeted tests:
  - `tests/unit/test_mpu_upload_part_stream_cleanup.py::test_mpu_upload_part_stream_cleans_up_on_oversize` — pass
  - `tests/unit/api/test_bucket_create_validation.py` — both tests pass
- [ ] Validate in staging: benchmark concurrent `get_object` against a 1 GB object and watch DB pool `used` metric (expect: stays near 0 because conns are returned within ms of metadata read; pre-refactor: rises with every concurrent download)
- [ ] Validate in staging: same benchmark for `ListObjects` against `teutonic-sn3` (expect: conn released as soon as the 18 s query returns, instead of after XML serialization + response send)
- [ ] Watch `DB pool connections` Grafana panel after deploy — should stop spiking under load

## Out of scope (deferred)

- `teutonic-sn3/dashboard.json` version bloat (161,838 versions on one key from a single client) — captured separately in `bloat.md`. Independent fix; not part of this PR.
- `list_objects.sql` LIMIT + pagination + streaming — addresses the 18 s query cost itself (independent of the conn-hold fix). Captured in `bloat.md`.
- HAProxy stick-table per-IP rate-limit (was an earlier proposal targeting the pi-backup client at the edge).

## Why two patterns coexist

`handle_get_object` / `handle_head_object` use **manual `try/finally`** with `pool.acquire()` + `pool.release()`. Other handlers use **`async with pool.acquire() as conn:`**. Both are correct: manual is needed for handlers that return a `StreamingResponse` (the conn must be released *before* the function returns so it isn't held while bytes stream); `async with` is the idiomatic pattern when the handler owns the response lifecycle entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)