### PR TITLE
chore(ci): split deploy workflow into staging-deploy + production-deploy

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -1,9 +1,8 @@
-name: deploy
+name: production-deploy
 
 on:
   push:
     branches:
-      - staging
       - k8s-production
 
 permissions:
@@ -111,139 +110,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy-staging:
-    runs-on: ubuntu-latest
-    needs: build-images
-    if: github.ref == 'refs/heads/staging'
-    environment: staging
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@v3
-
-      - name: Configure kubeconfig
-        run: |
-          mkdir -p $HOME/.kube
-          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > $HOME/.kube/config
-
-      - name: Create namespace if needed
-        run: |
-          kubectl create namespace hippius-s3-staging --dry-run=client -o yaml | kubectl apply -f -
-
-      - name: Update secrets
-        run: |
-          DATABASE_URL="postgresql://postgres:${{ secrets.DATABASE_PASSWORD }}@postgres-rw:5432/hippius?sslmode=disable"
-
-          kubectl create secret generic hippius-s3-secrets \
-            --from-literal=DATABASE_PASSWORD='${{ secrets.DATABASE_PASSWORD }}' \
-            --from-literal=DATABASE_URL="${DATABASE_URL}" \
-            --from-literal=HIPPIUS_KEYSTORE_DATABASE_URL="${DATABASE_URL}" \
-            --from-literal=REDIS_URL='redis://redis-cluster.hippius-s3-staging.svc.cluster.local:6379?cluster=true' \
-            --from-literal=REDIS_ACCOUNTS_URL='redis://redis-accounts:6379' \
-            --from-literal=REDIS_CHAIN_URL='redis://redis-chain:6379' \
-            --from-literal=REDIS_QUEUES_URL='redis://redis-queues:6379' \
-            --from-literal=REDIS_RATE_LIMITING_URL='redis://redis-rate-limiting:6379' \
-            --from-literal=REDIS_ACL_URL='redis://redis-acl:6379' \
-            --from-literal=HIPPIUS_SERVICE_KEY='${{ secrets.HIPPIUS_SERVICE_KEY }}' \
-            --from-literal=ARION_SERVICE_KEY='${{ secrets.ARION_SERVICE_KEY }}' \
-            --from-literal=ARION_BEARER_TOKEN='${{ secrets.ARION_BEARER_TOKEN }}' \
-            --from-literal=ARION_BILLING_BYPASS_KEY='${{ secrets.ARION_BILLING_BYPASS_KEY }}' \
-            --from-literal=ARION_RATE_LIMITING_PROXY_BYPASS_KEY='${{ secrets.ARION_RATE_LIMITING_PROXY_BYPASS_KEY }}' \
-            --from-literal=HIPPIUS_AUTH_ENCRYPTION_KEY='${{ secrets.HIPPIUS_AUTH_ENCRYPTION_KEY }}' \
-            --from-literal=HIPPIUS_UPLOAD_QUEUE_NAMES='${{ secrets.HIPPIUS_UPLOAD_QUEUE_NAMES }}' \
-            --from-literal=HIPPIUS_DOWNLOAD_QUEUE_NAMES='${{ secrets.HIPPIUS_DOWNLOAD_QUEUE_NAMES }}' \
-            --from-literal=FRONTEND_HMAC_SECRET='${{ secrets.FRONTEND_HMAC_SECRET }}' \
-            --from-literal=DISCORD_WEBHOOK_URL='${{ secrets.DISCORD_WEBHOOK_URL }}' \
-            --from-literal=HIPPIUS_OVH_KMS_ENDPOINT='${{ secrets.HIPPIUS_OVH_KMS_ENDPOINT }}' \
-            --from-literal=HIPPIUS_OVH_KMS_DEFAULT_KEY_ID='${{ secrets.HIPPIUS_OVH_KMS_DEFAULT_KEY_ID }}' \
-            --from-literal=HIPPIUS_OVH_KMS_OKMS_ID='${{ secrets.HIPPIUS_OVH_KMS_OKMS_ID }}' \
-            --from-literal=RESUBMISSION_SEED_PHRASE='${{ secrets.RESUBMISSION_SEED_PHRASE }}' \
-            --from-literal=HIPPIUS_UPLOAD_BACKENDS='${{ secrets.HIPPIUS_UPLOAD_BACKENDS }}' \
-            --from-literal=HIPPIUS_DOWNLOAD_BACKENDS='${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}' \
-            --from-literal=HIPPIUS_DELETE_BACKENDS='${{ secrets.HIPPIUS_DELETE_BACKENDS }}' \
-            --from-literal=ATS_CACHE_ENDPOINT='${{ secrets.ATS_CACHE_ENDPOINT }}' \
-            --namespace=hippius-s3-staging \
-            --dry-run=client -o yaml | kubectl apply -f -
-
-      - name: Create postgres superuser secret
-        run: |
-          kubectl create secret generic postgres-superuser \
-            --from-literal=username=postgres \
-            --from-literal=password='${{ secrets.DATABASE_PASSWORD }}' \
-            --namespace=hippius-s3-staging \
-            --dry-run=client -o yaml | kubectl apply -f -
-          kubectl label secret postgres-superuser cnpg.io/reload=true \
-            --namespace=hippius-s3-staging --overwrite
-
-      - name: Create postgres backup credentials
-        run: |
-          kubectl create secret generic postgres-backup-creds \
-            --from-literal=ACCESS_KEY_ID='${{ secrets.OVH_BACKUP_ACCESS_KEY_ID }}' \
-            --from-literal=ACCESS_KEY_SECRET='${{ secrets.OVH_BACKUP_SECRET_ACCESS_KEY }}' \
-            --namespace=hippius-s3-staging \
-            --dry-run=client -o yaml | kubectl apply -f -
-
-      - name: Substitute backup configuration values
-        run: |
-          sed -i "s|OVH_BACKUP_BUCKET_PLACEHOLDER|${{ secrets.OVH_BACKUP_BUCKET }}|g" k8s/staging/postgres-objectstore.yaml
-          sed -i "s|OVH_BACKUP_ENDPOINT_URL_PLACEHOLDER|${{ secrets.OVH_BACKUP_ENDPOINT_URL }}|g" k8s/staging/postgres-objectstore.yaml
-
-      - name: Substitute Arion configuration values
-        run: |
-          ARION_URL="${{ secrets.HIPPIUS_ARION_BASE_URL }}"
-          ARION_SSL="${{ secrets.HIPPIUS_ARION_VERIFY_SSL }}"
-          sed -i "s|HIPPIUS_ARION_BASE_URL_PLACEHOLDER|${ARION_URL:-https://arion.hippius.com/}|g" k8s/base/workers-deployments.yaml
-          sed -i "s|HIPPIUS_ARION_VERIFY_SSL_PLACEHOLDER|${ARION_SSL:-true}|g" k8s/base/workers-deployments.yaml
-
-      - name: Substitute Sentry DSN
-        run: |
-          sed -i "s|SENTRY_DSN_PLACEHOLDER|${{ secrets.SENTRY_DSN }}|g" k8s/staging/environment-patch.yaml
-
-      - name: Update image tags
-        run: |
-          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
-          cd k8s/staging
-          kustomize edit set image \
-            ghcr.io/thenervelab/hippius-s3/api:${SHORT_SHA} \
-            ghcr.io/thenervelab/hippius-s3/gateway:${SHORT_SHA} \
-            ghcr.io/thenervelab/hippius-s3/workers:${SHORT_SHA}
-
-      - name: Delete old migration job
-        run: |
-          kubectl delete job db-migrations -n hippius-s3-staging --ignore-not-found=true
-
-      - name: Deploy Redis cluster
-        run: |
-          kubectl apply -f k8s/redis-cluster/staging.yaml
-
-      - name: Deploy to staging
-        run: |
-          kubectl apply -k k8s/staging
-
-      - name: Wait for rollout
-        run: |
-          kubectl rollout status deployment/gateway -n hippius-s3-staging --timeout=10m
-          kubectl rollout status deployment/api -n hippius-s3-staging --timeout=10m
-          kubectl rollout status deployment/arion-downloader -n hippius-s3-staging --timeout=10m
-          kubectl rollout status deployment/arion-uploader -n hippius-s3-staging --timeout=10m
-
-      - name: Restart external deployments
-        run: |
-          kubectl rollout restart deployment/hydrator -n hippius-s3-staging --ignore-not-found || true
-          kubectl rollout restart deployment/backup -n hippius-s3-staging --ignore-not-found || true
-
-      - name: Verify deployment
-        run: |
-          kubectl get pods -n hippius-s3-staging
-          kubectl get services -n hippius-s3-staging
-          kubectl get ingress -n hippius-s3-staging
-
   deploy-production:
     runs-on: ubuntu-latest
     needs: build-images
