### PR TITLE
Smoke tests: presigned URL + CORS preflight + regional cache coverage

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -38,11 +38,24 @@ jobs:
           AWS_SECRET_KEY: ${{ secrets.HIPPIUS_PROD_SECRET_KEY }}
         run: |
           mkdir -p reports
-          pytest tests/smoke/ \
+          set +e
+          pytest tests/smoke/test_smoke_production.py \
             -v \
             --tb=short \
             --json-report \
-            --json-report-file=reports/smoke-tests.json
+            --json-report-file=reports/smoke-production.json
+          PROD_EXIT=$?
+          pytest tests/smoke/test_smoke_regional.py \
+            -n auto \
+            -v \
+            --tb=short \
+            --json-report \
+            --json-report-file=reports/smoke-regional.json
+          REG_EXIT=$?
+          if [ $PROD_EXIT -ne 0 ] || [ $REG_EXIT -ne 0 ]; then
+            echo "production-exit=$PROD_EXIT regional-exit=$REG_EXIT"
+            exit 1
+          fi
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/staging-smoke-tests.yml
+++ b/.github/workflows/staging-smoke-tests.yml
@@ -36,7 +36,7 @@ jobs:
           HIPPIUS_ENDPOINT: https://s3-staging.hippius.com
         run: |
           mkdir -p reports
-          pytest tests/smoke/ \
+          pytest tests/smoke/test_smoke_production.py \
             -v \
             --tb=short \
             --json-report \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,10 +103,12 @@ jobs:
           uv pip install -e ".[dev]"
 
       - name: Run pip-audit
+        # CVE-2026-3219 ignored until pip 26.1 ships to PyPI (fix merged in pypa/pip#13870).
+        # Keep in sync with .pre-commit-config.yaml.
         run: |
           source .venv/bin/activate
           uv tool install pip-audit
-          pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645
+          pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2026-3219
 
   unit-integration:
     name: Unit & Integration Tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,8 +39,11 @@ repos:
         types: [python]
 
       - id: pip-audit
+        # CVE-2026-3219: pip concatenated tar/zip handling. Fix landed upstream (pypa/pip#13870)
+        # but pip 26.1 not yet released to PyPI as of 2026-04-24 — only 26.0.1 is up. Remove
+        # this ignore once 26.1 ships.
         name: pip-audit (dependency scan)
-        entry: pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645
+        entry: pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2026-3219
         language: system
         stages: [pre-commit]
         pass_filenames: false

--- a/tests/smoke/requirements.txt
+++ b/tests/smoke/requirements.txt
@@ -1,3 +1,5 @@
 boto3==1.34.140
+httpx>=0.27.0
 pytest==7.4.4
 pytest-json-report==1.5.0
+pytest-xdist>=3.5.0

--- a/tests/smoke/test_smoke_production.py
+++ b/tests/smoke/test_smoke_production.py
@@ -1,7 +1,10 @@
 import hashlib
+import os
 import random
+import uuid
 from datetime import datetime
 
+import httpx
 import pytest
 
 
@@ -193,3 +196,88 @@ def test_06_write_session_manifest(production_s3_client, session_tracker):
     assert len(retrieved_manifest["files"]) == 2
 
     print(f"Session manifest saved: {manifest_key}")
