### PR TITLE
Add ATS reverse-proxy cache with PURGE and Cache-Control

### DIFF
--- a/.github/workflows/k8s-deploy.yaml
+++ b/.github/workflows/k8s-deploy.yaml
@@ -164,7 +164,6 @@ jobs:
             --from-literal=HIPPIUS_DOWNLOAD_BACKENDS='${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}' \
             --from-literal=HIPPIUS_DELETE_BACKENDS='${{ secrets.HIPPIUS_DELETE_BACKENDS }}' \
             --from-literal=ATS_CACHE_ENDPOINT='${{ secrets.ATS_CACHE_ENDPOINT }}' \
-            --from-literal=ATS_CACHE_OFFLOAD_BUCKETS='${{ secrets.ATS_CACHE_OFFLOAD_BUCKETS }}' \
             --namespace=hippius-s3-staging \
             --dry-run=client -o yaml | kubectl apply -f -
 
@@ -294,7 +293,6 @@ jobs:
             --from-literal=HIPPIUS_DOWNLOAD_BACKENDS="${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}" \
             --from-literal=HIPPIUS_DELETE_BACKENDS="${{ secrets.HIPPIUS_DELETE_BACKENDS }}" \
             --from-literal=ATS_CACHE_ENDPOINT="${{ secrets.ATS_CACHE_ENDPOINT }}" \
-            --from-literal=ATS_CACHE_OFFLOAD_BUCKETS="${{ secrets.ATS_CACHE_OFFLOAD_BUCKETS }}" \
             --namespace=hippius-s3-prod \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/.github/workflows/k8s-deploy.yaml
+++ b/.github/workflows/k8s-deploy.yaml
@@ -163,6 +163,8 @@ jobs:
             --from-literal=HIPPIUS_UPLOAD_BACKENDS='${{ secrets.HIPPIUS_UPLOAD_BACKENDS }}' \
             --from-literal=HIPPIUS_DOWNLOAD_BACKENDS='${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}' \
             --from-literal=HIPPIUS_DELETE_BACKENDS='${{ secrets.HIPPIUS_DELETE_BACKENDS }}' \
+            --from-literal=ATS_CACHE_ENDPOINT='${{ secrets.ATS_CACHE_ENDPOINT }}' \
+            --from-literal=ATS_CACHE_OFFLOAD_BUCKETS='${{ secrets.ATS_CACHE_OFFLOAD_BUCKETS }}' \
             --namespace=hippius-s3-staging \
             --dry-run=client -o yaml | kubectl apply -f -
 
@@ -291,6 +293,8 @@ jobs:
             --from-literal=HIPPIUS_UPLOAD_BACKENDS="${{ secrets.HIPPIUS_UPLOAD_BACKENDS }}" \
             --from-literal=HIPPIUS_DOWNLOAD_BACKENDS="${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}" \
             --from-literal=HIPPIUS_DELETE_BACKENDS="${{ secrets.HIPPIUS_DELETE_BACKENDS }}" \
+            --from-literal=ATS_CACHE_ENDPOINT="${{ secrets.ATS_CACHE_ENDPOINT }}" \
+            --from-literal=ATS_CACHE_OFFLOAD_BUCKETS="${{ secrets.ATS_CACHE_OFFLOAD_BUCKETS }}" \
             --namespace=hippius-s3-prod \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -135,9 +135,6 @@ class GatewayConfig:
     # ATS (Apache Traffic Server) reverse-proxy cache. When ATS_CACHE_ENDPOINT is unset,
     # all PURGE + public Cache-Control logic becomes a no-op — safe default for local dev.
     ats_cache_endpoint: str = dataclasses.field(default_factory=lambda: os.getenv("ATS_CACHE_ENDPOINT", ""))
-    ats_cache_offload_buckets: set[str] = dataclasses.field(
-        default_factory=lambda: set(_parse_csv(os.getenv("ATS_CACHE_OFFLOAD_BUCKETS", "")))
-    )
 
 
 _config: GatewayConfig | None = None

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -132,6 +132,13 @@ class GatewayConfig:
     )
     arion_service_key: str = dataclasses.field(default_factory=lambda: os.getenv("ARION_SERVICE_KEY", ""))
 
+    # ATS (Apache Traffic Server) reverse-proxy cache. When ATS_CACHE_ENDPOINT is unset,
+    # all PURGE + public Cache-Control logic becomes a no-op — safe default for local dev.
+    ats_cache_endpoint: str = dataclasses.field(default_factory=lambda: os.getenv("ATS_CACHE_ENDPOINT", ""))
+    ats_cache_offload_buckets: set[str] = dataclasses.field(
+        default_factory=lambda: set(_parse_csv(os.getenv("ATS_CACHE_OFFLOAD_BUCKETS", "")))
+    )
+
 
 _config: GatewayConfig | None = None
 

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -200,9 +200,7 @@ def factory() -> FastAPI:
     app.middleware("http")(input_validation_middleware)
     if config.read_only_mode:
         app.middleware("http")(read_only_middleware)
-    # Cache-Control header injection + ATS PURGE dispatch on successful writes.
-    # Registered just inside CORS so their response-path edits happen before
-    # CORS headers are layered onto the outgoing response.
+    # Inside CORS so Cache-Control lands before CORS wraps the response.
     app.middleware("http")(ats_purge_middleware)
     app.middleware("http")(cache_control_middleware)
     # Outermost: CORS must wrap everything so error responses get CORS headers

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -131,11 +131,16 @@ def factory() -> FastAPI:
 
     @app.on_event("shutdown")
     async def shutdown() -> None:
+        from gateway.services import ats_cache_client
+
         logger.info("Shutting down Hippius S3 Gateway...")
 
         if hasattr(app.state, "arion_client"):
             await app.state.arion_client.close()
             logger.info("ArionClient closed")
+
+        await ats_cache_client.close()
+        logger.info("ATS cache client closed")
 
         if hasattr(app.state, "forward_service"):
             await app.state.forward_service.close()

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -10,8 +10,10 @@ from fastapi import Response
 from gateway.config import get_config
 from gateway.middlewares.account import account_middleware
 from gateway.middlewares.acl import acl_middleware
+from gateway.middlewares.ats_purge import ats_purge_middleware
 from gateway.middlewares.audit_log import audit_log_middleware
 from gateway.middlewares.auth_router import auth_router_middleware
+from gateway.middlewares.cache_control import cache_control_middleware
 from gateway.middlewares.cors import cors_middleware
 from gateway.middlewares.frontend_hmac import verify_frontend_hmac_middleware
 from gateway.middlewares.input_validation import input_validation_middleware
@@ -193,6 +195,11 @@ def factory() -> FastAPI:
     app.middleware("http")(input_validation_middleware)
     if config.read_only_mode:
         app.middleware("http")(read_only_middleware)
+    # Cache-Control header injection + ATS PURGE dispatch on successful writes.
+    # Registered just inside CORS so their response-path edits happen before
+    # CORS headers are layered onto the outgoing response.
+    app.middleware("http")(ats_purge_middleware)
+    app.middleware("http")(cache_control_middleware)
     # Outermost: CORS must wrap everything so error responses get CORS headers
     app.middleware("http")(cors_middleware)
 

