### PR TITLE
fix(api): return NoSuchBucket vs NoSuchKey on missing-bucket reads

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,12 @@ repos:
         # CVE-2026-3219: pip concatenated tar/zip handling. Fix landed upstream (pypa/pip#13870)
         # but pip 26.1 not yet released to PyPI as of 2026-04-24 — only 26.0.1 is up. Remove
         # this ignore once 26.1 ships.
+        # CVE-2026-6357: pip self-update deferred imports ACE. Also fixed in pip 26.1
+        # (released 2026-04-26). Same situation — pip-audit's hook env still resolves
+        # 26.0.1 even though the project venv is on 26.1. Remove once the hook env
+        # picks up 26.1.
         name: pip-audit (dependency scan)
-        entry: pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2026-3219
+        entry: pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357
         language: system
         stages: [pre-commit]
         pass_filenames: false

--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -128,6 +128,17 @@ async def handle_get_object(
                     version_id,
                 )
                 if not object_info:
+                    bucket_exists = await db.fetchval(
+                        "SELECT 1 FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL",
+                        bucket_name,
+                    )
+                    if not bucket_exists:
+                        return errors.s3_error_response(
+                            code="NoSuchBucket",
+                            message=f"The specified bucket {bucket_name} does not exist",
+                            status_code=404,
+                            BucketName=bucket_name,
+                        )
                     object_exists = await db.fetchval(
                         """
                         SELECT 1 FROM objects o
@@ -158,6 +169,17 @@ async def handle_get_object(
                     object_key,
                 )
                 if not object_info:
+                    bucket_exists = await db.fetchval(
+                        "SELECT 1 FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL",
+                        bucket_name,
+                    )
+                    if not bucket_exists:
+                        return errors.s3_error_response(
+                            code="NoSuchBucket",
+                            message=f"The specified bucket {bucket_name} does not exist",
+                            status_code=404,
+                            BucketName=bucket_name,
+                        )
                     return errors.s3_error_response(
                         code="NoSuchKey",
                         message=f"The specified key {object_key} does not exist or you don't have permission to access it",

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -40,6 +40,16 @@ async def _get_object_with_permissions_min(
             bucket_name, object_key, version, main_account_id
         )
         if not row:
+            bucket_exists = await db.fetchval(
+                "SELECT 1 FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL",
+                bucket_name,
+            )
+            if not bucket_exists:
+                raise errors.S3Error(
+                    code="NoSuchBucket",
+                    status_code=404,
+                    message=f"The specified bucket {bucket_name} does not exist",
+                )
             object_exists = await db.fetchval(
                 """
                 SELECT 1 FROM objects o
@@ -63,6 +73,16 @@ async def _get_object_with_permissions_min(
     else:
         row = await ObjectRepository(db).get_for_download_with_permissions(bucket_name, object_key, main_account_id)
         if not row:
+            bucket_exists = await db.fetchval(
+                "SELECT 1 FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL",
+                bucket_name,
+            )
+            if not bucket_exists:
+                raise errors.S3Error(
+                    code="NoSuchBucket",
+                    status_code=404,
+                    message=f"The specified bucket {bucket_name} does not exist",
+                )
             raise errors.S3Error(
                 code="NoSuchKey",
                 status_code=404,


### PR DESCRIPTION
## Summary

Pre-existing bug exposed by the new soft-delete e2e test in PR #164: `GetObject`/`HeadObject` against a non-existent (or now: soft-deleted) bucket returned `NoSuchKey` instead of the AWS-correct `NoSuchBucket`.

## Why

The download query JOINs on `buckets`, so a missing bucket and a missing key both return zero rows from the same query. The endpoints were collapsing both into `NoSuchKey`. Existing endpoints (CopyObject, ObjectTagging, BucketTagging, etc.) already disambiguate; this aligns the two read endpoints.

## Changes

- `hippius_s3/api/s3/objects/get_object_endpoint.py` — both versioned and non-versioned branches probe `buckets` (filtered on `deleted_at IS NULL`) before falling through to `NoSuchKey`. If the bucket itself is missing, return `NoSuchBucket`.
- `hippius_s3/api/s3/objects/head_object_endpoint.py` — same fix.
- `.pre-commit-config.yaml` — adds `CVE-2026-6357` to the pip-audit ignore list. Same false-positive as the existing `CVE-2026-3219` ignore: fixed in pip 26.1, but pip-audit's hook env still resolves 26.0.1.

## Test plan

- [x] Existing 1342 unit tests pass
- [x] `ruff check` + `ruff format` + `ty check` clean
- [ ] E2E `test_DeleteBucket_soft.py::test_delete_bucket_returns_204_and_hides_bucket` passes (the failing case in PR #164's CI run)
- [ ] No regression in other e2e tests (CI to confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)