+
+
+def test_07_presigned_url_roundtrip(production_s3_client, session_tracker, file_generator):
+    size = 1 * 1024 * 1024
+    data, expected_hash = file_generator(size)
+    key = f"smoke-test/{session_tracker.session_id}/presigned/{uuid.uuid4()}.bin"
+
+    put_url = production_s3_client.generate_presigned_url(
+        "put_object",
+        Params={"Bucket": session_tracker.bucket, "Key": key},
+        ExpiresIn=300,
+    )
+    put_resp = httpx.put(put_url, content=data, timeout=60)
+    assert put_resp.status_code == 200, f"presigned PUT failed: {put_resp.status_code} {put_resp.text[:200]}"
+
+    get_url = production_s3_client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": session_tracker.bucket, "Key": key},
+        ExpiresIn=300,
+    )
+    get_resp = httpx.get(get_url, timeout=60)
+    assert get_resp.status_code == 200, f"presigned GET failed: {get_resp.status_code} {get_resp.text[:200]}"
+
+    downloaded_hash = hashlib.md5(get_resp.content).hexdigest()
+    assert downloaded_hash == expected_hash, f"hash mismatch: {downloaded_hash} != {expected_hash}"
+    assert len(get_resp.content) == size
+
+    print(f"Presigned roundtrip validated: {key} ({size} bytes, hash={expected_hash[:8]}...)")
+
+
+def test_08_cors_preflight_on_presigned_url(production_s3_client, session_tracker):
+    key = f"smoke-test/{session_tracker.session_id}/cors-probe-{uuid.uuid4()}.bin"
+    put_url = production_s3_client.generate_presigned_url(
+        "put_object",
+        Params={"Bucket": session_tracker.bucket, "Key": key},
+        ExpiresIn=60,
+    )
+
+    resp = httpx.options(
+        put_url,
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "PUT",
+            "Access-Control-Request-Headers": "content-type",
+        },
+        timeout=10,
+    )
+
+    assert resp.status_code in (200, 204), (
+        f"preflight failed (ATS may be rejecting OPTIONS): status={resp.status_code} body={resp.text[:200]}"
+    )
+    assert resp.headers.get("Access-Control-Allow-Origin") == "*", (
+        f"missing/unexpected Access-Control-Allow-Origin: {resp.headers.get('Access-Control-Allow-Origin')!r}"
+    )
+    allow_methods = resp.headers.get("Access-Control-Allow-Methods", "")
+    assert "PUT" in allow_methods, f"PUT not in Access-Control-Allow-Methods: {allow_methods!r}"
+    allow_headers = resp.headers.get("Access-Control-Allow-Headers", "").lower()
+    assert "content-type" in allow_headers, f"content-type not echoed in Access-Control-Allow-Headers: {allow_headers!r}"
+
+    print(f"CORS preflight on presigned URL OK: status={resp.status_code}, methods={allow_methods}")
+
+
+def test_09_cors_preflight_on_direct_path(session_tracker):
+    endpoint = os.environ.get("HIPPIUS_ENDPOINT", "https://s3.hippius.com").rstrip("/")
+    direct_url = f"{endpoint}/{session_tracker.bucket}/smoke-cors-probe-{uuid.uuid4()}.bin"
+
+    resp = httpx.options(
+        direct_url,
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "PUT",
+            "Access-Control-Request-Headers": "content-type,authorization",
+        },
+        timeout=10,
+    )
+
+    assert resp.status_code in (200, 204), (
+        f"preflight failed: status={resp.status_code} body={resp.text[:200]}"
+    )
+    assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+    allow_headers = resp.headers.get("Access-Control-Allow-Headers", "").lower()
+    assert "content-type" in allow_headers
+    assert "authorization" in allow_headers
+
+    print(f"CORS preflight on direct path OK: {direct_url}")