--- a/gateway/middlewares/acl.py
+++ b/gateway/middlewares/acl.py
@@ -126,6 +126,20 @@ async def acl_middleware(
 
     request.state.bucket_owner_id = bucket_owner_id
 
+    # Compute anonymous_read_allowed once, before any auth-bypass paths, so
+    # master-token and presigned-URL reads of public objects also populate ATS cache.
+    # Gated on ATS being active to avoid a Redis round-trip when there's no consumer.
+    request.state.anonymous_read_allowed = False
+    if get_config().ats_cache_endpoint and request.method in ("GET", "HEAD") and key is not None:
+        request.state.anonymous_read_allowed = await acl_service.check_permission(
+            account_id=None,
+            bucket=bucket,
+            key=key,
+            permission=Permission.READ,
+            access_key=None,
+            bucket_owner_id=bucket_owner_id,
+        )
+
     if auth_method == "access_key" and token_type == "master" and bucket_owner_id == account_id:
         logger.info(f"Master token bypass for account {account_id} on bucket {bucket}")
         request.state.bucket_owner_id = bucket_owner_id
@@ -165,28 +179,6 @@ async def acl_middleware(
 
     is_anonymous = account_id is None or account_id == "anonymous"
     request.state.is_anonymous_access = is_anonymous
-
-    # Only probe AllUsers grant when ATS caching is active — otherwise no consumer.
-    # Master-token bypass above returns early, so those reads default to False and won't
-    # populate the ATS cache; the next anon reader will.
-    request.state.anonymous_read_allowed = False
-    if (
-        get_config().ats_cache_endpoint
-        and request.method in ("GET", "HEAD")
-        and key is not None
-        and permission == Permission.READ
-    ):
-        if is_anonymous:
-            request.state.anonymous_read_allowed = True
-        else:
-            request.state.anonymous_read_allowed = await acl_service.check_permission(
-                account_id=None,
-                bucket=bucket,
-                key=key,
-                permission=Permission.READ,
-                access_key=None,
-                bucket_owner_id=bucket_owner_id,
-            )
 
     response = await call_next(request)
 

--- a/gateway/middlewares/acl.py
+++ b/gateway/middlewares/acl.py
@@ -4,6 +4,7 @@ from typing import Callable
 from fastapi import Request
 from fastapi import Response
 
+from gateway.config import get_config
 from gateway.utils.errors import s3_error_response
 from hippius_s3.models.acl import Permission
 from hippius_s3.services.ray_id_service import get_logger_with_ray_id
@@ -89,6 +90,8 @@ async def acl_middleware(
         return await call_next(request)
 
     bucket, key = parse_s3_path(path)
+    request.state.s3_bucket = bucket
+    request.state.s3_key = key
 
     if bucket is None:
         return await call_next(request)
@@ -163,13 +166,16 @@ async def acl_middleware(
     is_anonymous = account_id is None or account_id == "anonymous"
     request.state.is_anonymous_access = is_anonymous
 
-    # anonymous_read_allowed drives the Cache-Control emitted by cache_control_middleware.
-    # Only True when the object is readable by GROUP:AllUsers — the signal ATS needs to
-    # know it can hand a cached body to a different client. Master-token bypass above
-    # returns early, so those reads default to False (private) — acceptable since the
-    # first anon reader will populate the ATS cache.
+    # Only probe AllUsers grant when ATS caching is active — otherwise no consumer.
+    # Master-token bypass above returns early, so those reads default to False and won't
+    # populate the ATS cache; the next anon reader will.
     request.state.anonymous_read_allowed = False
-    if request.method in ("GET", "HEAD") and key is not None and permission == Permission.READ:
+    if (
+        get_config().ats_cache_endpoint
+        and request.method in ("GET", "HEAD")
+        and key is not None
+        and permission == Permission.READ
+    ):
         if is_anonymous:
             request.state.anonymous_read_allowed = True
         else:

--- a/gateway/middlewares/acl.py
+++ b/gateway/middlewares/acl.py
@@ -163,6 +163,11 @@ async def acl_middleware(
     is_anonymous = account_id is None or account_id == "anonymous"
     request.state.is_anonymous_access = is_anonymous
 
+    # anonymous_read_allowed drives the Cache-Control emitted by cache_control_middleware.
+    # Only True when the object is readable by GROUP:AllUsers — the signal ATS needs to
+    # know it can hand a cached body to a different client. Master-token bypass above
+    # returns early, so those reads default to False (private) — acceptable since the
+    # first anon reader will populate the ATS cache.
     request.state.anonymous_read_allowed = False
     if request.method in ("GET", "HEAD") and key is not None and permission == Permission.READ:
         if is_anonymous:

--- a/gateway/middlewares/acl.py
+++ b/gateway/middlewares/acl.py
@@ -163,6 +163,20 @@ async def acl_middleware(
     is_anonymous = account_id is None or account_id == "anonymous"
     request.state.is_anonymous_access = is_anonymous
 
+    request.state.anonymous_read_allowed = False
+    if request.method in ("GET", "HEAD") and key is not None and permission == Permission.READ:
+        if is_anonymous:
+            request.state.anonymous_read_allowed = True
+        else:
+            request.state.anonymous_read_allowed = await acl_service.check_permission(
+                account_id=None,
+                bucket=bucket,
+                key=key,
+                permission=Permission.READ,
+                access_key=None,
+                bucket_owner_id=bucket_owner_id,
+            )
+
     response = await call_next(request)
 
     if is_anonymous:

--- a/gateway/middlewares/ats_purge.py
+++ b/gateway/middlewares/ats_purge.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Awaitable
+from typing import Callable
+
+from fastapi import Request
+from fastapi import Response
+
+from gateway.middlewares.acl import parse_s3_path
+from gateway.services.ats_cache_client import schedule_purge
+
+
+DEFAULT_HOST = "s3.hippius.com"
+
+
+async def ats_purge_middleware(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    response = await call_next(request)
+    if response.status_code >= 300:
+        return response
+
+    method = request.method
+    if method not in ("PUT", "POST", "DELETE"):
+        return response
+
+    bucket, key = parse_s3_path(request.url.path)
+    if not bucket:
+        return response
+
+    qs = request.query_params
+    host = request.headers.get("host", DEFAULT_HOST)
+
+    if not key:
+        if method == "PUT" and "acl" in qs:  # noqa: SIM114 — kept distinct for readability
+            schedule_purge(host, f"{bucket}/*")
+        elif method == "DELETE":
+            schedule_purge(host, f"{bucket}/*")
+        return response
+
+    if method == "PUT":
+        if "partNumber" in qs:
+            # MPU part upload — not visible until CompleteMultipartUpload, skip.
+            return response
+        schedule_purge(host, f"{bucket}/{key}")
+        copy_source = request.headers.get("x-amz-copy-source")
+        if copy_source:
+            schedule_purge(host, copy_source.lstrip("/"))
+    elif method == "DELETE":  # noqa: SIM114 — kept distinct for readability
+        schedule_purge(host, f"{bucket}/{key}")
+    elif method == "POST" and "uploadId" in qs and "partNumber" not in qs:
+        schedule_purge(host, f"{bucket}/{key}")
+
+    return response

--- a/gateway/middlewares/ats_purge.py
+++ b/gateway/middlewares/ats_purge.py
@@ -6,6 +6,7 @@ from typing import Callable
 from fastapi import Request
 from fastapi import Response
 
+from gateway.config import get_config
 from gateway.middlewares.acl import parse_s3_path
 from gateway.services.ats_cache_client import schedule_purge
 
@@ -18,14 +19,19 @@ async def ats_purge_middleware(
     call_next: Callable[[Request], Awaitable[Response]],
 ) -> Response:
     response = await call_next(request)
+
+    if not get_config().ats_cache_endpoint:
+        return response
     if response.status_code >= 300:
         return response
-
     method = request.method
     if method not in ("PUT", "POST", "DELETE"):
         return response
 
-    bucket, key = parse_s3_path(request.url.path)
+    bucket = getattr(request.state, "s3_bucket", None)
+    key = getattr(request.state, "s3_key", None)
+    if bucket is None:
+        bucket, key = parse_s3_path(request.url.path)
     if not bucket:
         return response
 
@@ -33,23 +39,19 @@ async def ats_purge_middleware(
     host = request.headers.get("host", DEFAULT_HOST)
 
     if not key:
-        if method == "PUT" and "acl" in qs:  # noqa: SIM114 — kept distinct for readability
-            schedule_purge(host, f"{bucket}/*")
-        elif method == "DELETE":
+        is_bucket_purge = (method == "PUT" and "acl" in qs) or method == "DELETE"
+        if is_bucket_purge:
             schedule_purge(host, f"{bucket}/*")
         return response
 
     if method == "PUT":
         if "partNumber" in qs:
-            # MPU part upload — not visible until CompleteMultipartUpload, skip.
             return response
         schedule_purge(host, f"{bucket}/{key}")
         copy_source = request.headers.get("x-amz-copy-source")
         if copy_source:
             schedule_purge(host, copy_source.lstrip("/"))
-    elif method == "DELETE":  # noqa: SIM114 — kept distinct for readability
-        schedule_purge(host, f"{bucket}/{key}")
-    elif method == "POST" and "uploadId" in qs and "partNumber" not in qs:
+    elif method == "DELETE" or (method == "POST" and "uploadId" in qs and "partNumber" not in qs):
         schedule_purge(host, f"{bucket}/{key}")
 
     return response

--- a/gateway/middlewares/cache_control.py
+++ b/gateway/middlewares/cache_control.py
@@ -6,12 +6,10 @@ from typing import Callable
 from fastapi import Request
 from fastapi import Response
 
-from gateway.config import get_config
 from gateway.middlewares.acl import parse_s3_path
 
 
-REVALIDATE_ALWAYS = "public, max-age=0, must-revalidate"
-STANDARD_PUBLIC = "public, max-age=300, stale-while-revalidate=60"
+PUBLIC_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=60"
 PRIVATE_CACHE_CONTROL = "private, no-store"
 
 
@@ -34,14 +32,8 @@ async def cache_control_middleware(
         response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
         return response
 
-    anon_readable = bool(getattr(request.state, "anonymous_read_allowed", False))
-    if not anon_readable:
-        response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
-        return response
-
-    offload = get_config().ats_cache_offload_buckets
-    if bucket in offload:
-        response.headers["Cache-Control"] = STANDARD_PUBLIC
+    if getattr(request.state, "anonymous_read_allowed", False):
+        response.headers["Cache-Control"] = PUBLIC_CACHE_CONTROL
     else:
-        response.headers["Cache-Control"] = REVALIDATE_ALWAYS
+        response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
     return response

--- a/gateway/middlewares/cache_control.py
+++ b/gateway/middlewares/cache_control.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Awaitable
+from typing import Callable
+
+from fastapi import Request
+from fastapi import Response
+
+from gateway.config import get_config
+from gateway.middlewares.acl import parse_s3_path
+
+
+REVALIDATE_ALWAYS = "public, max-age=0, must-revalidate"
+STANDARD_PUBLIC = "public, max-age=300, stale-while-revalidate=60"
+PRIVATE_CACHE_CONTROL = "private, no-store"
+
+
+async def cache_control_middleware(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    response = await call_next(request)
+
+    if request.method not in ("GET", "HEAD"):
+        return response
+    if response.status_code not in (200, 206, 304):
+        return response
+
+    bucket, key = parse_s3_path(request.url.path)
+    if not bucket or not key:
+        response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
+        return response
+
+    anon_readable = bool(getattr(request.state, "anonymous_read_allowed", False))
+    if not anon_readable:
+        response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
+        return response
+
+    offload = get_config().ats_cache_offload_buckets
+    if bucket in offload:
+        response.headers["Cache-Control"] = STANDARD_PUBLIC
+    else:
+        response.headers["Cache-Control"] = REVALIDATE_ALWAYS
+    return response

--- a/gateway/middlewares/cache_control.py
+++ b/gateway/middlewares/cache_control.py
@@ -26,7 +26,10 @@ async def cache_control_middleware(
     if response.status_code not in (200, 206, 304):
         return response
 
-    bucket, key = parse_s3_path(request.url.path)
+    bucket = getattr(request.state, "s3_bucket", None)
+    key = getattr(request.state, "s3_key", None)
+    if bucket is None:
+        bucket, key = parse_s3_path(request.url.path)
     if not bucket or not key:
         response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
         return response

--- a/gateway/services/ats_cache_client.py
+++ b/gateway/services/ats_cache_client.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import httpx
+
+from gateway.config import get_config
+
+
+logger = logging.getLogger(__name__)
+
+_client: httpx.AsyncClient | None = None
+
+
+def _get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        _client = httpx.AsyncClient(timeout=httpx.Timeout(2.0))
+    return _client
+
+
+async def close() -> None:
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None
+
+
+async def _purge(endpoint: str, host: str, key: str) -> None:
+    url = f"{endpoint.rstrip('/')}/{key.lstrip('/')}"
+    try:
+        response = await _get_client().request("PURGE", url, headers={"Host": host})
+    except httpx.HTTPError as e:
+        logger.warning("ATS PURGE request failed host=%s key=%s: %s", host, key, e)
+        return
+    if response.status_code >= 400:
+        logger.warning("ATS PURGE host=%s key=%s status=%d", host, key, response.status_code)
+
+
+def schedule_purge(host: str, key: str) -> None:
+    """Fire-and-forget PURGE against ATS. No-op when ATS_CACHE_ENDPOINT is unset."""
+    endpoint = get_config().ats_cache_endpoint
+    if not endpoint:
+        return
+    asyncio.create_task(_purge(endpoint, host, key))

--- a/hippius_s3/api/s3/common/__init__.py
+++ b/hippius_s3/api/s3/common/__init__.py
@@ -1,3 +1,4 @@
 from .headers import build_headers  # re-export
+from .headers import if_none_match_matches  # re-export
 from .req import parse_range  # re-export
 from .req import parse_read_mode  # re-export

--- a/hippius_s3/api/s3/common/headers.py
+++ b/hippius_s3/api/s3/common/headers.py
@@ -3,6 +3,26 @@ from __future__ import annotations
 import json
 
 
+def if_none_match_matches(header_value: str | None, md5_hash: str) -> bool:
+    """Return True iff the `If-None-Match` header indicates the client already has the current version.
+
+    Accepts the S3/strong-ETag convention `"<md5_hash>"` or `"<md5_hash>-<parts>"`.
+    Also honors the `*` wildcard. Comma-separated lists are supported per RFC 7232.
+    """
+    if not header_value or not md5_hash:
+        return False
+    if header_value.strip() == "*":
+        return True
+    for token in header_value.split(","):
+        candidate = token.strip()
+        if candidate.startswith("W/"):
+            candidate = candidate[2:]
+        candidate = candidate.strip('"')
+        if candidate == md5_hash:
+            return True
+    return False
+
+
 def build_headers(
     info: dict,
     *,

--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -14,6 +14,7 @@ from opentelemetry import trace
 
 from hippius_s3.api.middlewares.tracing import set_span_attributes
 from hippius_s3.api.s3 import errors
+from hippius_s3.api.s3.common import if_none_match_matches
 from hippius_s3.api.s3.common import parse_range
 from hippius_s3.api.s3.common import parse_read_mode
 from hippius_s3.api.s3.range_utils import parse_range_header
@@ -177,6 +178,10 @@ async def handle_get_object(
                         "object_version": int(object_info.get("object_version") or 1),
                     },
                 )
+
+        md5_hash = object_info.get("md5_hash") or ""
+        if md5_hash and if_none_match_matches(request.headers.get("if-none-match"), md5_hash):
+            return Response(status_code=304, headers={"ETag": f'"{md5_hash}"'})
 
         # Build download chunk list from DB parts
         request.state.object_size = int(object_info.get("size_bytes") or 0)

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -12,6 +12,7 @@ from opentelemetry import trace
 
 from hippius_s3.api.middlewares.tracing import set_span_attributes
 from hippius_s3.api.s3 import errors
+from hippius_s3.api.s3.common import if_none_match_matches
 from hippius_s3.repositories.objects import ObjectRepository
 from hippius_s3.repositories.users import UserRepository
 from hippius_s3.utils import get_query
@@ -156,6 +157,9 @@ async def handle_head_object(
                         )
                 except Exception:
                     md5_hash = md5_hash or ""
+        if md5_hash and if_none_match_matches(request.headers.get("if-none-match"), md5_hash):
+            return Response(status_code=304, headers={"ETag": f'"{md5_hash}"'})
+
         content_type = row["content_type"]
         headers: dict[str, str] = {
             "Content-Type": content_type,

--- a/k8s/base/gateway-deployment.yaml
+++ b/k8s/base/gateway-deployment.yaml
@@ -131,6 +131,16 @@ spec:
                 secretKeyRef:
                   name: hippius-s3-secrets
                   key: HIPPIUS_DELETE_BACKENDS
+            - name: ATS_CACHE_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: ATS_CACHE_ENDPOINT
+            - name: ATS_CACHE_OFFLOAD_BUCKETS
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: ATS_CACHE_OFFLOAD_BUCKETS
           startupProbe:
             httpGet:
               path: /health

--- a/k8s/base/gateway-deployment.yaml
+++ b/k8s/base/gateway-deployment.yaml
@@ -136,11 +136,6 @@ spec:
                 secretKeyRef:
                   name: hippius-s3-secrets
                   key: ATS_CACHE_ENDPOINT
-            - name: ATS_CACHE_OFFLOAD_BUCKETS
-              valueFrom:
-                secretKeyRef:
-                  name: hippius-s3-secrets
-                  key: ATS_CACHE_OFFLOAD_BUCKETS
           startupProbe:
             httpGet:
               path: /health

--- a/tests/unit/gateway/test_anonymous_read_flag.py
+++ b/tests/unit/gateway/test_anonymous_read_flag.py
@@ -1,0 +1,134 @@
+"""Tests for request.state.anonymous_read_allowed — the load-bearing flag for ATS public caching."""
+
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi import Response
+from httpx import ASGITransport
+from httpx import AsyncClient
+
+from gateway.middlewares.acl import acl_middleware
+
+
+def _build_app(acl_service: Any, *, account_id: str | None = None) -> Any:
+    app = FastAPI()
+    app.state.acl_service = acl_service
+
+    @app.api_route("/{path:path}", methods=["GET", "HEAD", "PUT", "DELETE"])
+    async def catch_all(request: Request) -> dict[str, Any]:
+        return {"anonymous_read_allowed": bool(getattr(request.state, "anonymous_read_allowed", False))}
+
+    async def stub_auth(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        request.state.account_id = account_id
+        return await call_next(request)
+
+    app.middleware("http")(acl_middleware)
+    app.middleware("http")(stub_auth)
+    return app
+
+
+def _make_service(*, primary_permits: bool = True, anon_permits: bool = False) -> Any:
+    service = AsyncMock()
+    service.get_bucket_owner = AsyncMock(return_value="owner-id")
+
+    async def check_permission(
+        *, account_id: str | None, bucket: str, key: str | None, permission: Any, access_key: Any, bucket_owner_id: Any
+    ) -> bool:
+        if account_id is None:
+            return anon_permits
+        return primary_permits
+
+    service.check_permission = AsyncMock(side_effect=check_permission)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_anonymous_get_on_public_bucket_sets_flag_true() -> None:
+    service = _make_service(primary_permits=True, anon_permits=True)
+    app = _build_app(service)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/public-bucket/foo.txt")
+    assert r.status_code == 200
+    assert r.json()["anonymous_read_allowed"] is True
+
+
+@pytest.mark.asyncio
+async def test_anonymous_get_on_private_bucket_denied() -> None:
+    """When anonymous access is denied, the request is 403'd before the flag matters."""
+    service = _make_service(primary_permits=False, anon_permits=False)
+    app = _build_app(service)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/private-bucket/foo.txt")
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_put_does_not_set_flag() -> None:
+    """The flag is only set for GET/HEAD reads."""
+    service = _make_service(primary_permits=True, anon_permits=True)
+    app = _build_app(service)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.put("/public-bucket/foo.txt", content=b"x")
+    assert r.status_code == 200
+    assert r.json()["anonymous_read_allowed"] is False
+
+
+@pytest.mark.asyncio
+async def test_bucket_level_request_does_not_set_flag() -> None:
+    """Bucket-listing is not per-object; no public caching decision applies."""
+    service = _make_service(primary_permits=True, anon_permits=True)
+    app = _build_app(service)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/public-bucket")
+    assert r.status_code == 200
+    assert r.json()["anonymous_read_allowed"] is False
+
+
+@pytest.mark.asyncio
+async def test_head_sets_flag_like_get() -> None:
+    service = _make_service(primary_permits=True, anon_permits=True)
+    app = _build_app(service)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.head("/public-bucket/foo.txt")
+    assert r.status_code == 200
+    # HEAD strips body — the endpoint would have set the flag in request.state,
+    # but since HEAD suppresses body, we can't read JSON. Just assert 200.
+
+
+@pytest.mark.asyncio
+async def test_authenticated_get_on_public_bucket_sets_flag_true() -> None:
+    """Authenticated user reading a public object — flag True because AllUsers grant applies."""
+    service = _make_service(primary_permits=True, anon_permits=True)
+    app = _build_app(service, account_id="alice")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/public-bucket/foo.txt")
+    assert r.status_code == 200
+    assert r.json()["anonymous_read_allowed"] is True
+
+
+@pytest.mark.asyncio
+async def test_authenticated_get_on_private_object_sets_flag_false() -> None:
+    """Per-object ACL override: object is private even if bucket is public → flag False."""
+    service = _make_service(primary_permits=True, anon_permits=False)
+    app = _build_app(service, account_id="alice")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/public-bucket/secret.txt")
+    assert r.status_code == 200
+    assert r.json()["anonymous_read_allowed"] is False
+
+
+@pytest.mark.asyncio
+async def test_authenticated_check_permission_called_twice() -> None:
+    """Authenticated GET should trigger two check_permission calls: caller + anon probe."""
+    service = _make_service(primary_permits=True, anon_permits=True)
+    app = _build_app(service, account_id="alice")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.get("/public-bucket/foo.txt")
+    assert service.check_permission.await_count == 2
+    seen_account_ids = {call.kwargs["account_id"] for call in service.check_permission.await_args_list}
+    assert seen_account_ids == {"alice", None}

--- a/tests/unit/gateway/test_anonymous_read_flag.py
+++ b/tests/unit/gateway/test_anonymous_read_flag.py
@@ -25,7 +25,13 @@ def _ats_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     gateway_config._config = None
 
 
-def _build_app(acl_service: Any, *, account_id: str | None = None) -> Any:
+def _build_app(
+    acl_service: Any,
+    *,
+    account_id: str | None = None,
+    auth_method: str | None = None,
+    token_type: str | None = None,
+) -> Any:
     app = FastAPI()
     app.state.acl_service = acl_service
 
@@ -35,6 +41,8 @@ def _build_app(acl_service: Any, *, account_id: str | None = None) -> Any:
 
     async def stub_auth(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
         request.state.account_id = account_id
+        request.state.auth_method = auth_method
+        request.state.token_type = token_type
         return await call_next(request)
 
     app.middleware("http")(acl_middleware)
@@ -156,3 +164,28 @@ async def test_probe_skipped_when_ats_disabled(monkeypatch: pytest.MonkeyPatch) 
     assert r.status_code == 200
     assert r.json()["anonymous_read_allowed"] is False
     assert service.check_permission.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_master_token_read_on_public_bucket_sets_flag_true() -> None:
+    """Master-token owner reading a public object — flag must be True so ATS caches it.
+
+    Regression guard: the master-token bypass runs AFTER anonymous_read_allowed is computed.
+    """
+    service = _make_service(primary_permits=True, anon_permits=True)
+    app = _build_app(service, account_id="owner-id", auth_method="access_key", token_type="master")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/public-bucket/foo.txt")
+    assert r.status_code == 200
+    assert r.json()["anonymous_read_allowed"] is True
+
+
+@pytest.mark.asyncio
+async def test_master_token_read_on_private_object_sets_flag_false() -> None:
+    """Master-token owner reading a private object — flag False so ATS does not cache it."""
+    service = _make_service(primary_permits=True, anon_permits=False)
+    app = _build_app(service, account_id="owner-id", auth_method="access_key", token_type="master")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/private-bucket/foo.txt")
+    assert r.status_code == 200
+    assert r.json()["anonymous_read_allowed"] is False

--- a/tests/unit/gateway/test_anonymous_read_flag.py
+++ b/tests/unit/gateway/test_anonymous_read_flag.py
@@ -12,7 +12,17 @@ from fastapi import Response
 from httpx import ASGITransport
 from httpx import AsyncClient
 
+from gateway import config as gateway_config
 from gateway.middlewares.acl import acl_middleware
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def _ats_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enable ATS so the anonymous_read_allowed probe runs."""
+    monkeypatch.setenv("ATS_CACHE_ENDPOINT", "http://ats.local:8080")
+    gateway_config._config = None
+    yield
+    gateway_config._config = None
 
 
 def _build_app(acl_service: Any, *, account_id: str | None = None) -> Any:
@@ -132,3 +142,17 @@ async def test_authenticated_check_permission_called_twice() -> None:
     assert service.check_permission.await_count == 2
     seen_account_ids = {call.kwargs["account_id"] for call in service.check_permission.await_args_list}
     assert seen_account_ids == {"alice", None}
+
+
+@pytest.mark.asyncio
+async def test_probe_skipped_when_ats_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ATS is off, the anon-read probe is skipped to save a Redis round-trip."""
+    monkeypatch.setenv("ATS_CACHE_ENDPOINT", "")
+    gateway_config._config = None
+    service = _make_service(primary_permits=True, anon_permits=True)
+    app = _build_app(service, account_id="alice")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/public-bucket/foo.txt")
+    assert r.status_code == 200
+    assert r.json()["anonymous_read_allowed"] is False
+    assert service.check_permission.await_count == 1

--- a/tests/unit/gateway/test_ats_cache_client.py
+++ b/tests/unit/gateway/test_ats_cache_client.py
@@ -1,0 +1,91 @@
+"""Tests for ATS PURGE client: no-op when unset, fires httpx PURGE when configured."""
+
+import asyncio
+
+import httpx
+import pytest
+
+from gateway import config as gateway_config
+from gateway.services import ats_cache_client
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def _reset_state() -> None:
+    gateway_config._config = None
+    ats_cache_client._client = None
+    yield
+    gateway_config._config = None
+    ats_cache_client._client = None
+
+
+@pytest.mark.asyncio
+async def test_schedule_purge_noop_when_endpoint_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATS_CACHE_ENDPOINT", raising=False)
+    called = []
+
+    async def fake_purge(*args: object, **kwargs: object) -> None:
+        called.append(args)
+
+    monkeypatch.setattr(ats_cache_client, "_purge", fake_purge)
+
+    ats_cache_client.schedule_purge("s3.hippius.com", "bucket/key")
+    await asyncio.sleep(0)  # let any scheduled task run
+    assert called == []
+
+
+@pytest.mark.asyncio
+async def test_schedule_purge_fires_task_when_endpoint_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATS_CACHE_ENDPOINT", "http://ats.local:8080")
+    called: list[tuple[str, str, str]] = []
+
+    async def fake_purge(endpoint: str, host: str, key: str) -> None:
+        called.append((endpoint, host, key))
+
+    monkeypatch.setattr(ats_cache_client, "_purge", fake_purge)
+
+    ats_cache_client.schedule_purge("s3.hippius.com", "bucket/key")
+    # Let the scheduled task run
+    await asyncio.sleep(0.01)
+    assert called == [("http://ats.local:8080", "s3.hippius.com", "bucket/key")]
+
+
+@pytest.mark.asyncio
+async def test_purge_issues_http_purge_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = {}
+
+    async def fake_request(self: httpx.AsyncClient, method: str, url: str, **kwargs: object) -> httpx.Response:
+        captured["method"] = method
+        captured["url"] = url
+        captured["headers"] = kwargs.get("headers")
+        return httpx.Response(200)
+
+    monkeypatch.setattr(httpx.AsyncClient, "request", fake_request)
+
+    await ats_cache_client._purge("http://ats.local:8080", "s3.hippius.com", "bucket/key")
+    assert captured["method"] == "PURGE"
+    assert captured["url"] == "http://ats.local:8080/bucket/key"
+    assert captured["headers"] == {"Host": "s3.hippius.com"}
+
+
+@pytest.mark.asyncio
+async def test_purge_swallows_http_errors(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    async def fake_request(self: httpx.AsyncClient, method: str, url: str, **kwargs: object) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(httpx.AsyncClient, "request", fake_request)
+
+    # Should not raise
+    await ats_cache_client._purge("http://ats.local:8080", "s3.hippius.com", "bucket/key")
+
+
+@pytest.mark.asyncio
+async def test_purge_logs_on_4xx_5xx(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    async def fake_request(self: httpx.AsyncClient, method: str, url: str, **kwargs: object) -> httpx.Response:
+        return httpx.Response(404)
+
+    monkeypatch.setattr(httpx.AsyncClient, "request", fake_request)
+
+    with caplog.at_level("WARNING"):
+        await ats_cache_client._purge("http://ats.local:8080", "s3.hippius.com", "bucket/key")
+
+    assert any("PURGE" in record.message for record in caplog.records)

--- a/tests/unit/gateway/test_ats_cache_client_close.py
+++ b/tests/unit/gateway/test_ats_cache_client_close.py
@@ -1,0 +1,39 @@
+"""Tests for ats_cache_client lifecycle — close() and lazy client creation."""
+
+import pytest
+
+from gateway.services import ats_cache_client
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def _reset_state() -> None:
+    ats_cache_client._client = None
+    yield
+    ats_cache_client._client = None
+
+
+def test_get_client_is_lazy() -> None:
+    assert ats_cache_client._client is None
+    client = ats_cache_client._get_client()
+    assert ats_cache_client._client is client
+
+
+def test_get_client_reuses_instance() -> None:
+    a = ats_cache_client._get_client()
+    b = ats_cache_client._get_client()
+    assert a is b
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent() -> None:
+    await ats_cache_client.close()  # no client yet — no-op
+    await ats_cache_client.close()  # still no-op
+    assert ats_cache_client._client is None
+
+
+@pytest.mark.asyncio
+async def test_close_resets_client() -> None:
+    ats_cache_client._get_client()
+    assert ats_cache_client._client is not None
+    await ats_cache_client.close()
+    assert ats_cache_client._client is None

--- a/tests/unit/gateway/test_ats_config.py
+++ b/tests/unit/gateway/test_ats_config.py
@@ -1,0 +1,48 @@
+"""Tests for ATS-related config fields."""
+
+import pytest
+
+from gateway import config as gateway_config
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def _reset_config() -> None:
+    gateway_config._config = None
+    yield
+    gateway_config._config = None
+
+
+def test_ats_cache_endpoint_defaults_to_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATS_CACHE_ENDPOINT", raising=False)
+    cfg = gateway_config.GatewayConfig()
+    assert cfg.ats_cache_endpoint == ""
+
+
+def test_ats_cache_endpoint_loaded_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATS_CACHE_ENDPOINT", "http://192.168.1.155:8080")
+    cfg = gateway_config.GatewayConfig()
+    assert cfg.ats_cache_endpoint == "http://192.168.1.155:8080"
+
+
+def test_offload_buckets_defaults_to_empty_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ATS_CACHE_OFFLOAD_BUCKETS", raising=False)
+    cfg = gateway_config.GatewayConfig()
+    assert cfg.ats_cache_offload_buckets == set()
+
+
+def test_offload_buckets_parses_csv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATS_CACHE_OFFLOAD_BUCKETS", "assets,media,static-bundles")
+    cfg = gateway_config.GatewayConfig()
+    assert cfg.ats_cache_offload_buckets == {"assets", "media", "static-bundles"}
+
+
+def test_offload_buckets_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATS_CACHE_OFFLOAD_BUCKETS", " assets , media ")
+    cfg = gateway_config.GatewayConfig()
+    assert cfg.ats_cache_offload_buckets == {"assets", "media"}
+
+
+def test_offload_buckets_ignores_empty_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATS_CACHE_OFFLOAD_BUCKETS", "assets,,media,")
+    cfg = gateway_config.GatewayConfig()
+    assert cfg.ats_cache_offload_buckets == {"assets", "media"}

--- a/tests/unit/gateway/test_ats_config.py
+++ b/tests/unit/gateway/test_ats_config.py
@@ -22,27 +22,3 @@ def test_ats_cache_endpoint_loaded_from_env(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setenv("ATS_CACHE_ENDPOINT", "http://192.168.1.155:8080")
     cfg = gateway_config.GatewayConfig()
     assert cfg.ats_cache_endpoint == "http://192.168.1.155:8080"
-
-
-def test_offload_buckets_defaults_to_empty_set(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("ATS_CACHE_OFFLOAD_BUCKETS", raising=False)
-    cfg = gateway_config.GatewayConfig()
-    assert cfg.ats_cache_offload_buckets == set()
-
-
-def test_offload_buckets_parses_csv(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ATS_CACHE_OFFLOAD_BUCKETS", "assets,media,static-bundles")
-    cfg = gateway_config.GatewayConfig()
-    assert cfg.ats_cache_offload_buckets == {"assets", "media", "static-bundles"}
-
-
-def test_offload_buckets_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ATS_CACHE_OFFLOAD_BUCKETS", " assets , media ")
-    cfg = gateway_config.GatewayConfig()
-    assert cfg.ats_cache_offload_buckets == {"assets", "media"}
-
-
-def test_offload_buckets_ignores_empty_entries(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ATS_CACHE_OFFLOAD_BUCKETS", "assets,,media,")
-    cfg = gateway_config.GatewayConfig()
-    assert cfg.ats_cache_offload_buckets == {"assets", "media"}

--- a/tests/unit/gateway/test_ats_purge_middleware.py
+++ b/tests/unit/gateway/test_ats_purge_middleware.py
@@ -9,7 +9,16 @@ from fastapi import Response
 from httpx import ASGITransport
 from httpx import AsyncClient
 
+from gateway import config as gateway_config
 from gateway.middlewares.ats_purge import ats_purge_middleware
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def _ats_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATS_CACHE_ENDPOINT", "http://ats.local:8080")
+    gateway_config._config = None
+    yield
+    gateway_config._config = None
 
 
 @pytest.fixture  # type: ignore[misc]
@@ -162,3 +171,16 @@ async def test_host_header_propagated(app: Any, captured_purges: list[tuple[str,
         r = await client.put("/mybucket/k", content=b"x")
     assert r.status_code == 200
     assert captured_purges == [("s3-staging.hippius.com", "mybucket/k")]
+
+
+@pytest.mark.asyncio
+async def test_middleware_is_noop_when_endpoint_unset(
+    app: Any, captured_purges: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Early-return path: no PURGE scheduled when ATS_CACHE_ENDPOINT is empty."""
+    monkeypatch.setenv("ATS_CACHE_ENDPOINT", "")
+    gateway_config._config = None
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.put("/mybucket/k", content=b"x")
+    assert r.status_code == 200
+    assert captured_purges == []

--- a/tests/unit/gateway/test_ats_purge_middleware.py
+++ b/tests/unit/gateway/test_ats_purge_middleware.py
@@ -1,0 +1,164 @@
+"""Tests for ats_purge_middleware — checks that PURGE calls are dispatched correctly per HTTP verb."""
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi import Response
+from httpx import ASGITransport
+from httpx import AsyncClient
+
+from gateway.middlewares.ats_purge import ats_purge_middleware
+
+
+@pytest.fixture  # type: ignore[misc]
+def captured_purges(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    calls: list[tuple[str, str]] = []
+
+    def fake_schedule_purge(host: str, key: str) -> None:
+        calls.append((host, key))
+
+    monkeypatch.setattr("gateway.middlewares.ats_purge.schedule_purge", fake_schedule_purge)
+    return calls
+
+
+@pytest.fixture  # type: ignore[misc]
+def app(captured_purges: list[tuple[str, str]]) -> Any:
+    app = FastAPI()
+    app.middleware("http")(ats_purge_middleware)
+
+    @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"])
+    async def catch_all(request: Request) -> Response:
+        status = int(request.headers.get("x-test-status", "200"))
+        return Response(status_code=status, content=b"ok")
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_put_object_purges_key(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.put("/mybucket/my/key.bin", content=b"data")
+    assert r.status_code == 200
+    assert captured_purges == [("s3.hippius.com", "mybucket/my/key.bin")]
+
+
+@pytest.mark.asyncio
+async def test_delete_object_purges_key(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.delete("/mybucket/foo.txt")
+    assert r.status_code == 200
+    assert captured_purges == [("s3.hippius.com", "mybucket/foo.txt")]
+
+
+@pytest.mark.asyncio
+async def test_copy_object_purges_both_source_and_destination(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.put(
+            "/destbucket/dest/key",
+            content=b"",
+            headers={"x-amz-copy-source": "/srcbucket/src/key"},
+        )
+    assert r.status_code == 200
+    assert ("s3.hippius.com", "destbucket/dest/key") in captured_purges
+    assert ("s3.hippius.com", "srcbucket/src/key") in captured_purges
+    assert len(captured_purges) == 2
+
+
+@pytest.mark.asyncio
+async def test_complete_multipart_upload_purges_key(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.post("/mybucket/big/obj?uploadId=abc123", content=b"<CompleteMultipartUpload/>")
+    assert r.status_code == 200
+    assert captured_purges == [("s3.hippius.com", "mybucket/big/obj")]
+
+
+@pytest.mark.asyncio
+async def test_part_upload_does_not_purge(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    """UploadPart (PUT with uploadId + partNumber) is invisible until CompleteMultipartUpload."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.put("/mybucket/big/obj?uploadId=abc&partNumber=1", content=b"part-data")
+    assert r.status_code == 200
+    assert captured_purges == []
+
+
+@pytest.mark.asyncio
+async def test_post_with_partNumber_does_not_purge(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.post("/mybucket/big/obj?uploadId=abc&partNumber=2", content=b"")
+    assert r.status_code == 200
+    assert captured_purges == []
+
+
+@pytest.mark.asyncio
+async def test_batch_delete_does_not_purge_in_v1(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    """`POST /{bucket}?delete` is deliberately skipped in v1 — see plan."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.post("/mybucket?delete", content=b"<Delete/>")
+    assert r.status_code == 200
+    assert captured_purges == []
+
+
+@pytest.mark.asyncio
+async def test_bucket_acl_flip_purges_wildcard(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.put("/mybucket?acl", content=b"<AccessControlPolicy/>")
+    assert r.status_code == 200
+    assert captured_purges == [("s3.hippius.com", "mybucket/*")]
+
+
+@pytest.mark.asyncio
+async def test_bucket_delete_purges_wildcard(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.delete("/mybucket")
+    assert r.status_code == 200
+    assert captured_purges == [("s3.hippius.com", "mybucket/*")]
+
+
+@pytest.mark.asyncio
+async def test_failed_write_does_not_purge(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.put("/mybucket/k", content=b"x", headers={"x-test-status": "500"})
+    assert r.status_code == 500
+    assert captured_purges == []
+
+
+@pytest.mark.asyncio
+async def test_client_error_does_not_purge(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.delete("/mybucket/k", headers={"x-test-status": "403"})
+    assert r.status_code == 403
+    assert captured_purges == []
+
+
+@pytest.mark.asyncio
+async def test_get_does_not_purge(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.get("/mybucket/k")
+    assert r.status_code == 200
+    assert captured_purges == []
+
+
+@pytest.mark.asyncio
+async def test_head_does_not_purge(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.head("/mybucket/k")
+    assert r.status_code == 200
+    assert captured_purges == []
+
+
+@pytest.mark.asyncio
+async def test_root_path_does_not_purge(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.put("/", content=b"")
+    assert r.status_code == 200
+    assert captured_purges == []
+
+
+@pytest.mark.asyncio
+async def test_host_header_propagated(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3-staging.hippius.com") as client:
+        r = await client.put("/mybucket/k", content=b"x")
+    assert r.status_code == 200
+    assert captured_purges == [("s3-staging.hippius.com", "mybucket/k")]

--- a/tests/unit/gateway/test_cache_control_middleware.py
+++ b/tests/unit/gateway/test_cache_control_middleware.py
@@ -9,10 +9,8 @@ from fastapi import Response
 from httpx import ASGITransport
 from httpx import AsyncClient
 
-from gateway.config import get_config
 from gateway.middlewares.cache_control import PRIVATE_CACHE_CONTROL
-from gateway.middlewares.cache_control import REVALIDATE_ALWAYS
-from gateway.middlewares.cache_control import STANDARD_PUBLIC
+from gateway.middlewares.cache_control import PUBLIC_CACHE_CONTROL
 from gateway.middlewares.cache_control import cache_control_middleware
 
 
@@ -42,28 +40,17 @@ async def test_private_bucket_gets_no_store(app: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_public_bucket_default_is_revalidate_always(app: Any) -> None:
+async def test_public_bucket_gets_cacheable_policy(app: Any) -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         r = await client.get("/public-bucket/foo.txt", headers={"x-test-anon-read": "true"})
-    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+    assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
 
 
 @pytest.mark.asyncio
-async def test_offload_bucket_gets_standard_public(app: Any, monkeypatch: pytest.MonkeyPatch) -> None:
-    get_config().ats_cache_offload_buckets.add("assets")
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            r = await client.get("/assets/icon.png", headers={"x-test-anon-read": "true"})
-        assert r.headers["Cache-Control"] == STANDARD_PUBLIC
-    finally:
-        get_config().ats_cache_offload_buckets.discard("assets")
-
-
-@pytest.mark.asyncio
-async def test_head_public_bucket_gets_revalidate_always(app: Any) -> None:
+async def test_head_public_bucket_gets_cacheable_policy(app: Any) -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         r = await client.head("/public-bucket/foo.txt", headers={"x-test-anon-read": "true"})
-    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+    assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
 
 
 @pytest.mark.asyncio
@@ -98,7 +85,7 @@ async def test_304_response_still_gets_cache_control(app: Any) -> None:
             headers={"x-test-status": "304", "x-test-anon-read": "true"},
         )
     assert r.status_code == 304
-    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+    assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
 
 
 @pytest.mark.asyncio
@@ -109,7 +96,7 @@ async def test_partial_content_206_gets_cache_control(app: Any) -> None:
             headers={"x-test-status": "206", "x-test-anon-read": "true"},
         )
     assert r.status_code == 206
-    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+    assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
 
 
 @pytest.mark.asyncio

--- a/tests/unit/gateway/test_cache_control_middleware.py
+++ b/tests/unit/gateway/test_cache_control_middleware.py
@@ -1,0 +1,128 @@
+"""Tests for cache_control_middleware — Cache-Control header injection by method/status/ACL."""
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi import Response
+from httpx import ASGITransport
+from httpx import AsyncClient
+
+from gateway.config import get_config
+from gateway.middlewares.cache_control import PRIVATE_CACHE_CONTROL
+from gateway.middlewares.cache_control import REVALIDATE_ALWAYS
+from gateway.middlewares.cache_control import STANDARD_PUBLIC
+from gateway.middlewares.cache_control import cache_control_middleware
+
+
+@pytest.fixture  # type: ignore[misc]
+def app() -> Any:
+    app = FastAPI()
+    app.middleware("http")(cache_control_middleware)
+
+    @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"])
+    async def catch_all(request: Request) -> Response:
+        status = int(request.headers.get("x-test-status", "200"))
+        # Simulate acl_middleware wiring
+        if request.headers.get("x-test-anon-read") == "true":
+            request.state.anonymous_read_allowed = True
+        else:
+            request.state.anonymous_read_allowed = False
+        return Response(status_code=status, content=b"ok")
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_private_bucket_gets_no_store(app: Any) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/private-bucket/foo.txt")
+    assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL
+
+
+@pytest.mark.asyncio
+async def test_public_bucket_default_is_revalidate_always(app: Any) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/public-bucket/foo.txt", headers={"x-test-anon-read": "true"})
+    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+
+
+@pytest.mark.asyncio
+async def test_offload_bucket_gets_standard_public(app: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    get_config().ats_cache_offload_buckets.add("assets")
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.get("/assets/icon.png", headers={"x-test-anon-read": "true"})
+        assert r.headers["Cache-Control"] == STANDARD_PUBLIC
+    finally:
+        get_config().ats_cache_offload_buckets.discard("assets")
+
+
+@pytest.mark.asyncio
+async def test_head_public_bucket_gets_revalidate_always(app: Any) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.head("/public-bucket/foo.txt", headers={"x-test-anon-read": "true"})
+    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+
+
+@pytest.mark.asyncio
+async def test_put_gets_no_cache_control_header(app: Any) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.put("/public-bucket/foo.txt", content=b"x", headers={"x-test-anon-read": "true"})
+    assert "Cache-Control" not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_delete_gets_no_cache_control_header(app: Any) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.delete("/public-bucket/foo.txt", headers={"x-test-anon-read": "true"})
+    assert "Cache-Control" not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_error_responses_get_no_cache_control(app: Any) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/public-bucket/foo.txt",
+            headers={"x-test-status": "500", "x-test-anon-read": "true"},
+        )
+    assert "Cache-Control" not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_304_response_still_gets_cache_control(app: Any) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/public-bucket/foo.txt",
+            headers={"x-test-status": "304", "x-test-anon-read": "true"},
+        )
+    assert r.status_code == 304
+    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+
+
+@pytest.mark.asyncio
+async def test_partial_content_206_gets_cache_control(app: Any) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/public-bucket/foo.txt",
+            headers={"x-test-status": "206", "x-test-anon-read": "true"},
+        )
+    assert r.status_code == 206
+    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+
+
+@pytest.mark.asyncio
+async def test_bucket_listing_gets_private(app: Any) -> None:
+    """GET on a bucket (no key) should never be marked publicly cacheable."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/public-bucket", headers={"x-test-anon-read": "true"})
+    assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL
+
+
+@pytest.mark.asyncio
+async def test_missing_flag_defaults_to_private(app: Any) -> None:
+    """If acl middleware didn't wire the flag (e.g., request was a healthcheck), default private."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/public-bucket/foo.txt")  # no x-test-anon-read header
+    assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL

--- a/tests/unit/gateway/test_cache_middleware_integration.py
+++ b/tests/unit/gateway/test_cache_middleware_integration.py
@@ -12,11 +12,20 @@ from fastapi import Response
 from httpx import ASGITransport
 from httpx import AsyncClient
 
+from gateway import config as gateway_config
 from gateway.middlewares.acl import acl_middleware
 from gateway.middlewares.ats_purge import ats_purge_middleware
 from gateway.middlewares.cache_control import PRIVATE_CACHE_CONTROL
 from gateway.middlewares.cache_control import REVALIDATE_ALWAYS
 from gateway.middlewares.cache_control import cache_control_middleware
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def _ats_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ATS_CACHE_ENDPOINT", "http://ats.local:8080")
+    gateway_config._config = None
+    yield
+    gateway_config._config = None
 
 
 def _make_service(*, primary: bool = True, anon: bool = False) -> Any:

--- a/tests/unit/gateway/test_cache_middleware_integration.py
+++ b/tests/unit/gateway/test_cache_middleware_integration.py
@@ -1,0 +1,149 @@
+"""Integration: full gateway middleware stack (ACL + cache-control + ats-purge)."""
+
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi import Response
+from httpx import ASGITransport
+from httpx import AsyncClient
+
+from gateway.middlewares.acl import acl_middleware
+from gateway.middlewares.ats_purge import ats_purge_middleware
+from gateway.middlewares.cache_control import PRIVATE_CACHE_CONTROL
+from gateway.middlewares.cache_control import REVALIDATE_ALWAYS
+from gateway.middlewares.cache_control import cache_control_middleware
+
+
+def _make_service(*, primary: bool = True, anon: bool = False) -> Any:
+    service = AsyncMock()
+    service.get_bucket_owner = AsyncMock(return_value="owner-id")
+
+    async def check_permission(
+        *, account_id: str | None, bucket: str, key: str | None, permission: Any, access_key: Any, bucket_owner_id: Any
+    ) -> bool:
+        if account_id is None:
+            return anon
+        return primary
+
+    service.check_permission = AsyncMock(side_effect=check_permission)
+    return service
+
+
+def _build_app(
+    acl_service: Any,
+    *,
+    captured_purges: list[tuple[str, str]],
+    account_id: str | None = None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Any:
+    app = FastAPI()
+    app.state.acl_service = acl_service
+
+    @app.api_route("/{path:path}", methods=["GET", "HEAD", "PUT", "POST", "DELETE"])
+    async def catch_all(request: Request) -> Response:
+        return Response(status_code=200, content=b"ok")
+
+    def fake_schedule_purge(host: str, key: str) -> None:
+        captured_purges.append((host, key))
+
+    monkeypatch.setattr("gateway.middlewares.ats_purge.schedule_purge", fake_schedule_purge)
+
+    async def stub_auth(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        request.state.account_id = account_id
+        return await call_next(request)
+
+    # Register inner-to-outer — last registered is outermost
+    app.middleware("http")(ats_purge_middleware)
+    app.middleware("http")(cache_control_middleware)
+    app.middleware("http")(acl_middleware)
+    app.middleware("http")(stub_auth)
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_anon_get_public_bucket_emits_public_cache_control(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _make_service(primary=True, anon=True)
+    purges: list[tuple[str, str]] = []
+    app = _build_app(service, captured_purges=purges, monkeypatch=monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.get("/public-bucket/foo.txt")
+    assert r.status_code == 200
+    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+    assert purges == []
+
+
+@pytest.mark.asyncio
+async def test_anon_get_private_bucket_denied_no_cache_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _make_service(primary=False, anon=False)
+    purges: list[tuple[str, str]] = []
+    app = _build_app(service, captured_purges=purges, monkeypatch=monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.get("/private-bucket/foo.txt")
+    assert r.status_code == 403
+    assert "Cache-Control" not in r.headers
+    assert purges == []
+
+
+@pytest.mark.asyncio
+async def test_authenticated_get_private_object_emits_private(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _make_service(primary=True, anon=False)
+    purges: list[tuple[str, str]] = []
+    app = _build_app(service, captured_purges=purges, account_id="alice", monkeypatch=monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.get("/private-bucket/foo.txt")
+    assert r.status_code == 200
+    assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL
+    assert purges == []
+
+
+@pytest.mark.asyncio
+async def test_put_fires_purge_and_does_not_set_cache_control(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _make_service(primary=True, anon=False)
+    purges: list[tuple[str, str]] = []
+    app = _build_app(service, captured_purges=purges, account_id="alice", monkeypatch=monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.put("/public-bucket/foo.txt", content=b"data")
+    assert r.status_code == 200
+    assert "Cache-Control" not in r.headers
+    assert purges == [("s3.hippius.com", "public-bucket/foo.txt")]
+
+
+@pytest.mark.asyncio
+async def test_authenticated_denied_no_purge_no_cache_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _make_service(primary=False, anon=False)
+    purges: list[tuple[str, str]] = []
+    app = _build_app(service, captured_purges=purges, account_id="alice", monkeypatch=monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.put("/public-bucket/foo.txt", content=b"data")
+    assert r.status_code == 403
+    assert purges == []
+    assert "Cache-Control" not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_bucket_acl_flip_fires_wildcard_purge(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = _make_service(primary=True, anon=False)
+    purges: list[tuple[str, str]] = []
+    app = _build_app(service, captured_purges=purges, account_id="alice", monkeypatch=monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.put("/public-bucket?acl", content=b"<AccessControlPolicy/>")
+    assert r.status_code == 200
+    assert purges == [("s3.hippius.com", "public-bucket/*")]
+
+
+@pytest.mark.asyncio
+async def test_object_acl_put_fires_single_key_purge(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PUT /{bucket}/{key}?acl changes object ACL — only that key's cache needs invalidating."""
+    service = _make_service(primary=True, anon=False)
+    purges: list[tuple[str, str]] = []
+    app = _build_app(service, captured_purges=purges, account_id="alice", monkeypatch=monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
+        r = await client.put("/public-bucket/foo.txt?acl", content=b"<AccessControlPolicy/>")
+    assert r.status_code == 200
+    assert purges == [("s3.hippius.com", "public-bucket/foo.txt")]

--- a/tests/unit/gateway/test_cache_middleware_integration.py
+++ b/tests/unit/gateway/test_cache_middleware_integration.py
@@ -16,7 +16,7 @@ from gateway import config as gateway_config
 from gateway.middlewares.acl import acl_middleware
 from gateway.middlewares.ats_purge import ats_purge_middleware
 from gateway.middlewares.cache_control import PRIVATE_CACHE_CONTROL
-from gateway.middlewares.cache_control import REVALIDATE_ALWAYS
+from gateway.middlewares.cache_control import PUBLIC_CACHE_CONTROL
 from gateway.middlewares.cache_control import cache_control_middleware
 
 
@@ -83,7 +83,7 @@ async def test_anon_get_public_bucket_emits_public_cache_control(monkeypatch: py
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
         r = await client.get("/public-bucket/foo.txt")
     assert r.status_code == 200
-    assert r.headers["Cache-Control"] == REVALIDATE_ALWAYS
+    assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
     assert purges == []
 
 

--- a/tests/unit/test_if_none_match_matches.py
+++ b/tests/unit/test_if_none_match_matches.py
@@ -1,0 +1,28 @@
+"""Tests for If-None-Match header comparison helper."""
+
+import pytest
+
+from hippius_s3.api.s3.common.headers import if_none_match_matches
+
+
+@pytest.mark.parametrize(
+    "header,md5_hash,expected",
+    [
+        ('"abc123"', "abc123", True),
+        ('"abc123"', "def456", False),
+        ("*", "abc123", True),
+        (" * ", "abc123", True),
+        ('"abc-5"', "abc-5", True),  # multipart ETag form
+        ('W/"abc123"', "abc123", True),  # weak ETag
+        ('"abc123", "def456"', "abc123", True),  # list
+        ('"abc123", "def456"', "def456", True),  # list, second entry
+        ('"abc123", "def456"', "ghi789", False),  # list, no match
+        ("", "abc123", False),
+        (None, "abc123", False),
+        ('"abc123"', "", False),
+        ("abc123", "abc123", True),  # unquoted (lenient)
+        ('""', "abc123", False),
+    ],
+)
+def test_if_none_match_matches(header: str | None, md5_hash: str, expected: bool) -> None:
+    assert if_none_match_matches(header, md5_hash) is expected


### PR DESCRIPTION
## Summary

Wires Apache Traffic Server in as a reverse-proxy cache in front of the gateway. Public-object reads emit cacheable `Cache-Control` responses, mutations fire fire-and-forget `PURGE` calls to ATS, and GET/HEAD now honor `If-None-Match` to return 304s. Safe no-op default when `ATS_CACHE_ENDPOINT` is unset — local dev is unchanged.

## Changes

- **`cache_control_middleware`** — stamps `public, max-age=300, stale-while-revalidate=60` on anonymous-readable GET/HEAD responses, `private, no-store` on everything else. Only touches 200/206/304 responses; skipped for bucket-listing requests.
- **`ats_purge_middleware`** — schedules PURGE on successful PUT/POST/DELETE. Handles copy-source invalidation (`x-amz-copy-source`), object-ACL PUTs, and emits bucket-wildcard (`bucket/*`) on bucket-ACL flips and bucket deletes. Skips UploadPart / `partNumber` traffic.
- **ACL middleware** — probes anonymous READ permission once per request (gated on ATS being active) and stashes the result on `request.state.anonymous_read_allowed`. Runs *before* the master-token and presigned-URL bypasses so owner reads of public objects still populate ATS.
- **`ats_cache_client`** — shared `httpx.AsyncClient` with lazy init, idempotent `close()` wired into the gateway shutdown hook, and a `schedule_purge` helper that no-ops when `ATS_CACHE_ENDPOINT` is empty. Swallows network/HTTP errors so cache-invalidation flakes never fail client mutations.
- **304 Not Modified** — GET and HEAD now short-circuit to 304 when `If-None-Match` matches, via a new `if_none_match_matches` helper that handles `*`, weak tags (`W/"..."`), multipart ETags (`"<md5>-<parts>"`), and comma-separated lists per RFC 7232.
- **Config + deploy** — new `GatewayConfig.ats_cache_endpoint` field plus `ATS_CACHE_ENDPOINT` plumbed through the k8s deploy workflow and the gateway deployment manifest.
- **Tests** — unit coverage for the middlewares, the PURGE client lifecycle, the anonymous-read flag (including master-token and presigned regressions), the If-None-Match helper, and an integration test exercising the full ACL → cache-control → purge stack.

## Conclusion

Opt-in via a single env var. When `ATS_CACHE_ENDPOINT` is unset every new code path short-circuits — nothing changes for local dev, and production behavior only changes once the secret is populated.