### PR TITLE
fix(api): ListObjectsV2 keyset pagination + S3-compliant response

### DIFF
--- a/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
+++ b/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
@@ -81,6 +81,7 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
                 BucketName=bucket_name,
             )
 
+        # (prefix, cursor, limit=1): we only need to know whether any object exists.
         objects = await db.fetch(
             get_query("list_objects"),
             bucket["bucket_id"],

--- a/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
+++ b/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
@@ -85,6 +85,8 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
             get_query("list_objects"),
             bucket["bucket_id"],
             None,
+            None,
+            1,
         )
 
         # S3 semantics: refuse to delete a non-empty bucket

--- a/hippius_s3/api/s3/buckets/list_buckets_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_buckets_endpoint.py
@@ -1,22 +1,18 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from typing import Any
 
 from fastapi import Response
 from lxml import etree as ET  # ty: ignore[unresolved-import]
 
 from hippius_s3.api.s3 import errors
+from hippius_s3.api.s3.common import format_s3_timestamp
 from hippius_s3.dependencies import RequestContext
 from hippius_s3.utils import get_query
 
 
 logger = logging.getLogger(__name__)
-
-
-def _format_s3_timestamp(dt: datetime) -> str:
-    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
 
 
 async def handle_list_buckets(ctx: RequestContext, db: Any) -> Response:
@@ -31,7 +27,7 @@ async def handle_list_buckets(ctx: RequestContext, db: Any) -> Response:
         for row in results:
             bucket = ET.SubElement(buckets, "Bucket")
             ET.SubElement(bucket, "Name").text = row["bucket_name"]
-            ET.SubElement(bucket, "CreationDate").text = _format_s3_timestamp(row["created_at"])
+            ET.SubElement(bucket, "CreationDate").text = format_s3_timestamp(row["created_at"])
         xml_content = ET.tostring(root, encoding="UTF-8", xml_declaration=True, pretty_print=True)
         return Response(content=xml_content, media_type="application/xml")
     except Exception:

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 
 MAX_KEYS_LIMIT = 1000
 DEFAULT_MAX_KEYS = 1000
+# Cap continuation token length to avoid an attacker forcing a giant DB cursor bind.
+MAX_CONTINUATION_TOKEN_LEN = 4096
 
 
 def _format_s3_timestamp(dt: datetime) -> str:
@@ -56,6 +58,10 @@ async def handle_list_objects(
     if delimiter:
         logger.info("ListObjectsV2 delimiter=%r ignored (CommonPrefixes not implemented yet)", delimiter)
 
+    # Treat empty query strings as absent (FastAPI hands "?prefix=" through as "").
+    prefix = prefix or None
+    start_after = start_after or None
+
     if max_keys is None or max_keys == "":
         effective_max_keys = DEFAULT_MAX_KEYS
     else:
@@ -77,6 +83,12 @@ async def handle_list_objects(
 
     cursor: str | None
     if continuation_token:
+        if len(continuation_token) > MAX_CONTINUATION_TOKEN_LEN:
+            return errors.s3_error_response(
+                code="InvalidArgument",
+                message="The continuation token provided is incorrect",
+                status_code=400,
+            )
         try:
             cursor = _decode_continuation_token(continuation_token)
         except (binascii.Error, UnicodeDecodeError, ValueError):
@@ -86,7 +98,7 @@ async def handle_list_objects(
                 status_code=400,
             )
     else:
-        cursor = start_after or None
+        cursor = start_after
 
     bucket = await pool.fetchrow(
         get_query("get_bucket_by_name"),
@@ -101,6 +113,7 @@ async def handle_list_objects(
         )
 
     bucket_id = bucket["bucket_id"]
+    bucket_owner = bucket["main_account_id"] or ctx.main_account_id
 
     # Fetch one extra row so we can detect truncation without a separate count query.
     fetch_limit = effective_max_keys + 1 if effective_max_keys > 0 else 0
@@ -110,20 +123,22 @@ async def handle_list_objects(
     if is_truncated:
         rows = rows[:effective_max_keys]
 
+    # Element order follows the AWS ListObjectsV2 response schema so strict XML
+    # validators (some Java SDKs, S3-spec test suites) accept it.
     root = ET.Element("ListBucketResult", xmlns="http://s3.amazonaws.com/doc/2006-03-01/")
     ET.SubElement(root, "Name").text = bucket_name
     ET.SubElement(root, "Prefix").text = _maybe_url_encode(prefix or "", encoding_type)
-    if delimiter:
-        ET.SubElement(root, "Delimiter").text = _maybe_url_encode(delimiter, encoding_type)
-    if start_after is not None:
-        ET.SubElement(root, "StartAfter").text = _maybe_url_encode(start_after, encoding_type)
     if continuation_token:
         ET.SubElement(root, "ContinuationToken").text = continuation_token
-    ET.SubElement(root, "KeyCount").text = str(len(rows))
+    if start_after:
+        ET.SubElement(root, "StartAfter").text = _maybe_url_encode(start_after, encoding_type)
     ET.SubElement(root, "MaxKeys").text = str(effective_max_keys)
+    if delimiter:
+        ET.SubElement(root, "Delimiter").text = _maybe_url_encode(delimiter, encoding_type)
+    ET.SubElement(root, "IsTruncated").text = "true" if is_truncated else "false"
     if encoding_type:
         ET.SubElement(root, "EncodingType").text = encoding_type
-    ET.SubElement(root, "IsTruncated").text = "true" if is_truncated else "false"
+    ET.SubElement(root, "KeyCount").text = str(len(rows))
     if is_truncated and rows:
         ET.SubElement(root, "NextContinuationToken").text = _encode_continuation_token(rows[-1]["object_key"])
 
@@ -137,8 +152,8 @@ async def handle_list_objects(
         ET.SubElement(content, "Size").text = str(obj["size_bytes"])
         ET.SubElement(content, "StorageClass").text = "STANDARD"
         owner = ET.SubElement(content, "Owner")
-        ET.SubElement(owner, "ID").text = ctx.main_account_id
-        ET.SubElement(owner, "DisplayName").text = ctx.main_account_id
+        ET.SubElement(owner, "ID").text = bucket_owner
+        ET.SubElement(owner, "DisplayName").text = bucket_owner
 
     xml_content = ET.tostring(root, encoding="UTF-8", xml_declaration=True, pretty_print=True)
 

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -3,16 +3,18 @@ from __future__ import annotations
 import base64
 import binascii
 import logging
-from datetime import datetime
 from urllib.parse import quote as urlquote
 
 import asyncpg
 from fastapi import Response
-from lxml import etree as ET  # ty: ignore[unresolved-import]
 
 from hippius_s3.api.s3 import errors
+from hippius_s3.api.s3.common import format_s3_timestamp
 from hippius_s3.dependencies import RequestContext
 from hippius_s3.utils import get_query
+from hippius_s3.xml_helpers import add_subelement
+from hippius_s3.xml_helpers import create_element
+from hippius_s3.xml_helpers import to_xml_bytes
 
 
 logger = logging.getLogger(__name__)
@@ -23,8 +25,8 @@ DEFAULT_MAX_KEYS = 1000
 MAX_CONTINUATION_TOKEN_LEN = 4096
 
 
-def _format_s3_timestamp(dt: datetime) -> str:
-    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+def _invalid_arg(message: str) -> Response:
+    return errors.s3_error_response(code="InvalidArgument", message=message, status_code=400)
 
 
 def _encode_continuation_token(last_key: str) -> str:
@@ -58,7 +60,7 @@ async def handle_list_objects(
     if delimiter:
         logger.info("ListObjectsV2 delimiter=%r ignored (CommonPrefixes not implemented yet)", delimiter)
 
-    # Treat empty query strings as absent (FastAPI hands "?prefix=" through as "").
+    # FastAPI hands "?prefix=" / "?start-after=" through as "" — treat as absent.
     prefix = prefix or None
     start_after = start_after or None
 
@@ -68,42 +70,21 @@ async def handle_list_objects(
         try:
             effective_max_keys = int(max_keys)
         except ValueError:
-            return errors.s3_error_response(
-                code="InvalidArgument",
-                message="max-keys must be an integer",
-                status_code=400,
-            )
+            return _invalid_arg("max-keys must be an integer")
         if effective_max_keys < 0:
-            return errors.s3_error_response(
-                code="InvalidArgument",
-                message="max-keys must be non-negative",
-                status_code=400,
-            )
+            return _invalid_arg("max-keys must be non-negative")
         effective_max_keys = min(effective_max_keys, MAX_KEYS_LIMIT)
 
-    cursor: str | None
+    cursor: str | None = start_after
     if continuation_token:
         if len(continuation_token) > MAX_CONTINUATION_TOKEN_LEN:
-            return errors.s3_error_response(
-                code="InvalidArgument",
-                message="The continuation token provided is incorrect",
-                status_code=400,
-            )
+            return _invalid_arg("The continuation token provided is incorrect")
         try:
             cursor = _decode_continuation_token(continuation_token)
         except (binascii.Error, UnicodeDecodeError, ValueError):
-            return errors.s3_error_response(
-                code="InvalidArgument",
-                message="The continuation token provided is incorrect",
-                status_code=400,
-            )
-    else:
-        cursor = start_after
+            return _invalid_arg("The continuation token provided is incorrect")
 
-    bucket = await pool.fetchrow(
-        get_query("get_bucket_by_name"),
-        bucket_name,
-    )
+    bucket = await pool.fetchrow(get_query("get_bucket_by_name"), bucket_name)
     if not bucket:
         return errors.s3_error_response(
             code="NoSuchBucket",
@@ -125,54 +106,37 @@ async def handle_list_objects(
 
     # Element order follows the AWS ListObjectsV2 response schema so strict XML
     # validators (some Java SDKs, S3-spec test suites) accept it.
-    root = ET.Element("ListBucketResult", xmlns="http://s3.amazonaws.com/doc/2006-03-01/")
-    ET.SubElement(root, "Name").text = bucket_name
-    ET.SubElement(root, "Prefix").text = _maybe_url_encode(prefix or "", encoding_type)
+    root = create_element("ListBucketResult", xmlns="http://s3.amazonaws.com/doc/2006-03-01/")
+    add_subelement(root, "Name", bucket_name)
+    add_subelement(root, "Prefix", _maybe_url_encode(prefix or "", encoding_type))
     if continuation_token:
-        ET.SubElement(root, "ContinuationToken").text = continuation_token
+        add_subelement(root, "ContinuationToken", continuation_token)
     if start_after:
-        ET.SubElement(root, "StartAfter").text = _maybe_url_encode(start_after, encoding_type)
-    ET.SubElement(root, "MaxKeys").text = str(effective_max_keys)
+        add_subelement(root, "StartAfter", _maybe_url_encode(start_after, encoding_type))
+    add_subelement(root, "MaxKeys", str(effective_max_keys))
     if delimiter:
-        ET.SubElement(root, "Delimiter").text = _maybe_url_encode(delimiter, encoding_type)
-    ET.SubElement(root, "IsTruncated").text = "true" if is_truncated else "false"
+        add_subelement(root, "Delimiter", _maybe_url_encode(delimiter, encoding_type))
+    add_subelement(root, "IsTruncated", "true" if is_truncated else "false")
     if encoding_type:
-        ET.SubElement(root, "EncodingType").text = encoding_type
-    ET.SubElement(root, "KeyCount").text = str(len(rows))
+        add_subelement(root, "EncodingType", encoding_type)
+    add_subelement(root, "KeyCount", str(len(rows)))
     if is_truncated and rows:
-        ET.SubElement(root, "NextContinuationToken").text = _encode_continuation_token(rows[-1]["object_key"])
+        add_subelement(root, "NextContinuationToken", _encode_continuation_token(rows[-1]["object_key"]))
 
     for obj in rows:
-        content = ET.SubElement(root, "Contents")
-        ET.SubElement(content, "Key").text = _maybe_url_encode(obj["object_key"], encoding_type)
-        ET.SubElement(content, "LastModified").text = _format_s3_timestamp(obj["created_at"])
+        content = add_subelement(root, "Contents")
+        add_subelement(content, "Key", _maybe_url_encode(obj["object_key"], encoding_type))
+        add_subelement(content, "LastModified", format_s3_timestamp(obj["created_at"]))
         # ETag is a quoted hex string per S3 spec; SDKs round-trip the quotes.
-        md5 = obj.get("md5_hash") or ""
-        ET.SubElement(content, "ETag").text = f'"{md5}"'
-        ET.SubElement(content, "Size").text = str(obj["size_bytes"])
-        ET.SubElement(content, "StorageClass").text = "STANDARD"
-        owner = ET.SubElement(content, "Owner")
-        ET.SubElement(owner, "ID").text = bucket_owner
-        ET.SubElement(owner, "DisplayName").text = bucket_owner
-
-    xml_content = ET.tostring(root, encoding="UTF-8", xml_declaration=True, pretty_print=True)
-
-    total_objects = len(rows)
-    objects_with_cid = sum(1 for obj in rows if obj.get("arion_file_hash"))
-    status_counts: dict[str, int] = {}
-    for obj in rows:
-        status = obj.get("status", "unknown")
-        status_counts[status] = status_counts.get(status, 0) + 1
-
-    headers = {
-        "x-hippius-total-objects": str(total_objects),
-        "x-hippius-objects-with-cid": str(objects_with_cid),
-        "x-hippius-status-counts": ",".join(f"{k}:{v}" for k, v in status_counts.items()),
-    }
+        add_subelement(content, "ETag", f'"{obj["md5_hash"] or ""}"')
+        add_subelement(content, "Size", str(obj["size_bytes"]))
+        add_subelement(content, "StorageClass", "STANDARD")
+        owner = add_subelement(content, "Owner")
+        add_subelement(owner, "ID", bucket_owner)
+        add_subelement(owner, "DisplayName", bucket_owner)
 
     return Response(
-        content=xml_content,
+        content=to_xml_bytes(root, pretty_print=False),
         media_type="application/xml",
         status_code=200,
-        headers=headers,
     )

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
 from datetime import datetime
+from urllib.parse import quote as urlquote
 
 import asyncpg
 from fastapi import Response
@@ -14,84 +17,147 @@ from hippius_s3.utils import get_query
 
 logger = logging.getLogger(__name__)
 
+MAX_KEYS_LIMIT = 1000
+DEFAULT_MAX_KEYS = 1000
+
 
 def _format_s3_timestamp(dt: datetime) -> str:
     return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _encode_continuation_token(last_key: str) -> str:
+    return base64.urlsafe_b64encode(last_key.encode("utf-8")).decode("ascii")
+
+
+def _decode_continuation_token(token: str) -> str | None:
+    if not token:
+        return None
+    return base64.urlsafe_b64decode(token.encode("ascii")).decode("utf-8")
+
+
+def _maybe_url_encode(value: str, encoding_type: str | None) -> str:
+    if encoding_type and encoding_type.lower() == "url":
+        return urlquote(value, safe="")
+    return value
 
 
 async def handle_list_objects(
     bucket_name: str,
     ctx: RequestContext,
     pool: asyncpg.Pool,
+    *,
     prefix: str | None,
+    start_after: str | None,
+    continuation_token: str | None,
+    max_keys: str | None,
+    encoding_type: str | None,
+    delimiter: str | None,
 ) -> Response:
-    try:
-        logger.error(f"bucket name {bucket_name}")
-        bucket = await pool.fetchrow(
-            get_query("get_bucket_by_name"),
-            bucket_name,
-        )
-        if not bucket:
+    if delimiter:
+        logger.info("ListObjectsV2 delimiter=%r ignored (CommonPrefixes not implemented yet)", delimiter)
+
+    if max_keys is None or max_keys == "":
+        effective_max_keys = DEFAULT_MAX_KEYS
+    else:
+        try:
+            effective_max_keys = int(max_keys)
+        except ValueError:
             return errors.s3_error_response(
-                code="NoSuchBucket",
-                message=f"The specified bucket {bucket_name} does not exist",
-                status_code=404,
-                BucketName=bucket_name,
+                code="InvalidArgument",
+                message="max-keys must be an integer",
+                status_code=400,
             )
+        if effective_max_keys < 0:
+            return errors.s3_error_response(
+                code="InvalidArgument",
+                message="max-keys must be non-negative",
+                status_code=400,
+            )
+        effective_max_keys = min(effective_max_keys, MAX_KEYS_LIMIT)
 
-        bucket_id = bucket["bucket_id"]
-        # list-objects supports optional Prefix filtering
+    cursor: str | None
+    if continuation_token:
+        try:
+            cursor = _decode_continuation_token(continuation_token)
+        except (binascii.Error, UnicodeDecodeError, ValueError):
+            return errors.s3_error_response(
+                code="InvalidArgument",
+                message="The continuation token provided is incorrect",
+                status_code=400,
+            )
+    else:
+        cursor = start_after or None
 
-        results = await pool.fetch(get_query("list_objects"), bucket_id, prefix)
-        # Defensive filter if backend query ignored prefix
-        if prefix:
-            results = [r for r in results if str(r["object_key"]).startswith(prefix)]
-
-        root = ET.Element("ListBucketResult", xmlns="http://s3.amazonaws.com/doc/2006-03-01/")
-        ET.SubElement(root, "Name").text = bucket_name
-        ET.SubElement(root, "Prefix").text = prefix or ""
-        ET.SubElement(root, "Marker").text = ""
-        ET.SubElement(root, "MaxKeys").text = "1000"
-        ET.SubElement(root, "IsTruncated").text = "false"
-
-        for obj in results:
-            content = ET.SubElement(root, "Contents")
-            ET.SubElement(content, "Key").text = obj["object_key"]
-            ET.SubElement(content, "LastModified").text = _format_s3_timestamp(obj["created_at"])
-            ET.SubElement(content, "ETag").text = obj["md5_hash"]
-            ET.SubElement(content, "Size").text = str(obj["size_bytes"])
-            storage_class = ET.SubElement(content, "StorageClass")
-            storage_class.text = "multipart" if obj.get("multipart") else "standard"
-            owner = ET.SubElement(content, "Owner")
-            ET.SubElement(owner, "ID").text = (obj.get("arion_file_hash") or "").strip() or "pending"
-            ET.SubElement(owner, "DisplayName").text = ctx.main_account_id
-
-        xml_content = ET.tostring(root, encoding="UTF-8", xml_declaration=True, pretty_print=True)
-
-        # Custom headers (optional diagnostics)
-        total_objects = len(results)
-        objects_with_cid = sum(1 for obj in results if obj.get("arion_file_hash"))
-        status_counts: dict[str, int] = {}
-        for obj in results:
-            status = obj.get("status", "unknown")
-            status_counts[status] = status_counts.get(status, 0) + 1
-
-        headers = {
-            "x-hippius-total-objects": str(total_objects),
-            "x-hippius-objects-with-cid": str(objects_with_cid),
-            "x-hippius-status-counts": ",".join(f"{k}:{v}" for k, v in status_counts.items()),
-        }
-
-        return Response(
-            content=xml_content,
-            media_type="application/xml",
-            status_code=200,
-            headers=headers,
-        )
-    except Exception:
-        logger.exception("Error listing objects")
+    bucket = await pool.fetchrow(
+        get_query("get_bucket_by_name"),
+        bucket_name,
+    )
+    if not bucket:
         return errors.s3_error_response(
-            "InternalError",
-            "We encountered an internal error. Please try again.",
-            status_code=500,
+            code="NoSuchBucket",
+            message=f"The specified bucket {bucket_name} does not exist",
+            status_code=404,
+            BucketName=bucket_name,
         )
+
+    bucket_id = bucket["bucket_id"]
+
+    # Fetch one extra row so we can detect truncation without a separate count query.
+    fetch_limit = effective_max_keys + 1 if effective_max_keys > 0 else 0
+    rows = await pool.fetch(get_query("list_objects"), bucket_id, prefix, cursor, fetch_limit)
+
+    is_truncated = len(rows) > effective_max_keys
+    if is_truncated:
+        rows = rows[:effective_max_keys]
+
+    root = ET.Element("ListBucketResult", xmlns="http://s3.amazonaws.com/doc/2006-03-01/")
+    ET.SubElement(root, "Name").text = bucket_name
+    ET.SubElement(root, "Prefix").text = _maybe_url_encode(prefix or "", encoding_type)
+    if delimiter:
+        ET.SubElement(root, "Delimiter").text = _maybe_url_encode(delimiter, encoding_type)
+    if start_after is not None:
+        ET.SubElement(root, "StartAfter").text = _maybe_url_encode(start_after, encoding_type)
+    if continuation_token:
+        ET.SubElement(root, "ContinuationToken").text = continuation_token
+    ET.SubElement(root, "KeyCount").text = str(len(rows))
+    ET.SubElement(root, "MaxKeys").text = str(effective_max_keys)
+    if encoding_type:
+        ET.SubElement(root, "EncodingType").text = encoding_type
+    ET.SubElement(root, "IsTruncated").text = "true" if is_truncated else "false"
+    if is_truncated and rows:
+        ET.SubElement(root, "NextContinuationToken").text = _encode_continuation_token(rows[-1]["object_key"])
+
+    for obj in rows:
+        content = ET.SubElement(root, "Contents")
+        ET.SubElement(content, "Key").text = _maybe_url_encode(obj["object_key"], encoding_type)
+        ET.SubElement(content, "LastModified").text = _format_s3_timestamp(obj["created_at"])
+        # ETag is a quoted hex string per S3 spec; SDKs round-trip the quotes.
+        md5 = obj.get("md5_hash") or ""
+        ET.SubElement(content, "ETag").text = f'"{md5}"'
+        ET.SubElement(content, "Size").text = str(obj["size_bytes"])
+        ET.SubElement(content, "StorageClass").text = "STANDARD"
+        owner = ET.SubElement(content, "Owner")
+        ET.SubElement(owner, "ID").text = ctx.main_account_id
+        ET.SubElement(owner, "DisplayName").text = ctx.main_account_id
+
+    xml_content = ET.tostring(root, encoding="UTF-8", xml_declaration=True, pretty_print=True)
+
+    total_objects = len(rows)
+    objects_with_cid = sum(1 for obj in rows if obj.get("arion_file_hash"))
+    status_counts: dict[str, int] = {}
+    for obj in rows:
+        status = obj.get("status", "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+
+    headers = {
+        "x-hippius-total-objects": str(total_objects),
+        "x-hippius-objects-with-cid": str(objects_with_cid),
+        "x-hippius-status-counts": ",".join(f"{k}:{v}" for k, v in status_counts.items()),
+    }
+
+    return Response(
+        content=xml_content,
+        media_type="application/xml",
+        status_code=200,
+        headers=headers,
+    )

--- a/hippius_s3/api/s3/buckets/router.py
+++ b/hippius_s3/api/s3/buckets/router.py
@@ -60,7 +60,18 @@ async def get_bucket(
         async with pool.acquire() as conn:
             return await policy_get_bucket_policy(bucket_name, conn, request.state.account.main_account)
     ctx = get_request_context(request)
-    return await handle_list_objects(bucket_name, ctx, pool, request.query_params.get("prefix"))
+    qp = request.query_params
+    return await handle_list_objects(
+        bucket_name,
+        ctx,
+        pool,
+        prefix=qp.get("prefix"),
+        start_after=qp.get("start-after"),
+        continuation_token=qp.get("continuation-token"),
+        max_keys=qp.get("max-keys"),
+        encoding_type=qp.get("encoding-type"),
+        delimiter=qp.get("delimiter"),
+    )
 
 
 @router.put("/{bucket_name}")

--- a/hippius_s3/api/s3/common/__init__.py
+++ b/hippius_s3/api/s3/common/__init__.py
@@ -1,3 +1,4 @@
+from .format import format_s3_timestamp  # re-export
 from .headers import build_headers  # re-export
 from .headers import if_none_match_matches  # re-export
 from .req import parse_range  # re-export

--- a/hippius_s3/api/s3/common/format.py
+++ b/hippius_s3/api/s3/common/format.py
@@ -1,0 +1,6 @@
+from datetime import datetime
+
+
+def format_s3_timestamp(dt: datetime) -> str:
+    """ISO-8601 with millisecond precision and trailing Z, matching AWS S3 responses."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"

--- a/hippius_s3/sql/queries/list_objects.sql
+++ b/hippius_s3/sql/queries/list_objects.sql
@@ -1,5 +1,5 @@
--- List objects in a bucket with optional prefix
--- Parameters: $1: bucket_id, $2: prefix (optional)
+-- List objects in a bucket with optional prefix and keyset pagination.
+-- Parameters: $1: bucket_id, $2: prefix (optional), $3: cursor / start-after key (optional), $4: limit
 SELECT o.object_id, o.bucket_id, o.object_key, o.current_object_version,
        COALESCE(c.cid, ov.ipfs_cid) as ipfs_cid,
        cb_arion.backend_identifier as arion_file_hash,
@@ -29,5 +29,7 @@ LEFT JOIN chunk_backend cb_arion ON cb_arion.chunk_id = pc0.id
   AND cb_arion.backend_identifier IS NOT NULL
 WHERE o.bucket_id = $1
   AND ($2::text IS NULL OR o.object_key LIKE $2::text || '%')
+  AND ($3::text IS NULL OR o.object_key > $3::text)
   AND o.deleted_at IS NULL
 ORDER BY o.object_key COLLATE "C"
+LIMIT $4::int

--- a/hippius_s3/sql/queries/list_objects.sql
+++ b/hippius_s3/sql/queries/list_objects.sql
@@ -1,10 +1,13 @@
 -- List objects in a bucket with optional prefix and keyset pagination.
 -- Parameters: $1: bucket_id, $2: prefix (optional), $3: cursor / start-after key (optional), $4: limit
-SELECT o.object_id, o.bucket_id, o.object_key, o.current_object_version,
-       COALESCE(c.cid, ov.ipfs_cid) as ipfs_cid,
-       cb_arion.backend_identifier as arion_file_hash,
-       ov.size_bytes, ov.content_type, o.created_at, ov.md5_hash,
-       ov.status, b.bucket_name, ov.multipart
+SELECT o.object_id,
+       o.object_key,
+       ov.size_bytes,
+       ov.content_type,
+       o.created_at,
+       ov.md5_hash,
+       ov.status,
+       ov.multipart
 FROM objects o
 JOIN object_versions ov ON ov.object_id = o.object_id AND ov.object_version = (
     -- Skip incomplete multipart placeholders (InitiateMultipartUpload without Complete)
@@ -16,25 +19,10 @@ JOIN object_versions ov ON ov.object_id = o.object_id AND ov.object_version = (
     ORDER BY v.object_version DESC
     LIMIT 1
 )
-JOIN buckets b ON o.bucket_id = b.bucket_id
-LEFT JOIN cids c ON ov.cid_id = c.id
-LEFT JOIN parts p1 ON p1.object_id = o.object_id
-  AND p1.object_version = ov.object_version
-  AND p1.part_number = 1
-LEFT JOIN part_chunks pc0 ON pc0.part_id = p1.part_id
-  AND pc0.chunk_index = 0
-LEFT JOIN chunk_backend cb_arion ON cb_arion.chunk_id = pc0.id
-  AND cb_arion.backend = 'arion'
-  AND NOT cb_arion.deleted
-  AND cb_arion.backend_identifier IS NOT NULL
 WHERE o.bucket_id = $1
   AND ($2::text IS NULL OR o.object_key LIKE $2::text || '%')
   AND ($3::text IS NULL OR o.object_key > $3::text)
   AND o.deleted_at IS NULL
--- No COLLATE clause: the database is created with C collation, so the default
--- text ordering is already byte-order. An explicit COLLATE "C" here prevents
--- the planner from using the (bucket_id, object_key) index for an ordered scan,
--- which makes this query fall back to a Sort and re-introduces the timeout
--- on large buckets.
+-- DB is C-collation; an explicit COLLATE here would defeat the (bucket_id, object_key) index ordered scan.
 ORDER BY o.object_key
 LIMIT $4::int

--- a/hippius_s3/sql/queries/list_objects.sql
+++ b/hippius_s3/sql/queries/list_objects.sql
@@ -31,5 +31,10 @@ WHERE o.bucket_id = $1
   AND ($2::text IS NULL OR o.object_key LIKE $2::text || '%')
   AND ($3::text IS NULL OR o.object_key > $3::text)
   AND o.deleted_at IS NULL
-ORDER BY o.object_key COLLATE "C"
+-- No COLLATE clause: the database is created with C collation, so the default
+-- text ordering is already byte-order. An explicit COLLATE "C" here prevents
+-- the planner from using the (bucket_id, object_key) index for an ordered scan,
+-- which makes this query fall back to a Sort and re-introduces the timeout
+-- on large buckets.
+ORDER BY o.object_key
 LIMIT $4::int

--- a/tests/unit/api/s3/test_list_objects_pagination.py
+++ b/tests/unit/api/s3/test_list_objects_pagination.py
@@ -29,11 +29,10 @@ def _row(key: str, *, size: int = 100, md5: str = "deadbeef", multipart: bool = 
         "object_key": key,
         "size_bytes": size,
         "md5_hash": md5,
+        "content_type": "application/octet-stream",
         "created_at": SAMPLE_TS,
         "multipart": multipart,
         "status": "uploaded",
-        "arion_file_hash": None,
-        "ipfs_cid": None,
     }
 
 
@@ -442,7 +441,7 @@ async def test_encoding_type_url_percent_encodes_keys_and_prefix() -> None:
 async def test_owner_is_bucket_owner_not_requestor() -> None:
     # Even though the requestor is "5HWAJ-test-account", Owner must report the
     # bucket's main_account_id so that listings against shared/public buckets
-    # don't impersonate the caller (P1 from PR #161 review).
+    # don't impersonate the caller.
     pool = _make_pool(bucket_row=_bucket(owner="5BUCKET-OWNER"), list_rows=[_row("k")])
     resp = await handle_list_objects(
         "b",
@@ -523,8 +522,7 @@ async def test_prefix_is_passed_to_sql() -> None:
 
 @pytest.mark.asyncio
 async def test_oversized_continuation_token_returns_400_without_db_call() -> None:
-    # P2 from PR #161 review: cap token length to avoid an attacker forcing a
-    # 10 MB DB cursor bind.
+    # Cap token length so an attacker can't force a multi-megabyte DB cursor bind.
     pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     huge = "A" * (list_objects_endpoint.MAX_CONTINUATION_TOKEN_LEN + 1)
     resp = await handle_list_objects(

--- a/tests/unit/api/s3/test_list_objects_pagination.py
+++ b/tests/unit/api/s3/test_list_objects_pagination.py
@@ -37,6 +37,10 @@ def _row(key: str, *, size: int = 100, md5: str = "deadbeef", multipart: bool = 
     }
 
 
+def _bucket(*, owner: str = "5BUCKET-OWNER") -> dict[str, Any]:
+    return {"bucket_id": "bid", "main_account_id": owner}
+
+
 def _make_pool(bucket_row: dict[str, Any] | None, list_rows: list[dict[str, Any]]) -> Any:
     pool = AsyncMock()
     pool.fetchrow = AsyncMock(return_value=bucket_row)
@@ -87,9 +91,15 @@ def test_url_encode_only_when_requested() -> None:
 async def test_returns_404_for_unknown_bucket() -> None:
     pool = _make_pool(bucket_row=None, list_rows=[])
     resp = await handle_list_objects(
-        "missing", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys=None, encoding_type=None, delimiter=None,
+        "missing",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     assert resp.status_code == 404
     assert b"NoSuchBucket" in resp.body
@@ -97,11 +107,17 @@ async def test_returns_404_for_unknown_bucket() -> None:
 
 @pytest.mark.asyncio
 async def test_empty_bucket_returns_zero_keycount_not_truncated() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys=None, encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     assert resp.status_code == 200
     root = _parse(resp.body)
@@ -115,11 +131,17 @@ async def test_empty_bucket_returns_zero_keycount_not_truncated() -> None:
 @pytest.mark.asyncio
 async def test_returns_keys_within_max_keys_no_truncation() -> None:
     rows = [_row(f"k{i:03d}") for i in range(50)]
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=rows)
+    pool = _make_pool(bucket_row=_bucket(), list_rows=rows)
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys="50", encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys="50",
+        encoding_type=None,
+        delimiter=None,
     )
     root = _parse(resp.body)
     assert _text(root, "KeyCount") == "50"
@@ -134,11 +156,17 @@ async def test_returns_keys_within_max_keys_no_truncation() -> None:
 @pytest.mark.asyncio
 async def test_truncated_when_more_rows_than_max_keys() -> None:
     rows = [_row(f"k{i:03d}") for i in range(101)]  # 101 rows for max_keys=100
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=rows)
+    pool = _make_pool(bucket_row=_bucket(), list_rows=rows)
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys="100", encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys="100",
+        encoding_type=None,
+        delimiter=None,
     )
     root = _parse(resp.body)
     assert _text(root, "KeyCount") == "100"
@@ -155,13 +183,19 @@ async def test_truncated_when_more_rows_than_max_keys() -> None:
 
 @pytest.mark.asyncio
 async def test_continuation_token_resumes_from_last_key() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     last_key = "deep/nested/key.bam"
     token = _encode_continuation_token(last_key)
     await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=token,
-        max_keys=None, encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=token,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     # SQL positional args: 0=SQL_text, 1=bucket_id, 2=prefix, 3=cursor, 4=limit
     call_args = pool.fetch.call_args.args
@@ -170,12 +204,18 @@ async def test_continuation_token_resumes_from_last_key() -> None:
 
 @pytest.mark.asyncio
 async def test_continuation_token_takes_precedence_over_start_after() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     token = _encode_continuation_token("from-token")
     await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after="from-start-after", continuation_token=token,
-        max_keys=None, encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after="from-start-after",
+        continuation_token=token,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     call_args = pool.fetch.call_args.args
     assert call_args[3] == "from-token"
@@ -183,11 +223,17 @@ async def test_continuation_token_takes_precedence_over_start_after() -> None:
 
 @pytest.mark.asyncio
 async def test_start_after_used_when_no_continuation_token() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after="explicit-start", continuation_token=None,
-        max_keys=None, encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after="explicit-start",
+        continuation_token=None,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     call_args = pool.fetch.call_args.args
     assert call_args[3] == "explicit-start"
@@ -195,11 +241,17 @@ async def test_start_after_used_when_no_continuation_token() -> None:
 
 @pytest.mark.asyncio
 async def test_invalid_continuation_token_returns_400() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token="not!base64!@@@",
-        max_keys=None, encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token="not!base64!@@@",
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     assert resp.status_code == 400
     assert b"InvalidArgument" in resp.body
@@ -209,23 +261,35 @@ async def test_invalid_continuation_token_returns_400() -> None:
 
 @pytest.mark.asyncio
 async def test_continuation_token_with_invalid_utf8_returns_400() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     bad_token = base64.urlsafe_b64encode(b"\xff\xfe\x80").decode("ascii")
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=bad_token,
-        max_keys=None, encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=bad_token,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     assert resp.status_code == 400
 
 
 @pytest.mark.asyncio
 async def test_max_keys_above_1000_is_clamped() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys="5000", encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys="5000",
+        encoding_type=None,
+        delimiter=None,
     )
     root = _parse(resp.body)
     assert _text(root, "MaxKeys") == "1000"
@@ -235,11 +299,17 @@ async def test_max_keys_above_1000_is_clamped() -> None:
 
 @pytest.mark.asyncio
 async def test_max_keys_zero_returns_empty() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys="0", encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys="0",
+        encoding_type=None,
+        delimiter=None,
     )
     assert resp.status_code == 200
     root = _parse(resp.body)
@@ -249,11 +319,17 @@ async def test_max_keys_zero_returns_empty() -> None:
 
 @pytest.mark.asyncio
 async def test_max_keys_negative_returns_400() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys="-5", encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys="-5",
+        encoding_type=None,
+        delimiter=None,
     )
     assert resp.status_code == 400
     assert b"InvalidArgument" in resp.body
@@ -261,11 +337,17 @@ async def test_max_keys_negative_returns_400() -> None:
 
 @pytest.mark.asyncio
 async def test_max_keys_non_integer_returns_400() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys="lots", encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys="lots",
+        encoding_type=None,
+        delimiter=None,
     )
     assert resp.status_code == 400
     assert b"InvalidArgument" in resp.body
@@ -273,11 +355,17 @@ async def test_max_keys_non_integer_returns_400() -> None:
 
 @pytest.mark.asyncio
 async def test_etag_is_double_quoted() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[_row("only", md5="abc123")])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[_row("only", md5="abc123")])
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys=None, encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     root = _parse(resp.body)
     etag = root.find(f"{S3_NS}Contents/{S3_NS}ETag").text
@@ -287,11 +375,17 @@ async def test_etag_is_double_quoted() -> None:
 @pytest.mark.asyncio
 async def test_storage_class_is_uppercase_standard_for_all_objects() -> None:
     rows = [_row("simple", multipart=False), _row("mpu", multipart=True)]
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=rows)
+    pool = _make_pool(bucket_row=_bucket(), list_rows=rows)
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys=None, encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     root = _parse(resp.body)
     classes = [c.text for c in root.iterfind(f"{S3_NS}Contents/{S3_NS}StorageClass")]
@@ -302,11 +396,17 @@ async def test_storage_class_is_uppercase_standard_for_all_objects() -> None:
 async def test_delimiter_silently_ignored_returns_flat_list() -> None:
     # Pre-fix this returned 501 NotImplemented; we now log and ignore so aws s3 ls works.
     rows = [_row("a/x"), _row("a/y"), _row("b/z")]
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=rows)
+    pool = _make_pool(bucket_row=_bucket(), list_rows=rows)
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys=None, encoding_type=None, delimiter="/",
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys=None,
+        encoding_type=None,
+        delimiter="/",
     )
     assert resp.status_code == 200
     root = _parse(resp.body)
@@ -319,11 +419,17 @@ async def test_delimiter_silently_ignored_returns_flat_list() -> None:
 @pytest.mark.asyncio
 async def test_encoding_type_url_percent_encodes_keys_and_prefix() -> None:
     rows = [_row("path/with space/é.bam")]
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=rows)
+    pool = _make_pool(bucket_row=_bucket(), list_rows=rows)
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix="path/", start_after=None, continuation_token=None,
-        max_keys=None, encoding_type="url", delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix="path/",
+        start_after=None,
+        continuation_token=None,
+        max_keys=None,
+        encoding_type="url",
+        delimiter=None,
     )
     root = _parse(resp.body)
     assert _text(root, "Prefix") == "path%2F"
@@ -333,28 +439,64 @@ async def test_encoding_type_url_percent_encodes_keys_and_prefix() -> None:
 
 
 @pytest.mark.asyncio
-async def test_owner_id_and_display_name_are_main_account() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[_row("k")])
+async def test_owner_is_bucket_owner_not_requestor() -> None:
+    # Even though the requestor is "5HWAJ-test-account", Owner must report the
+    # bucket's main_account_id so that listings against shared/public buckets
+    # don't impersonate the caller (P1 from PR #161 review).
+    pool = _make_pool(bucket_row=_bucket(owner="5BUCKET-OWNER"), list_rows=[_row("k")])
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=None,
-        max_keys=None, encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     root = _parse(resp.body)
     owner_id = root.find(f"{S3_NS}Contents/{S3_NS}Owner/{S3_NS}ID").text
     owner_dn = root.find(f"{S3_NS}Contents/{S3_NS}Owner/{S3_NS}DisplayName").text
+    assert owner_id == "5BUCKET-OWNER"
+    assert owner_dn == "5BUCKET-OWNER"
+
+
+@pytest.mark.asyncio
+async def test_owner_falls_back_to_requestor_when_bucket_owner_missing() -> None:
+    # Defensive: if the buckets row is somehow missing main_account_id (legacy
+    # data?), fall back to the requestor rather than emitting <ID/> with None.
+    pool = _make_pool(bucket_row={"bucket_id": "bid", "main_account_id": None}, list_rows=[_row("k")])
+    resp = await handle_list_objects(
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=None,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
+    )
+    root = _parse(resp.body)
+    owner_id = root.find(f"{S3_NS}Contents/{S3_NS}Owner/{S3_NS}ID").text
     assert owner_id == "5HWAJ-test-account"
-    assert owner_dn == "5HWAJ-test-account"
 
 
 @pytest.mark.asyncio
 async def test_request_echoes_continuation_token_when_provided() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     token = _encode_continuation_token("k50")
     resp = await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix=None, start_after=None, continuation_token=token,
-        max_keys=None, encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=token,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     root = _parse(resp.body)
     assert _text(root, "ContinuationToken") == token
@@ -362,15 +504,123 @@ async def test_request_echoes_continuation_token_when_provided() -> None:
 
 @pytest.mark.asyncio
 async def test_prefix_is_passed_to_sql() -> None:
-    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
     await handle_list_objects(
-        "b", _ctx(), pool,
-        prefix="genomes/HG001/", start_after=None, continuation_token=None,
-        max_keys=None, encoding_type=None, delimiter=None,
+        "b",
+        _ctx(),
+        pool,
+        prefix="genomes/HG001/",
+        start_after=None,
+        continuation_token=None,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
     )
     # SQL positional args: 0=SQL_text, 1=bucket_id, 2=prefix, 3=cursor, 4=limit
     call_args = pool.fetch.call_args.args
     assert call_args[2] == "genomes/HG001/"
+
+
+@pytest.mark.asyncio
+async def test_oversized_continuation_token_returns_400_without_db_call() -> None:
+    # P2 from PR #161 review: cap token length to avoid an attacker forcing a
+    # 10 MB DB cursor bind.
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
+    huge = "A" * (list_objects_endpoint.MAX_CONTINUATION_TOKEN_LEN + 1)
+    resp = await handle_list_objects(
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after=None,
+        continuation_token=huge,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
+    )
+    assert resp.status_code == 400
+    assert b"InvalidArgument" in resp.body
+    pool.fetchrow.assert_not_called()
+    pool.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_empty_prefix_query_string_normalized_to_none() -> None:
+    # FastAPI hands "?prefix=" through as "" — that should NOT be turned into
+    # `LIKE '' || '%'` (which matches everything but adds planner cost). Verify
+    # the SQL receives None.
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
+    await handle_list_objects(
+        "b",
+        _ctx(),
+        pool,
+        prefix="",
+        start_after=None,
+        continuation_token=None,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
+    )
+    call_args = pool.fetch.call_args.args
+    assert call_args[2] is None
+
+
+@pytest.mark.asyncio
+async def test_empty_start_after_normalized_and_not_echoed() -> None:
+    pool = _make_pool(bucket_row=_bucket(), list_rows=[])
+    resp = await handle_list_objects(
+        "b",
+        _ctx(),
+        pool,
+        prefix=None,
+        start_after="",
+        continuation_token=None,
+        max_keys=None,
+        encoding_type=None,
+        delimiter=None,
+    )
+    # Cursor passed to SQL is None, not ""
+    assert pool.fetch.call_args.args[3] is None
+    # XML must not echo an empty <StartAfter></StartAfter>
+    root = _parse(resp.body)
+    assert root.find(f"{S3_NS}StartAfter") is None
+
+
+@pytest.mark.asyncio
+async def test_xml_element_order_matches_aws_spec() -> None:
+    # AWS schema order:
+    #   Name, Prefix, ContinuationToken, StartAfter, MaxKeys, Delimiter,
+    #   IsTruncated, EncodingType, KeyCount, NextContinuationToken, Contents...
+    # boto3 doesn't care about order, but stricter XML-validating SDKs do.
+    rows = [_row(f"k{i:02d}") for i in range(2)]
+    pool = _make_pool(bucket_row=_bucket(), list_rows=rows + [_row("k99")])
+    token = _encode_continuation_token("prev")
+    resp = await handle_list_objects(
+        "b",
+        _ctx(),
+        pool,
+        prefix="p/",
+        start_after="s",
+        continuation_token=token,
+        max_keys="2",
+        encoding_type="url",
+        delimiter="/",
+    )
+    root = _parse(resp.body)
+    top_level_tags = [ET.QName(child).localname for child in root if ET.QName(child).localname != "Contents"]
+    expected_order = [
+        "Name",
+        "Prefix",
+        "ContinuationToken",
+        "StartAfter",
+        "MaxKeys",
+        "Delimiter",
+        "IsTruncated",
+        "EncodingType",
+        "KeyCount",
+        "NextContinuationToken",
+    ]
+    assert top_level_tags == expected_order
 
 
 def test_constants_match_aws_spec() -> None:

--- a/tests/unit/api/s3/test_list_objects_pagination.py
+++ b/tests/unit/api/s3/test_list_objects_pagination.py
@@ -1,0 +1,379 @@
+"""Unit tests for ListObjectsV2 keyset pagination behaviour."""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from lxml import etree as ET  # ty: ignore[unresolved-import]
+
+from hippius_s3.api.s3.buckets import list_objects_endpoint
+from hippius_s3.api.s3.buckets.list_objects_endpoint import _decode_continuation_token
+from hippius_s3.api.s3.buckets.list_objects_endpoint import _encode_continuation_token
+from hippius_s3.api.s3.buckets.list_objects_endpoint import _maybe_url_encode
+from hippius_s3.api.s3.buckets.list_objects_endpoint import handle_list_objects
+from hippius_s3.dependencies import RequestContext
+
+
+S3_NS = "{http://s3.amazonaws.com/doc/2006-03-01/}"
+SAMPLE_TS = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _row(key: str, *, size: int = 100, md5: str = "deadbeef", multipart: bool = False) -> dict[str, Any]:
+    return {
+        "object_id": f"id-{key}",
+        "object_key": key,
+        "size_bytes": size,
+        "md5_hash": md5,
+        "created_at": SAMPLE_TS,
+        "multipart": multipart,
+        "status": "uploaded",
+        "arion_file_hash": None,
+        "ipfs_cid": None,
+    }
+
+
+def _make_pool(bucket_row: dict[str, Any] | None, list_rows: list[dict[str, Any]]) -> Any:
+    pool = AsyncMock()
+    pool.fetchrow = AsyncMock(return_value=bucket_row)
+    pool.fetch = AsyncMock(return_value=list_rows)
+    return pool
+
+
+def _ctx() -> RequestContext:
+    return RequestContext(main_account_id="5HWAJ-test-account", seed_phrase="")
+
+
+def _parse(xml_bytes: bytes) -> ET._Element:
+    return ET.fromstring(xml_bytes)
+
+
+def _text(root: ET._Element, tag: str) -> str | None:
+    el = root.find(f"{S3_NS}{tag}")
+    return el.text if el is not None else None
+
+
+def _all(root: ET._Element, tag: str) -> list[ET._Element]:
+    return list(root.iterfind(f"{S3_NS}{tag}"))
+
+
+# ---- pure helper round-trips --------------------------------------------------
+
+
+def test_continuation_token_round_trip() -> None:
+    for key in ["a/b.txt", "ünicode/é.bam", "with space/and+plus", "0", "z" * 200]:
+        token = _encode_continuation_token(key)
+        assert _decode_continuation_token(token) == key
+
+
+def test_continuation_token_decodes_empty_to_none() -> None:
+    assert _decode_continuation_token("") is None
+
+
+def test_url_encode_only_when_requested() -> None:
+    assert _maybe_url_encode("a/b c", None) == "a/b c"
+    assert _maybe_url_encode("a/b c", "url") == "a%2Fb%20c"
+    assert _maybe_url_encode("é", "URL") == "%C3%A9"
+
+
+# ---- endpoint behaviour -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_404_for_unknown_bucket() -> None:
+    pool = _make_pool(bucket_row=None, list_rows=[])
+    resp = await handle_list_objects(
+        "missing", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    assert resp.status_code == 404
+    assert b"NoSuchBucket" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_empty_bucket_returns_zero_keycount_not_truncated() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    assert resp.status_code == 200
+    root = _parse(resp.body)
+    assert _text(root, "KeyCount") == "0"
+    assert _text(root, "IsTruncated") == "false"
+    assert _text(root, "MaxKeys") == "1000"
+    assert root.find(f"{S3_NS}NextContinuationToken") is None
+    assert _all(root, "Contents") == []
+
+
+@pytest.mark.asyncio
+async def test_returns_keys_within_max_keys_no_truncation() -> None:
+    rows = [_row(f"k{i:03d}") for i in range(50)]
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=rows)
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys="50", encoding_type=None, delimiter=None,
+    )
+    root = _parse(resp.body)
+    assert _text(root, "KeyCount") == "50"
+    assert _text(root, "IsTruncated") == "false"
+    assert root.find(f"{S3_NS}NextContinuationToken") is None
+    # SQL gets max_keys+1 to detect truncation
+    pool.fetch.assert_awaited_once()
+    call_args = pool.fetch.call_args.args
+    assert call_args[-1] == 51
+
+
+@pytest.mark.asyncio
+async def test_truncated_when_more_rows_than_max_keys() -> None:
+    rows = [_row(f"k{i:03d}") for i in range(101)]  # 101 rows for max_keys=100
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=rows)
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys="100", encoding_type=None, delimiter=None,
+    )
+    root = _parse(resp.body)
+    assert _text(root, "KeyCount") == "100"
+    assert _text(root, "IsTruncated") == "true"
+    next_tok = _text(root, "NextContinuationToken")
+    assert next_tok is not None
+    # Token decodes back to the 100th (last returned) key
+    assert _decode_continuation_token(next_tok) == "k099"
+    # 101st row should not appear in response
+    contents_keys = [c.find(f"{S3_NS}Key").text for c in _all(root, "Contents")]
+    assert "k100" not in contents_keys
+    assert len(contents_keys) == 100
+
+
+@pytest.mark.asyncio
+async def test_continuation_token_resumes_from_last_key() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    last_key = "deep/nested/key.bam"
+    token = _encode_continuation_token(last_key)
+    await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=token,
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    # SQL positional args: 0=SQL_text, 1=bucket_id, 2=prefix, 3=cursor, 4=limit
+    call_args = pool.fetch.call_args.args
+    assert call_args[3] == last_key
+
+
+@pytest.mark.asyncio
+async def test_continuation_token_takes_precedence_over_start_after() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    token = _encode_continuation_token("from-token")
+    await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after="from-start-after", continuation_token=token,
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    call_args = pool.fetch.call_args.args
+    assert call_args[3] == "from-token"
+
+
+@pytest.mark.asyncio
+async def test_start_after_used_when_no_continuation_token() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after="explicit-start", continuation_token=None,
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    call_args = pool.fetch.call_args.args
+    assert call_args[3] == "explicit-start"
+
+
+@pytest.mark.asyncio
+async def test_invalid_continuation_token_returns_400() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token="not!base64!@@@",
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    assert resp.status_code == 400
+    assert b"InvalidArgument" in resp.body
+    # No DB fetch should happen on bad token (we never reach get_bucket_by_name)
+    pool.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_continuation_token_with_invalid_utf8_returns_400() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    bad_token = base64.urlsafe_b64encode(b"\xff\xfe\x80").decode("ascii")
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=bad_token,
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_max_keys_above_1000_is_clamped() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys="5000", encoding_type=None, delimiter=None,
+    )
+    root = _parse(resp.body)
+    assert _text(root, "MaxKeys") == "1000"
+    # SQL also called with the clamped value (+1 for truncation detection)
+    assert pool.fetch.call_args.args[-1] == 1001
+
+
+@pytest.mark.asyncio
+async def test_max_keys_zero_returns_empty() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys="0", encoding_type=None, delimiter=None,
+    )
+    assert resp.status_code == 200
+    root = _parse(resp.body)
+    assert _text(root, "MaxKeys") == "0"
+    assert _text(root, "KeyCount") == "0"
+
+
+@pytest.mark.asyncio
+async def test_max_keys_negative_returns_400() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys="-5", encoding_type=None, delimiter=None,
+    )
+    assert resp.status_code == 400
+    assert b"InvalidArgument" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_max_keys_non_integer_returns_400() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys="lots", encoding_type=None, delimiter=None,
+    )
+    assert resp.status_code == 400
+    assert b"InvalidArgument" in resp.body
+
+
+@pytest.mark.asyncio
+async def test_etag_is_double_quoted() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[_row("only", md5="abc123")])
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    root = _parse(resp.body)
+    etag = root.find(f"{S3_NS}Contents/{S3_NS}ETag").text
+    assert etag == '"abc123"'
+
+
+@pytest.mark.asyncio
+async def test_storage_class_is_uppercase_standard_for_all_objects() -> None:
+    rows = [_row("simple", multipart=False), _row("mpu", multipart=True)]
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=rows)
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    root = _parse(resp.body)
+    classes = [c.text for c in root.iterfind(f"{S3_NS}Contents/{S3_NS}StorageClass")]
+    assert classes == ["STANDARD", "STANDARD"]
+
+
+@pytest.mark.asyncio
+async def test_delimiter_silently_ignored_returns_flat_list() -> None:
+    # Pre-fix this returned 501 NotImplemented; we now log and ignore so aws s3 ls works.
+    rows = [_row("a/x"), _row("a/y"), _row("b/z")]
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=rows)
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys=None, encoding_type=None, delimiter="/",
+    )
+    assert resp.status_code == 200
+    root = _parse(resp.body)
+    keys = [c.find(f"{S3_NS}Key").text for c in _all(root, "Contents")]
+    assert keys == ["a/x", "a/y", "b/z"]
+    # Delimiter is echoed back even though we don't fold CommonPrefixes yet.
+    assert _text(root, "Delimiter") == "/"
+
+
+@pytest.mark.asyncio
+async def test_encoding_type_url_percent_encodes_keys_and_prefix() -> None:
+    rows = [_row("path/with space/é.bam")]
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=rows)
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix="path/", start_after=None, continuation_token=None,
+        max_keys=None, encoding_type="url", delimiter=None,
+    )
+    root = _parse(resp.body)
+    assert _text(root, "Prefix") == "path%2F"
+    assert _text(root, "EncodingType") == "url"
+    encoded_key = root.find(f"{S3_NS}Contents/{S3_NS}Key").text
+    assert encoded_key == "path%2Fwith%20space%2F%C3%A9.bam"
+
+
+@pytest.mark.asyncio
+async def test_owner_id_and_display_name_are_main_account() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[_row("k")])
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=None,
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    root = _parse(resp.body)
+    owner_id = root.find(f"{S3_NS}Contents/{S3_NS}Owner/{S3_NS}ID").text
+    owner_dn = root.find(f"{S3_NS}Contents/{S3_NS}Owner/{S3_NS}DisplayName").text
+    assert owner_id == "5HWAJ-test-account"
+    assert owner_dn == "5HWAJ-test-account"
+
+
+@pytest.mark.asyncio
+async def test_request_echoes_continuation_token_when_provided() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    token = _encode_continuation_token("k50")
+    resp = await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix=None, start_after=None, continuation_token=token,
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    root = _parse(resp.body)
+    assert _text(root, "ContinuationToken") == token
+
+
+@pytest.mark.asyncio
+async def test_prefix_is_passed_to_sql() -> None:
+    pool = _make_pool(bucket_row={"bucket_id": "bid"}, list_rows=[])
+    await handle_list_objects(
+        "b", _ctx(), pool,
+        prefix="genomes/HG001/", start_after=None, continuation_token=None,
+        max_keys=None, encoding_type=None, delimiter=None,
+    )
+    # SQL positional args: 0=SQL_text, 1=bucket_id, 2=prefix, 3=cursor, 4=limit
+    call_args = pool.fetch.call_args.args
+    assert call_args[2] == "genomes/HG001/"
+
+
+def test_constants_match_aws_spec() -> None:
+    # AWS hard cap for ListObjectsV2 page size.
+    assert list_objects_endpoint.MAX_KEYS_LIMIT == 1000
+    assert list_objects_endpoint.DEFAULT_MAX_KEYS == 1000


### PR DESCRIPTION
## Summary

Fixes a 30-second timeout on `ListObjectsV2` for buckets with thousands of objects — the customer bucket `genotypenet-mutations` (34,811 objects, 421 GB) was 500'ing on every UI request. The query had no `LIMIT`, no cursor, and the endpoint ignored every pagination param except `Prefix`. This PR adds proper S3 keyset pagination (`ContinuationToken` + `StartAfter`), drops a `COLLATE "C"` clause that was preventing the planner from using the right index, and brings the XML response into line with the AWS spec so strict S3 clients are happy.

After the fix: `EXPLAIN ANALYZE` on the customer bucket goes from 15.9 s to 173 ms (92× speedup), and the endpoint behaves correctly under boto3's paginator, `aws s3 ls`, `aws s3 sync`, and `s3cmd`.

## Changes (largest → smallest)

- **`list_objects_endpoint.py` (full rewrite, ~150 lines).** Accepts `start-after`, `continuation-token`, `max-keys`, `encoding-type`, `delimiter`. ContinuationToken is `urlsafe-base64(last_key)`. `MaxKeys` clamped to `[0, 1000]`. Bad / oversized tokens return `400 InvalidArgument`. Empty `?prefix=` and `?start-after=` are normalised to `None`. `Owner.ID` is now the bucket owner (not the requestor), with fall-back to the requestor when the bucket row lacks `main_account_id`. Response XML element order matches the AWS schema. ETag is double-quoted per spec. `StorageClass` is `STANDARD`. `Delimiter` is silently ignored (logged) so `aws s3 ls s3://bucket/folder/` doesn't error — `CommonPrefixes` is a separate follow-up. Blanket `try/except` removed; errors bubble per repo convention.
- **`tests/unit/api/s3/test_list_objects_pagination.py` (new, 29 cases, +412 lines).** Round-trip helpers, max_keys clamp / negative / non-integer, oversized token, empty string normalisation, owner-from-bucket-row, ETag quoting, `STANDARD` storage class, delimiter ignored gracefully, URL encoding, XML element order, AWS spec constants.
- **`router.py`.** Forwards the new query params from `request.query_params` to `handle_list_objects`.
- **`list_objects.sql`.** Adds `WHERE key > $3` cursor and `LIMIT $4`. Drops the explicit `COLLATE "C"` from `ORDER BY` (DB default collation is already C; the explicit clause was blocking the `(bucket_id, object_key)` index). Comment in-file explains the planner gotcha.
- **`bucket_delete_endpoint.py`.** Updated the `list_objects` call to pass the new `cursor=None, limit=1` positional args so the non-empty bucket check still works.

## Verification

- Postgres `EXPLAIN ANALYZE` on the customer bucket: 173 ms (was 15.9 s; was previously timing out at 30 s under prod load).
- `pytest tests/unit`: **1,310 passed, 37 skipped, 0 failed.**
- `ruff check` + `ruff format` + `ty check`: clean on touched files.
- Compatible clients verified by spec review: AWS CLI (`aws s3 ls`, `aws s3 sync`, `aws s3 cp`), boto3 paginator, boto3 `StartAfter` resumes, `s3cmd ls`, MinIO `mc`.