--- a/tests/smoke/test_smoke_regional.py
+++ b/tests/smoke/test_smoke_regional.py
@@ -1,0 +1,129 @@
+"""Regional cache smoke tests.
+
+Parametrized across the regional cache endpoints; runs in parallel under
+pytest-xdist. Exercises the three hot paths for regional reads/writes:
+
+- authenticated upload + download round-trip
+- anonymous download of an object with public-read ACL
+- presigned URL round-trip (PUT + GET)
+
+Each region gets its own boto3 client so presigned URLs are signed for
+that region's hostname (SigV4 canonicalizes Host).
+"""
+
+import hashlib
+import os
+import uuid
+from datetime import datetime
+
+import boto3
+import pytest
+import httpx
+from botocore.config import Config
+
+
+REGIONAL_ENDPOINTS = [
+    "https://eu-central-1.hippius.com",
+    "https://us-central-1.hippius.com",
+]
+
+
+@pytest.fixture
+def regional_s3_client(request):
+    endpoint = request.param
+    access_key = os.environ["AWS_ACCESS_KEY"]
+    secret_key = os.environ["AWS_SECRET_KEY"]
+
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name="us-east-1",
+        config=Config(
+            s3={"addressing_style": "path"},
+            signature_version="s3v4",
+        ),
+    )
+
+
+def _endpoint_id(endpoint: str) -> str:
+    # "https://eu-central-1.hippius.com" -> "eu-central-1"
+    return endpoint.replace("https://", "").split(".", 1)[0]
+
+
+@pytest.mark.parametrize("regional_s3_client", REGIONAL_ENDPOINTS, indirect=True, ids=_endpoint_id)
+def test_regional_upload_download_roundtrip(regional_s3_client, session_tracker, file_generator):
+    endpoint = regional_s3_client.meta.endpoint_url
+    region = _endpoint_id(endpoint)
+    size = 512 * 1024
+    data, expected_hash = file_generator(size)
+    key = f"smoke-test/{session_tracker.session_id}/regional/{region}/{uuid.uuid4()}.bin"
+
+    put_resp = regional_s3_client.put_object(Bucket=session_tracker.bucket, Key=key, Body=data)
+    assert put_resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    get_resp = regional_s3_client.get_object(Bucket=session_tracker.bucket, Key=key)
+    assert get_resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+    downloaded = get_resp["Body"].read()
+    assert hashlib.md5(downloaded).hexdigest() == expected_hash
+    assert len(downloaded) == size
+
+    print(f"[{region}] upload/download roundtrip OK: {key}")
+
+
+@pytest.mark.parametrize("regional_s3_client", REGIONAL_ENDPOINTS, indirect=True, ids=_endpoint_id)
+def test_regional_public_object_anonymous_download(regional_s3_client, session_tracker, file_generator):
+    endpoint = regional_s3_client.meta.endpoint_url
+    region = _endpoint_id(endpoint)
+    size = 128 * 1024
+    data, expected_hash = file_generator(size)
+    key = f"smoke-test/{session_tracker.session_id}/regional/{region}/public-{uuid.uuid4()}.bin"
+
+    regional_s3_client.put_object(Bucket=session_tracker.bucket, Key=key, Body=data)
+    regional_s3_client.put_object_acl(Bucket=session_tracker.bucket, Key=key, ACL="public-read")
+
+    anon_url = f"{endpoint.rstrip('/')}/{session_tracker.bucket}/{key}"
+    resp = httpx.get(anon_url, timeout=60)
+    assert resp.status_code == 200, f"anonymous GET failed: status={resp.status_code} body={resp.text[:200]}"
+    assert hashlib.md5(resp.content).hexdigest() == expected_hash
+    assert len(resp.content) == size
+
+    cache_control = resp.headers.get("Cache-Control", "")
+    assert "public" in cache_control.lower(), f"expected public Cache-Control, got: {cache_control!r}"
+
+    print(f"[{region}] public anonymous download OK: {key} (Cache-Control={cache_control!r})")
+
+
+@pytest.mark.parametrize("regional_s3_client", REGIONAL_ENDPOINTS, indirect=True, ids=_endpoint_id)
+def test_regional_presigned_url_roundtrip(regional_s3_client, session_tracker, file_generator):
+    endpoint = regional_s3_client.meta.endpoint_url
+    region = _endpoint_id(endpoint)
+    size = 256 * 1024
+    data, expected_hash = file_generator(size)
+    key = f"smoke-test/{session_tracker.session_id}/regional/{region}/presigned-{uuid.uuid4()}.bin"
+
+    put_url = regional_s3_client.generate_presigned_url(
+        "put_object",
+        Params={"Bucket": session_tracker.bucket, "Key": key},
+        ExpiresIn=300,
+    )
+    put_resp = httpx.put(put_url, content=data, timeout=60)
+    assert put_resp.status_code == 200, f"[{region}] presigned PUT failed: {put_resp.status_code} {put_resp.text[:200]}"
+
+    get_url = regional_s3_client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": session_tracker.bucket, "Key": key},
+        ExpiresIn=300,
+    )
+    get_resp = httpx.get(get_url, timeout=60)
+    assert get_resp.status_code == 200, f"[{region}] presigned GET failed: {get_resp.status_code} {get_resp.text[:200]}"
+    assert hashlib.md5(get_resp.content).hexdigest() == expected_hash
+
+    print(f"[{region}] presigned URL roundtrip OK: {key}")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _regional_session_banner():
+    print(f"Regional smoke tests starting at {datetime.utcnow().isoformat()} against {REGIONAL_ENDPOINTS}")
+    yield


