### PR TITLE
Cache all publicly-readable content via ATS

### DIFF
--- a/.github/workflows/k8s-deploy.yaml
+++ b/.github/workflows/k8s-deploy.yaml
@@ -164,7 +164,6 @@ jobs:
             --from-literal=HIPPIUS_DOWNLOAD_BACKENDS='${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}' \
             --from-literal=HIPPIUS_DELETE_BACKENDS='${{ secrets.HIPPIUS_DELETE_BACKENDS }}' \
             --from-literal=ATS_CACHE_ENDPOINT='${{ secrets.ATS_CACHE_ENDPOINT }}' \
-            --from-literal=ATS_CACHE_OFFLOAD_BUCKETS='${{ secrets.ATS_CACHE_OFFLOAD_BUCKETS }}' \
             --namespace=hippius-s3-staging \
             --dry-run=client -o yaml | kubectl apply -f -
 
@@ -294,7 +293,6 @@ jobs:
             --from-literal=HIPPIUS_DOWNLOAD_BACKENDS="${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}" \
             --from-literal=HIPPIUS_DELETE_BACKENDS="${{ secrets.HIPPIUS_DELETE_BACKENDS }}" \
             --from-literal=ATS_CACHE_ENDPOINT="${{ secrets.ATS_CACHE_ENDPOINT }}" \
-            --from-literal=ATS_CACHE_OFFLOAD_BUCKETS="${{ secrets.ATS_CACHE_OFFLOAD_BUCKETS }}" \
             --namespace=hippius-s3-prod \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -135,9 +135,6 @@ class GatewayConfig:
     # ATS (Apache Traffic Server) reverse-proxy cache. When ATS_CACHE_ENDPOINT is unset,
     # all PURGE + public Cache-Control logic becomes a no-op — safe default for local dev.
     ats_cache_endpoint: str = dataclasses.field(default_factory=lambda: os.getenv("ATS_CACHE_ENDPOINT", ""))
-    ats_cache_offload_buckets: set[str] = dataclasses.field(
-        default_factory=lambda: set(_parse_csv(os.getenv("ATS_CACHE_OFFLOAD_BUCKETS", "")))
-    )
 
 
 _config: GatewayConfig | None = None