-    if: github.ref == 'refs/heads/k8s-production'
     environment: production
     steps:
       - name: Checkout code

--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -1,0 +1,239 @@
+name: staging-deploy
+
+on:
+  push:
+    branches:
+      - staging
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ${{ github.repository_owner }}/hippius-s3
+
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    outputs:
+      base_image: ${{ steps.base-image.outputs.image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/base
+          tags: |
+            type=sha,prefix=,format=short
+            type=raw,value=latest
+
+      - name: Build and push base image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.base
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          outputs: type=registry,oci-mediatypes=true,compression=gzip,compression-level=9
+
+      - name: Set base image output
+        id: base-image
+        run: |
+          echo "image=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/base:$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
+  build-images:
+    runs-on: ubuntu-latest
+    needs: build-base
+    strategy:
+      matrix:
+        service: [api, gateway, workers]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.service }}
+          tags: |
+            type=sha,prefix=,format=short
+            type=raw,value=latest
+
+      - name: Determine Dockerfile
+        id: dockerfile
+        run: |
+          if [ "${{ matrix.service }}" = "api" ]; then
+            echo "dockerfile=./Dockerfile" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.service }}" = "gateway" ]; then
+            echo "dockerfile=./gateway/Dockerfile" >> $GITHUB_OUTPUT
+          elif [ "${{ matrix.service }}" = "workers" ]; then
+            echo "dockerfile=./workers/Dockerfile" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ steps.dockerfile.outputs.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            BASE_IMAGE=${{ needs.build-base.outputs.base_image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy-staging:
+    runs-on: ubuntu-latest
+    needs: build-images
+    environment: staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > $HOME/.kube/config
+
+      - name: Create namespace if needed
+        run: |
+          kubectl create namespace hippius-s3-staging --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Update secrets
+        run: |
+          DATABASE_URL="postgresql://postgres:${{ secrets.DATABASE_PASSWORD }}@postgres-rw:5432/hippius?sslmode=disable"
+
+          kubectl create secret generic hippius-s3-secrets \
+            --from-literal=DATABASE_PASSWORD='${{ secrets.DATABASE_PASSWORD }}' \
+            --from-literal=DATABASE_URL="${DATABASE_URL}" \
+            --from-literal=HIPPIUS_KEYSTORE_DATABASE_URL="${DATABASE_URL}" \
+            --from-literal=REDIS_URL='redis://redis-cluster.hippius-s3-staging.svc.cluster.local:6379?cluster=true' \
+            --from-literal=REDIS_ACCOUNTS_URL='redis://redis-accounts:6379' \
+            --from-literal=REDIS_CHAIN_URL='redis://redis-chain:6379' \
+            --from-literal=REDIS_QUEUES_URL='redis://redis-queues:6379' \
+            --from-literal=REDIS_RATE_LIMITING_URL='redis://redis-rate-limiting:6379' \
+            --from-literal=REDIS_ACL_URL='redis://redis-acl:6379' \
+            --from-literal=HIPPIUS_SERVICE_KEY='${{ secrets.HIPPIUS_SERVICE_KEY }}' \
+            --from-literal=ARION_SERVICE_KEY='${{ secrets.ARION_SERVICE_KEY }}' \
+            --from-literal=ARION_BEARER_TOKEN='${{ secrets.ARION_BEARER_TOKEN }}' \
+            --from-literal=ARION_BILLING_BYPASS_KEY='${{ secrets.ARION_BILLING_BYPASS_KEY }}' \
+            --from-literal=ARION_RATE_LIMITING_PROXY_BYPASS_KEY='${{ secrets.ARION_RATE_LIMITING_PROXY_BYPASS_KEY }}' \
+            --from-literal=HIPPIUS_AUTH_ENCRYPTION_KEY='${{ secrets.HIPPIUS_AUTH_ENCRYPTION_KEY }}' \
+            --from-literal=HIPPIUS_UPLOAD_QUEUE_NAMES='${{ secrets.HIPPIUS_UPLOAD_QUEUE_NAMES }}' \
+            --from-literal=HIPPIUS_DOWNLOAD_QUEUE_NAMES='${{ secrets.HIPPIUS_DOWNLOAD_QUEUE_NAMES }}' \
+            --from-literal=FRONTEND_HMAC_SECRET='${{ secrets.FRONTEND_HMAC_SECRET }}' \
+            --from-literal=DISCORD_WEBHOOK_URL='${{ secrets.DISCORD_WEBHOOK_URL }}' \
+            --from-literal=HIPPIUS_OVH_KMS_ENDPOINT='${{ secrets.HIPPIUS_OVH_KMS_ENDPOINT }}' \
+            --from-literal=HIPPIUS_OVH_KMS_DEFAULT_KEY_ID='${{ secrets.HIPPIUS_OVH_KMS_DEFAULT_KEY_ID }}' \
+            --from-literal=HIPPIUS_OVH_KMS_OKMS_ID='${{ secrets.HIPPIUS_OVH_KMS_OKMS_ID }}' \
+            --from-literal=RESUBMISSION_SEED_PHRASE='${{ secrets.RESUBMISSION_SEED_PHRASE }}' \
+            --from-literal=HIPPIUS_UPLOAD_BACKENDS='${{ secrets.HIPPIUS_UPLOAD_BACKENDS }}' \
+            --from-literal=HIPPIUS_DOWNLOAD_BACKENDS='${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}' \
+            --from-literal=HIPPIUS_DELETE_BACKENDS='${{ secrets.HIPPIUS_DELETE_BACKENDS }}' \
+            --from-literal=ATS_CACHE_ENDPOINT='${{ secrets.ATS_CACHE_ENDPOINT }}' \
+            --namespace=hippius-s3-staging \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create postgres superuser secret
+        run: |
+          kubectl create secret generic postgres-superuser \
+            --from-literal=username=postgres \
+            --from-literal=password='${{ secrets.DATABASE_PASSWORD }}' \
+            --namespace=hippius-s3-staging \
+            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl label secret postgres-superuser cnpg.io/reload=true \
+            --namespace=hippius-s3-staging --overwrite
+
+      - name: Create postgres backup credentials
+        run: |
+          kubectl create secret generic postgres-backup-creds \
+            --from-literal=ACCESS_KEY_ID='${{ secrets.OVH_BACKUP_ACCESS_KEY_ID }}' \
+            --from-literal=ACCESS_KEY_SECRET='${{ secrets.OVH_BACKUP_SECRET_ACCESS_KEY }}' \
+            --namespace=hippius-s3-staging \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Substitute backup configuration values
+        run: |
+          sed -i "s|OVH_BACKUP_BUCKET_PLACEHOLDER|${{ secrets.OVH_BACKUP_BUCKET }}|g" k8s/staging/postgres-objectstore.yaml
+          sed -i "s|OVH_BACKUP_ENDPOINT_URL_PLACEHOLDER|${{ secrets.OVH_BACKUP_ENDPOINT_URL }}|g" k8s/staging/postgres-objectstore.yaml
+
+      - name: Substitute Arion configuration values
+        run: |
+          ARION_URL="${{ secrets.HIPPIUS_ARION_BASE_URL }}"
+          ARION_SSL="${{ secrets.HIPPIUS_ARION_VERIFY_SSL }}"
+          sed -i "s|HIPPIUS_ARION_BASE_URL_PLACEHOLDER|${ARION_URL:-https://arion.hippius.com/}|g" k8s/base/workers-deployments.yaml
+          sed -i "s|HIPPIUS_ARION_VERIFY_SSL_PLACEHOLDER|${ARION_SSL:-true}|g" k8s/base/workers-deployments.yaml
+
+      - name: Substitute Sentry DSN
+        run: |
+          sed -i "s|SENTRY_DSN_PLACEHOLDER|${{ secrets.SENTRY_DSN }}|g" k8s/staging/environment-patch.yaml
+
+      - name: Update image tags
+        run: |
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          cd k8s/staging
+          kustomize edit set image \
+            ghcr.io/thenervelab/hippius-s3/api:${SHORT_SHA} \
+            ghcr.io/thenervelab/hippius-s3/gateway:${SHORT_SHA} \
+            ghcr.io/thenervelab/hippius-s3/workers:${SHORT_SHA}
+
+      - name: Delete old migration job
+        run: |
+          kubectl delete job db-migrations -n hippius-s3-staging --ignore-not-found=true
+
+      - name: Deploy Redis cluster
+        run: |
+          kubectl apply -f k8s/redis-cluster/staging.yaml
+
+      - name: Deploy to staging
+        run: |
+          kubectl apply -k k8s/staging
+
+      - name: Wait for rollout
+        run: |
+          kubectl rollout status deployment/gateway -n hippius-s3-staging --timeout=10m
+          kubectl rollout status deployment/api -n hippius-s3-staging --timeout=10m
+          kubectl rollout status deployment/arion-downloader -n hippius-s3-staging --timeout=10m
+          kubectl rollout status deployment/arion-uploader -n hippius-s3-staging --timeout=10m
+
+      - name: Restart external deployments
+        run: |
+          kubectl rollout restart deployment/hydrator -n hippius-s3-staging --ignore-not-found || true
+          kubectl rollout restart deployment/backup -n hippius-s3-staging --ignore-not-found || true
+
+      - name: Verify deployment
+        run: |
+          kubectl get pods -n hippius-s3-staging
+          kubectl get services -n hippius-s3-staging
+          kubectl get ingress -n hippius-s3-staging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,11 +395,12 @@ Kustomize-based. Namespaces: `hippius-s3-staging` and `hippius-s3-prod`.
 
 ### 10.1 CI/CD
 
-[.github/workflows/deploy.yaml](.github/workflows/deploy.yaml). Three top-level jobs:
+Two deploy workflows, one per environment:
 
-- `deploy-staging` — on pushes to the `staging` branch.
-- `deploy-production` — on pushes to the `k8s-production` branch.
-- `deploy-cache-production` ([deploy.yaml:370-498](/.github/workflows/deploy.yaml)) — **currently DISABLED** (`if: false` at line 373). This was the regional cache rollout for `us-0` / `eu-0`; to be re-enabled once the FS cache NVMe PVC story is finalized per region.
+- [.github/workflows/staging-deploy.yaml](.github/workflows/staging-deploy.yaml) — triggers on pushes to the `staging` branch. Job: `deploy-staging`.
+- [.github/workflows/production-deploy.yaml](.github/workflows/production-deploy.yaml) — triggers on pushes to the `k8s-production` branch. Jobs: `deploy-production`, `deploy-cache-production` (**currently DISABLED** via `if: false` — regional cache rollout for `us-0` / `eu-0`, to be re-enabled once the FS cache NVMe PVC story is finalized per region).
+
+Both share the same `build-base` and `build-images` jobs (duplicated, since GitHub Actions can't share jobs across workflows without `workflow_call`).
 
 ### 10.2 Monitoring
 


### PR DESCRIPTION
## Summary

The unified \`deploy.yaml\` triggered on pushes to both \`staging\` and \`k8s-production\` and gated each environment's job with \`if:\`. That collapsed both deployments into one entry in the GitHub Actions UI.

Splits into two files, each tied to its own branch trigger:

- \`staging-deploy.yaml\` — on push to \`staging\`, deploys \`hippius-s3-staging\`.
- \`production-deploy.yaml\` — on push to \`k8s-production\`, deploys \`hippius-s3-prod\` (incl. \`deploy-cache-production\`, still \`if: false\`).

Both share \`build-base\` and \`build-images\` (duplicated, since GitHub Actions has no cross-workflow job sharing without \`workflow_call\`). Per-push CI cost is unchanged because each push only triggers one of the two workflows.

Logical content moved 1:1 — no behaviour change other than the UI grouping. CLAUDE.md sec 10.1 updated.

## Test plan

- [ ] Merge to main, then to staging — \`staging-deploy\` runs and deploys cleanly.
- [ ] After staging green, merge to k8s-production — \`production-deploy\` runs.
- [ ] GH Actions UI shows separate entries for \`staging-deploy\` and \`production-deploy\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)