### PR TITLE
fix(db): add missing FK cascade index on object_acls(object_id)

### DIFF
--- a/hippius_s3/sql/migrations/20260504000000_add_object_acls_object_id_index.sql
+++ b/hippius_s3/sql/migrations/20260504000000_add_object_acls_object_id_index.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+
+-- The fk_object_acls_object FK has ON DELETE CASCADE from objects(object_id),
+-- but no leading-column index on object_acls(object_id). Both existing composite
+-- indexes start with bucket_id (idx_object_acls_bucket_object,
+-- object_acls_bucket_object_key), so cascade enforcement falls back to a seq
+-- scan of object_acls per deleted object — painful when DELETE FROM buckets
+-- cascades through tens of thousands of objects.
+-- object_acls is small (~8 MB in prod), so a plain CREATE INDEX is fine.
+CREATE INDEX IF NOT EXISTS idx_object_acls_object_id
+    ON public.object_acls (object_id);
+
+-- migrate:down
+
+DROP INDEX IF EXISTS idx_object_acls_object_id;


### PR DESCRIPTION
## Summary

Closes a missing FK cascade index identified during a slow `DELETE FROM buckets` investigation.

## Background

`s3api delete-bucket` against a bucket containing ~34k soft-deleted objects on prod was failing with `InternalError` after 9 retries. Each attempt hit the gateway → API → Postgres path and timed out at exactly 30s — the API's `statement_timeout`.

The endpoint query is trivial (`DELETE FROM buckets WHERE bucket_id = $1`); the slowness is the FK cascade chain:

```
buckets → objects → object_versions → parts → part_chunks → chunk_backend
        → multipart_uploads (CASCADE via bucket_id, SET NULL via object_id)
        → bucket_acls
        → object_acls
```

Wait event during the running delete was `IO/DataFileRead` — disk reads, not lock contention.

## Audit of FK indexes on the cascade chain

| Child column | Cascade target | Index | OK? |
|---|---|---|---|
| `objects.bucket_id` | `buckets.bucket_id` | `idx_objects_bucket_prefix(bucket_id, object_key)` | ✅ |
| `object_versions.object_id` | `objects.object_id` | `idx_object_versions_object_created_desc(object_id, ...)` | ✅ |
| `parts.object_id` | `objects.object_id` | `idx_parts_object_version(object_id, object_version)` | ✅ |
| `parts.upload_id` | `multipart_uploads.upload_id` | `idx_parts_upload(upload_id)` | ✅ |
| `part_chunks.part_id` | `parts.part_id` | `part_chunks_part_idx(part_id)` | ✅ |
| `chunk_backend.chunk_id` | `part_chunks.id` | PK `(chunk_id, backend)` (leading col) | ✅ |
| `multipart_uploads.bucket_id` | `buckets.bucket_id` | `idx_multipart_uploads_bucket(bucket_id)` | ✅ |
| `multipart_uploads.object_id` | `objects.object_id` | `idx_multipart_uploads_object_id(object_id)` | ✅ |
| `bucket_acls.bucket_id` | `buckets.bucket_id` | `idx_bucket_acls_bucket_id(bucket_id)` | ✅ |
| `object_acls.bucket_id` | `buckets.bucket_id` | `idx_object_acls_bucket_object(bucket_id, object_id)` | ✅ |
| **`object_acls.object_id`** | **`objects.object_id`** | **none with `object_id` leading** | ❌ |

The two existing indexes on `object_acls` containing `object_id` both lead with `bucket_id` (`idx_object_acls_bucket_object` and the unique `object_acls_bucket_object_key`), so the planner can't use them for the per-object `WHERE object_id = X` lookups that the cascade enforcement requires. Falls back to a seq scan of `object_acls` per deleted object.

## Changes

- New migration `20260504000000_add_object_acls_object_id_index.sql` — adds `idx_object_acls_object_id ON object_acls(object_id)`. Plain (non-CONCURRENT) `CREATE INDEX` because the table is tiny in prod (~8 MB, ~12k rows).

## Conclusion

This closes one real index gap. **It does not by itself solve the original 30s timeout** on the pagination-test-40k bucket — that bucket had 0 ACL rows, so this index doesn't change its plan. The dominant cost there is bulk I/O on the `chunk_backend` cascade (67k rows scattered in a 10 GB / 53M-row table) and `multipart_uploads` SET NULL work (33k rows in a 10 GB table). Those need separate work — likely application-level batched cleanup before the bucket DELETE, or restructuring the soft-delete + janitor pipeline so cascades don't accumulate this much state.

## Test plan

- [ ] Run dbmate migration against staging, confirm `idx_object_acls_object_id` is present and VALID
- [ ] On a bucket with non-trivial `object_acls` rows, compare `EXPLAIN ANALYZE DELETE FROM buckets WHERE bucket_id = ...` before/after — expect to see index scan on `idx_object_acls_object_id` instead of seq scan on `object_acls`
- [ ] Confirm `DELETE FROM object_acls WHERE object_id = ...` now uses the index

🤖 Generated with [Claude Code](https://claude.com/claude-code)