--- a/gateway/middlewares/acl.py
+++ b/gateway/middlewares/acl.py
@@ -126,6 +126,20 @@ async def acl_middleware(
 
     request.state.bucket_owner_id = bucket_owner_id
 
+    # Compute anonymous_read_allowed once, before any auth-bypass paths, so
+    # master-token and presigned-URL reads of public objects also populate ATS cache.
+    # Gated on ATS being active to avoid a Redis round-trip when there's no consumer.
+    request.state.anonymous_read_allowed = False
+    if get_config().ats_cache_endpoint and request.method in ("GET", "HEAD") and key is not None:
+        request.state.anonymous_read_allowed = await acl_service.check_permission(
+            account_id=None,
+            bucket=bucket,
+            key=key,
+            permission=Permission.READ,
+            access_key=None,
+            bucket_owner_id=bucket_owner_id,
+        )
+
     if auth_method == "access_key" and token_type == "master" and bucket_owner_id == account_id:
         logger.info(f"Master token bypass for account {account_id} on bucket {bucket}")
         request.state.bucket_owner_id = bucket_owner_id
@@ -165,28 +179,6 @@ async def acl_middleware(
 
     is_anonymous = account_id is None or account_id == "anonymous"
     request.state.is_anonymous_access = is_anonymous
-
-    # Only probe AllUsers grant when ATS caching is active — otherwise no consumer.
-    # Master-token bypass above returns early, so those reads default to False and won't
-    # populate the ATS cache; the next anon reader will.
-    request.state.anonymous_read_allowed = False
-    if (
-        get_config().ats_cache_endpoint
-        and request.method in ("GET", "HEAD")
-        and key is not None
-        and permission == Permission.READ
-    ):
-        if is_anonymous:
-            request.state.anonymous_read_allowed = True
-        else:
-            request.state.anonymous_read_allowed = await acl_service.check_permission(
-                account_id=None,
-                bucket=bucket,
-                key=key,
-                permission=Permission.READ,
-                access_key=None,
-                bucket_owner_id=bucket_owner_id,
-            )
 
     response = await call_next(request)
 

--- a/gateway/middlewares/cache_control.py
+++ b/gateway/middlewares/cache_control.py
@@ -6,12 +6,10 @@ from typing import Callable
 from fastapi import Request
 from fastapi import Response
 
-from gateway.config import get_config
 from gateway.middlewares.acl import parse_s3_path
 
 
-REVALIDATE_ALWAYS = "public, max-age=0, must-revalidate"
-STANDARD_PUBLIC = "public, max-age=300, stale-while-revalidate=60"
+PUBLIC_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=60"
 PRIVATE_CACHE_CONTROL = "private, no-store"
 
 
@@ -34,14 +32,8 @@ async def cache_control_middleware(
         response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
         return response
 
-    anon_readable = bool(getattr(request.state, "anonymous_read_allowed", False))
-    if not anon_readable:
-        response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
-        return response
-
-    offload = get_config().ats_cache_offload_buckets
-    if bucket in offload:
-        response.headers["Cache-Control"] = STANDARD_PUBLIC
+    if getattr(request.state, "anonymous_read_allowed", False):
+        response.headers["Cache-Control"] = PUBLIC_CACHE_CONTROL
     else:
-        response.headers["Cache-Control"] = REVALIDATE_ALWAYS
+        response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
     return response

--- a/k8s/base/gateway-deployment.yaml
+++ b/k8s/base/gateway-deployment.yaml
@@ -136,11 +136,6 @@ spec:
                 secretKeyRef:
                   name: hippius-s3-secrets
                   key: ATS_CACHE_ENDPOINT
-            - name: ATS_CACHE_OFFLOAD_BUCKETS
-              valueFrom:
-                secretKeyRef:
-                  name: hippius-s3-secrets
-                  key: ATS_CACHE_OFFLOAD_BUCKETS
           startupProbe:
             httpGet:
               path: /health

--- a/tests/unit/gateway/test_anonymous_read_flag.py
+++ b/tests/unit/gateway/test_anonymous_read_flag.py
@@ -25,7 +25,13 @@ def _ats_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     gateway_config._config = None
 
 
-def _build_app(acl_service: Any, *, account_id: str | None = None) -> Any:
+def _build_app(
+    acl_service: Any,
+    *,
+    account_id: str | None = None,
+    auth_method: str | None = None,
+    token_type: str | None = None,
+) -> Any:
     app = FastAPI()
     app.state.acl_service = acl_service
 
@@ -35,6 +41,8 @@ def _build_app(acl_service: Any, *, account_id: str | None = None) -> Any:
 
     async def stub_auth(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
         request.state.account_id = account_id
+        request.state.auth_method = auth_method
+        request.state.token_type = token_type
         return await call_next(request)
 
     app.middleware("http")(acl_middleware)
@@ -156,3 +164,28 @@ async def test_probe_skipped_when_ats_disabled(monkeypatch: pytest.MonkeyPatch) 
     assert r.status_code == 200
     assert r.json()["anonymous_read_allowed"] is False
     assert service.check_permission.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_master_token_read_on_public_bucket_sets_flag_true() -> None:
+    """Master-token owner reading a public object — flag must be True so ATS caches it.
+
+    Regression guard: the master-token bypass runs AFTER anonymous_read_allowed is computed.
+    """
+    service = _make_service(primary_permits=True, anon_permits=True)
+    app = _build_app(service, account_id="owner-id", auth_method="access_key", token_type="master")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/public-bucket/foo.txt")
+    assert r.status_code == 200
+    assert r.json()["anonymous_read_allowed"] is True
+
+
+@pytest.mark.asyncio
+async def test_master_token_read_on_private_object_sets_flag_false() -> None:
+    """Master-token owner reading a private object — flag False so ATS does not cache it."""
+    service = _make_service(primary_permits=True, anon_permits=False)
+    app = _build_app(service, account_id="owner-id", auth_method="access_key", token_type="master")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/private-bucket/foo.txt")
+    assert r.status_code == 200
+    assert r.json()["anonymous_read_allowed"] is False

--- a/tests/unit/gateway/test_ats_config.py
+++ b/tests/unit/gateway/test_ats_config.py
@@ -22,27 +22,3 @@ def test_ats_cache_endpoint_loaded_from_env(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setenv("ATS_CACHE_ENDPOINT", "http://192.168.1.155:8080")
     cfg = gateway_config.GatewayConfig()
     assert cfg.ats_cache_endpoint == "http://192.168.1.155:8080"
-
-
-def test_offload_buckets_defaults_to_empty_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("ATS_CACHE_OFFLOAD_BUCKETS", raising=False)
-    cfg = gateway_config.GatewayConfig()
-    assert cfg.ats_cache_offload_buckets == set()
-
-
-def test_offload_buckets_parses_csv(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ATS_CACHE_OFFLOAD_BUCKETS", "assets,media,static-bundles")
-    cfg = gateway_config.GatewayConfig()
-    assert cfg.ats_cache_offload_buckets == {"assets", "media", "static-bundles"}
-
-
-def test_offload_buckets_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ATS_CACHE_OFFLOAD_BUCKETS", " assets , media ")
-    cfg = gateway_config.GatewayConfig()
-    assert cfg.ats_cache_offload_buckets == {"assets", "media"}
-
-
-def test_offload_buckets_ignores_empty_entries(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ATS_CACHE_OFFLOAD_BUCKETS", "assets,,media,")
-    cfg = gateway_config.GatewayConfig()
-    assert cfg.ats_cache_offload_buckets == {"assets", "media"}

--- a/tests/unit/gateway/test_cache_control_middleware.py
+++ b/tests/unit/gateway/test_cache_control_middleware.py
@@ -9,10 +9,8 @@ from fastapi import Response
 from httpx import ASGITransport
 from httpx import AsyncClient
 
-from gateway.config import get_config
 from gateway.middlewares.cache_control import PRIVATE_CACHE_CONTROL
-from gateway.middlewares.cache_control import REVALIDATE_ALWAYS
-from gateway.middlewares.cache_control import STANDARD_PUBLIC
+from gateway.middlewares.cache_control import PUBLIC_CACHE_CONTROL
 from gateway.middlewares.cache_control import cache_control_middleware
 
 
@@ -42,28 +40,17 @@ async def test_private_bucket_gets_no_store(app: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_public_bucket_default_is_revalidate_always(app: Any) -> None:
+async def test_public_bucket_gets_cacheable_policy(app: Any) -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         r = await client.get("/public-bucket/foo.txt", headers={"x-test-anon-read": "true"})
-    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+    assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
 
 
 @pytest.mark.asyncio
-async def test_offload_bucket_gets_standard_public(app: Any, monkeypatch: pytest.MonkeyPatch) -> None:
-    get_config().ats_cache_offload_buckets.add("assets")
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            r = await client.get("/assets/icon.png", headers={"x-test-anon-read": "true"})
-        assert r.headers["Cache-Control"] == STANDARD_PUBLIC
-    finally:
-        get_config().ats_cache_offload_buckets.discard("assets")
-
-
-@pytest.mark.asyncio
-async def test_head_public_bucket_gets_revalidate_always(app: Any) -> None:
+async def test_head_public_bucket_gets_cacheable_policy(app: Any) -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         r = await client.head("/public-bucket/foo.txt", headers={"x-test-anon-read": "true"})
-    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+    assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
 
 
 @pytest.mark.asyncio
@@ -98,7 +85,7 @@ async def test_304_response_still_gets_cache_control(app: Any) -> None:
             headers={"x-test-status": "304", "x-test-anon-read": "true"},
         )
     assert r.status_code == 304
-    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+    assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
 
 
 @pytest.mark.asyncio
@@ -109,7 +96,7 @@ async def test_partial_content_206_gets_cache_control(app: Any) -> None:
             headers={"x-test-status": "206", "x-test-anon-read": "true"},
         )
     assert r.status_code == 206
-    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+    assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
 
 
 @pytest.mark.asyncio

--- a/tests/unit/gateway/test_cache_middleware_integration.py
+++ b/tests/unit/gateway/test_cache_middleware_integration.py
@@ -16,7 +16,7 @@ from gateway import config as gateway_config
 from gateway.middlewares.acl import acl_middleware
 from gateway.middlewares.ats_purge import ats_purge_middleware
 from gateway.middlewares.cache_control import PRIVATE_CACHE_CONTROL
-from gateway.middlewares.cache_control import REVALIDATE_ALWAYS
+from gateway.middlewares.cache_control import PUBLIC_CACHE_CONTROL
 from gateway.middlewares.cache_control import cache_control_middleware
 
 
@@ -83,7 +83,7 @@ async def test_anon_get_public_bucket_emits_public_cache_control(monkeypatch: py
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
         r = await client.get("/public-bucket/foo.txt")
     assert r.status_code == 200
-    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+    assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
     assert purges == []
 
 


### PR DESCRIPTION
## Summary

Make ATS aggressively cache every publicly-readable object — including presigned URLs and reads authenticated via master token — instead of requiring per-bucket opt-in.

Before: default was \`max-age=0, must-revalidate\`. ATS revalidated against the gateway on every request → no backend offload. The \`STANDARD_PUBLIC\` policy (5-min cache) was opt-in via \`ATS_CACHE_OFFLOAD_BUCKETS\`.

After: any object where the effective ACL grants \`AllUsers: READ\` gets \`public, max-age=300, stale-while-revalidate=60\`. ATS serves bodies directly for up to 5 minutes without touching the gateway.

## Changes (biggest → smallest)

- **Drop \`ATS_CACHE_OFFLOAD_BUCKETS\`** — config field, GitHub secret wiring in \`.github/workflows/k8s-deploy.yaml\`, and \`env\` entry in \`k8s/base/gateway-deployment.yaml\` all removed. No longer needed — every public object now uses the same policy.
- **\`gateway/middlewares/acl.py\`** — \`anonymous_read_allowed\` is now computed *before* the master-token bypass returns. Previously presigned URLs and master-token owner reads skipped the flag, so ATS got \`private, no-store\` for content that's otherwise publicly readable. Now they get the correct public Cache-Control.
- **\`gateway/middlewares/cache_control.py\`** — simplified to two outcomes: \`PUBLIC_CACHE_CONTROL\` when the flag is set, \`PRIVATE_CACHE_CONTROL\` otherwise. \`REVALIDATE_ALWAYS\` constant removed.
- **Tests** — updated expectations and added master-token-path regression tests:
  - \`test_master_token_read_on_public_bucket_sets_flag_true\`
  - \`test_master_token_read_on_private_object_sets_flag_false\`
  - Removed offload-bucket tests that tested the opt-in branch.

## Security invariant unchanged

The per-object \`check_permission(None, bucket, key, ...)\` probe still runs (against \`redis-acl\`, ~sub-ms on cache hit). A private object inside a public bucket still returns \`private, no-store\` — per-object ACL overrides the bucket-level public grant.

## Conclusion

Removes a rollout knob in exchange for default-on caching. One small correctness improvement (presigned/master-token paths now cacheable) and meaningful backend-load reduction: with ATS in front of staging, anonymous reads now hit the gateway at most once per 5 minutes instead of every request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)