### PR TITLE
fix(api): PUT /user/sub-tokens/{key}/scope 500s on unknown access keys

### DIFF
--- a/hippius_s3/services/hippius_api_service.py
+++ b/hippius_s3/services/hippius_api_service.py
@@ -65,12 +65,18 @@ class UnpinResponse(BaseModel):
 
 
 class TokenAuthResponse(BaseModel):
+    # api.hippius.com returns one of two shapes from POST /objectstore/tokens/auth/:
+    #   - valid key  → {valid: true, status, account_address, token_type, encrypted_secret, nonce}
+    #   - unknown    → {valid: false, detail: "unknown accessKeyId"}
+    # All except `valid` are optional so the error shape parses cleanly; callers
+    # gate on `valid` before consuming the rest.
     valid: bool
-    status: str
-    account_address: str
-    token_type: str
-    encrypted_secret: str
-    nonce: str
+    status: str | None = None
+    account_address: str | None = None
+    token_type: str | None = None
+    encrypted_secret: str | None = None
+    nonce: str | None = None
+    detail: str | None = None
 
 
 class UploadResponse(BaseModel):

--- a/tests/unit/test_hippius_api_service.py
+++ b/tests/unit/test_hippius_api_service.py
@@ -8,6 +8,7 @@ import pytest
 
 from hippius_s3.services.hippius_api_service import FileStatusResponse
 from hippius_s3.services.hippius_api_service import HippiusApiClient
+from hippius_s3.services.hippius_api_service import TokenAuthResponse
 from hippius_s3.services.hippius_api_service import UploadResponse
 
 
@@ -251,3 +252,64 @@ async def test_upload_file_json_content():
         files_param = call_args.kwargs["files"]
         file_tuple = files_param["file"]
         assert file_tuple[2] == "application/json"
+
+
+# ---- TokenAuthResponse — error-shape parsing -------------------------------
+#
+# api.hippius.com returns one of two shapes from POST /objectstore/tokens/auth/:
+#   - valid key  → all six fields populated
+#   - unknown    → {"valid": false, "detail": "unknown accessKeyId"}
+#
+# Before the fix in this PR the model required all six populated fields, so
+# the error shape raised pydantic.ValidationError and the FastAPI handler
+# returned 500. The /user/sub-tokens/{key}/scope endpoint surfaces this bug
+# any time the operator-supplied access_key_id is unknown.
+
+
+def test_token_auth_response_parses_unknown_key_error_shape():
+    """Regression: error response shape must parse without ValidationError."""
+    parsed = TokenAuthResponse.model_validate({"valid": False, "detail": "unknown accessKeyId"})
+    assert parsed.valid is False
+    assert parsed.detail == "unknown accessKeyId"
+    assert parsed.status is None
+    assert parsed.account_address is None
+    assert parsed.token_type is None
+    assert parsed.encrypted_secret is None
+    assert parsed.nonce is None
+
+
+def test_token_auth_response_parses_valid_key_full_shape():
+    """Happy path: a valid key still parses with every field populated."""
+    parsed = TokenAuthResponse.model_validate(
+        {
+            "valid": True,
+            "status": "active",
+            "account_address": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+            "token_type": "master",
+            "encrypted_secret": "AAAA",
+            "nonce": "BBBB",
+        }
+    )
+    assert parsed.valid is True
+    assert parsed.status == "active"
+    assert parsed.token_type == "master"
+    assert parsed.encrypted_secret == "AAAA"
+
+
+@pytest.mark.asyncio
+async def test_auth_returns_unknown_key_response_without_500():
+    """End-to-end on the client: an `unknown accessKeyId` 200 response should
+    parse cleanly into a TokenAuthResponse with `valid=False`. Callers gate on
+    `valid` to translate this into a 4xx, never a 500."""
+    client = HippiusApiClient()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"valid": False, "detail": "unknown accessKeyId"}
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(client._client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_response
+        result = await client.auth(access_key="hip_does_not_exist")
+
+    assert result.valid is False
+    assert result.detail == "unknown accessKeyId"


### PR DESCRIPTION
## Summary

\`PUT /user/sub-tokens/{access_key_id}/scope\` was returning 500 with a pydantic \`ValidationError\` trace whenever the supplied access key wasn't known to api.hippius.com.

## Root cause

The handler at \`hippius_s3/api/sub_token_scopes.py:160\` calls \`HippiusApiClient.auth(access_key_id)\` to verify the target sub-token belongs to the caller's account. \`api.hippius.com\` returns one of two shapes:

- **Valid**: \`{valid, status, account_address, token_type, encrypted_secret, nonce}\`
- **Unknown**: \`{\"valid\": false, \"detail\": \"unknown accessKeyId\"}\` ← **this case**

But \`TokenAuthResponse\` required all six fields. The error shape raised \`pydantic.ValidationError\` (5 missing fields), which bubbled up uncaught → FastAPI 500.

Pre-PR #149, \`auth()\` was only called with keys SigV4 had already validated, so this branch never fired. PR #149's new control-plane endpoint accepts arbitrary access_key_ids from the URL — user typos / wrong account / revoked keys now hit this code path.

Confirmed live in prod gateway logs:
\`\`\`
PUT /user/sub-tokens/hip_82266c431385543ed1c2f689/scope  →  500
ValidationError: 5 validation errors for TokenAuthResponse
  status: Field required
  account_address: Field required
  token_type: Field required
  encrypted_secret: Field required
  nonce: Field required
\`\`\`

## Fix

Six lines: every \`TokenAuthResponse\` field except \`valid\` becomes optional + \`detail\` is added for the error-path payload. The existing \`if not token_response.valid: _raise(...)\` at \`sub_token_scopes.py:161\` then converts it into the documented \`400 InvalidArgument: target access key not valid\`.

Verified all callers (\`gateway/middlewares/access_key_auth.py\`, \`hippius_s3/api/sub_token_scopes.py\`) already gate on \`valid\` (or truthy field checks) before consuming downstream fields, so \`None\` values on the error path can't crash anything.

## Test coverage

Three regression tests in \`tests/unit/test_hippius_api_service.py\`:

1. \`test_token_auth_response_parses_unknown_key_error_shape\` — error-shape parses cleanly (this is what would catch a future regression of the model).
2. \`test_token_auth_response_parses_valid_key_full_shape\` — happy-path full shape still parses.
3. \`test_auth_returns_unknown_key_response_without_500\` — end-to-end on the client: 200 + error-shape body returns a usable \`TokenAuthResponse\` with \`valid=False\`.

Plus the broader unit suite stays green: 1265 passed / 37 skipped.

## Test plan

- [ ] CI \`Type Check (ty)\` and \`Test and Lint\` go green.
- [ ] Merge to main → deploy to staging → manual smoke: \`PUT /user/sub-tokens/hip_does_not_exist/scope\` returns 400 (not 500).
- [ ] Promote main → k8s-production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)