### PR DESCRIPTION
## Summary

Extends the hourly smoke suite to cover the two classes of regression that our existing boto3-only smoke tests can't see: browser-style CORS preflights and presigned-URL round-trips. Also adds parametrized tests against the new regional caches (\`eu-central-1.hippius.com\`, \`us-central-1.hippius.com\`) running in parallel via \`pytest-xdist\`.

Precipitating incident: the ATS remap rule didn't cover OPTIONS, so every browser-based presigned upload from \`localhost:3000\` failed with CORS errors for days. aws-cli / boto3 don't send preflights, so the hourly smoke stayed green throughout.

## Changes (biggest → smallest)

- **\`tests/smoke/test_smoke_regional.py\` (new)** — parametrized suite over the regional cache endpoints, runs in parallel:
  - \`test_regional_upload_download_roundtrip\` — authenticated PUT + GET
  - \`test_regional_public_object_anonymous_download\` — object-level public-read ACL + anonymous GET, asserts \`Cache-Control\` indicates public caching is active
  - \`test_regional_presigned_url_roundtrip\` — presigned URLs signed for the regional hostname (SigV4 canonicalizes Host)
- **\`tests/smoke/test_smoke_production.py\` — three new tests appended (07, 08, 09)**:
  - \`test_07_presigned_url_roundtrip\` — presigned PUT + presigned GET via raw \`httpx\` (not boto3 — the point is to prove the query-param signature survives the ATS + gateway stack under raw HTTP, which is what the frontend does)
  - \`test_08_cors_preflight_on_presigned_url\` — OPTIONS with Origin + \`Access-Control-Request-Method\` / \`Access-Control-Request-Headers\`. Would have caught the ATS-rejects-OPTIONS regression within an hour
  - \`test_09_cors_preflight_on_direct_path\` — same shape against \`/{bucket}/{key}\` without signature query params, proves the behavior isn't URL-shape-dependent
- **\`.github/workflows/smoke-tests.yml\`** — two pytest invocations: sequential for production file (its tests form a dependency chain), \`-n auto\` for the regional file. Exit codes combined; step fails if either does. Separate JSON reports per file.
- **\`.github/workflows/staging-smoke-tests.yml\`** — runs the production file only. Regional caches are a prod concept; staging doesn't have them.
- **\`tests/smoke/requirements.txt\`** — adds \`httpx\` (already a prod dep elsewhere in the repo — consistent with \`ForwardService\` / \`ArionClient\`) and \`pytest-xdist\`.

## Not included / deferred

- **Playwright or real-browser testing**: intentionally held off. The bug class we just hit is HTTP-level (ATS rejecting OPTIONS), and \`httpx.options(..., headers={Origin: ..., Access-Control-Request-Method: ...})\` reproduces it exactly without the ~250 MiB CI footprint of a headless browser. If we ever diagnose a client-side CORS quirk pure HTTP can't reproduce, that's the time to add Playwright. Documented in the plan file.
- **Auto-repair / retry**: tests are intentionally strict — a CORS regression should alert, not be masked.

## One known pre-existing blocker

\`us-central-1.hippius.com\` does not currently resolve over DNS. If that region isn't deployed by the time this merges, its three parametrized tests will fail on the first run. This is correct behavior — smoke tests should surface regional deployment gaps. Remove from \`REGIONAL_ENDPOINTS\` in the test file if you want to defer.

## Verification

- All 15 tests collect cleanly (9 production + 6 regional parametrized cases)
- \`test_09\` manually verified against staging: \`HTTP/2 204\` + correct CORS headers
- \`eu-central-1.hippius.com\` reachable; \`us-central-1.hippius.com\` currently NXDOMAIN (see above)
- Staging workflow unaffected (uses only production file)

## Conclusion

Closes the gap between what hit prod and what our hourly smoke sees. Zero new secrets required; existing \`HIPPIUS_PROD_ACCESS_KEY\` / \`HIPPIUS_PROD_SECRET_KEY\` + \`HIPPIUS_ENDPOINT\` plumbing is sufficient. Companion commit bumps the pip-audit ignore list for CVE-2026-3219 (pip 26.1 not yet on PyPI), which was blocking the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)