### PR TITLE
fix(scripts): use Redis.close() instead of aclose() to satisfy ty

### DIFF
--- a/hippius_s3/scripts/nuke_user.py
+++ b/hippius_s3/scripts/nuke_user.py
@@ -244,7 +244,7 @@ async def main_async(args: argparse.Namespace) -> int:
             )
             return 0
         finally:
-            await redis_queues_client.aclose()
+            await redis_queues_client.close()
 
     db = await asyncpg.connect(config.database_url)
 
@@ -328,7 +328,7 @@ async def main_async(args: argparse.Namespace) -> int:
     finally:
         await db.close()
         if redis_queues_client:
-            await redis_queues_client.aclose()
+            await redis_queues_client.close()
 
 
 def main() -> None:

--- a/hippius_s3/scripts/purge_buckets.py
+++ b/hippius_s3/scripts/purge_buckets.py
@@ -355,7 +355,7 @@ async def main_async(args: argparse.Namespace) -> int:
     finally:
         await db.close()
         if redis_queues_client:
-            await redis_queues_client.aclose()
+            await redis_queues_client.close()
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

CI's `ty check` was failing with three `unresolved-attribute` errors on `redis_queues_client.aclose()` in:

- \`hippius_s3/scripts/nuke_user.py:247\`
- \`hippius_s3/scripts/nuke_user.py:331\`
- \`hippius_s3/scripts/purge_buckets.py:358\`

The redis-py async type stubs ty consumes don't expose \`aclose()\` (only the older \`close()\`).

## Fix

Swap the 3 \`.aclose()\` calls to \`.close()\` — matches what every other operational script in this dir already does (\`dlq_requeue.py\`, \`resubmit_failed_pins.py\`, \`dlq_seed.py\`, \`recover_missing_backend.py\`).

## Why \`.close()\` over a \`# ty: ignore\` comment

\`Redis.close()\` and \`Redis.aclose()\` are functionally identical on redis-py 5.x — \`aclose()\` is the newer name and \`close()\` is the original alias kept for compatibility. Switching keeps these scripts consistent with the rest of the family and adds zero new ignore comments.

## Verification

- \`ty check hippius_s3/scripts/nuke_user.py hippius_s3/scripts/purge_buckets.py\` → All checks passed.
- Pre-commit hooks (ruff, ty, pip-audit) all green.

## Test plan

- [ ] CI `Type Check (ty)` job goes green.
- [ ] Merge to main; user merges main → staging afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)