### PR TITLE
release: bucket soft-delete (Phase 1) + response-* overrides + dep CVE bumps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,12 @@ repos:
         # CVE-2026-3219: pip concatenated tar/zip handling. Fix landed upstream (pypa/pip#13870)
         # but pip 26.1 not yet released to PyPI as of 2026-04-24 — only 26.0.1 is up. Remove
         # this ignore once 26.1 ships.
+        # CVE-2026-6357: pip self-update deferred imports ACE. Also fixed in pip 26.1
+        # (released 2026-04-26). Same situation — pip-audit's hook env still resolves
+        # 26.0.1 even though the project venv is on 26.1. Remove once the hook env
+        # picks up 26.1.
         name: pip-audit (dependency scan)
-        entry: pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2026-3219
+        entry: pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357
         language: system
         stages: [pre-commit]
         pass_filenames: false

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -14,6 +14,7 @@ from gateway.middlewares.ats_purge import ats_purge_middleware
 from gateway.middlewares.audit_log import audit_log_middleware
 from gateway.middlewares.auth_router import auth_router_middleware
 from gateway.middlewares.cache_control import cache_control_middleware
+from gateway.middlewares.cache_invalidation import cache_invalidation_middleware
 from gateway.middlewares.cors import cors_middleware
 from gateway.middlewares.frontend_hmac import verify_frontend_hmac_middleware
 from gateway.middlewares.input_validation import input_validation_middleware
@@ -205,6 +206,7 @@ def factory() -> FastAPI:
     if config.read_only_mode:
         app.middleware("http")(read_only_middleware)
     # Inside CORS so Cache-Control lands before CORS wraps the response.
+    app.middleware("http")(cache_invalidation_middleware)
     app.middleware("http")(ats_purge_middleware)
     app.middleware("http")(cache_control_middleware)
     # Outermost: CORS must wrap everything so error responses get CORS headers
@@ -221,5 +223,10 @@ if __name__ == "__main__":
     config = get_config()
     debug_mode = os.getenv("DEBUG", "false").lower() == "true"
     uvicorn.run(
-        "gateway.main:factory", host="0.0.0.0", port=config.port, reload=debug_mode, access_log=True, factory=True
+        "gateway.main:factory",
+        host="0.0.0.0",
+        port=config.port,
+        reload=debug_mode,
+        access_log=True,
+        factory=True,
     )

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -1,5 +1,7 @@
 import asyncio
 import time
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
 from typing import Dict
 
 import asyncpg
@@ -45,16 +47,9 @@ def factory() -> FastAPI:
     configure_otel("hippius-s3-gateway")
 
     init_sentry("hippius-s3-gateway")
-    app = FastAPI(
-        title="Hippius S3 API",
-        version="1.0.0",
-        docs_url=None,
-        redoc_url=None,
-        openapi_url=None,
-    )
 
-    @app.on_event("startup")
-    async def startup() -> None:
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         from hippius_s3.redis_utils import create_redis_client
 
         logger.info("Starting Hippius S3 Gateway...")
@@ -134,8 +129,8 @@ def factory() -> FastAPI:
 
         logger.info("Gateway startup complete")
 
-    @app.on_event("shutdown")
-    async def shutdown() -> None:
+        yield
+
         from gateway.services import ats_cache_client
 
         logger.info("Shutting down Hippius S3 Gateway...")
@@ -175,6 +170,15 @@ def factory() -> FastAPI:
             logger.info("Redis ACL client closed")
 
         logger.info("Gateway shutdown complete")
+
+    app = FastAPI(
+        title="Hippius S3 API",
+        version="1.0.0",
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+        lifespan=lifespan,
+    )
 
     @app.get("/health")
     async def health() -> Dict[str, str]:

--- a/gateway/middlewares/cache_control.py
+++ b/gateway/middlewares/cache_control.py
@@ -42,10 +42,7 @@ async def cache_control_middleware(
     # ignores it for them, so any cache-control they smuggle won't be on the
     # response anyway. We additionally guard here so the gateway can't be tricked
     # by an unsigned URL that happens to carry the query param.
-    if (
-        "response-cache-control" in request.query_params
-        and getattr(request.state, "auth_method", None) != "anonymous"
-    ):
+    if "response-cache-control" in request.query_params and getattr(request.state, "auth_method", None) != "anonymous":
         return response
 
     bucket = getattr(request.state, "s3_bucket", None)

--- a/gateway/middlewares/cache_control.py
+++ b/gateway/middlewares/cache_control.py
@@ -37,6 +37,17 @@ async def cache_control_middleware(
         response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
         return response
 
+    # Honor the S3 response-cache-control override when a signed client opted in.
+    # Anonymous callers can't set this — parse_response_overrides on the API side
+    # ignores it for them, so any cache-control they smuggle won't be on the
+    # response anyway. We additionally guard here so the gateway can't be tricked
+    # by an unsigned URL that happens to carry the query param.
+    if (
+        "response-cache-control" in request.query_params
+        and getattr(request.state, "auth_method", None) != "anonymous"
+    ):
+        return response
+
     bucket = getattr(request.state, "s3_bucket", None)
     key = getattr(request.state, "s3_key", None)
     if bucket is None:

--- a/gateway/middlewares/cache_invalidation.py
+++ b/gateway/middlewares/cache_invalidation.py
@@ -38,10 +38,9 @@ async def cache_invalidation_middleware(
     if acl_service is None:
         return response
 
-    # Best-effort invalidation. If redis-acl is unreachable, swallow and log:
-    # the upstream API has already committed the soft-delete, and a 500 here
-    # would confuse the client (DeleteBucket appears to have failed but the
-    # bucket IS deleted). Cache TTL bounds staleness to 600s.
+    # Best-effort: a redis-acl outage at delete time must not turn a successful
+    # 204 into a 500 (the upstream API has already committed the soft-delete).
+    # Cache TTL (600s) bounds staleness if invalidation fails.
     try:
         await _invalidate_bucket_acl_cache(acl_service, bucket_name)
     except Exception:

--- a/gateway/middlewares/cache_invalidation.py
+++ b/gateway/middlewares/cache_invalidation.py
@@ -30,10 +30,7 @@ async def cache_invalidation_middleware(
     if not _is_successful_bucket_delete(request, response):
         return response
 
-    # Prefer the bucket name parsed by acl_middleware (`request.state.s3_bucket`)
-    # so we use the same key the cache was written under. Fall back to the raw
-    # path when state isn't populated (e.g. early failure paths).
-    bucket_name = getattr(request.state, "s3_bucket", None) or _bucket_from_path(request.url.path)
+    bucket_name = _bucket_from_path(request.url.path)
     if not bucket_name:
         return response
 

--- a/gateway/middlewares/cache_invalidation.py
+++ b/gateway/middlewares/cache_invalidation.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+from typing import Awaitable
+from typing import Callable
+
+from fastapi import Request
+from fastapi import Response
+
+from gateway.repositories.cached_acl_repository import CachedACLRepository
+from gateway.services.acl_service import ACLService
+
+
+logger = logging.getLogger(__name__)
+
+
+async def cache_invalidation_middleware(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    """Purge gateway-side caches after operations that change bucket state.
+
+    Today: invalidates the ACL cache (`redis-acl`, TTL 600s) on a successful
+    DeleteBucket. Without this, cached public-bucket grants would keep
+    authorizing anonymous reads against a soft-deleted bucket for up to the
+    cache TTL — a real authz hole.
+    """
+    response = await call_next(request)
+
+    if not _is_successful_bucket_delete(request, response):
+        return response
+
+    bucket_name = _bucket_from_path(request.url.path)
+    if not bucket_name:
+        return response
+
+    acl_service = getattr(request.app.state, "acl_service", None)
+    if acl_service is None:
+        return response
+
+    await _invalidate_bucket_acl_cache(acl_service, bucket_name)
+    return response
+
+
+def _is_successful_bucket_delete(request: Request, response: Response) -> bool:
+    if request.method != "DELETE":
+        return False
+    if response.status_code != 204:
+        return False
+    # DELETE /<bucket>?tagging removes only tags; bucket itself stays.
+    return "tagging" not in request.query_params
+
+
+def _bucket_from_path(path: str) -> str | None:
+    """Return the bucket name iff `path` is exactly `/<bucket>` (no key)."""
+    stripped = path.strip("/")
+    if not stripped or "/" in stripped:
+        return None
+    return stripped
+
+
+async def _invalidate_bucket_acl_cache(acl_service: ACLService, bucket_name: str) -> None:
+    if not isinstance(acl_service.acl_repo, CachedACLRepository):
+        return
+    cached = acl_service.acl_repo
+    await cached.invalidate_bucket_acl(bucket_name)
+    await cached.invalidate_all_bucket_objects(bucket_name)

--- a/gateway/middlewares/cache_invalidation.py
+++ b/gateway/middlewares/cache_invalidation.py
@@ -30,7 +30,10 @@ async def cache_invalidation_middleware(
     if not _is_successful_bucket_delete(request, response):
         return response
 
-    bucket_name = _bucket_from_path(request.url.path)
+    # Prefer the bucket name parsed by acl_middleware (`request.state.s3_bucket`)
+    # so we use the same key the cache was written under. Fall back to the raw
+    # path when state isn't populated (e.g. early failure paths).
+    bucket_name = getattr(request.state, "s3_bucket", None) or _bucket_from_path(request.url.path)
     if not bucket_name:
         return response
 
@@ -38,7 +41,14 @@ async def cache_invalidation_middleware(
     if acl_service is None:
         return response
 
-    await _invalidate_bucket_acl_cache(acl_service, bucket_name)
+    # Best-effort invalidation. If redis-acl is unreachable, swallow and log:
+    # the upstream API has already committed the soft-delete, and a 500 here
+    # would confuse the client (DeleteBucket appears to have failed but the
+    # bucket IS deleted). Cache TTL bounds staleness to 600s.
+    try:
+        await _invalidate_bucket_acl_cache(acl_service, bucket_name)
+    except Exception:
+        logger.exception(f"Failed to invalidate ACL cache for soft-deleted bucket {bucket_name}")
     return response
 
 

--- a/gateway/services/acl_service.py
+++ b/gateway/services/acl_service.py
@@ -63,13 +63,13 @@ class ACLService:
 
     async def get_bucket_owner(self, bucket: str) -> str | None:
         """Get bucket owner from buckets table."""
-        query = "SELECT main_account_id FROM buckets WHERE bucket_name = $1"
+        query = "SELECT main_account_id FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL"
         row = await self.acl_repo.db.fetchrow(query, bucket)
         return str(row["main_account_id"]) if row else None
 
     async def get_bucket_id(self, bucket: str) -> str | None:
         """Get bucket UUID from buckets table."""
-        query = "SELECT bucket_id FROM buckets WHERE bucket_name = $1"
+        query = "SELECT bucket_id FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL"
         row = await self.acl_repo.db.fetchrow(query, bucket)
         return str(row["bucket_id"]) if row else None
 
@@ -80,7 +80,10 @@ class ACLService:
         on hot paths (e.g. acl_middleware). Returns None when the bucket does
         not exist.
         """
-        query = "SELECT main_account_id, bucket_id, is_cache_warm FROM buckets WHERE bucket_name = $1"
+        query = (
+            "SELECT main_account_id, bucket_id, is_cache_warm FROM buckets "
+            "WHERE bucket_name = $1 AND deleted_at IS NULL"
+        )
         row = await self.acl_repo.db.fetchrow(query, bucket)
         if row is None:
             return None
@@ -96,7 +99,7 @@ class ACLService:
             SELECT b.main_account_id
             FROM objects o
             JOIN buckets b ON o.bucket_id = b.bucket_id
-            WHERE b.bucket_name = $1 AND o.object_key = $2
+            WHERE b.bucket_name = $1 AND o.object_key = $2 AND b.deleted_at IS NULL
         """
         row = await self.acl_repo.db.fetchrow(query, bucket, key)
         return str(row["main_account_id"]) if row else None

--- a/hippius_s3/api/middlewares/fs_cache_pressure.py
+++ b/hippius_s3/api/middlewares/fs_cache_pressure.py
@@ -49,35 +49,29 @@ async def fs_cache_pressure_middleware(
     request: Request,
     call_next: Callable[[Request], Awaitable[Response]],
 ) -> Response:
-    try:
-        if not _should_gate_request(request):
-            return await call_next(request)
-
-        config = getattr(request.app.state, "config", None)
-        if config is None:
-            # Shouldn't happen; fail open.
-            return await call_next(request)
-
-        reject, retry_after, pressure, reason = should_reject_fs_cache_write(config=config)
-        if not reject:
-            return await call_next(request)
-
-        # IMPORTANT: return BEFORE reading request body to avoid moving pressure to RAM.
-        logger.warning(
-            "FS cache pressure: rejecting request method=%s path=%s free_bytes=%s free_ratio=%.4f reason=%s",
-            request.method,
-            request.url.path,
-            int(pressure.free_bytes),
-            float(pressure.free_ratio),
-            reason,
-        )
-        return s3_errors.s3_error_response(
-            code="SlowDown",
-            message="Upload temporarily throttled due to filesystem cache pressure. Please retry.",
-            status_code=503,
-            extra_headers={"Retry-After": str(retry_after)},
-        )
-    except Exception:
-        # Fail open to avoid taking down the API on middleware bug.
-        logger.exception("fs_cache_pressure_middleware error (failing open)")
+    if not _should_gate_request(request):
         return await call_next(request)
+
+    config = getattr(request.app.state, "config", None)
+    if config is None:
+        return await call_next(request)
+
+    reject, retry_after, pressure, reason = should_reject_fs_cache_write(config=config)
+    if not reject:
+        return await call_next(request)
+
+    # IMPORTANT: return BEFORE reading request body to avoid moving pressure to RAM.
+    logger.warning(
+        "FS cache pressure: rejecting request method=%s path=%s free_bytes=%s free_ratio=%.4f reason=%s",
+        request.method,
+        request.url.path,
+        int(pressure.free_bytes),
+        float(pressure.free_ratio),
+        reason,
+    )
+    return s3_errors.s3_error_response(
+        code="SlowDown",
+        message="Upload temporarily throttled due to filesystem cache pressure. Please retry.",
+        status_code=503,
+        extra_headers={"Retry-After": str(retry_after)},
+    )

--- a/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
+++ b/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
@@ -7,14 +7,10 @@ from fastapi import Request
 from fastapi import Response
 
 from hippius_s3.api.s3 import errors
-from hippius_s3.config import get_config
-from hippius_s3.queue import BucketReapRequest
-from hippius_s3.queue import enqueue_bucket_reap_request
 from hippius_s3.utils import get_query
 
 
 logger = logging.getLogger(__name__)
-config = get_config()
 
 
 async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redis_client: Any) -> Response:
@@ -22,10 +18,14 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
     Delete a bucket using S3 protocol (DELETE /{bucket_name}).
     Also handles removing bucket tags (DELETE /{bucket_name}?tagging).
 
-    Soft-deletes the bucket by setting buckets.deleted_at and enqueues a
-    BucketReapRequest for the async reaper worker to drain child rows. Returns
-    204 in O(1) — the previous synchronous DELETE FROM buckets cascade hit
-    the API's statement_timeout for buckets with significant child-row residue.
+    Soft-deletes the bucket by setting buckets.deleted_at. Returns 204 in O(1).
+    The Phase 2 bucket_reaper worker discovers soft-deleted buckets by polling
+    `buckets WHERE deleted_at IS NOT NULL` (via idx_buckets_deleted_at_pending)
+    and drains child rows leaves-up. There is intentionally no Redis queue —
+    the DB partial index is the single source of truth.
+
+    The previous synchronous DELETE FROM buckets cascade hit the API's
+    statement_timeout for buckets with significant child-row residue.
     """
     # If tagging is in query params, we're just deleting tags
     if "tagging" in request.query_params:
@@ -112,14 +112,5 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
             status_code=404,
             BucketName=bucket_name,
         )
-
-    ray_id = getattr(request.state, "ray_id", None)
-    await enqueue_bucket_reap_request(
-        BucketReapRequest(
-            bucket_id=str(soft_deleted["bucket_id"]),
-            bucket_name=str(soft_deleted["bucket_name"]),
-            ray_id=ray_id,
-        ),
-    )
 
     return Response(status_code=204)

--- a/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
+++ b/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
@@ -7,10 +7,9 @@ from fastapi import Request
 from fastapi import Response
 
 from hippius_s3.api.s3 import errors
-from hippius_s3.cache import RedisObjectPartsCache
 from hippius_s3.config import get_config
-from hippius_s3.queue import UnpinChainRequest
-from hippius_s3.queue import enqueue_unpin_request
+from hippius_s3.queue import BucketReapRequest
+from hippius_s3.queue import enqueue_bucket_reap_request
 from hippius_s3.utils import get_query
 
 
@@ -23,15 +22,14 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
     Delete a bucket using S3 protocol (DELETE /{bucket_name}).
     Also handles removing bucket tags (DELETE /{bucket_name}?tagging).
 
-    This endpoint is compatible with the S3 protocol used by MinIO and other S3 clients.
+    Soft-deletes the bucket by setting buckets.deleted_at and enqueues a
+    BucketReapRequest for the async reaper worker to drain child rows. Returns
+    204 in O(1) — the previous synchronous DELETE FROM buckets cascade hit
+    the API's statement_timeout for buckets with significant child-row residue.
     """
     # If tagging is in query params, we're just deleting tags
     if "tagging" in request.query_params:
         try:
-            # Get user for user-scoped bucket lookup
-            main_account_id = request.state.account.main_account
-
-            # Get bucket for this main account
             bucket = await db.fetchrow(
                 get_query("get_bucket_by_name"),
                 bucket_name,
@@ -45,7 +43,6 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
                     BucketName=bucket_name,
                 )
 
-            # Clear bucket tags by setting to empty JSON
             logger.info(f"Deleting all tags for bucket '{bucket_name}' via S3 protocol")
 
             await db.fetchrow(
@@ -64,95 +61,65 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
                 status_code=500,
             )
 
-    try:
-        # Get bucket for this main account
-        main_account_id = request.state.account.main_account
-        bucket = await db.fetchrow(
-            get_query("get_bucket_by_name"),
-            bucket_name,
-        )
+    bucket = await db.fetchrow(
+        get_query("get_bucket_by_name"),
+        bucket_name,
+    )
 
-        if not bucket:
-            # For S3 compatibility, return an XML error response
-            return errors.s3_error_response(
-                "NoSuchBucket",
-                f"The specified bucket {bucket_name} does not exist",
-                status_code=404,
-                BucketName=bucket_name,
-            )
-
-        # (prefix, cursor, limit=1): we only need to know whether any object exists.
-        objects = await db.fetch(
-            get_query("list_objects"),
-            bucket["bucket_id"],
-            None,
-            None,
-            1,
-        )
-
-        # S3 semantics: refuse to delete a non-empty bucket
-        if objects:
-            return errors.s3_error_response(
-                "BucketNotEmpty",
-                "The bucket you tried to delete is not empty",
-                status_code=409,
-                BucketName=bucket_name,
-            )
-
-        # Also block deletion if there are ongoing multipart uploads (required)
-        ongoing_uploads = await db.fetch(get_query("list_multipart_uploads"), bucket["bucket_id"], None)
-        if ongoing_uploads:
-            return errors.s3_error_response(
-                "BucketNotEmpty",
-                "The bucket has ongoing multipart uploads",
-                status_code=409,
-                BucketName=bucket_name,
-            )
-
-        # Delete bucket (permission is checked via main_account_id ownership)
-        deleted_bucket = await db.fetchrow(get_query("delete_bucket"), bucket["bucket_id"])
-
-        if not deleted_bucket:
-            logger.warning(f"Account {main_account_id} tried to delete bucket {bucket_name} without permission")
-            return errors.s3_error_response(
-                "AccessDenied",
-                f"You do not have permission to delete bucket {bucket_name}",
-                status_code=403,
-                BucketName=bucket_name,
-            )
-
-        # If we got here, the bucket was successfully deleted, so now enqueue objects for unpinning
-        ray_id = getattr(request.state, "ray_id", None)
-        for obj in objects:
-            try:
-                await enqueue_unpin_request(
-                    payload=UnpinChainRequest(
-                        address=request.state.account.main_account,
-                        object_id=str(obj["object_id"]),
-                        object_version=obj.get("current_object_version"),
-                        cid=obj["ipfs_cid"],
-                        ray_id=ray_id,
-                    ),
-                )
-            except Exception:
-                logger.debug("Failed to enqueue unpin for object during bucket delete", exc_info=True)
-
-        # Clean up cache keys under versioned obj namespace (best effort)
-        try:
-            roc = RedisObjectPartsCache(redis_client)
-            for obj in objects:
-                # probe a small set of parts to expire keys
-                for pn in range(0, 4):
-                    await roc.expire(str(obj["object_id"]), int(obj.get("current_object_version") or 1), pn, ttl=1)
-        except Exception:
-            logger.debug("Failed to expire object part cache during bucket delete", exc_info=True)
-
-        return Response(status_code=204)
-
-    except Exception:
-        logger.exception("Error deleting bucket via S3 protocol")
+    if not bucket:
         return errors.s3_error_response(
-            "InternalError",
-            "We encountered an internal error. Please try again.",
-            status_code=500,
+            "NoSuchBucket",
+            f"The specified bucket {bucket_name} does not exist",
+            status_code=404,
+            BucketName=bucket_name,
         )
+
+    # S3 semantics: refuse to delete a non-empty bucket. (prefix, cursor, limit=1):
+    # we only need to know whether any object exists.
+    objects = await db.fetch(
+        get_query("list_objects"),
+        bucket["bucket_id"],
+        None,
+        None,
+        1,
+    )
+    if objects:
+        return errors.s3_error_response(
+            "BucketNotEmpty",
+            "The bucket you tried to delete is not empty",
+            status_code=409,
+            BucketName=bucket_name,
+        )
+
+    # Block deletion if there are ongoing multipart uploads (S3 spec).
+    ongoing_uploads = await db.fetch(get_query("list_multipart_uploads"), bucket["bucket_id"], None)
+    if ongoing_uploads:
+        return errors.s3_error_response(
+            "BucketNotEmpty",
+            "The bucket has ongoing multipart uploads",
+            status_code=409,
+            BucketName=bucket_name,
+        )
+
+    # Soft-delete: set deleted_at. Idempotent — a concurrent caller may have
+    # already won this race; an empty result means the bucket is already gone
+    # (return 404 NoSuchBucket per S3 spec, NOT 403 — auth is enforced upstream).
+    soft_deleted = await db.fetchrow(get_query("soft_delete_bucket"), bucket["bucket_id"])
+    if not soft_deleted:
+        return errors.s3_error_response(
+            "NoSuchBucket",
+            f"The specified bucket {bucket_name} does not exist",
+            status_code=404,
+            BucketName=bucket_name,
+        )
+
+    ray_id = getattr(request.state, "ray_id", None)
+    await enqueue_bucket_reap_request(
+        BucketReapRequest(
+            bucket_id=str(soft_deleted["bucket_id"]),
+            bucket_name=str(soft_deleted["bucket_name"]),
+            ray_id=ray_id,
+        ),
+    )
+
+    return Response(status_code=204)

--- a/hippius_s3/api/s3/common/__init__.py
+++ b/hippius_s3/api/s3/common/__init__.py
@@ -1,5 +1,7 @@
 from .format import format_s3_timestamp  # re-export
+from .headers import apply_response_overrides  # re-export
 from .headers import build_headers  # re-export
 from .headers import if_none_match_matches  # re-export
+from .headers import parse_response_overrides  # re-export
 from .req import parse_range  # re-export
 from .req import parse_read_mode  # re-export

--- a/hippius_s3/api/s3/common/headers.py
+++ b/hippius_s3/api/s3/common/headers.py
@@ -1,6 +1,53 @@
 from __future__ import annotations
 
 import json
+from typing import Protocol
+
+from starlette.datastructures import QueryParams
+
+
+class _HeadersLike(Protocol):
+    def __setitem__(self, key: str, value: str, /) -> None: ...
+
+
+RESPONSE_OVERRIDE_PARAMS: dict[str, str] = {
+    "response-content-type": "Content-Type",
+    "response-content-disposition": "Content-Disposition",
+    "response-content-encoding": "Content-Encoding",
+    "response-content-language": "Content-Language",
+    "response-cache-control": "Cache-Control",
+    "response-expires": "Expires",
+}
+
+MAX_OVERRIDE_VALUE_LEN = 4096
+
+
+def parse_response_overrides(query_params: QueryParams, auth_method: str | None) -> dict[str, str]:
+    """Parse the six S3 response-header override query params.
+
+    Returns a mapping of {Response-Header-Name: value}. Empty for anonymous requests
+    (per S3 spec, overrides only apply to signed requests).
+    Raises ValueError on CRLF or oversize values to prevent header injection.
+    """
+    if auth_method == "anonymous":
+        return {}
+    out: dict[str, str] = {}
+    for qparam, header_name in RESPONSE_OVERRIDE_PARAMS.items():
+        if qparam not in query_params:
+            continue
+        value = query_params[qparam]
+        if len(value) > MAX_OVERRIDE_VALUE_LEN:
+            raise ValueError(f"{qparam} value exceeds {MAX_OVERRIDE_VALUE_LEN} bytes")
+        if "\r" in value or "\n" in value:
+            raise ValueError(f"{qparam} contains forbidden CRLF")
+        out[header_name] = value
+    return out
+
+
+def apply_response_overrides(headers: _HeadersLike, overrides: dict[str, str]) -> None:
+    """Overwrite the given headers mapping with parsed response-header overrides."""
+    for name, value in overrides.items():
+        headers[name] = value
 
 
 def if_none_match_matches(header_value: str | None, md5_hash: str) -> bool:

--- a/hippius_s3/api/s3/common/headers.py
+++ b/hippius_s3/api/s3/common/headers.py
@@ -22,14 +22,14 @@ RESPONSE_OVERRIDE_PARAMS: dict[str, str] = {
 MAX_OVERRIDE_VALUE_LEN = 4096
 
 
-def parse_response_overrides(query_params: QueryParams, auth_method: str | None) -> dict[str, str]:
+def parse_response_overrides(query_params: QueryParams, account_id: str | None) -> dict[str, str]:
     """Parse the six S3 response-header override query params.
 
     Returns a mapping of {Response-Header-Name: value}. Empty for anonymous requests
     (per S3 spec, overrides only apply to signed requests).
     Raises ValueError on CRLF or oversize values to prevent header injection.
     """
-    if auth_method == "anonymous":
+    if account_id == "anonymous" or account_id is None:
         return {}
     out: dict[str, str] = {}
     for qparam, header_name in RESPONSE_OVERRIDE_PARAMS.items():

--- a/hippius_s3/api/s3/common/headers.py
+++ b/hippius_s3/api/s3/common/headers.py
@@ -22,14 +22,14 @@ RESPONSE_OVERRIDE_PARAMS: dict[str, str] = {
 MAX_OVERRIDE_VALUE_LEN = 4096
 
 
-def parse_response_overrides(query_params: QueryParams, account_id: str | None) -> dict[str, str]:
+def parse_response_overrides(query_params: QueryParams, *, is_anonymous: bool) -> dict[str, str]:
     """Parse the six S3 response-header override query params.
 
     Returns a mapping of {Response-Header-Name: value}. Empty for anonymous requests
     (per S3 spec, overrides only apply to signed requests).
     Raises ValueError on CRLF or oversize values to prevent header injection.
     """
-    if account_id == "anonymous" or account_id is None:
+    if is_anonymous:
         return {}
     out: dict[str, str] = {}
     for qparam, header_name in RESPONSE_OVERRIDE_PARAMS.items():

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -584,6 +584,7 @@ async def upload_part(
                 FROM multipart_uploads mu
                 JOIN buckets b ON b.bucket_id = mu.bucket_id
                 WHERE mu.upload_id = $1
+                  AND b.deleted_at IS NULL
                 LIMIT 1
                 """,
                 upload_id,

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -24,6 +24,7 @@ from starlette.requests import ClientDisconnect
 
 from hippius_s3 import dependencies
 from hippius_s3 import utils
+from hippius_s3.api.s3.common import format_s3_timestamp
 from hippius_s3.api.s3.errors import s3_error_response
 from hippius_s3.cache import RedisObjectPartsCache
 from hippius_s3.config import get_config
@@ -181,7 +182,7 @@ async def list_parts_internal(
         # Use CreatedAt as LastModified if available
         ts = part.get("created_at")
         if ts:
-            add_subelement(p, "LastModified", ts.isoformat())
+            add_subelement(p, "LastModified", format_s3_timestamp(ts))
 
     xml_content = to_xml_bytes(root)
     return Response(
@@ -682,7 +683,7 @@ async def upload_part(
             xml = f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <CopyPartResult>
   <ETag>\"{part_result["etag"]}\"</ETag>
-  <LastModified>{datetime.now(timezone.utc).isoformat()}</LastModified>
+  <LastModified>{format_s3_timestamp(datetime.now(timezone.utc))}</LastModified>
 </CopyPartResult>
 """.encode("utf-8")
             return Response(content=xml, media_type="application/xml", status_code=200)
@@ -853,7 +854,7 @@ async def list_multipart_uploads(
                 "UploadId",
                 str(upload["upload_id"]) if upload.get("upload_id") is not None else "",
             )
-            add_subelement(upload_elem, "Initiated", upload["initiated_at"].isoformat())
+            add_subelement(upload_elem, "Initiated", format_s3_timestamp(upload["initiated_at"]))
 
         # Generate XML with proper declaration
         xml_content = to_xml_bytes(root)

--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -132,7 +132,7 @@ async def handle_get_object(
                         """
                         SELECT 1 FROM objects o
                         JOIN buckets b ON o.bucket_id = b.bucket_id
-                        WHERE b.bucket_name = $1 AND o.object_key = $2
+                        WHERE b.bucket_name = $1 AND o.object_key = $2 AND b.deleted_at IS NULL
                         """,
                         bucket_name,
                         object_key,

--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -14,9 +14,11 @@ from opentelemetry import trace
 
 from hippius_s3.api.middlewares.tracing import set_span_attributes
 from hippius_s3.api.s3 import errors
+from hippius_s3.api.s3.common import apply_response_overrides
 from hippius_s3.api.s3.common import if_none_match_matches
 from hippius_s3.api.s3.common import parse_range
 from hippius_s3.api.s3.common import parse_read_mode
+from hippius_s3.api.s3.common import parse_response_overrides
 from hippius_s3.api.s3.range_utils import parse_range_header
 from hippius_s3.config import get_config
 from hippius_s3.monitoring import get_metrics_collector
@@ -102,6 +104,15 @@ async def handle_get_object(
         account = getattr(request.state, "account", None)
 
         account_id = account.main_account if account else "anonymous"
+
+        try:
+            response_overrides = parse_response_overrides(request.query_params, account_id)
+        except ValueError as e:
+            return errors.s3_error_response(
+                code="InvalidArgument",
+                message=str(e),
+                status_code=400,
+            )
 
         # Skip user creation for anonymous accounts
         if account and account.main_account != "anonymous":
@@ -351,6 +362,7 @@ async def handle_get_object(
         if response.status_code in (200, 206):
             object_version = int(object_info.get("object_version") or 1)
             response.headers["x-amz-version-id"] = str(object_version)
+            apply_response_overrides(response.headers, response_overrides)
 
             bytes_transferred = int(object_info["size_bytes"])
             if range_header and start_byte is not None and end_byte is not None:

--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -101,9 +101,13 @@ async def handle_get_object(
     # Backend trusts the account information from gateway
     account = getattr(request.state, "account", None)
     account_id = account.main_account if account else "anonymous"
+    # Anonymous reads on a public bucket still carry the bucket owner as main_account,
+    # so we gate on account.id. Gateway sets it to literal "anonymous" for unsigned requests;
+    # an empty string would mean the gateway didn't run account_middleware — treat as anon.
+    is_anonymous = account is None or account.id in ("", "anonymous")
 
     try:
-        response_overrides = parse_response_overrides(request.query_params, account_id)
+        response_overrides = parse_response_overrides(request.query_params, is_anonymous=is_anonymous)
     except ValueError as e:
         return errors.s3_error_response(
             code="InvalidArgument",

--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -97,23 +97,22 @@ async def handle_get_object(
             f"GET start {bucket_name}/{object_key} read_mode={hdr_mode or 'auto'} range={bool(range_header)} version={version_id or 'current'}"
         )
 
+    # Gateway now handles all ACL/permission checks
+    # Backend trusts the account information from gateway
+    account = getattr(request.state, "account", None)
+    account_id = account.main_account if account else "anonymous"
+
+    try:
+        response_overrides = parse_response_overrides(request.query_params, account_id)
+    except ValueError as e:
+        return errors.s3_error_response(
+            code="InvalidArgument",
+            message=str(e),
+            status_code=400,
+        )
+
     db = await pool.acquire()
     try:
-        # Gateway now handles all ACL/permission checks
-        # Backend trusts the account information from gateway
-        account = getattr(request.state, "account", None)
-
-        account_id = account.main_account if account else "anonymous"
-
-        try:
-            response_overrides = parse_response_overrides(request.query_params, account_id)
-        except ValueError as e:
-            return errors.s3_error_response(
-                code="InvalidArgument",
-                message=str(e),
-                status_code=400,
-            )
-
         # Skip user creation for anonymous accounts
         if account and account.main_account != "anonymous":
             with tracer.start_as_current_span(

--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -128,6 +128,17 @@ async def handle_get_object(
                     version_id,
                 )
                 if not object_info:
+                    bucket_exists = await db.fetchval(
+                        "SELECT 1 FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL",
+                        bucket_name,
+                    )
+                    if not bucket_exists:
+                        return errors.s3_error_response(
+                            code="NoSuchBucket",
+                            message=f"The specified bucket {bucket_name} does not exist",
+                            status_code=404,
+                            BucketName=bucket_name,
+                        )
                     object_exists = await db.fetchval(
                         """
                         SELECT 1 FROM objects o
@@ -158,6 +169,17 @@ async def handle_get_object(
                     object_key,
                 )
                 if not object_info:
+                    bucket_exists = await db.fetchval(
+                        "SELECT 1 FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL",
+                        bucket_name,
+                    )
+                    if not bucket_exists:
+                        return errors.s3_error_response(
+                            code="NoSuchBucket",
+                            message=f"The specified bucket {bucket_name} does not exist",
+                            status_code=404,
+                            BucketName=bucket_name,
+                        )
                     return errors.s3_error_response(
                         code="NoSuchKey",
                         message=f"The specified key {object_key} does not exist or you don't have permission to access it",

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -12,7 +12,9 @@ from opentelemetry import trace
 
 from hippius_s3.api.middlewares.tracing import set_span_attributes
 from hippius_s3.api.s3 import errors
+from hippius_s3.api.s3.common import apply_response_overrides
 from hippius_s3.api.s3.common import if_none_match_matches
+from hippius_s3.api.s3.common import parse_response_overrides
 from hippius_s3.repositories.objects import ObjectRepository
 from hippius_s3.repositories.users import UserRepository
 from hippius_s3.utils import get_query
@@ -102,6 +104,17 @@ async def handle_head_object(
     account = getattr(request.state, "account", None)
 
     main_account_id = account.main_account if account else "anonymous"
+
+    try:
+        response_overrides = parse_response_overrides(request.query_params, main_account_id)
+    except ValueError as e:
+        return Response(
+            status_code=400,
+            headers={
+                "x-amz-error-code": "InvalidArgument",
+                "x-amz-error-message": str(e),
+            },
+        )
 
     # Parse versionId query parameter
     version_id = None
@@ -248,6 +261,7 @@ async def handle_head_object(
             for k, v in meta_val.items():
                 if k != "ipfs" and not isinstance(v, dict):
                     headers[f"x-amz-meta-{k}"] = str(v)
+        apply_response_overrides(headers, response_overrides)
         return Response(status_code=200, headers=headers)
 
     except errors.S3Error as e:

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -105,17 +105,6 @@ async def handle_head_object(
 
     main_account_id = account.main_account if account else "anonymous"
 
-    try:
-        response_overrides = parse_response_overrides(request.query_params, main_account_id)
-    except ValueError as e:
-        return Response(
-            status_code=400,
-            headers={
-                "x-amz-error-code": "InvalidArgument",
-                "x-amz-error-message": str(e),
-            },
-        )
-
     # Parse versionId query parameter
     version_id = None
     if "versionId" in request.query_params:
@@ -150,6 +139,17 @@ async def handle_head_object(
             except Exception:
                 logger.exception("Error in HEAD tagging request")
                 return Response(status_code=500)
+
+    try:
+        response_overrides = parse_response_overrides(request.query_params, main_account_id)
+    except ValueError as e:
+        return Response(
+            status_code=400,
+            headers={
+                "x-amz-error-code": "InvalidArgument",
+                "x-amz-error-message": str(e),
+            },
+        )
 
     db = await pool.acquire()
     try:

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -44,7 +44,7 @@ async def _get_object_with_permissions_min(
                 """
                 SELECT 1 FROM objects o
                 JOIN buckets b ON o.bucket_id = b.bucket_id
-                WHERE b.bucket_name = $1 AND o.object_key = $2
+                WHERE b.bucket_name = $1 AND o.object_key = $2 AND b.deleted_at IS NULL
                 """,
                 bucket_name,
                 object_key,

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -140,8 +140,12 @@ async def handle_head_object(
                 logger.exception("Error in HEAD tagging request")
                 return Response(status_code=500)
 
+    # Anonymous reads on a public bucket still carry the bucket owner as main_account,
+    # so we gate on account.id. Gateway sets it to literal "anonymous" for unsigned requests;
+    # an empty string would mean the gateway didn't run account_middleware — treat as anon.
+    is_anonymous = account is None or account.id in ("", "anonymous")
     try:
-        response_overrides = parse_response_overrides(request.query_params, main_account_id)
+        response_overrides = parse_response_overrides(request.query_params, is_anonymous=is_anonymous)
     except ValueError as e:
         return Response(
             status_code=400,

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -40,6 +40,16 @@ async def _get_object_with_permissions_min(
             bucket_name, object_key, version, main_account_id
         )
         if not row:
+            bucket_exists = await db.fetchval(
+                "SELECT 1 FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL",
+                bucket_name,
+            )
+            if not bucket_exists:
+                raise errors.S3Error(
+                    code="NoSuchBucket",
+                    status_code=404,
+                    message=f"The specified bucket {bucket_name} does not exist",
+                )
             object_exists = await db.fetchval(
                 """
                 SELECT 1 FROM objects o
@@ -63,6 +73,16 @@ async def _get_object_with_permissions_min(
     else:
         row = await ObjectRepository(db).get_for_download_with_permissions(bucket_name, object_key, main_account_id)
         if not row:
+            bucket_exists = await db.fetchval(
+                "SELECT 1 FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL",
+                bucket_name,
+            )
+            if not bucket_exists:
+                raise errors.S3Error(
+                    code="NoSuchBucket",
+                    status_code=404,
+                    message=f"The specified bucket {bucket_name} does not exist",
+                )
             raise errors.S3Error(
                 code="NoSuchKey",
                 status_code=404,

--- a/hippius_s3/queue.py
+++ b/hippius_s3/queue.py
@@ -344,48 +344,6 @@ async def move_due_unpin_retries(
     return moved
 
 
-BUCKET_REAP_QUEUE = "bucket_reap_requests"
-
-
-class BucketReapRequest(RetryableRequest):
-    """Request to reap a soft-deleted bucket. Phase 1 produces these from the
-    DeleteBucket endpoint; the bucket_reaper worker (Phase 2) consumes them
-    and batch-deletes child rows leaves-up before hard-deleting the bucket row.
-    """
-
-    bucket_id: str
-    bucket_name: str
-
-    @property
-    def name(self) -> str:
-        return f"reap::{self.bucket_id}"
-
-
-async def enqueue_bucket_reap_request(payload: BucketReapRequest) -> None:
-    """Enqueue a bucket-reap request. Single queue (no backend fan-out)."""
-    client = get_queue_client()
-    if payload.request_id is None:
-        payload.request_id = uuid.uuid4().hex
-    if payload.first_enqueued_at is None:
-        payload.first_enqueued_at = time.time()
-    if payload.attempts is None:
-        payload.attempts = 0
-
-    raw = payload.model_dump_json()
-    await client.lpush(BUCKET_REAP_QUEUE, raw)
-    logger.info(f"Enqueued bucket reap {payload.name=} queue={BUCKET_REAP_QUEUE}")
-
-
-async def dequeue_bucket_reap_request() -> BucketReapRequest | None:
-    """Phase 2 reaper consumes from this queue."""
-    client = get_queue_client()
-    result = await client.brpop(BUCKET_REAP_QUEUE, timeout=3)
-    if result:
-        _, queue_data = result
-        return BucketReapRequest.model_validate_json(queue_data)
-    return None
-
-
 async def enqueue_download_request(payload: DownloadChainRequest) -> None:
     """Add a download request to per-backend download queues."""
     client = get_queue_client()

--- a/hippius_s3/queue.py
+++ b/hippius_s3/queue.py
@@ -344,6 +344,48 @@ async def move_due_unpin_retries(
     return moved
 
 
+BUCKET_REAP_QUEUE = "bucket_reap_requests"
+
+
+class BucketReapRequest(RetryableRequest):
+    """Request to reap a soft-deleted bucket. Phase 1 produces these from the
+    DeleteBucket endpoint; the bucket_reaper worker (Phase 2) consumes them
+    and batch-deletes child rows leaves-up before hard-deleting the bucket row.
+    """
+
+    bucket_id: str
+    bucket_name: str
+
+    @property
+    def name(self) -> str:
+        return f"reap::{self.bucket_id}"
+
+
+async def enqueue_bucket_reap_request(payload: BucketReapRequest) -> None:
+    """Enqueue a bucket-reap request. Single queue (no backend fan-out)."""
+    client = get_queue_client()
+    if payload.request_id is None:
+        payload.request_id = uuid.uuid4().hex
+    if payload.first_enqueued_at is None:
+        payload.first_enqueued_at = time.time()
+    if payload.attempts is None:
+        payload.attempts = 0
+
+    raw = payload.model_dump_json()
+    await client.lpush(BUCKET_REAP_QUEUE, raw)
+    logger.info(f"Enqueued bucket reap {payload.name=} queue={BUCKET_REAP_QUEUE}")
+
+
+async def dequeue_bucket_reap_request() -> BucketReapRequest | None:
+    """Phase 2 reaper consumes from this queue."""
+    client = get_queue_client()
+    result = await client.brpop(BUCKET_REAP_QUEUE, timeout=3)
+    if result:
+        _, queue_data = result
+        return BucketReapRequest.model_validate_json(queue_data)
+    return None
+
+
 async def enqueue_download_request(payload: DownloadChainRequest) -> None:
     """Add a download request to per-backend download queues."""
     client = get_queue_client()

--- a/hippius_s3/repositories/acl_repository.py
+++ b/hippius_s3/repositories/acl_repository.py
@@ -15,7 +15,7 @@ class ACLRepository:
         self.db = db_pool
 
     async def _get_bucket_id(self, bucket_name: str) -> Optional[str]:
-        query = "SELECT bucket_id FROM buckets WHERE bucket_name = $1"
+        query = "SELECT bucket_id FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL"
         row = await self.db.fetchrow(query, bucket_name)
         return str(row["bucket_id"]) if row else None
 
@@ -24,7 +24,7 @@ class ACLRepository:
         SELECT o.object_id
         FROM objects o
         JOIN buckets b ON o.bucket_id = b.bucket_id
-        WHERE b.bucket_name = $1 AND o.object_key = $2
+        WHERE b.bucket_name = $1 AND o.object_key = $2 AND b.deleted_at IS NULL
         """
         row = await self.db.fetchrow(query, bucket_name, object_key)
         return str(row["object_id"]) if row else None
@@ -49,7 +49,7 @@ class ACLRepository:
         SELECT ba.owner_id, ba.acl_json
         FROM bucket_acls ba
         JOIN buckets b ON ba.bucket_id = b.bucket_id
-        WHERE b.bucket_name = $1
+        WHERE b.bucket_name = $1 AND b.deleted_at IS NULL
         """
         row = await self.db.fetchrow(query, bucket_name)
         if not row:
@@ -114,7 +114,7 @@ class ACLRepository:
         FROM object_acls oa
         JOIN objects o ON oa.object_id = o.object_id
         JOIN buckets b ON o.bucket_id = b.bucket_id
-        WHERE b.bucket_name = $1 AND o.object_key = $2
+        WHERE b.bucket_name = $1 AND o.object_key = $2 AND b.deleted_at IS NULL
         """
         row = await self.db.fetchrow(query, bucket_name, object_key)
         if not row:
@@ -131,7 +131,7 @@ class ACLRepository:
         SELECT b.bucket_id, $1, $2, $3::jsonb
         FROM objects o
         JOIN buckets b ON o.bucket_id = b.bucket_id
-        WHERE o.object_id = $1
+        WHERE o.object_id = $1 AND b.deleted_at IS NULL
         ON CONFLICT (bucket_id, object_id)
         DO UPDATE SET
             owner_id = EXCLUDED.owner_id,
@@ -166,7 +166,7 @@ class ACLRepository:
         SELECT b.bucket_name, ba.acl_json
         FROM bucket_acls ba
         JOIN buckets b ON ba.bucket_id = b.bucket_id
-        WHERE ba.owner_id = $1
+        WHERE ba.owner_id = $1 AND b.deleted_at IS NULL
         ORDER BY b.bucket_name
         """
         rows = await self.db.fetch(query, owner_id)
@@ -185,7 +185,7 @@ class ACLRepository:
         FROM object_acls oa
         JOIN objects o ON oa.object_id = o.object_id
         JOIN buckets b ON oa.bucket_id = b.bucket_id
-        WHERE b.bucket_name = $1
+        WHERE b.bucket_name = $1 AND b.deleted_at IS NULL
         ORDER BY o.object_key
         """
         rows = await self.db.fetch(query, bucket_name)
@@ -203,7 +203,7 @@ class ACLRepository:
         query = """
         SELECT 1 FROM objects o
         JOIN buckets b ON o.bucket_id = b.bucket_id
-        WHERE b.bucket_name = $1 AND o.object_key = $2
+        WHERE b.bucket_name = $1 AND o.object_key = $2 AND b.deleted_at IS NULL
         LIMIT 1
         """
         row = await self.db.fetchrow(query, bucket_name, object_key)

--- a/hippius_s3/services/acl_helper.py
+++ b/hippius_s3/services/acl_helper.py
@@ -10,7 +10,7 @@ from hippius_s3.models.acl import WellKnownGroups
 
 
 async def get_bucket_owner(db: asyncpg.Pool, bucket: str) -> str | None:
-    query = "SELECT main_account_id FROM buckets WHERE bucket_name = $1"
+    query = "SELECT main_account_id FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL"
     row = await db.fetchrow(query, bucket)
     return str(row["main_account_id"]) if row else None
 

--- a/hippius_s3/sql/migrations/20260507000000_add_buckets_deleted_at.sql
+++ b/hippius_s3/sql/migrations/20260507000000_add_buckets_deleted_at.sql
@@ -20,15 +20,6 @@ CREATE UNIQUE INDEX IF NOT EXISTS buckets_bucket_name_active_key
 CREATE INDEX IF NOT EXISTS idx_buckets_deleted_at_pending
     ON public.buckets (deleted_at) WHERE deleted_at IS NOT NULL;
 
--- Backfill: the prod bucket pagination-test-40k-1777583359 has been stuck
--- in the cascade-timeout state since 2026-05-04. Without this backfill it
--- reappears as "live" once the column lands. Idempotent: WHERE clause
--- ensures the UPDATE no-ops on staging or any DB where the row is absent.
-UPDATE public.buckets
-   SET deleted_at = now()
- WHERE bucket_id = '799b6ccc-5aae-4db7-8e92-40c864165d70'
-   AND deleted_at IS NULL;
-
 -- migrate:down
 
 DROP INDEX IF EXISTS idx_buckets_deleted_at_pending;

--- a/hippius_s3/sql/migrations/20260507000000_add_buckets_deleted_at.sql
+++ b/hippius_s3/sql/migrations/20260507000000_add_buckets_deleted_at.sql
@@ -1,0 +1,28 @@
+-- migrate:up
+
+-- Soft-delete column. DeleteBucket sets this and returns 204 in O(1) instead
+-- of running a 6-table FK cascade that exceeds the API's 30s statement_timeout
+-- on buckets with significant child-row residue. Hard cleanup runs async via
+-- the bucket_reaper worker.
+ALTER TABLE public.buckets ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+-- Replace the global unique constraint with a partial unique index so a name
+-- becomes reusable the instant the prior bucket is soft-deleted (matches S3
+-- DeleteBucket semantics: name immediately reusable). Live-set uniqueness is
+-- still enforced — the constraint named buckets_bucket_name_key was restored
+-- in 20251126000000 specifically for S3 spec compliance, so do NOT replace
+-- it with a per-account composite.
+ALTER TABLE public.buckets DROP CONSTRAINT IF EXISTS buckets_bucket_name_key;
+CREATE UNIQUE INDEX IF NOT EXISTS buckets_bucket_name_active_key
+    ON public.buckets (bucket_name) WHERE deleted_at IS NULL;
+
+-- Lookup index for the reaper to find pending work without scanning live rows.
+CREATE INDEX IF NOT EXISTS idx_buckets_deleted_at_pending
+    ON public.buckets (deleted_at) WHERE deleted_at IS NOT NULL;
+
+-- migrate:down
+
+DROP INDEX IF EXISTS idx_buckets_deleted_at_pending;
+DROP INDEX IF EXISTS buckets_bucket_name_active_key;
+ALTER TABLE public.buckets ADD CONSTRAINT buckets_bucket_name_key UNIQUE(bucket_name);
+ALTER TABLE public.buckets DROP COLUMN IF EXISTS deleted_at;

--- a/hippius_s3/sql/migrations/20260507000000_add_buckets_deleted_at.sql
+++ b/hippius_s3/sql/migrations/20260507000000_add_buckets_deleted_at.sql
@@ -20,6 +20,15 @@ CREATE UNIQUE INDEX IF NOT EXISTS buckets_bucket_name_active_key
 CREATE INDEX IF NOT EXISTS idx_buckets_deleted_at_pending
     ON public.buckets (deleted_at) WHERE deleted_at IS NOT NULL;
 
+-- Backfill: the prod bucket pagination-test-40k-1777583359 has been stuck
+-- in the cascade-timeout state since 2026-05-04. Without this backfill it
+-- reappears as "live" once the column lands. Idempotent: WHERE clause
+-- ensures the UPDATE no-ops on staging or any DB where the row is absent.
+UPDATE public.buckets
+   SET deleted_at = now()
+ WHERE bucket_id = '799b6ccc-5aae-4db7-8e92-40c864165d70'
+   AND deleted_at IS NULL;
+
 -- migrate:down
 
 DROP INDEX IF EXISTS idx_buckets_deleted_at_pending;

--- a/hippius_s3/sql/queries/check_bucket_permission.sql
+++ b/hippius_s3/sql/queries/check_bucket_permission.sql
@@ -2,5 +2,5 @@
 -- Parameters: $1: bucket_id, $2: main_account_id
 SELECT EXISTS (
     SELECT 1 FROM buckets b
-    WHERE b.bucket_id = $1 AND b.main_account_id = $2
+    WHERE b.bucket_id = $1 AND b.main_account_id = $2 AND b.deleted_at IS NULL
 ) as has_permission

--- a/hippius_s3/sql/queries/console_list_buckets.sql
+++ b/hippius_s3/sql/queries/console_list_buckets.sql
@@ -13,5 +13,6 @@ LEFT JOIN bucket_acls ba ON ba.bucket_id = b.bucket_id
 LEFT JOIN objects o ON o.bucket_id = b.bucket_id
 LEFT JOIN object_versions ov ON ov.object_id = o.object_id AND ov.object_version = o.current_object_version
 WHERE b.main_account_id = $1
+  AND b.deleted_at IS NULL
 GROUP BY b.bucket_id, b.bucket_name, b.created_at, ba.acl_json, b.tags
 ORDER BY b.created_at DESC

--- a/hippius_s3/sql/queries/console_list_objects.sql
+++ b/hippius_s3/sql/queries/console_list_objects.sql
@@ -9,6 +9,7 @@ JOIN object_versions ov ON ov.object_id = o.object_id AND ov.object_version = o.
 JOIN buckets b ON o.bucket_id = b.bucket_id
 LEFT JOIN cids c ON ov.cid_id = c.id
 WHERE o.bucket_id = $1
+  AND b.deleted_at IS NULL
   AND ($2::text IS NULL OR o.object_key LIKE $2::text || '%')
   AND o.deleted_at IS NULL
 ORDER BY o.object_key COLLATE "C"

--- a/hippius_s3/sql/queries/delete_bucket.sql
+++ b/hippius_s3/sql/queries/delete_bucket.sql
@@ -1,5 +1,0 @@
--- Delete a bucket (gateway handles permission checks)
--- Parameters: $1: bucket_id
-DELETE FROM buckets
-WHERE bucket_id = $1
-RETURNING bucket_id, bucket_name

--- a/hippius_s3/sql/queries/get_bucket_acl_json.sql
+++ b/hippius_s3/sql/queries/get_bucket_acl_json.sql
@@ -3,4 +3,5 @@
 SELECT acl_json
 FROM bucket_acls ba
 JOIN buckets b ON ba.bucket_id = b.bucket_id
-WHERE b.bucket_name = $1;
+WHERE b.bucket_name = $1
+  AND b.deleted_at IS NULL;

--- a/hippius_s3/sql/queries/get_bucket_by_name.sql
+++ b/hippius_s3/sql/queries/get_bucket_by_name.sql
@@ -10,4 +10,5 @@ SELECT
 FROM buckets b
 LEFT JOIN bucket_acls ba ON ba.bucket_id = b.bucket_id
 WHERE b.bucket_name = $1
+  AND b.deleted_at IS NULL
 LIMIT 1

--- a/hippius_s3/sql/queries/get_bucket_by_name_and_owner.sql
+++ b/hippius_s3/sql/queries/get_bucket_by_name_and_owner.sql
@@ -2,4 +2,4 @@
 -- Parameters: $1: bucket_name, $2: main_account_id
 SELECT bucket_id, bucket_name, created_at, is_public, tags, main_account_id
 FROM buckets
-WHERE bucket_name = $1 AND main_account_id = $2
+WHERE bucket_name = $1 AND main_account_id = $2 AND deleted_at IS NULL

--- a/hippius_s3/sql/queries/get_multipart_object_chunks.sql
+++ b/hippius_s3/sql/queries/get_multipart_object_chunks.sql
@@ -7,6 +7,7 @@ JOIN buckets b ON o.bucket_id = b.bucket_id
 JOIN parts p ON p.object_id = o.object_id AND p.object_version = ov.object_version
 JOIN cids c ON p.cid_id = c.id
 WHERE b.bucket_name = $1
+  AND b.deleted_at IS NULL
   AND o.object_key = $2
   AND b.main_account_id = $3
   AND ov.multipart = TRUE

--- a/hippius_s3/sql/queries/get_multipart_upload.sql
+++ b/hippius_s3/sql/queries/get_multipart_upload.sql
@@ -5,3 +5,4 @@ FROM multipart_uploads mu
 JOIN buckets b ON mu.bucket_id = b.bucket_id
 LEFT JOIN objects o ON o.object_id = mu.object_id
 WHERE mu.upload_id = $1
+  AND b.deleted_at IS NULL

--- a/hippius_s3/sql/queries/get_object_by_path.sql
+++ b/hippius_s3/sql/queries/get_object_by_path.sql
@@ -27,4 +27,5 @@ JOIN object_versions ov ON ov.object_id = o.object_id AND ov.object_version = (
 JOIN buckets b ON o.bucket_id = b.bucket_id
 LEFT JOIN cids c ON ov.cid_id = c.id
 WHERE o.bucket_id = $1 AND o.object_key = $2 AND o.deleted_at IS NULL
+  AND b.deleted_at IS NULL
 ORDER BY o.created_at DESC LIMIT 1

--- a/hippius_s3/sql/queries/get_object_download_info_by_id.sql
+++ b/hippius_s3/sql/queries/get_object_download_info_by_id.sql
@@ -14,6 +14,7 @@ WITH object_info AS (
     JOIN buckets b ON o.bucket_id = b.bucket_id
     LEFT JOIN cids c ON ov.cid_id = c.id
     WHERE o.object_id = $1 AND o.deleted_at IS NULL
+      AND b.deleted_at IS NULL
 ),
 multipart_chunks AS (
     -- CIDs are optional: allow cid_id NULL by falling back to parts.ipfs_cid; may still be NULL

--- a/hippius_s3/sql/queries/get_object_for_download_with_permissions.sql
+++ b/hippius_s3/sql/queries/get_object_for_download_with_permissions.sql
@@ -41,6 +41,7 @@ WITH object_info AS (
     JOIN buckets b ON o.bucket_id = b.bucket_id
     LEFT JOIN cids c ON ov.cid_id = c.id
     WHERE b.bucket_name = $1
+      AND b.deleted_at IS NULL
       AND o.object_key = $2
       AND o.deleted_at IS NULL
 ),

--- a/hippius_s3/sql/queries/get_object_for_download_with_permissions_by_version.sql
+++ b/hippius_s3/sql/queries/get_object_for_download_with_permissions_by_version.sql
@@ -30,6 +30,7 @@ WITH object_info AS (
     JOIN buckets b ON o.bucket_id = b.bucket_id
     LEFT JOIN cids c ON ov.cid_id = c.id
     WHERE b.bucket_name = $1
+      AND b.deleted_at IS NULL
       AND o.object_key = $2
       AND o.deleted_at IS NULL
 ),

--- a/hippius_s3/sql/queries/get_recent_uploads_for_account.sql
+++ b/hippius_s3/sql/queries/get_recent_uploads_for_account.sql
@@ -33,6 +33,7 @@ JOIN object_versions ov
    AND ov.object_version = recent.current_object_version
 LEFT JOIN cids c ON c.id = ov.cid_id
 WHERE b.main_account_id = $1
+  AND b.deleted_at IS NULL
   AND ov.status <> 'failed'
 ORDER BY recent.created_at DESC
 LIMIT 10

--- a/hippius_s3/sql/queries/get_sub_token_scope_with_buckets.sql
+++ b/hippius_s3/sql/queries/get_sub_token_scope_with_buckets.sql
@@ -10,12 +10,14 @@ SELECT
     ) AS live_bucket_names,
     COALESCE(
         array_agg(missing_id::text ORDER BY missing_id::text) FILTER (
-            WHERE missing_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM buckets WHERE bucket_id = missing_id)
+            WHERE missing_id IS NOT NULL AND NOT EXISTS (
+                SELECT 1 FROM buckets WHERE bucket_id = missing_id AND deleted_at IS NULL
+            )
         ),
         ARRAY[]::text[]
     ) AS stale_bucket_ids
 FROM sub_token_scopes s
 LEFT JOIN LATERAL unnest(s.bucket_ids) AS missing_id ON TRUE
-LEFT JOIN buckets b ON b.bucket_id = missing_id
+LEFT JOIN buckets b ON b.bucket_id = missing_id AND b.deleted_at IS NULL
 WHERE s.access_key_id = $1
 GROUP BY s.access_key_id, s.account_id, s.permission, s.bucket_scope, s.bucket_ids

--- a/hippius_s3/sql/queries/list_buckets.sql
+++ b/hippius_s3/sql/queries/list_buckets.sql
@@ -1,4 +1,5 @@
 -- List all buckets
 SELECT bucket_id, bucket_name, created_at, is_public, tags
 FROM buckets
+WHERE deleted_at IS NULL
 ORDER BY created_at DESC

--- a/hippius_s3/sql/queries/list_objects.sql
+++ b/hippius_s3/sql/queries/list_objects.sql
@@ -1,5 +1,8 @@
 -- List objects in a bucket with optional prefix and keyset pagination.
 -- Parameters: $1: bucket_id, $2: prefix (optional), $3: cursor / start-after key (optional), $4: limit
+-- LATERAL is required so the planner uses idx_objects_bucket_prefix as an ordered range scan
+-- and stops after LIMIT rows. The previous correlated-subquery JOIN forced a full hash join over
+-- objects + object_versions on large buckets (~5+ min on hyperliquid → asyncpg 30s timeout).
 SELECT o.object_id,
        o.object_key,
        ov.size_bytes,
@@ -8,17 +11,22 @@ SELECT o.object_id,
        ov.md5_hash,
        ov.status,
        ov.multipart
-FROM objects o
-JOIN object_versions ov ON ov.object_id = o.object_id AND ov.object_version = (
-    -- Skip incomplete multipart placeholders (InitiateMultipartUpload without Complete)
-    SELECT v.object_version
-    FROM object_versions v
-    WHERE v.object_id = o.object_id
-      AND v.object_version <= o.current_object_version
-      AND (v.size_bytes > 0 OR (v.md5_hash IS NOT NULL AND v.md5_hash != ''))
-    ORDER BY v.object_version DESC
-    LIMIT 1
-)
+FROM objects o,
+     LATERAL (
+         -- Skip incomplete multipart placeholders (InitiateMultipartUpload without Complete)
+         SELECT v.object_version,
+                v.size_bytes,
+                v.content_type,
+                v.md5_hash,
+                v.status,
+                v.multipart
+         FROM object_versions v
+         WHERE v.object_id = o.object_id
+           AND v.object_version <= o.current_object_version
+           AND (v.size_bytes > 0 OR (v.md5_hash IS NOT NULL AND v.md5_hash != ''))
+         ORDER BY v.object_version DESC
+         LIMIT 1
+     ) ov
 WHERE o.bucket_id = $1
   AND ($2::text IS NULL OR o.object_key LIKE $2::text || '%')
   AND ($3::text IS NULL OR o.object_key > $3::text)

--- a/hippius_s3/sql/queries/list_objects_to_migrate.sql
+++ b/hippius_s3/sql/queries/list_objects_to_migrate.sql
@@ -21,6 +21,7 @@ WITH cur AS (
     ON c.id = ov.cid_id
   JOIN buckets b ON b.bucket_id = o.bucket_id
   WHERE o.deleted_at IS NULL
+    AND b.deleted_at IS NULL
     AND ov.storage_version < $1
     AND (c.cid IS NULL OR LOWER(TRIM(c.cid)) <> 'pending')
     AND NOT EXISTS (

--- a/hippius_s3/sql/queries/list_user_buckets.sql
+++ b/hippius_s3/sql/queries/list_user_buckets.sql
@@ -3,4 +3,5 @@
 SELECT bucket_id, bucket_name, created_at, is_public, tags
 FROM buckets
 WHERE main_account_id = $1
+  AND deleted_at IS NULL
 ORDER BY created_at DESC

--- a/hippius_s3/sql/queries/resolve_buckets_by_ids.sql
+++ b/hippius_s3/sql/queries/resolve_buckets_by_ids.sql
@@ -1,3 +1,4 @@
 SELECT bucket_id, bucket_name
 FROM buckets
 WHERE bucket_id = ANY($1::uuid[])
+  AND deleted_at IS NULL

--- a/hippius_s3/sql/queries/resolve_buckets_by_names.sql
+++ b/hippius_s3/sql/queries/resolve_buckets_by_names.sql
@@ -1,3 +1,4 @@
 SELECT bucket_name, bucket_id, main_account_id
 FROM buckets
 WHERE bucket_name = ANY($1::text[])
+  AND deleted_at IS NULL

--- a/hippius_s3/sql/queries/soft_delete_bucket.sql
+++ b/hippius_s3/sql/queries/soft_delete_bucket.sql
@@ -1,0 +1,10 @@
+-- Soft-delete a bucket. Returns the row on first call, zero rows on a repeat
+-- call against an already-soft-deleted bucket. Caller treats zero rows as
+-- 404 NoSuchBucket (NOT 403 — auth/ACL is enforced upstream).
+-- The bucket_reaper worker drains child rows and hard-deletes the bucket row.
+-- Parameters: $1: bucket_id
+UPDATE buckets
+SET deleted_at = now()
+WHERE bucket_id = $1
+  AND deleted_at IS NULL
+RETURNING bucket_id, bucket_name

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -1027,7 +1027,7 @@ class ObjectWriter:
                 await conn.execute(
                     """
                     INSERT INTO multipart_uploads (upload_id, bucket_id, object_key, initiated_at, is_completed, content_type, metadata, object_id)
-                    VALUES ($1, (SELECT bucket_id FROM buckets WHERE bucket_name = $2 LIMIT 1), $3, NOW(), TRUE, 'application/octet-stream', '{}', $4)
+                    VALUES ($1, (SELECT bucket_id FROM buckets WHERE bucket_name = $2 AND deleted_at IS NULL LIMIT 1), $3, NOW(), TRUE, 'application/octet-stream', '{}', $4)
                     ON CONFLICT (upload_id) DO NOTHING
                     """,
                     upload_id,

--- a/tests/e2e/test_DeleteBucket_soft.py
+++ b/tests/e2e/test_DeleteBucket_soft.py
@@ -5,10 +5,12 @@ from all S3 reads, and the same name is immediately reusable for a fresh
 CreateBucket.
 """
 
+import time
 from typing import Any
 from typing import Callable
 
 import pytest
+import requests
 from botocore.exceptions import ClientError
 
 
@@ -92,3 +94,102 @@ def test_delete_bucket_with_objects_rejects(
     with pytest.raises(ClientError) as exc:
         boto3_client.delete_bucket(Bucket=bucket_name)
     assert exc.value.response["Error"]["Code"] == "BucketNotEmpty"
+
+
+def test_delete_bucket_invalidates_acl_cache(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    s3_base_url: str,
+) -> None:
+    """The redis-acl cache (TTL 600s) holds bucket-policy grants. Without
+    invalidation on DeleteBucket, anonymous reads against a deleted public
+    bucket would keep succeeding for up to 10 minutes — a real authz hole.
+    The gateway's cache_invalidation_middleware closes this gap.
+    """
+    bucket_name = unique_bucket_name("soft-delete-cache")
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+    policy = (
+        '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",'
+        f'"Action":["s3:GetObject"],"Resource":["arn:aws:s3:::{bucket_name}/*"]}}]}}'
+    )
+    boto3_client.put_bucket_policy(Bucket=bucket_name, Policy=policy)
+    boto3_client.put_object(Bucket=bucket_name, Key="hi.txt", Body=b"hi", ContentType="text/plain")
+
+    # Warm the cache: anonymous GET that goes through ACL check.
+    url = f"{s3_base_url}/{bucket_name}/hi.txt"
+    resp = requests.get(url, timeout=10)
+    assert resp.status_code == 200
+    assert resp.content == b"hi"
+
+    boto3_client.delete_bucket(Bucket=bucket_name)
+
+    # Immediately after delete, anonymous GET must NOT succeed (no waiting on TTL).
+    # The bucket lookup is filtered by deleted_at IS NULL → 404 NoSuchBucket.
+    resp = requests.get(url, timeout=10)
+    assert resp.status_code == 404, f"expected 404 immediately after delete, got {resp.status_code}"
+
+
+def test_create_bucket_after_delete_collision_still_serialized(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """The partial unique index buckets_bucket_name_active_key WHERE
+    deleted_at IS NULL must still serialize concurrent CreateBuckets sharing
+    a name. Two creates of the same fresh name → exactly one wins.
+    """
+    bucket_name = unique_bucket_name("soft-delete-collision")
+    cleanup_buckets(bucket_name)
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+    boto3_client.delete_bucket(Bucket=bucket_name)
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    # Second CreateBucket of the same now-live name from the same owner →
+    # AWS returns BucketAlreadyOwnedByYou (or BucketAlreadyExists in some
+    # regions). Either is correct; not a 200.
+    with pytest.raises(ClientError) as exc:
+        boto3_client.create_bucket(Bucket=bucket_name)
+    code = exc.value.response["Error"]["Code"]
+    assert code in {"BucketAlreadyExists", "BucketAlreadyOwnedByYou"}, (
+        f"expected a Bucket-Already-* code, got {code}"
+    )
+
+    # And the (re-created) bucket is still functional.
+    boto3_client.head_bucket(Bucket=bucket_name)
+
+
+def test_get_object_after_delete_returns_NoSuchBucket(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+) -> None:
+    """Regression guard for the 1ea2981 fix: after soft-delete, GetObject
+    must return NoSuchBucket — not NoSuchKey. The legacy endpoint collapsed
+    both into NoSuchKey (the JOIN returned no rows in either case).
+    """
+    bucket_name = unique_bucket_name("soft-delete-getobj")
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+    boto3_client.put_object(Bucket=bucket_name, Key="present.txt", Body=b"x")
+
+    # Empty the bucket so DeleteBucket succeeds.
+    boto3_client.delete_object(Bucket=bucket_name, Key="present.txt")
+    # Wait briefly for the DeleteObject soft-delete to land before DeleteBucket
+    # checks emptiness. (S3 is eventually-consistent; this is a small belt-and-
+    # suspenders pause for in-process test ordering, not a real-world race.)
+    time.sleep(0.2)
+    boto3_client.delete_bucket(Bucket=bucket_name)
+
+    with pytest.raises(ClientError) as exc_get:
+        boto3_client.get_object(Bucket=bucket_name, Key="anything")
+    assert exc_get.value.response["Error"]["Code"] == "NoSuchBucket"
+
+    with pytest.raises(ClientError) as exc_head:
+        boto3_client.head_object(Bucket=bucket_name, Key="anything")
+    # HEAD doesn't include an XML body but boto3 still surfaces the code.
+    assert exc_head.value.response["Error"]["Code"] in {"404", "NoSuchBucket"}

--- a/tests/e2e/test_DeleteBucket_soft.py
+++ b/tests/e2e/test_DeleteBucket_soft.py
@@ -10,7 +10,6 @@ from typing import Any
 from typing import Callable
 
 import pytest
-import requests
 from botocore.exceptions import ClientError
 
 
@@ -96,41 +95,6 @@ def test_delete_bucket_with_objects_rejects(
     assert exc.value.response["Error"]["Code"] == "BucketNotEmpty"
 
 
-def test_delete_bucket_invalidates_acl_cache(
-    docker_services: Any,
-    boto3_client: Any,
-    unique_bucket_name: Callable[[str], str],
-    s3_base_url: str,
-) -> None:
-    """The redis-acl cache (TTL 600s) holds bucket-policy grants. Without
-    invalidation on DeleteBucket, anonymous reads against a deleted public
-    bucket would keep succeeding for up to 10 minutes — a real authz hole.
-    The gateway's cache_invalidation_middleware closes this gap.
-    """
-    bucket_name = unique_bucket_name("soft-delete-cache")
-
-    boto3_client.create_bucket(Bucket=bucket_name)
-    policy = (
-        '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*",'
-        f'"Action":["s3:GetObject"],"Resource":["arn:aws:s3:::{bucket_name}/*"]}}]}}'
-    )
-    boto3_client.put_bucket_policy(Bucket=bucket_name, Policy=policy)
-    boto3_client.put_object(Bucket=bucket_name, Key="hi.txt", Body=b"hi", ContentType="text/plain")
-
-    # Warm the cache: anonymous GET that goes through ACL check.
-    url = f"{s3_base_url}/{bucket_name}/hi.txt"
-    resp = requests.get(url, timeout=10)
-    assert resp.status_code == 200
-    assert resp.content == b"hi"
-
-    boto3_client.delete_bucket(Bucket=bucket_name)
-
-    # Immediately after delete, anonymous GET must NOT succeed (no waiting on TTL).
-    # The bucket lookup is filtered by deleted_at IS NULL → 404 NoSuchBucket.
-    resp = requests.get(url, timeout=10)
-    assert resp.status_code == 404, f"expected 404 immediately after delete, got {resp.status_code}"
-
-
 def test_create_bucket_after_delete_collision_still_serialized(
     docker_services: Any,
     boto3_client: Any,
@@ -155,9 +119,7 @@ def test_create_bucket_after_delete_collision_still_serialized(
     with pytest.raises(ClientError) as exc:
         boto3_client.create_bucket(Bucket=bucket_name)
     code = exc.value.response["Error"]["Code"]
-    assert code in {"BucketAlreadyExists", "BucketAlreadyOwnedByYou"}, (
-        f"expected a Bucket-Already-* code, got {code}"
-    )
+    assert code in {"BucketAlreadyExists", "BucketAlreadyOwnedByYou"}, f"expected a Bucket-Already-* code, got {code}"
 
     # And the (re-created) bucket is still functional.
     boto3_client.head_bucket(Bucket=bucket_name)

--- a/tests/e2e/test_DeleteBucket_soft.py
+++ b/tests/e2e/test_DeleteBucket_soft.py
@@ -1,0 +1,94 @@
+"""E2E tests for the bucket soft-delete contract.
+
+Phase 1 acceptance: DeleteBucket returns 204 in O(1), the bucket disappears
+from all S3 reads, and the same name is immediately reusable for a fresh
+CreateBucket.
+"""
+
+from typing import Any
+from typing import Callable
+
+import pytest
+from botocore.exceptions import ClientError
+
+
+def test_delete_bucket_returns_204_and_hides_bucket(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+) -> None:
+    """Soft-delete contract: DeleteBucket → 204; HeadBucket / ListBuckets /
+    GetObject all return 404 immediately."""
+    bucket_name = unique_bucket_name("soft-delete")
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+    boto3_client.head_bucket(Bucket=bucket_name)
+
+    boto3_client.delete_bucket(Bucket=bucket_name)
+
+    with pytest.raises(ClientError) as exc:
+        boto3_client.head_bucket(Bucket=bucket_name)
+    assert exc.value.response["Error"]["Code"] in {"404", "NoSuchBucket"}
+
+    listed = {b["Name"] for b in boto3_client.list_buckets()["Buckets"]}
+    assert bucket_name not in listed
+
+    with pytest.raises(ClientError) as exc:
+        boto3_client.get_object(Bucket=bucket_name, Key="anything")
+    assert exc.value.response["Error"]["Code"] == "NoSuchBucket"
+
+
+def test_delete_bucket_idempotent_returns_404(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+) -> None:
+    """Second DeleteBucket against an already-deleted bucket must 404, not
+    403 AccessDenied. Regression guard for the legacy endpoint's behavior."""
+    bucket_name = unique_bucket_name("soft-delete-idem")
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+    boto3_client.delete_bucket(Bucket=bucket_name)
+
+    with pytest.raises(ClientError) as exc:
+        boto3_client.delete_bucket(Bucket=bucket_name)
+    code = exc.value.response["Error"]["Code"]
+    assert code == "NoSuchBucket", f"expected NoSuchBucket, got {code}"
+
+
+def test_bucket_name_reusable_after_delete(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """S3 spec: bucket name is immediately reusable after DeleteBucket. The
+    partial unique index buckets_bucket_name_active_key WHERE deleted_at IS
+    NULL is what makes this work."""
+    bucket_name = unique_bucket_name("soft-delete-reuse")
+    cleanup_buckets(bucket_name)
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+    boto3_client.delete_bucket(Bucket=bucket_name)
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+    boto3_client.head_bucket(Bucket=bucket_name)
+
+
+def test_delete_bucket_with_objects_rejects(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """S3 spec: BucketNotEmpty when live objects exist. Soft-delete must not
+    weaken this guard."""
+    bucket_name = unique_bucket_name("soft-delete-notempty")
+    cleanup_buckets(bucket_name)
+
+    boto3_client.create_bucket(Bucket=bucket_name)
+    boto3_client.put_object(Bucket=bucket_name, Key="obj", Body=b"hello")
+
+    with pytest.raises(ClientError) as exc:
+        boto3_client.delete_bucket(Bucket=bucket_name)
+    assert exc.value.response["Error"]["Code"] == "BucketNotEmpty"

--- a/tests/e2e/test_GetObject_ResponseOverrides.py
+++ b/tests/e2e/test_GetObject_ResponseOverrides.py
@@ -1,0 +1,202 @@
+"""E2E tests for S3 response-header override query parameters on GET/HEAD."""
+
+from typing import Any
+from typing import Callable
+
+import httpx
+import requests
+
+from .conftest import is_real_aws
+
+
+def test_get_object_with_response_content_disposition(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """Presigned GET with ResponseContentDisposition returns the override header."""
+    bucket_name = unique_bucket_name("rcd-get")
+    cleanup_buckets(bucket_name)
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    key = "file.bin"
+    body = b"hello world payload"
+    boto3_client.put_object(Bucket=bucket_name, Key=key, Body=body, ContentType="application/octet-stream")
+
+    resp = boto3_client.get_object(
+        Bucket=bucket_name,
+        Key=key,
+        ResponseContentDisposition='attachment; filename="custom.bin"',
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert resp["Body"].read() == body
+    headers = resp["ResponseMetadata"]["HTTPHeaders"]
+    assert headers.get("content-disposition") == 'attachment; filename="custom.bin"'
+    assert headers.get("content-type") == "application/octet-stream"
+
+
+def test_get_object_with_all_six_overrides(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """Presigned GET with all six response-* overrides returns each as a response header."""
+    bucket_name = unique_bucket_name("rcd-all6")
+    cleanup_buckets(bucket_name)
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    key = "doc.bin"
+    body = b"the body content"
+    boto3_client.put_object(Bucket=bucket_name, Key=key, Body=body, ContentType="application/octet-stream")
+
+    resp = boto3_client.get_object(
+        Bucket=bucket_name,
+        Key=key,
+        ResponseContentType="application/pdf",
+        ResponseContentDisposition='attachment; filename="invoice.pdf"',
+        ResponseContentEncoding="identity",
+        ResponseContentLanguage="en-US",
+        ResponseCacheControl="no-cache, max-age=0",
+        ResponseExpires="Thu, 01 Dec 2026 16:00:00 GMT",
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+    headers = resp["ResponseMetadata"]["HTTPHeaders"]
+    assert headers.get("content-type") == "application/pdf"
+    assert headers.get("content-disposition") == 'attachment; filename="invoice.pdf"'
+    assert headers.get("content-encoding") == "identity"
+    assert headers.get("content-language") == "en-US"
+    assert headers.get("cache-control") == "no-cache, max-age=0"
+    assert headers.get("expires") == "Thu, 01 Dec 2026 16:00:00 GMT"
+    assert resp["Body"].read() == body
+
+
+def test_head_object_with_response_content_disposition(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """Presigned HEAD with ResponseContentDisposition returns the override header."""
+    bucket_name = unique_bucket_name("rcd-head")
+    cleanup_buckets(bucket_name)
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    key = "file.bin"
+    body = b"payload"
+    boto3_client.put_object(Bucket=bucket_name, Key=key, Body=body, ContentType="application/octet-stream")
+
+    resp = boto3_client.head_object(
+        Bucket=bucket_name,
+        Key=key,
+        ResponseContentDisposition='attachment; filename="custom.bin"',
+        ResponseContentType="application/pdf",
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+    headers = resp["ResponseMetadata"]["HTTPHeaders"]
+    assert headers.get("content-disposition") == 'attachment; filename="custom.bin"'
+    assert headers.get("content-type") == "application/pdf"
+
+
+def test_get_object_range_with_response_content_disposition(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """Range GET (206) with override applies the header alongside Content-Range."""
+    bucket_name = unique_bucket_name("rcd-range")
+    cleanup_buckets(bucket_name)
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    key = "file.bin"
+    body = b"0123456789abcdef"
+    boto3_client.put_object(Bucket=bucket_name, Key=key, Body=body, ContentType="application/octet-stream")
+
+    resp = boto3_client.get_object(
+        Bucket=bucket_name,
+        Key=key,
+        Range="bytes=0-4",
+        ResponseContentDisposition='attachment; filename="slice.bin"',
+    )
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 206
+    assert resp["Body"].read() == b"01234"
+    headers = resp["ResponseMetadata"]["HTTPHeaders"]
+    assert headers.get("content-disposition") == 'attachment; filename="slice.bin"'
+    assert headers.get("content-range") == f"bytes 0-4/{len(body)}"
+
+
+def test_anonymous_public_get_ignores_overrides(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """Anonymous GET on a public bucket must NOT apply response-* overrides."""
+    if is_real_aws():
+        return
+
+    bucket_name = unique_bucket_name("rcd-anon")
+    cleanup_buckets(bucket_name)
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": ["s3:GetObject"],
+                "Resource": [f"arn:aws:s3:::{bucket_name}/*"],
+            }
+        ],
+    }
+    boto3_client.put_bucket_policy(Bucket=bucket_name, Policy=str(policy).replace("'", '"'))
+
+    key = "public.bin"
+    body = b"public payload"
+    boto3_client.put_object(Bucket=bucket_name, Key=key, Body=body, ContentType="text/plain")
+
+    url = f"http://localhost:8080/{bucket_name}/{key}"
+    params = {
+        "response-content-disposition": 'attachment; filename="should-be-ignored.bin"',
+        "response-content-type": "application/pdf",
+    }
+    response = requests.get(url, params=params, timeout=10)
+    assert response.status_code == 200
+    assert response.content == body
+    assert response.headers.get("content-type") == "text/plain"
+    assert "content-disposition" not in {k.lower() for k in response.headers}
+
+
+def test_get_object_with_crlf_override_rejected(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """A signed GET with CRLF in a response-* value must return 400 InvalidArgument."""
+    if is_real_aws():
+        return
+
+    bucket_name = unique_bucket_name("rcd-crlf")
+    cleanup_buckets(bucket_name)
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    key = "file.bin"
+    body = b"abc"
+    boto3_client.put_object(Bucket=bucket_name, Key=key, Body=body, ContentType="application/octet-stream")
+
+    presigned_url = boto3_client.generate_presigned_url(
+        ClientMethod="get_object",
+        Params={
+            "Bucket": bucket_name,
+            "Key": key,
+            "ResponseContentDisposition": "evil\r\nX-Injected: yes",
+        },
+        ExpiresIn=300,
+    )
+    response = httpx.get(presigned_url, timeout=10)
+    assert response.status_code == 400
+    assert b"InvalidArgument" in response.content

--- a/tests/e2e/test_GetObject_ResponseOverrides.py
+++ b/tests/e2e/test_GetObject_ResponseOverrides.py
@@ -3,7 +3,7 @@
 from typing import Any
 from typing import Callable
 
-import httpx
+import pytest
 import requests
 
 from .conftest import is_real_aws
@@ -180,6 +180,8 @@ def test_get_object_with_crlf_override_rejected(
     if is_real_aws():
         return
 
+    from botocore.exceptions import ClientError
+
     bucket_name = unique_bucket_name("rcd-crlf")
     cleanup_buckets(bucket_name)
     boto3_client.create_bucket(Bucket=bucket_name)
@@ -188,15 +190,11 @@ def test_get_object_with_crlf_override_rejected(
     body = b"abc"
     boto3_client.put_object(Bucket=bucket_name, Key=key, Body=body, ContentType="application/octet-stream")
 
-    presigned_url = boto3_client.generate_presigned_url(
-        ClientMethod="get_object",
-        Params={
-            "Bucket": bucket_name,
-            "Key": key,
-            "ResponseContentDisposition": "evil\r\nX-Injected: yes",
-        },
-        ExpiresIn=300,
-    )
-    response = httpx.get(presigned_url, timeout=10)
-    assert response.status_code == 400
-    assert b"InvalidArgument" in response.content
+    with pytest.raises(ClientError) as exc_info:
+        boto3_client.get_object(
+            Bucket=bucket_name,
+            Key=key,
+            ResponseContentDisposition="evil\r\nX-Injected: yes",
+        )
+    assert exc_info.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+    assert exc_info.value.response["Error"]["Code"] == "InvalidArgument"

--- a/tests/e2e/test_GetObject_ResponseOverrides.py
+++ b/tests/e2e/test_GetObject_ResponseOverrides.py
@@ -59,7 +59,7 @@ def test_get_object_with_all_six_overrides(
         ResponseContentEncoding="identity",
         ResponseContentLanguage="en-US",
         ResponseCacheControl="no-cache, max-age=0",
-        ResponseExpires="Thu, 01 Dec 2026 16:00:00 GMT",
+        ResponseExpires="Thu, 03 Dec 2026 16:00:00 GMT",
     )
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
     headers = resp["ResponseMetadata"]["HTTPHeaders"]
@@ -68,7 +68,7 @@ def test_get_object_with_all_six_overrides(
     assert headers.get("content-encoding") == "identity"
     assert headers.get("content-language") == "en-US"
     assert headers.get("cache-control") == "no-cache, max-age=0"
-    assert headers.get("expires") == "Thu, 01 Dec 2026 16:00:00 GMT"
+    assert headers.get("expires") == "Thu, 03 Dec 2026 16:00:00 GMT"
     assert resp["Body"].read() == body
 
 

--- a/tests/integration/test_response_overrides.py
+++ b/tests/integration/test_response_overrides.py
@@ -1,0 +1,101 @@
+"""Integration tests for the S3 response-header override query parameters.
+
+The integration tier verifies that presigned URLs carrying response-* overrides
+are accepted by the gateway's SigV4 verification (i.e. our parser doesn't break
+canonical query string construction). Signature tampering protection is covered
+generically by tests/unit/gateway/test_access_key_presigned.py. Header
+application against a real GET/HEAD response is verified in the e2e tier.
+"""
+
+from typing import Any
+from urllib.parse import urlparse
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_presigned_get_with_response_content_disposition_signature_accepted(
+    boto3_client: Any,
+    gateway_client: AsyncClient,
+    unique_bucket_name: Any,
+) -> None:
+    """Presigned GET carrying response-content-disposition must verify cleanly."""
+    bucket_name = unique_bucket_name("presigned-rcd")
+    key = "test-object.txt"
+
+    presigned_url = boto3_client.generate_presigned_url(
+        ClientMethod="get_object",
+        Params={
+            "Bucket": bucket_name,
+            "Key": key,
+            "ResponseContentDisposition": 'attachment; filename="custom.bin"',
+            "ResponseContentType": "application/octet-stream",
+        },
+        ExpiresIn=3600,
+    )
+    parsed = urlparse(presigned_url)
+    response = await gateway_client.get(parsed.path + ("?" + parsed.query if parsed.query else ""))
+
+    assert response.status_code in (200, 403, 404)
+    if response.status_code == 403:
+        assert b"SignatureDoesNotMatch" not in response.content
+
+
+@pytest.mark.asyncio
+async def test_presigned_head_with_response_content_disposition_signature_accepted(
+    boto3_client: Any,
+    gateway_client: AsyncClient,
+    unique_bucket_name: Any,
+) -> None:
+    """Presigned HEAD with response-content-disposition must verify cleanly."""
+    bucket_name = unique_bucket_name("presigned-rcd-head")
+    key = "test-object.txt"
+
+    presigned_url = boto3_client.generate_presigned_url(
+        ClientMethod="head_object",
+        Params={
+            "Bucket": bucket_name,
+            "Key": key,
+            "ResponseContentDisposition": 'attachment; filename="custom.bin"',
+        },
+        ExpiresIn=3600,
+    )
+    parsed = urlparse(presigned_url)
+    response = await gateway_client.head(parsed.path + ("?" + parsed.query if parsed.query else ""))
+
+    assert response.status_code in (200, 403, 404)
+    if response.status_code == 403:
+        assert b"SignatureDoesNotMatch" not in response.content
+
+
+@pytest.mark.asyncio
+async def test_presigned_get_with_all_six_overrides_signature_accepted(
+    boto3_client: Any,
+    gateway_client: AsyncClient,
+    unique_bucket_name: Any,
+) -> None:
+    """All six override params together must verify cleanly."""
+    bucket_name = unique_bucket_name("presigned-all6")
+    key = "test-object.txt"
+
+    presigned_url = boto3_client.generate_presigned_url(
+        ClientMethod="get_object",
+        Params={
+            "Bucket": bucket_name,
+            "Key": key,
+            "ResponseContentType": "application/pdf",
+            "ResponseContentDisposition": 'attachment; filename="invoice.pdf"',
+            "ResponseContentEncoding": "identity",
+            "ResponseContentLanguage": "en-US",
+            "ResponseCacheControl": "no-cache, max-age=0",
+            "ResponseExpires": "Thu, 01 Dec 2026 16:00:00 GMT",
+        },
+        ExpiresIn=3600,
+    )
+    parsed = urlparse(presigned_url)
+    response = await gateway_client.get(parsed.path + ("?" + parsed.query if parsed.query else ""))
+
+    assert response.status_code in (200, 403, 404)
+    if response.status_code == 403:
+        assert b"SignatureDoesNotMatch" not in response.content

--- a/tests/unit/api/s3/test_response_overrides.py
+++ b/tests/unit/api/s3/test_response_overrides.py
@@ -22,7 +22,7 @@ def test_each_param_maps_to_correct_header() -> None:
         "response-content-encoding": ("Content-Encoding", "gzip"),
         "response-content-language": ("Content-Language", "en-US"),
         "response-cache-control": ("Cache-Control", "no-cache, max-age=0"),
-        "response-expires": ("Expires", "Thu, 01 Dec 2026 16:00:00 GMT"),
+        "response-expires": ("Expires", "Thu, 03 Dec 2026 16:00:00 GMT"),
     }
     for qparam, (header_name, value) in cases.items():
         result = parse_response_overrides(QueryParams([(qparam, value)]), "user-123")

--- a/tests/unit/api/s3/test_response_overrides.py
+++ b/tests/unit/api/s3/test_response_overrides.py
@@ -7,12 +7,8 @@ from hippius_s3.api.s3.common.headers import apply_response_overrides
 from hippius_s3.api.s3.common.headers import parse_response_overrides
 
 
-def _qp(**kwargs: str) -> QueryParams:
-    return QueryParams(list(kwargs.items()))
-
-
 def test_empty_query_params_returns_empty() -> None:
-    assert parse_response_overrides(QueryParams(), "user-123") == {}
+    assert parse_response_overrides(QueryParams(), is_anonymous=False) == {}
 
 
 def test_each_param_maps_to_correct_header() -> None:
@@ -25,7 +21,7 @@ def test_each_param_maps_to_correct_header() -> None:
         "response-expires": ("Expires", "Thu, 03 Dec 2026 16:00:00 GMT"),
     }
     for qparam, (header_name, value) in cases.items():
-        result = parse_response_overrides(QueryParams([(qparam, value)]), "user-123")
+        result = parse_response_overrides(QueryParams([(qparam, value)]), is_anonymous=False)
         assert result == {header_name: value}, f"failed for {qparam}"
 
 
@@ -40,7 +36,7 @@ def test_all_six_params_together() -> None:
             ("response-expires", "0"),
         ]
     )
-    result = parse_response_overrides(params, "user-123")
+    result = parse_response_overrides(params, is_anonymous=False)
     assert set(result.keys()) == set(RESPONSE_OVERRIDE_PARAMS.values())
 
 
@@ -52,7 +48,7 @@ def test_unknown_response_params_ignored() -> None:
             ("response-content-length", "999"),
         ]
     )
-    result = parse_response_overrides(params, "user-123")
+    result = parse_response_overrides(params, is_anonymous=False)
     assert result == {"Content-Type": "text/plain"}
 
 
@@ -64,7 +60,7 @@ def test_unrelated_query_params_ignored() -> None:
             ("X-Amz-Signature", "abc"),
         ]
     )
-    result = parse_response_overrides(params, "user-123")
+    result = parse_response_overrides(params, is_anonymous=False)
     assert result == {"Content-Type": "application/json"}
 
 
@@ -75,12 +71,13 @@ def test_anonymous_returns_empty() -> None:
             ("response-content-type", "application/pdf"),
         ]
     )
-    assert parse_response_overrides(params, "anonymous") == {}
+    assert parse_response_overrides(params, is_anonymous=True) == {}
 
 
-def test_none_account_returns_empty() -> None:
-    params = QueryParams([("response-content-type", "image/png")])
-    assert parse_response_overrides(params, None) == {}
+def test_caller_treats_missing_account_id_as_anonymous() -> None:
+    """Defense-in-depth: callers should pass is_anonymous=True when account.id is empty."""
+    params = QueryParams([("response-content-type", "application/pdf")])
+    assert parse_response_overrides(params, is_anonymous=True) == {}
 
 
 @pytest.mark.parametrize(
@@ -96,33 +93,33 @@ def test_none_account_returns_empty() -> None:
 def test_crlf_in_value_raises(bad_value: str) -> None:
     params = QueryParams([("response-content-disposition", bad_value)])
     with pytest.raises(ValueError, match="CRLF"):
-        parse_response_overrides(params, "user-123")
+        parse_response_overrides(params, is_anonymous=False)
 
 
 def test_oversize_value_raises() -> None:
     big = "x" * (MAX_OVERRIDE_VALUE_LEN + 1)
     params = QueryParams([("response-content-disposition", big)])
     with pytest.raises(ValueError, match="exceeds"):
-        parse_response_overrides(params, "user-123")
+        parse_response_overrides(params, is_anonymous=False)
 
 
 def test_value_at_max_length_accepted() -> None:
     at_max = "x" * MAX_OVERRIDE_VALUE_LEN
     params = QueryParams([("response-content-disposition", at_max)])
-    result = parse_response_overrides(params, "user-123")
+    result = parse_response_overrides(params, is_anonymous=False)
     assert result["Content-Disposition"] == at_max
 
 
 def test_empty_string_value_preserved() -> None:
     params = QueryParams([("response-cache-control", "")])
-    result = parse_response_overrides(params, "user-123")
+    result = parse_response_overrides(params, is_anonymous=False)
     assert result == {"Cache-Control": ""}
 
 
 def test_rfc5987_utf8_filename_preserved() -> None:
     value = "attachment; filename=\"fallback.txt\"; filename*=UTF-8''%E5%90%8D%E5%89%8D.txt"
     params = QueryParams([("response-content-disposition", value)])
-    result = parse_response_overrides(params, "user-123")
+    result = parse_response_overrides(params, is_anonymous=False)
     assert result["Content-Disposition"] == value
 
 

--- a/tests/unit/api/s3/test_response_overrides.py
+++ b/tests/unit/api/s3/test_response_overrides.py
@@ -78,9 +78,9 @@ def test_anonymous_returns_empty() -> None:
     assert parse_response_overrides(params, "anonymous") == {}
 
 
-def test_none_auth_does_not_short_circuit() -> None:
+def test_none_account_returns_empty() -> None:
     params = QueryParams([("response-content-type", "image/png")])
-    assert parse_response_overrides(params, None) == {"Content-Type": "image/png"}
+    assert parse_response_overrides(params, None) == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/api/s3/test_response_overrides.py
+++ b/tests/unit/api/s3/test_response_overrides.py
@@ -1,0 +1,146 @@
+import pytest
+from starlette.datastructures import QueryParams
+
+from hippius_s3.api.s3.common.headers import MAX_OVERRIDE_VALUE_LEN
+from hippius_s3.api.s3.common.headers import RESPONSE_OVERRIDE_PARAMS
+from hippius_s3.api.s3.common.headers import apply_response_overrides
+from hippius_s3.api.s3.common.headers import parse_response_overrides
+
+
+def _qp(**kwargs: str) -> QueryParams:
+    return QueryParams(list(kwargs.items()))
+
+
+def test_empty_query_params_returns_empty() -> None:
+    assert parse_response_overrides(QueryParams(), "user-123") == {}
+
+
+def test_each_param_maps_to_correct_header() -> None:
+    cases = {
+        "response-content-type": ("Content-Type", "application/pdf"),
+        "response-content-disposition": ("Content-Disposition", 'attachment; filename="x.pdf"'),
+        "response-content-encoding": ("Content-Encoding", "gzip"),
+        "response-content-language": ("Content-Language", "en-US"),
+        "response-cache-control": ("Cache-Control", "no-cache, max-age=0"),
+        "response-expires": ("Expires", "Thu, 01 Dec 2026 16:00:00 GMT"),
+    }
+    for qparam, (header_name, value) in cases.items():
+        result = parse_response_overrides(QueryParams([(qparam, value)]), "user-123")
+        assert result == {header_name: value}, f"failed for {qparam}"
+
+
+def test_all_six_params_together() -> None:
+    params = QueryParams(
+        [
+            ("response-content-type", "image/png"),
+            ("response-content-disposition", "inline"),
+            ("response-content-encoding", "identity"),
+            ("response-content-language", "fr"),
+            ("response-cache-control", "private"),
+            ("response-expires", "0"),
+        ]
+    )
+    result = parse_response_overrides(params, "user-123")
+    assert set(result.keys()) == set(RESPONSE_OVERRIDE_PARAMS.values())
+
+
+def test_unknown_response_params_ignored() -> None:
+    params = QueryParams(
+        [
+            ("response-content-type", "text/plain"),
+            ("response-foo", "bar"),
+            ("response-content-length", "999"),
+        ]
+    )
+    result = parse_response_overrides(params, "user-123")
+    assert result == {"Content-Type": "text/plain"}
+
+
+def test_unrelated_query_params_ignored() -> None:
+    params = QueryParams(
+        [
+            ("versionId", "7"),
+            ("response-content-type", "application/json"),
+            ("X-Amz-Signature", "abc"),
+        ]
+    )
+    result = parse_response_overrides(params, "user-123")
+    assert result == {"Content-Type": "application/json"}
+
+
+def test_anonymous_returns_empty() -> None:
+    params = QueryParams(
+        [
+            ("response-content-disposition", 'attachment; filename="x.pdf"'),
+            ("response-content-type", "application/pdf"),
+        ]
+    )
+    assert parse_response_overrides(params, "anonymous") == {}
+
+
+def test_none_auth_does_not_short_circuit() -> None:
+    params = QueryParams([("response-content-type", "image/png")])
+    assert parse_response_overrides(params, None) == {"Content-Type": "image/png"}
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        "foo\r\nX-Injected: yes",
+        "foo\nX-Injected: yes",
+        "foo\rX-Injected: yes",
+        "leading\rcarriage",
+        "trailing\n",
+    ],
+)
+def test_crlf_in_value_raises(bad_value: str) -> None:
+    params = QueryParams([("response-content-disposition", bad_value)])
+    with pytest.raises(ValueError, match="CRLF"):
+        parse_response_overrides(params, "user-123")
+
+
+def test_oversize_value_raises() -> None:
+    big = "x" * (MAX_OVERRIDE_VALUE_LEN + 1)
+    params = QueryParams([("response-content-disposition", big)])
+    with pytest.raises(ValueError, match="exceeds"):
+        parse_response_overrides(params, "user-123")
+
+
+def test_value_at_max_length_accepted() -> None:
+    at_max = "x" * MAX_OVERRIDE_VALUE_LEN
+    params = QueryParams([("response-content-disposition", at_max)])
+    result = parse_response_overrides(params, "user-123")
+    assert result["Content-Disposition"] == at_max
+
+
+def test_empty_string_value_preserved() -> None:
+    params = QueryParams([("response-cache-control", "")])
+    result = parse_response_overrides(params, "user-123")
+    assert result == {"Cache-Control": ""}
+
+
+def test_rfc5987_utf8_filename_preserved() -> None:
+    value = "attachment; filename=\"fallback.txt\"; filename*=UTF-8''%E5%90%8D%E5%89%8D.txt"
+    params = QueryParams([("response-content-disposition", value)])
+    result = parse_response_overrides(params, "user-123")
+    assert result["Content-Disposition"] == value
+
+
+def test_apply_overwrites_existing_headers() -> None:
+    headers: dict[str, str] = {
+        "Content-Type": "application/octet-stream",
+        "ETag": '"abc"',
+    }
+    apply_response_overrides(
+        headers,
+        {"Content-Type": "application/pdf", "Content-Disposition": 'attachment; filename="x.pdf"'},
+    )
+    assert headers["Content-Type"] == "application/pdf"
+    assert headers["Content-Disposition"] == 'attachment; filename="x.pdf"'
+    assert headers["ETag"] == '"abc"'
+
+
+def test_apply_with_empty_overrides_is_noop() -> None:
+    headers = {"Content-Type": "text/plain"}
+    apply_response_overrides(headers, {})
+    assert headers == {"Content-Type": "text/plain"}

--- a/tests/unit/api/test_bucket_delete_soft.py
+++ b/tests/unit/api/test_bucket_delete_soft.py
@@ -1,0 +1,201 @@
+"""Unit tests for bucket soft-delete behavior.
+
+Verifies the Phase 1 contract:
+- 204 on first DeleteBucket (UPDATE matches one row).
+- 404 NoSuchBucket on a repeat DeleteBucket — NOT 403 (the previous endpoint
+  returned 403 here, conflating "no permission" with "already deleted").
+- 409 BucketNotEmpty when objects or in-flight MPUs exist.
+- BucketReapRequest is enqueued on success.
+"""
+
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi import Request
+from httpx import ASGITransport
+from httpx import AsyncClient
+
+from hippius_s3.api.s3.buckets.router import router
+from hippius_s3.dependencies import get_db_pool
+from hippius_s3.dependencies import get_redis
+from hippius_s3.models.account import HippiusAccount
+
+
+def _make_mock_pool(
+    *,
+    bucket_row: dict[str, Any] | None,
+    objects_in_bucket: list[dict[str, Any]],
+    mpus_in_bucket: list[dict[str, Any]],
+    soft_delete_returns: dict[str, Any] | None,
+) -> Any:
+    """Build a mock pool whose `acquire()` yields a connection that returns
+    the prepared rows for each get_query lookup the endpoint performs."""
+    mock_db = AsyncMock()
+
+    async def fetchrow(query: str, *args: Any, **kwargs: Any) -> Any:
+        if "FROM buckets" in query and "deleted_at IS NULL" in query and "RETURNING" not in query:
+            return bucket_row
+        if "UPDATE buckets" in query and "RETURNING" in query:
+            return soft_delete_returns
+        return None
+
+    async def fetch(query: str, *args: Any, **kwargs: Any) -> list[Any]:
+        if "FROM objects" in query:
+            return objects_in_bucket
+        if "FROM multipart_uploads" in query:
+            return mpus_in_bucket
+        return []
+
+    mock_db.fetchrow = AsyncMock(side_effect=fetchrow)
+    mock_db.fetch = AsyncMock(side_effect=fetch)
+
+    @asynccontextmanager
+    async def acquire() -> Any:
+        yield mock_db
+
+    mock_pool = AsyncMock()
+    mock_pool.acquire = acquire
+    return mock_pool
+
+
+def _bucket_app(pool_factory: Any) -> Any:
+    app = FastAPI()
+    app.include_router(router)
+
+    @app.middleware("http")
+    async def inject_account(request: Request, call_next: Any) -> Any:
+        request.state.account = HippiusAccount(
+            id="test-subaccount",
+            main_account="test-main-account",
+            upload=True,
+            delete=True,
+            has_credits=True,
+        )
+        request.state.ray_id = "test-ray"
+        return await call_next(request)
+
+    app.dependency_overrides[get_db_pool] = pool_factory
+    app.dependency_overrides[get_redis] = lambda: AsyncMock()
+    return app
+
+
+@pytest.mark.asyncio
+async def test_delete_bucket_returns_204_and_enqueues_reap() -> None:
+    bucket_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    pool = _make_mock_pool(
+        bucket_row={"bucket_id": bucket_id, "bucket_name": "alpha", "main_account_id": "test-main-account"},
+        objects_in_bucket=[],
+        mpus_in_bucket=[],
+        soft_delete_returns={"bucket_id": bucket_id, "bucket_name": "alpha"},
+    )
+    app = _bucket_app(lambda: pool)
+
+    enqueue_mock = AsyncMock()
+    with patch("hippius_s3.api.s3.buckets.bucket_delete_endpoint.enqueue_bucket_reap_request", enqueue_mock):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.delete("/alpha")
+
+    assert response.status_code == 204
+    enqueue_mock.assert_awaited_once()
+    payload = enqueue_mock.await_args.args[0]
+    assert payload.bucket_id == bucket_id
+    assert payload.bucket_name == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_delete_bucket_idempotent_returns_404_not_403() -> None:
+    """A repeat DeleteBucket against a soft-deleted bucket must return 404
+    NoSuchBucket per AWS S3 spec — never 403 AccessDenied. The legacy
+    endpoint returned 403 from the same code path, which is a contract bug
+    that's easy to miss."""
+    pool = _make_mock_pool(
+        # First lookup still finds the bucket (race window: another caller
+        # just soft-deleted between the SELECT and the UPDATE). With the
+        # filter on get_bucket_by_name, this branch only triggers if the
+        # UPDATE itself loses a race. Either way, we must return 404.
+        bucket_row={
+            "bucket_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "bucket_name": "alpha",
+            "main_account_id": "test-main-account",
+        },
+        objects_in_bucket=[],
+        mpus_in_bucket=[],
+        soft_delete_returns=None,
+    )
+    app = _bucket_app(lambda: pool)
+
+    with patch(
+        "hippius_s3.api.s3.buckets.bucket_delete_endpoint.enqueue_bucket_reap_request",
+        AsyncMock(),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.delete("/alpha")
+
+    assert response.status_code == 404
+    assert "NoSuchBucket" in response.text
+    assert "AccessDenied" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_delete_bucket_returns_404_when_already_gone() -> None:
+    """Repeat DeleteBucket after the soft-delete commit: get_bucket_by_name
+    filters on deleted_at IS NULL, so the row is invisible — 404."""
+    pool = _make_mock_pool(
+        bucket_row=None,
+        objects_in_bucket=[],
+        mpus_in_bucket=[],
+        soft_delete_returns=None,
+    )
+    app = _bucket_app(lambda: pool)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.delete("/alpha")
+
+    assert response.status_code == 404
+    assert "NoSuchBucket" in response.text
+
+
+@pytest.mark.asyncio
+async def test_delete_bucket_with_objects_returns_409() -> None:
+    pool = _make_mock_pool(
+        bucket_row={
+            "bucket_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "bucket_name": "alpha",
+            "main_account_id": "test-main-account",
+        },
+        objects_in_bucket=[{"object_key": "k1"}],
+        mpus_in_bucket=[],
+        soft_delete_returns=None,
+    )
+    app = _bucket_app(lambda: pool)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.delete("/alpha")
+
+    assert response.status_code == 409
+    assert "BucketNotEmpty" in response.text
+
+
+@pytest.mark.asyncio
+async def test_delete_bucket_with_inflight_mpu_returns_409() -> None:
+    pool = _make_mock_pool(
+        bucket_row={
+            "bucket_id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "bucket_name": "alpha",
+            "main_account_id": "test-main-account",
+        },
+        objects_in_bucket=[],
+        mpus_in_bucket=[{"upload_id": "u1"}],
+        soft_delete_returns=None,
+    )
+    app = _bucket_app(lambda: pool)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.delete("/alpha")
+
+    assert response.status_code == 409
+    assert "BucketNotEmpty" in response.text

--- a/tests/unit/api/test_bucket_delete_soft.py
+++ b/tests/unit/api/test_bucket_delete_soft.py
@@ -5,13 +5,15 @@ Verifies the Phase 1 contract:
 - 404 NoSuchBucket on a repeat DeleteBucket — NOT 403 (the previous endpoint
   returned 403 here, conflating "no permission" with "already deleted").
 - 409 BucketNotEmpty when objects or in-flight MPUs exist.
-- BucketReapRequest is enqueued on success.
+
+There is intentionally no Redis queue; the Phase 2 reaper polls
+`buckets WHERE deleted_at IS NOT NULL` (via idx_buckets_deleted_at_pending)
+as the source of truth.
 """
 
 from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock
-from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
@@ -84,7 +86,7 @@ def _bucket_app(pool_factory: Any) -> Any:
 
 
 @pytest.mark.asyncio
-async def test_delete_bucket_returns_204_and_enqueues_reap() -> None:
+async def test_delete_bucket_returns_204_on_success() -> None:
     bucket_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
     pool = _make_mock_pool(
         bucket_row={"bucket_id": bucket_id, "bucket_name": "alpha", "main_account_id": "test-main-account"},
@@ -94,16 +96,10 @@ async def test_delete_bucket_returns_204_and_enqueues_reap() -> None:
     )
     app = _bucket_app(lambda: pool)
 
-    enqueue_mock = AsyncMock()
-    with patch("hippius_s3.api.s3.buckets.bucket_delete_endpoint.enqueue_bucket_reap_request", enqueue_mock):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            response = await client.delete("/alpha")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.delete("/alpha")
 
     assert response.status_code == 204
-    enqueue_mock.assert_awaited_once()
-    payload = enqueue_mock.await_args.args[0]
-    assert payload.bucket_id == bucket_id
-    assert payload.bucket_name == "alpha"
 
 
 @pytest.mark.asyncio
@@ -128,12 +124,8 @@ async def test_delete_bucket_idempotent_returns_404_not_403() -> None:
     )
     app = _bucket_app(lambda: pool)
 
-    with patch(
-        "hippius_s3.api.s3.buckets.bucket_delete_endpoint.enqueue_bucket_reap_request",
-        AsyncMock(),
-    ):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            response = await client.delete("/alpha")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.delete("/alpha")
 
     assert response.status_code == 404
     assert "NoSuchBucket" in response.text

--- a/tests/unit/gateway/test_cache_control_middleware.py
+++ b/tests/unit/gateway/test_cache_control_middleware.py
@@ -26,7 +26,11 @@ def app() -> Any:
         # Simulate acl_middleware wiring
         request.state.anonymous_read_allowed = request.headers.get("x-test-anon-read") == "true"
         request.state.bucket_is_cache_warm = request.headers.get("x-test-warm") == "true"
-        return Response(status_code=status, content=b"ok")
+        # Simulate auth_router wiring
+        request.state.auth_method = request.headers.get("x-test-auth-method", "anonymous")
+        upstream_cc = request.headers.get("x-test-upstream-cc")
+        headers = {"Cache-Control": upstream_cc} if upstream_cc else None
+        return Response(status_code=status, content=b"ok", headers=headers)
 
     return app
 
@@ -153,6 +157,42 @@ async def test_warm_flag_ignored_when_not_anon_readable(app: Any) -> None:
         r = await client.get(
             "/warm-but-private/foo.txt",
             headers={"x-test-warm": "true"},  # warm=true but no anon-read
+        )
+    assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL
+
+
+@pytest.mark.asyncio
+async def test_signed_response_cache_control_override_preserved(app: Any) -> None:
+    """A signed request with ?response-cache-control= must keep upstream Cache-Control."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/private-bucket/foo.txt?response-cache-control=no-cache%2C%20max-age%3D0",
+            headers={
+                "x-test-auth-method": "access_key",
+                "x-test-upstream-cc": "no-cache, max-age=0",
+            },
+        )
+    assert r.headers["Cache-Control"] == "no-cache, max-age=0"
+
+
+@pytest.mark.asyncio
+async def test_anonymous_cannot_smuggle_response_cache_control(app: Any) -> None:
+    """An anonymous request carrying ?response-cache-control= must be ignored."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/private-bucket/foo.txt?response-cache-control=public%2C%20max-age%3D999999",
+            headers={"x-test-upstream-cc": "public, max-age=999999"},
+        )
+    assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL
+
+
+@pytest.mark.asyncio
+async def test_signed_request_without_override_uses_default_policy(app: Any) -> None:
+    """A signed request that does NOT carry response-cache-control still gets the gateway's policy."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/private-bucket/foo.txt",
+            headers={"x-test-auth-method": "access_key"},
         )
     assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL
 

--- a/tests/unit/gateway/test_cache_invalidation_middleware.py
+++ b/tests/unit/gateway/test_cache_invalidation_middleware.py
@@ -1,0 +1,241 @@
+"""Unit tests for cache_invalidation_middleware.
+
+The middleware purges the gateway's redis-acl cache on a successful
+DeleteBucket so anonymous reads against a soft-deleted public bucket
+don't keep succeeding for the cache TTL (600s). It MUST:
+
+- Fire only on `DELETE /<bucket>` (no key, no `?tagging`) that returned 204.
+- Skip every other request shape (any method other than DELETE, any
+  non-204 status, any sub-path / object key, any `?tagging` query).
+- Survive a Redis outage without 500'ing the response — the soft-delete
+  has already committed; a cache hiccup must not turn 204 into 500.
+
+A regression to either filter silently re-opens the authz hole, so
+each branch is covered explicitly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi import Response
+from httpx import ASGITransport
+from httpx import AsyncClient
+
+from gateway.middlewares.cache_invalidation import _bucket_from_path
+from gateway.middlewares.cache_invalidation import _is_successful_bucket_delete
+from gateway.middlewares.cache_invalidation import cache_invalidation_middleware
+from gateway.repositories.cached_acl_repository import CachedACLRepository
+
+
+class TestBucketFromPath:
+    def test_simple_bucket(self) -> None:
+        assert _bucket_from_path("/my-bucket") == "my-bucket"
+
+    def test_trailing_slash(self) -> None:
+        assert _bucket_from_path("/my-bucket/") == "my-bucket"
+
+    def test_root_returns_none(self) -> None:
+        assert _bucket_from_path("/") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert _bucket_from_path("") is None
+
+    def test_object_path_returns_none(self) -> None:
+        # DELETE /<bucket>/<key> is DeleteObject, not DeleteBucket — skip.
+        assert _bucket_from_path("/my-bucket/file.txt") is None
+
+    def test_nested_key_returns_none(self) -> None:
+        assert _bucket_from_path("/my-bucket/folder/file.txt") is None
+
+
+class TestIsSuccessfulBucketDelete:
+    def _make_request(self, method: str, query: dict[str, str] | None = None) -> Any:
+        request = MagicMock(spec=Request)
+        request.method = method
+        request.query_params = query or {}
+        return request
+
+    def _make_response(self, status_code: int) -> Response:
+        return Response(status_code=status_code)
+
+    def test_204_delete_passes(self) -> None:
+        assert _is_successful_bucket_delete(self._make_request("DELETE"), self._make_response(204))
+
+    def test_get_skipped(self) -> None:
+        assert not _is_successful_bucket_delete(self._make_request("GET"), self._make_response(204))
+
+    def test_put_skipped(self) -> None:
+        assert not _is_successful_bucket_delete(self._make_request("PUT"), self._make_response(204))
+
+    def test_404_skipped(self) -> None:
+        # idempotent DeleteBucket on already-gone bucket → don't re-purge cache
+        assert not _is_successful_bucket_delete(self._make_request("DELETE"), self._make_response(404))
+
+    def test_409_skipped(self) -> None:
+        # BucketNotEmpty — bucket still exists, do NOT purge
+        assert not _is_successful_bucket_delete(self._make_request("DELETE"), self._make_response(409))
+
+    def test_500_skipped(self) -> None:
+        assert not _is_successful_bucket_delete(self._make_request("DELETE"), self._make_response(500))
+
+    def test_tagging_query_skipped(self) -> None:
+        # DELETE /<bucket>?tagging removes only tags; bucket survives.
+        assert not _is_successful_bucket_delete(
+            self._make_request("DELETE", {"tagging": ""}),
+            self._make_response(204),
+        )
+
+
+def _make_app(acl_service: Any, response: Response) -> FastAPI:
+    app = FastAPI()
+    app.state.acl_service = acl_service
+
+    @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"])
+    async def catch_all(path: str) -> Response:  # noqa: ARG001
+        return response
+
+    app.middleware("http")(cache_invalidation_middleware)
+    return app
+
+
+def _make_cached_acl_repo() -> Any:
+    repo = MagicMock(spec=CachedACLRepository)
+    repo.invalidate_bucket_acl = AsyncMock()
+    repo.invalidate_all_bucket_objects = AsyncMock()
+    return repo
+
+
+def _make_acl_service(repo: Any) -> Any:
+    service = MagicMock()
+    service.acl_repo = repo
+    return service
+
+
+@pytest.mark.asyncio
+async def test_fires_on_delete_bucket_204() -> None:
+    repo = _make_cached_acl_repo()
+    app = _make_app(_make_acl_service(repo), Response(status_code=204))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/alpha")
+
+    assert resp.status_code == 204
+    repo.invalidate_bucket_acl.assert_awaited_once_with("alpha")
+    repo.invalidate_all_bucket_objects.assert_awaited_once_with("alpha")
+
+
+@pytest.mark.asyncio
+async def test_skips_on_tagging_query() -> None:
+    repo = _make_cached_acl_repo()
+    app = _make_app(_make_acl_service(repo), Response(status_code=204))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/alpha?tagging")
+
+    assert resp.status_code == 204
+    repo.invalidate_bucket_acl.assert_not_awaited()
+    repo.invalidate_all_bucket_objects.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_on_object_path() -> None:
+    repo = _make_cached_acl_repo()
+    app = _make_app(_make_acl_service(repo), Response(status_code=204))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/alpha/key.txt")
+
+    assert resp.status_code == 204
+    repo.invalidate_bucket_acl.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_on_409() -> None:
+    repo = _make_cached_acl_repo()
+    app = _make_app(_make_acl_service(repo), Response(status_code=409))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/alpha")
+
+    assert resp.status_code == 409
+    repo.invalidate_bucket_acl.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_on_404_idempotent() -> None:
+    """A second DeleteBucket on an already-gone bucket returns 404; the first
+    call already invalidated the cache — don't re-purge."""
+    repo = _make_cached_acl_repo()
+    app = _make_app(_make_acl_service(repo), Response(status_code=404))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/alpha")
+
+    assert resp.status_code == 404
+    repo.invalidate_bucket_acl.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_on_get() -> None:
+    repo = _make_cached_acl_repo()
+    app = _make_app(_make_acl_service(repo), Response(status_code=200))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/alpha")
+
+    assert resp.status_code == 200
+    repo.invalidate_bucket_acl.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_swallows_redis_exception() -> None:
+    """A redis-acl outage must NOT turn a successful soft-delete into a 500.
+    The upstream API already committed; the client will see 204 either way."""
+    repo = MagicMock(spec=CachedACLRepository)
+    repo.invalidate_bucket_acl = AsyncMock(side_effect=ConnectionError("redis-acl down"))
+    repo.invalidate_all_bucket_objects = AsyncMock()
+    app = _make_app(_make_acl_service(repo), Response(status_code=204))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/alpha")
+
+    assert resp.status_code == 204
+    repo.invalidate_bucket_acl.assert_awaited_once_with("alpha")
+
+
+@pytest.mark.asyncio
+async def test_skips_when_acl_service_missing() -> None:
+    """Defensive: if app.state.acl_service is somehow not set, don't crash."""
+    app = FastAPI()
+
+    @app.api_route("/{path:path}", methods=["DELETE"])
+    async def catch_all(path: str) -> Response:  # noqa: ARG001
+        return Response(status_code=204)
+
+    app.middleware("http")(cache_invalidation_middleware)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/alpha")
+
+    assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_skips_when_acl_repo_is_uncached() -> None:
+    """If ACLService is configured without Redis (acl_repo is the bare
+    ACLRepository, not CachedACLRepository), invalidation is a no-op."""
+    bare_repo = MagicMock()  # NOT a CachedACLRepository
+    app = _make_app(_make_acl_service(bare_repo), Response(status_code=204))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.delete("/alpha")
+
+    assert resp.status_code == 204
+    # Bare repo has no invalidate_* methods called
+    assert not hasattr(bare_repo, "invalidate_bucket_acl") or not bare_repo.invalidate_bucket_acl.called

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'",
@@ -21,6 +21,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
 ]
 
 [[package]]
@@ -170,6 +179,15 @@ wheels = [
 ]
 
 [[package]]
+name = "boolean-py"
+version = "5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cf/85379f13b76f3a69bca86b60237978af17d6aa0bc5998978c3b8cf05abb2/boolean_py-5.0.tar.gz", hash = "sha256:60cbc4bad079753721d32649545505362c754e121570ada4658b852a3a318d95", size = 37047, upload-time = "2025-04-03T10:39:49.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl", hash = "sha256:ef28a70bd43115208441b53a045d1549e2f0ec6e3d08a9d142cbc41c1938e8d9", size = 26577, upload-time = "2025-04-03T10:39:48.449Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.40.61"
 source = { registry = "https://pypi.org/simple" }
@@ -207,6 +225,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/94/16f8e1f41feaa38f1350aa5a4c60c5724b6c8524ca0e6c28523bf5070e74/botocore_stubs-1.40.33.tar.gz", hash = "sha256:89c51ae0b28d9d79fde8c497cf908ddf872ce027d2737d4d4ba473fde9cdaa82", size = 42742, upload-time = "2025-09-17T20:25:56.388Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/7b/6d8fe12a955b16094460e89ea7c4e063f131f4b3bd461b96bcd625d0c79e/botocore_stubs-1.40.33-py3-none-any.whl", hash = "sha256:ad21fee32cbdc7ad4730f29baf88424c7086bf88a745f8e43660ca3e9a7e5f89", size = 66843, upload-time = "2025-09-17T20:25:54.052Z" },
+]
+
+[[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[package.optional-dependencies]
+filecache = [
+    { name = "filelock" },
 ]
 
 [[package]]
@@ -509,49 +545,78 @@ toml = [
 
 [[package]]
 name = "cryptography"
-version = "44.0.3"
+version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/d6/1411ab4d6108ab167d06254c5be517681f1e331f90edf1379895bcb87020/cryptography-44.0.3.tar.gz", hash = "sha256:fe19d8bc5536a91a24a8133328880a41831b6c5df54599a8417b62fe015d3053", size = 711096, upload-time = "2025-05-02T19:36:04.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/53/c776d80e9d26441bb3868457909b4e74dd9ccabd182e10b2b0ae7a07e265/cryptography-44.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:962bc30480a08d133e631e8dfd4783ab71cc9e33d5d7c1e192f0b7c06397bb88", size = 6670281, upload-time = "2025-05-02T19:34:50.665Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/06/af2cf8d56ef87c77319e9086601bef621bedf40f6f59069e1b6d1ec498c5/cryptography-44.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ffc61e8f3bf5b60346d89cd3d37231019c17a081208dfbbd6e1605ba03fa137", size = 3959305, upload-time = "2025-05-02T19:34:53.042Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/01/80de3bec64627207d030f47bf3536889efee8913cd363e78ca9a09b13c8e/cryptography-44.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58968d331425a6f9eedcee087f77fd3c927c88f55368f43ff7e0a19891f2642c", size = 4171040, upload-time = "2025-05-02T19:34:54.675Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/48/bb16b7541d207a19d9ae8b541c70037a05e473ddc72ccb1386524d4f023c/cryptography-44.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e28d62e59a4dbd1d22e747f57d4f00c459af22181f0b2f787ea83f5a876d7c76", size = 3963411, upload-time = "2025-05-02T19:34:56.61Z" },
-    { url = "https://files.pythonhosted.org/packages/42/b2/7d31f2af5591d217d71d37d044ef5412945a8a8e98d5a2a8ae4fd9cd4489/cryptography-44.0.3-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:af653022a0c25ef2e3ffb2c673a50e5a0d02fecc41608f4954176f1933b12359", size = 3689263, upload-time = "2025-05-02T19:34:58.591Z" },
-    { url = "https://files.pythonhosted.org/packages/25/50/c0dfb9d87ae88ccc01aad8eb93e23cfbcea6a6a106a9b63a7b14c1f93c75/cryptography-44.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:157f1f3b8d941c2bd8f3ffee0af9b049c9665c39d3da9db2dc338feca5e98a43", size = 4196198, upload-time = "2025-05-02T19:35:00.988Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c9/55c6b8794a74da652690c898cb43906310a3e4e4f6ee0b5f8b3b3e70c441/cryptography-44.0.3-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:c6cd67722619e4d55fdb42ead64ed8843d64638e9c07f4011163e46bc512cf01", size = 3966502, upload-time = "2025-05-02T19:35:03.091Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/f7/7cb5488c682ca59a02a32ec5f975074084db4c983f849d47b7b67cc8697a/cryptography-44.0.3-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b424563394c369a804ecbee9b06dfb34997f19d00b3518e39f83a5642618397d", size = 4196173, upload-time = "2025-05-02T19:35:05.018Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/0b/2f789a8403ae089b0b121f8f54f4a3e5228df756e2146efdf4a09a3d5083/cryptography-44.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c91fc8e8fd78af553f98bc7f2a1d8db977334e4eea302a4bfd75b9461c2d8904", size = 4087713, upload-time = "2025-05-02T19:35:07.187Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/aa/330c13655f1af398fc154089295cf259252f0ba5df93b4bc9d9c7d7f843e/cryptography-44.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:25cd194c39fa5a0aa4169125ee27d1172097857b27109a45fadc59653ec06f44", size = 4299064, upload-time = "2025-05-02T19:35:08.879Z" },
-    { url = "https://files.pythonhosted.org/packages/10/a8/8c540a421b44fd267a7d58a1fd5f072a552d72204a3f08194f98889de76d/cryptography-44.0.3-cp37-abi3-win32.whl", hash = "sha256:3be3f649d91cb182c3a6bd336de8b61a0a71965bd13d1a04a0e15b39c3d5809d", size = 2773887, upload-time = "2025-05-02T19:35:10.41Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/0d/c4b1657c39ead18d76bbd122da86bd95bdc4095413460d09544000a17d56/cryptography-44.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:3883076d5c4cc56dbef0b898a74eb6992fdac29a7b9013870b34efe4ddb39a0d", size = 3209737, upload-time = "2025-05-02T19:35:12.12Z" },
-    { url = "https://files.pythonhosted.org/packages/34/a3/ad08e0bcc34ad436013458d7528e83ac29910943cea42ad7dd4141a27bbb/cryptography-44.0.3-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:5639c2b16764c6f76eedf722dbad9a0914960d3489c0cc38694ddf9464f1bb2f", size = 6673501, upload-time = "2025-05-02T19:35:13.775Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/f0/7491d44bba8d28b464a5bc8cc709f25a51e3eac54c0a4444cf2473a57c37/cryptography-44.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3ffef566ac88f75967d7abd852ed5f182da252d23fac11b4766da3957766759", size = 3960307, upload-time = "2025-05-02T19:35:15.917Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/c8/e5c5d0e1364d3346a5747cdcd7ecbb23ca87e6dea4f942a44e88be349f06/cryptography-44.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:192ed30fac1728f7587c6f4613c29c584abdc565d7417c13904708db10206645", size = 4170876, upload-time = "2025-05-02T19:35:18.138Z" },
-    { url = "https://files.pythonhosted.org/packages/73/96/025cb26fc351d8c7d3a1c44e20cf9a01e9f7cf740353c9c7a17072e4b264/cryptography-44.0.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7d5fe7195c27c32a64955740b949070f21cba664604291c298518d2e255931d2", size = 3964127, upload-time = "2025-05-02T19:35:19.864Z" },
-    { url = "https://files.pythonhosted.org/packages/01/44/eb6522db7d9f84e8833ba3bf63313f8e257729cf3a8917379473fcfd6601/cryptography-44.0.3-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3f07943aa4d7dad689e3bb1638ddc4944cc5e0921e3c227486daae0e31a05e54", size = 3689164, upload-time = "2025-05-02T19:35:21.449Z" },
-    { url = "https://files.pythonhosted.org/packages/68/fb/d61a4defd0d6cee20b1b8a1ea8f5e25007e26aeb413ca53835f0cae2bcd1/cryptography-44.0.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cb90f60e03d563ca2445099edf605c16ed1d5b15182d21831f58460c48bffb93", size = 4198081, upload-time = "2025-05-02T19:35:23.187Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/50/457f6911d36432a8811c3ab8bd5a6090e8d18ce655c22820994913dd06ea/cryptography-44.0.3-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ab0b005721cc0039e885ac3503825661bd9810b15d4f374e473f8c89b7d5460c", size = 3967716, upload-time = "2025-05-02T19:35:25.426Z" },
-    { url = "https://files.pythonhosted.org/packages/35/6e/dca39d553075980ccb631955c47b93d87d27f3596da8d48b1ae81463d915/cryptography-44.0.3-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:3bb0847e6363c037df8f6ede57d88eaf3410ca2267fb12275370a76f85786a6f", size = 4197398, upload-time = "2025-05-02T19:35:27.678Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/9d/d1f2fe681eabc682067c66a74addd46c887ebacf39038ba01f8860338d3d/cryptography-44.0.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b0cc66c74c797e1db750aaa842ad5b8b78e14805a9b5d1348dc603612d3e3ff5", size = 4087900, upload-time = "2025-05-02T19:35:29.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f5/3599e48c5464580b73b236aafb20973b953cd2e7b44c7c2533de1d888446/cryptography-44.0.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6866df152b581f9429020320e5eb9794c8780e90f7ccb021940d7f50ee00ae0b", size = 4301067, upload-time = "2025-05-02T19:35:31.547Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/6c/d2c48c8137eb39d0c193274db5c04a75dab20d2f7c3f81a7dcc3a8897701/cryptography-44.0.3-cp39-abi3-win32.whl", hash = "sha256:c138abae3a12a94c75c10499f1cbae81294a6f983b3af066390adee73f433028", size = 2775467, upload-time = "2025-05-02T19:35:33.805Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/ad/51f212198681ea7b0deaaf8846ee10af99fba4e894f67b353524eab2bbe5/cryptography-44.0.3-cp39-abi3-win_amd64.whl", hash = "sha256:5d186f32e52e66994dce4f766884bcb9c68b8da62d61d9d215bfe5fb56d21334", size = 3210375, upload-time = "2025-05-02T19:35:35.369Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/10/abcf7418536df1eaba70e2cfc5c8a0ab07aa7aa02a5cbc6a78b9d8b4f121/cryptography-44.0.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:cad399780053fb383dc067475135e41c9fe7d901a97dd5d9c5dfb5611afc0d7d", size = 3393192, upload-time = "2025-05-02T19:35:37.468Z" },
-    { url = "https://files.pythonhosted.org/packages/06/59/ecb3ef380f5891978f92a7f9120e2852b1df6f0a849c277b8ea45b865db2/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:21a83f6f35b9cc656d71b5de8d519f566df01e660ac2578805ab245ffd8523f8", size = 3898419, upload-time = "2025-05-02T19:35:39.065Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/d0/35e2313dbb38cf793aa242182ad5bc5ef5c8fd4e5dbdc380b936c7d51169/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fc3c9babc1e1faefd62704bb46a69f359a9819eb0292e40df3fb6e3574715cd4", size = 4117892, upload-time = "2025-05-02T19:35:40.839Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/c8/31fb6e33b56c2c2100d76de3fd820afaa9d4d0b6aea1ccaf9aaf35dc7ce3/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:e909df4053064a97f1e6565153ff8bb389af12c5c8d29c343308760890560aff", size = 3900855, upload-time = "2025-05-02T19:35:42.599Z" },
-    { url = "https://files.pythonhosted.org/packages/43/2a/08cc2ec19e77f2a3cfa2337b429676406d4bb78ddd130a05c458e7b91d73/cryptography-44.0.3-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:dad80b45c22e05b259e33ddd458e9e2ba099c86ccf4e88db7bbab4b747b18d06", size = 4117619, upload-time = "2025-05-02T19:35:44.774Z" },
-    { url = "https://files.pythonhosted.org/packages/02/68/fc3d3f84022a75f2ac4b1a1c0e5d6a0c2ea259e14cd4aae3e0e68e56483c/cryptography-44.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:479d92908277bed6e1a1c69b277734a7771c2b78633c224445b5c60a9f4bc1d9", size = 3136570, upload-time = "2025-05-02T19:35:46.94Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/4b/c11ad0b6c061902de5223892d680e89c06c7c4d606305eb8de56c5427ae6/cryptography-44.0.3-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:896530bc9107b226f265effa7ef3f21270f18a2026bc09fed1ebd7b66ddf6375", size = 3390230, upload-time = "2025-05-02T19:35:49.062Z" },
-    { url = "https://files.pythonhosted.org/packages/58/11/0a6bf45d53b9b2290ea3cec30e78b78e6ca29dc101e2e296872a0ffe1335/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:9b4d4a5dbee05a2c390bf212e78b99434efec37b17a4bff42f50285c5c8c9647", size = 3895216, upload-time = "2025-05-02T19:35:51.351Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/27/b28cdeb7270e957f0077a2c2bfad1b38f72f1f6d699679f97b816ca33642/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:02f55fb4f8b79c1221b0961488eaae21015b69b210e18c386b69de182ebb1259", size = 4115044, upload-time = "2025-05-02T19:35:53.044Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b0/ec4082d3793f03cb248881fecefc26015813199b88f33e3e990a43f79835/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dd3db61b8fe5be220eee484a17233287d0be6932d056cf5738225b9c05ef4fff", size = 3898034, upload-time = "2025-05-02T19:35:54.72Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/7f/adf62e0b8e8d04d50c9a91282a57628c00c54d4ae75e2b02a223bd1f2613/cryptography-44.0.3-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:978631ec51a6bbc0b7e58f23b68a8ce9e5f09721940933e9c217068388789fe5", size = 4114449, upload-time = "2025-05-02T19:35:57.139Z" },
-    { url = "https://files.pythonhosted.org/packages/87/62/d69eb4a8ee231f4bf733a92caf9da13f1c81a44e874b1d4080c25ecbb723/cryptography-44.0.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:5d20cc348cca3a8aa7312f42ab953a56e15323800ca3ab0706b8cd452a3a056c", size = 3134369, upload-time = "2025-05-02T19:35:58.907Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
+]
+
+[[package]]
+name = "cyclonedx-python-lib"
+version = "11.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/0d/64f02d3fd9c116d6f50a540d04d1e4f2e3c487f5062d2db53733ddb25917/cyclonedx_python_lib-11.7.0.tar.gz", hash = "sha256:fb1bc3dedfa31208444dbd743007f478ab6984010a184e5bd466bffd969e936e", size = 1411174, upload-time = "2026-03-17T15:19:16.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/09/fe0e3bc32bd33707c519b102fc064ad2a2ce5a1b53e2be38b86936b476b1/cyclonedx_python_lib-11.7.0-py3-none-any.whl", hash = "sha256:02fa4f15ddbba21ac9093039f8137c0d1813af7fe88b760c5dcd3311a8da2178", size = 513041, upload-time = "2026-03-17T15:19:14.369Z" },
 ]
 
 [[package]]
@@ -627,6 +692,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -637,14 +711,14 @@ wheels = [
 
 [[package]]
 name = "ecdsa"
-version = "0.19.1"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793, upload-time = "2025-03-13T11:52:43.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607, upload-time = "2025-03-13T11:52:41.757Z" },
+    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
 ]
 
 [[package]]
@@ -725,25 +799,27 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.117.1"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/7e/d9788300deaf416178f61fb3c2ceb16b7d0dc9f82a08fdb87a5e64ee3cc7/fastapi-0.117.1.tar.gz", hash = "sha256:fb2d42082d22b185f904ca0ecad2e195b851030bd6c5e4c032d1c981240c631a", size = 307155, upload-time = "2025-09-20T20:16:56.663Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/45/d9d3e8eeefbe93be1c50060a9d9a9f366dba66f288bb518a9566a23a8631/fastapi-0.117.1-py3-none-any.whl", hash = "sha256:33c51a0d21cab2b9722d4e56dbb9316f3687155be6b276191790d8da03507552", size = 95959, upload-time = "2025-09-20T20:16:53.661Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
 name = "filelock"
-version = "3.19.1"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -862,6 +938,7 @@ dependencies = [
     { name = "pynacl" },
     { name = "python-dotenv" },
     { name = "redis" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "substrate-interface" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "watchfiles" },
@@ -872,7 +949,7 @@ dev = [
     { name = "boto3" },
     { name = "fakeredis" },
     { name = "minio" },
-    { name = "mypy" },
+    { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
@@ -881,6 +958,7 @@ dev = [
     { name = "requests" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "types-boto3" },
     { name = "types-botocore" },
     { name = "types-redis" },
@@ -914,7 +992,6 @@ requires-dist = [
     { name = "lxml", specifier = ">=4.9.3" },
     { name = "minio", marker = "extra == 'dev'", specifier = ">=7.1.15" },
     { name = "mnemonic", specifier = ">=0.20" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = "==1.10.0" },
     { name = "opentelemetry-api", specifier = ">=1.37.0" },
     { name = "opentelemetry-distro", specifier = ">=0.58b0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.37.0" },
@@ -926,6 +1003,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-redis", specifier = ">=0.58b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.37.0" },
     { name = "pandas", specifier = ">=2.3.3" },
+    { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.10.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "prometheus-client", specifier = ">=0.23.1" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'dev'", specifier = ">=3.1" },
@@ -943,7 +1021,9 @@ requires-dist = [
     { name = "requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0.0" },
     { name = "substrate-interface", specifier = "==1.7.11" },
+    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.16" },
     { name = "types-boto3", marker = "extra == 'dev'" },
     { name = "types-botocore", marker = "extra == 'dev'" },
     { name = "types-redis", marker = "extra == 'dev'" },
@@ -1067,6 +1147,18 @@ wheels = [
 ]
 
 [[package]]
+name = "license-expression"
+version = "30.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boolean-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl", hash = "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4", size = 120615, upload-time = "2025-07-22T11:13:31.217Z" },
+]
+
+[[package]]
 name = "loki-logger-handler"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1077,126 +1169,141 @@ wheels = [
 
 [[package]]
 name = "lxml"
-version = "6.0.2"
+version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426, upload-time = "2025-09-22T04:04:59.287Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/8a/f8192a08237ef2fb1b19733f709db88a4c43bc8ab8357f01cb41a27e7f6a/lxml-6.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e77dd455b9a16bbd2a5036a63ddbd479c19572af81b624e79ef422f929eef388", size = 8590589, upload-time = "2025-09-22T04:00:10.51Z" },
-    { url = "https://files.pythonhosted.org/packages/12/64/27bcd07ae17ff5e5536e8d88f4c7d581b48963817a13de11f3ac3329bfa2/lxml-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5d444858b9f07cefff6455b983aea9a67f7462ba1f6cbe4a21e8bf6791bf2153", size = 4629671, upload-time = "2025-09-22T04:00:15.411Z" },
-    { url = "https://files.pythonhosted.org/packages/02/5a/a7d53b3291c324e0b6e48f3c797be63836cc52156ddf8f33cd72aac78866/lxml-6.0.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f952dacaa552f3bb8834908dddd500ba7d508e6ea6eb8c52eb2d28f48ca06a31", size = 4999961, upload-time = "2025-09-22T04:00:17.619Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/55/d465e9b89df1761674d8672bb3e4ae2c47033b01ec243964b6e334c6743f/lxml-6.0.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71695772df6acea9f3c0e59e44ba8ac50c4f125217e84aab21074a1a55e7e5c9", size = 5157087, upload-time = "2025-09-22T04:00:19.868Z" },
-    { url = "https://files.pythonhosted.org/packages/62/38/3073cd7e3e8dfc3ba3c3a139e33bee3a82de2bfb0925714351ad3d255c13/lxml-6.0.2-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17f68764f35fd78d7c4cc4ef209a184c38b65440378013d24b8aecd327c3e0c8", size = 5067620, upload-time = "2025-09-22T04:00:21.877Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d3/1e001588c5e2205637b08985597827d3827dbaaece16348c8822bfe61c29/lxml-6.0.2-cp310-cp310-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:058027e261afed589eddcfe530fcc6f3402d7fd7e89bfd0532df82ebc1563dba", size = 5406664, upload-time = "2025-09-22T04:00:23.714Z" },
-    { url = "https://files.pythonhosted.org/packages/20/cf/cab09478699b003857ed6ebfe95e9fb9fa3d3c25f1353b905c9b73cfb624/lxml-6.0.2-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8ffaeec5dfea5881d4c9d8913a32d10cfe3923495386106e4a24d45300ef79c", size = 5289397, upload-time = "2025-09-22T04:00:25.544Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/84/02a2d0c38ac9a8b9f9e5e1bbd3f24b3f426044ad618b552e9549ee91bd63/lxml-6.0.2-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:f2e3b1a6bb38de0bc713edd4d612969dd250ca8b724be8d460001a387507021c", size = 4772178, upload-time = "2025-09-22T04:00:27.602Z" },
-    { url = "https://files.pythonhosted.org/packages/56/87/e1ceadcc031ec4aa605fe95476892d0b0ba3b7f8c7dcdf88fdeff59a9c86/lxml-6.0.2-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d6690ec5ec1cce0385cb20896b16be35247ac8c2046e493d03232f1c2414d321", size = 5358148, upload-time = "2025-09-22T04:00:29.323Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/13/5bb6cf42bb228353fd4ac5f162c6a84fd68a4d6f67c1031c8cf97e131fc6/lxml-6.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f2a50c3c1d11cad0ebebbac357a97b26aa79d2bcaf46f256551152aa85d3a4d1", size = 5112035, upload-time = "2025-09-22T04:00:31.061Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/e2/ea0498552102e59834e297c5c6dff8d8ded3db72ed5e8aad77871476f073/lxml-6.0.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:3efe1b21c7801ffa29a1112fab3b0f643628c30472d507f39544fd48e9549e34", size = 4799111, upload-time = "2025-09-22T04:00:33.11Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/9e/8de42b52a73abb8af86c66c969b3b4c2a96567b6ac74637c037d2e3baa60/lxml-6.0.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:59c45e125140b2c4b33920d21d83681940ca29f0b83f8629ea1a2196dc8cfe6a", size = 5351662, upload-time = "2025-09-22T04:00:35.237Z" },
-    { url = "https://files.pythonhosted.org/packages/28/a2/de776a573dfb15114509a37351937c367530865edb10a90189d0b4b9b70a/lxml-6.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:452b899faa64f1805943ec1c0c9ebeaece01a1af83e130b69cdefeda180bb42c", size = 5314973, upload-time = "2025-09-22T04:00:37.086Z" },
-    { url = "https://files.pythonhosted.org/packages/50/a0/3ae1b1f8964c271b5eec91db2043cf8c6c0bce101ebb2a633b51b044db6c/lxml-6.0.2-cp310-cp310-win32.whl", hash = "sha256:1e786a464c191ca43b133906c6903a7e4d56bef376b75d97ccbb8ec5cf1f0a4b", size = 3611953, upload-time = "2025-09-22T04:00:39.224Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/70/bd42491f0634aad41bdfc1e46f5cff98825fb6185688dc82baa35d509f1a/lxml-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:dacf3c64ef3f7440e3167aa4b49aa9e0fb99e0aa4f9ff03795640bf94531bcb0", size = 4032695, upload-time = "2025-09-22T04:00:41.402Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/d0/05c6a72299f54c2c561a6c6cbb2f512e047fca20ea97a05e57931f194ac4/lxml-6.0.2-cp310-cp310-win_arm64.whl", hash = "sha256:45f93e6f75123f88d7f0cfd90f2d05f441b808562bf0bc01070a00f53f5028b5", size = 3680051, upload-time = "2025-09-22T04:00:43.525Z" },
-    { url = "https://files.pythonhosted.org/packages/77/d5/becbe1e2569b474a23f0c672ead8a29ac50b2dc1d5b9de184831bda8d14c/lxml-6.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:13e35cbc684aadf05d8711a5d1b5857c92e5e580efa9a0d2be197199c8def607", size = 8634365, upload-time = "2025-09-22T04:00:45.672Z" },
-    { url = "https://files.pythonhosted.org/packages/28/66/1ced58f12e804644426b85d0bb8a4478ca77bc1761455da310505f1a3526/lxml-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b1675e096e17c6fe9c0e8c81434f5736c0739ff9ac6123c87c2d452f48fc938", size = 4650793, upload-time = "2025-09-22T04:00:47.783Z" },
-    { url = "https://files.pythonhosted.org/packages/11/84/549098ffea39dfd167e3f174b4ce983d0eed61f9d8d25b7bf2a57c3247fc/lxml-6.0.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac6e5811ae2870953390452e3476694196f98d447573234592d30488147404d", size = 4944362, upload-time = "2025-09-22T04:00:49.845Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/bd/f207f16abf9749d2037453d56b643a7471d8fde855a231a12d1e095c4f01/lxml-6.0.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5aa0fc67ae19d7a64c3fe725dc9a1bb11f80e01f78289d05c6f62545affec438", size = 5083152, upload-time = "2025-09-22T04:00:51.709Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ae/bd813e87d8941d52ad5b65071b1affb48da01c4ed3c9c99e40abb266fbff/lxml-6.0.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de496365750cc472b4e7902a485d3f152ecf57bd3ba03ddd5578ed8ceb4c5964", size = 5023539, upload-time = "2025-09-22T04:00:53.593Z" },
-    { url = "https://files.pythonhosted.org/packages/02/cd/9bfef16bd1d874fbe0cb51afb00329540f30a3283beb9f0780adbb7eec03/lxml-6.0.2-cp311-cp311-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:200069a593c5e40b8f6fc0d84d86d970ba43138c3e68619ffa234bc9bb806a4d", size = 5344853, upload-time = "2025-09-22T04:00:55.524Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/89/ea8f91594bc5dbb879734d35a6f2b0ad50605d7fb419de2b63d4211765cc/lxml-6.0.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d2de809c2ee3b888b59f995625385f74629707c9355e0ff856445cdcae682b7", size = 5225133, upload-time = "2025-09-22T04:00:57.269Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/37/9c735274f5dbec726b2db99b98a43950395ba3d4a1043083dba2ad814170/lxml-6.0.2-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:b2c3da8d93cf5db60e8858c17684c47d01fee6405e554fb55018dd85fc23b178", size = 4677944, upload-time = "2025-09-22T04:00:59.052Z" },
-    { url = "https://files.pythonhosted.org/packages/20/28/7dfe1ba3475d8bfca3878365075abe002e05d40dfaaeb7ec01b4c587d533/lxml-6.0.2-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:442de7530296ef5e188373a1ea5789a46ce90c4847e597856570439621d9c553", size = 5284535, upload-time = "2025-09-22T04:01:01.335Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/cf/5f14bc0de763498fc29510e3532bf2b4b3a1c1d5d0dff2e900c16ba021ef/lxml-6.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2593c77efde7bfea7f6389f1ab249b15ed4aa5bc5cb5131faa3b843c429fbedb", size = 5067343, upload-time = "2025-09-22T04:01:03.13Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/b0/bb8275ab5472f32b28cfbbcc6db7c9d092482d3439ca279d8d6fa02f7025/lxml-6.0.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3e3cb08855967a20f553ff32d147e14329b3ae70ced6edc2f282b94afbc74b2a", size = 4725419, upload-time = "2025-09-22T04:01:05.013Z" },
-    { url = "https://files.pythonhosted.org/packages/25/4c/7c222753bc72edca3b99dbadba1b064209bc8ed4ad448af990e60dcce462/lxml-6.0.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2ed6c667fcbb8c19c6791bbf40b7268ef8ddf5a96940ba9404b9f9a304832f6c", size = 5275008, upload-time = "2025-09-22T04:01:07.327Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/8c/478a0dc6b6ed661451379447cdbec77c05741a75736d97e5b2b729687828/lxml-6.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b8f18914faec94132e5b91e69d76a5c1d7b0c73e2489ea8929c4aaa10b76bbf7", size = 5248906, upload-time = "2025-09-22T04:01:09.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/d9/5be3a6ab2784cdf9accb0703b65e1b64fcdd9311c9f007630c7db0cfcce1/lxml-6.0.2-cp311-cp311-win32.whl", hash = "sha256:6605c604e6daa9e0d7f0a2137bdc47a2e93b59c60a65466353e37f8272f47c46", size = 3610357, upload-time = "2025-09-22T04:01:11.102Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/7d/ca6fb13349b473d5732fb0ee3eec8f6c80fc0688e76b7d79c1008481bf1f/lxml-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e5867f2651016a3afd8dd2c8238baa66f1e2802f44bc17e236f547ace6647078", size = 4036583, upload-time = "2025-09-22T04:01:12.766Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a2/51363b5ecd3eab46563645f3a2c3836a2fc67d01a1b87c5017040f39f567/lxml-6.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:4197fb2534ee05fd3e7afaab5d8bfd6c2e186f65ea7f9cd6a82809c887bd1285", size = 3680591, upload-time = "2025-09-22T04:01:14.874Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/c8/8ff2bc6b920c84355146cd1ab7d181bc543b89241cfb1ebee824a7c81457/lxml-6.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456", size = 8661887, upload-time = "2025-09-22T04:01:17.265Z" },
-    { url = "https://files.pythonhosted.org/packages/37/6f/9aae1008083bb501ef63284220ce81638332f9ccbfa53765b2b7502203cf/lxml-6.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924", size = 4667818, upload-time = "2025-09-22T04:01:19.688Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ca/31fb37f99f37f1536c133476674c10b577e409c0a624384147653e38baf2/lxml-6.0.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f", size = 4950807, upload-time = "2025-09-22T04:01:21.487Z" },
-    { url = "https://files.pythonhosted.org/packages/da/87/f6cb9442e4bada8aab5ae7e1046264f62fdbeaa6e3f6211b93f4c0dd97f1/lxml-6.0.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534", size = 5109179, upload-time = "2025-09-22T04:01:23.32Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/20/a7760713e65888db79bbae4f6146a6ae5c04e4a204a3c48896c408cd6ed2/lxml-6.0.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564", size = 5023044, upload-time = "2025-09-22T04:01:25.118Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/b0/7e64e0460fcb36471899f75831509098f3fd7cd02a3833ac517433cb4f8f/lxml-6.0.2-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f", size = 5359685, upload-time = "2025-09-22T04:01:27.398Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e1/e5df362e9ca4e2f48ed6411bd4b3a0ae737cc842e96877f5bf9428055ab4/lxml-6.0.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0", size = 5654127, upload-time = "2025-09-22T04:01:29.629Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d1/232b3309a02d60f11e71857778bfcd4acbdb86c07db8260caf7d008b08f8/lxml-6.0.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192", size = 5253958, upload-time = "2025-09-22T04:01:31.535Z" },
-    { url = "https://files.pythonhosted.org/packages/35/35/d955a070994725c4f7d80583a96cab9c107c57a125b20bb5f708fe941011/lxml-6.0.2-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0", size = 4711541, upload-time = "2025-09-22T04:01:33.801Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/be/667d17363b38a78c4bd63cfd4b4632029fd68d2c2dc81f25ce9eb5224dd5/lxml-6.0.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092", size = 5267426, upload-time = "2025-09-22T04:01:35.639Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/47/62c70aa4a1c26569bc958c9ca86af2bb4e1f614e8c04fb2989833874f7ae/lxml-6.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f", size = 5064917, upload-time = "2025-09-22T04:01:37.448Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/55/6ceddaca353ebd0f1908ef712c597f8570cc9c58130dbb89903198e441fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8", size = 4788795, upload-time = "2025-09-22T04:01:39.165Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e8/fd63e15da5e3fd4c2146f8bbb3c14e94ab850589beab88e547b2dbce22e1/lxml-6.0.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f", size = 5676759, upload-time = "2025-09-22T04:01:41.506Z" },
-    { url = "https://files.pythonhosted.org/packages/76/47/b3ec58dc5c374697f5ba37412cd2728f427d056315d124dd4b61da381877/lxml-6.0.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6", size = 5255666, upload-time = "2025-09-22T04:01:43.363Z" },
-    { url = "https://files.pythonhosted.org/packages/19/93/03ba725df4c3d72afd9596eef4a37a837ce8e4806010569bedfcd2cb68fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322", size = 5277989, upload-time = "2025-09-22T04:01:45.215Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/80/c06de80bfce881d0ad738576f243911fccf992687ae09fd80b734712b39c/lxml-6.0.2-cp312-cp312-win32.whl", hash = "sha256:3ae2ce7d6fedfb3414a2b6c5e20b249c4c607f72cb8d2bb7cc9c6ec7c6f4e849", size = 3611456, upload-time = "2025-09-22T04:01:48.243Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/d7/0cdfb6c3e30893463fb3d1e52bc5f5f99684a03c29a0b6b605cfae879cd5/lxml-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:72c87e5ee4e58a8354fb9c7c84cbf95a1c8236c127a5d1b7683f04bed8361e1f", size = 4011793, upload-time = "2025-09-22T04:01:50.042Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/7b/93c73c67db235931527301ed3785f849c78991e2e34f3fd9a6663ffda4c5/lxml-6.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:61cb10eeb95570153e0c0e554f58df92ecf5109f75eacad4a95baa709e26c3d6", size = 3672836, upload-time = "2025-09-22T04:01:52.145Z" },
-    { url = "https://files.pythonhosted.org/packages/53/fd/4e8f0540608977aea078bf6d79f128e0e2c2bba8af1acf775c30baa70460/lxml-6.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9b33d21594afab46f37ae58dfadd06636f154923c4e8a4d754b0127554eb2e77", size = 8648494, upload-time = "2025-09-22T04:01:54.242Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/f4/2a94a3d3dfd6c6b433501b8d470a1960a20ecce93245cf2db1706adf6c19/lxml-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c8963287d7a4c5c9a432ff487c52e9c5618667179c18a204bdedb27310f022f", size = 4661146, upload-time = "2025-09-22T04:01:56.282Z" },
-    { url = "https://files.pythonhosted.org/packages/25/2e/4efa677fa6b322013035d38016f6ae859d06cac67437ca7dc708a6af7028/lxml-6.0.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1941354d92699fb5ffe6ed7b32f9649e43c2feb4b97205f75866f7d21aa91452", size = 4946932, upload-time = "2025-09-22T04:01:58.989Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/0f/526e78a6d38d109fdbaa5049c62e1d32fdd70c75fb61c4eadf3045d3d124/lxml-6.0.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb2f6ca0ae2d983ded09357b84af659c954722bbf04dea98030064996d156048", size = 5100060, upload-time = "2025-09-22T04:02:00.812Z" },
-    { url = "https://files.pythonhosted.org/packages/81/76/99de58d81fa702cc0ea7edae4f4640416c2062813a00ff24bd70ac1d9c9b/lxml-6.0.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb2a12d704f180a902d7fa778c6d71f36ceb7b0d317f34cdc76a5d05aa1dd1df", size = 5019000, upload-time = "2025-09-22T04:02:02.671Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/35/9e57d25482bc9a9882cb0037fdb9cc18f4b79d85df94fa9d2a89562f1d25/lxml-6.0.2-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:6ec0e3f745021bfed19c456647f0298d60a24c9ff86d9d051f52b509663feeb1", size = 5348496, upload-time = "2025-09-22T04:02:04.904Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/8e/cb99bd0b83ccc3e8f0f528e9aa1f7a9965dfec08c617070c5db8d63a87ce/lxml-6.0.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:846ae9a12d54e368933b9759052d6206a9e8b250291109c48e350c1f1f49d916", size = 5643779, upload-time = "2025-09-22T04:02:06.689Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/34/9e591954939276bb679b73773836c6684c22e56d05980e31d52a9a8deb18/lxml-6.0.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef9266d2aa545d7374938fb5c484531ef5a2ec7f2d573e62f8ce722c735685fd", size = 5244072, upload-time = "2025-09-22T04:02:08.587Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/27/b29ff065f9aaca443ee377aff699714fcbffb371b4fce5ac4ca759e436d5/lxml-6.0.2-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:4077b7c79f31755df33b795dc12119cb557a0106bfdab0d2c2d97bd3cf3dffa6", size = 4718675, upload-time = "2025-09-22T04:02:10.783Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/f756f9c2cd27caa1a6ef8c32ae47aadea697f5c2c6d07b0dae133c244fbe/lxml-6.0.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a7c5d5e5f1081955358533be077166ee97ed2571d6a66bdba6ec2f609a715d1a", size = 5255171, upload-time = "2025-09-22T04:02:12.631Z" },
-    { url = "https://files.pythonhosted.org/packages/61/46/bb85ea42d2cb1bd8395484fd72f38e3389611aa496ac7772da9205bbda0e/lxml-6.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f8d0cbd0674ee89863a523e6994ac25fd5be9c8486acfc3e5ccea679bad2679", size = 5057175, upload-time = "2025-09-22T04:02:14.718Z" },
-    { url = "https://files.pythonhosted.org/packages/95/0c/443fc476dcc8e41577f0af70458c50fe299a97bb6b7505bb1ae09aa7f9ac/lxml-6.0.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:2cbcbf6d6e924c28f04a43f3b6f6e272312a090f269eff68a2982e13e5d57659", size = 4785688, upload-time = "2025-09-22T04:02:16.957Z" },
-    { url = "https://files.pythonhosted.org/packages/48/78/6ef0b359d45bb9697bc5a626e1992fa5d27aa3f8004b137b2314793b50a0/lxml-6.0.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dfb874cfa53340009af6bdd7e54ebc0d21012a60a4e65d927c2e477112e63484", size = 5660655, upload-time = "2025-09-22T04:02:18.815Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/ea/e1d33808f386bc1339d08c0dcada6e4712d4ed8e93fcad5f057070b7988a/lxml-6.0.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb8dae0b6b8b7f9e96c26fdd8121522ce5de9bb5538010870bd538683d30e9a2", size = 5247695, upload-time = "2025-09-22T04:02:20.593Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/47/eba75dfd8183673725255247a603b4ad606f4ae657b60c6c145b381697da/lxml-6.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:358d9adae670b63e95bc59747c72f4dc97c9ec58881d4627fe0120da0f90d314", size = 5269841, upload-time = "2025-09-22T04:02:22.489Z" },
-    { url = "https://files.pythonhosted.org/packages/76/04/5c5e2b8577bc936e219becb2e98cdb1aca14a4921a12995b9d0c523502ae/lxml-6.0.2-cp313-cp313-win32.whl", hash = "sha256:e8cd2415f372e7e5a789d743d133ae474290a90b9023197fd78f32e2dc6873e2", size = 3610700, upload-time = "2025-09-22T04:02:24.465Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/0a/4643ccc6bb8b143e9f9640aa54e38255f9d3b45feb2cbe7ae2ca47e8782e/lxml-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:b30d46379644fbfc3ab81f8f82ae4de55179414651f110a1514f0b1f8f6cb2d7", size = 4010347, upload-time = "2025-09-22T04:02:26.286Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ef/dcf1d29c3f530577f61e5fe2f1bd72929acf779953668a8a47a479ae6f26/lxml-6.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:13dcecc9946dca97b11b7c40d29fba63b55ab4170d3c0cf8c0c164343b9bfdcf", size = 3671248, upload-time = "2025-09-22T04:02:27.918Z" },
-    { url = "https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:b0c732aa23de8f8aec23f4b580d1e52905ef468afb4abeafd3fec77042abb6fe", size = 8659801, upload-time = "2025-09-22T04:02:30.113Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/e8/c128e37589463668794d503afaeb003987373c5f94d667124ffd8078bbd9/lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4468e3b83e10e0317a89a33d28f7aeba1caa4d1a6fd457d115dd4ffe90c5931d", size = 4659403, upload-time = "2025-09-22T04:02:32.119Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ce/74903904339decdf7da7847bb5741fc98a5451b42fc419a86c0c13d26fe2/lxml-6.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:abd44571493973bad4598a3be7e1d807ed45aa2adaf7ab92ab7c62609569b17d", size = 4966974, upload-time = "2025-09-22T04:02:34.155Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/d3/131dec79ce61c5567fecf82515bd9bc36395df42501b50f7f7f3bd065df0/lxml-6.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:370cd78d5855cfbffd57c422851f7d3864e6ae72d0da615fca4dad8c45d375a5", size = 5102953, upload-time = "2025-09-22T04:02:36.054Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ea/a43ba9bb750d4ffdd885f2cd333572f5bb900cd2408b67fdda07e85978a0/lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:901e3b4219fa04ef766885fb40fa516a71662a4c61b80c94d25336b4934b71c0", size = 5055054, upload-time = "2025-09-22T04:02:38.154Z" },
-    { url = "https://files.pythonhosted.org/packages/60/23/6885b451636ae286c34628f70a7ed1fcc759f8d9ad382d132e1c8d3d9bfd/lxml-6.0.2-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:a4bf42d2e4cf52c28cc1812d62426b9503cdb0c87a6de81442626aa7d69707ba", size = 5352421, upload-time = "2025-09-22T04:02:40.413Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5b/fc2ddfc94ddbe3eebb8e9af6e3fd65e2feba4967f6a4e9683875c394c2d8/lxml-6.0.2-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2c7fdaa4d7c3d886a42534adec7cfac73860b89b4e5298752f60aa5984641a0", size = 5673684, upload-time = "2025-09-22T04:02:42.288Z" },
-    { url = "https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98a5e1660dc7de2200b00d53fa00bcd3c35a3608c305d45a7bbcaf29fa16e83d", size = 5252463, upload-time = "2025-09-22T04:02:44.165Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/da/ba6eceb830c762b48e711ded880d7e3e89fc6c7323e587c36540b6b23c6b/lxml-6.0.2-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:dc051506c30b609238d79eda75ee9cab3e520570ec8219844a72a46020901e37", size = 4698437, upload-time = "2025-09-22T04:02:46.524Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/24/7be3f82cb7990b89118d944b619e53c656c97dc89c28cfb143fdb7cd6f4d/lxml-6.0.2-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8799481bbdd212470d17513a54d568f44416db01250f49449647b5ab5b5dccb9", size = 5269890, upload-time = "2025-09-22T04:02:48.812Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/bd/dcfb9ea1e16c665efd7538fc5d5c34071276ce9220e234217682e7d2c4a5/lxml-6.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9261bb77c2dab42f3ecd9103951aeca2c40277701eb7e912c545c1b16e0e4917", size = 5097185, upload-time = "2025-09-22T04:02:50.746Z" },
-    { url = "https://files.pythonhosted.org/packages/21/04/a60b0ff9314736316f28316b694bccbbabe100f8483ad83852d77fc7468e/lxml-6.0.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:65ac4a01aba353cfa6d5725b95d7aed6356ddc0a3cd734de00124d285b04b64f", size = 4745895, upload-time = "2025-09-22T04:02:52.968Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/bd/7d54bd1846e5a310d9c715921c5faa71cf5c0853372adf78aee70c8d7aa2/lxml-6.0.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:b22a07cbb82fea98f8a2fd814f3d1811ff9ed76d0fc6abc84eb21527596e7cc8", size = 5695246, upload-time = "2025-09-22T04:02:54.798Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/32/5643d6ab947bc371da21323acb2a6e603cedbe71cb4c99c8254289ab6f4e/lxml-6.0.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d759cdd7f3e055d6bc8d9bec3ad905227b2e4c785dc16c372eb5b5e83123f48a", size = 5260797, upload-time = "2025-09-22T04:02:57.058Z" },
-    { url = "https://files.pythonhosted.org/packages/33/da/34c1ec4cff1eea7d0b4cd44af8411806ed943141804ac9c5d565302afb78/lxml-6.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:945da35a48d193d27c188037a05fec5492937f66fb1958c24fc761fb9d40d43c", size = 5277404, upload-time = "2025-09-22T04:02:58.966Z" },
-    { url = "https://files.pythonhosted.org/packages/82/57/4eca3e31e54dc89e2c3507e1cd411074a17565fa5ffc437c4ae0a00d439e/lxml-6.0.2-cp314-cp314-win32.whl", hash = "sha256:be3aaa60da67e6153eb15715cc2e19091af5dc75faef8b8a585aea372507384b", size = 3670072, upload-time = "2025-09-22T04:03:38.05Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/e0/c96cf13eccd20c9421ba910304dae0f619724dcf1702864fd59dd386404d/lxml-6.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:fa25afbadead523f7001caf0c2382afd272c315a033a7b06336da2637d92d6ed", size = 4080617, upload-time = "2025-09-22T04:03:39.835Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5d/b3f03e22b3d38d6f188ef044900a9b29b2fe0aebb94625ce9fe244011d34/lxml-6.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8", size = 3754930, upload-time = "2025-09-22T04:03:41.565Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/5c/42c2c4c03554580708fc738d13414801f340c04c3eff90d8d2d227145275/lxml-6.0.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6162a86d86893d63084faaf4ff937b3daea233e3682fb4474db07395794fa80d", size = 8910380, upload-time = "2025-09-22T04:03:01.645Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/4f/12df843e3e10d18d468a7557058f8d3733e8b6e12401f30b1ef29360740f/lxml-6.0.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:414aaa94e974e23a3e92e7ca5b97d10c0cf37b6481f50911032c69eeb3991bba", size = 4775632, upload-time = "2025-09-22T04:03:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/0c/9dc31e6c2d0d418483cbcb469d1f5a582a1cd00a1f4081953d44051f3c50/lxml-6.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48461bd21625458dd01e14e2c38dd0aea69addc3c4f960c30d9f59d7f93be601", size = 4975171, upload-time = "2025-09-22T04:03:05.651Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/2b/9b870c6ca24c841bdd887504808f0417aa9d8d564114689266f19ddf29c8/lxml-6.0.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25fcc59afc57d527cfc78a58f40ab4c9b8fd096a9a3f964d2781ffb6eb33f4ed", size = 5110109, upload-time = "2025-09-22T04:03:07.452Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/0c/4f5f2a4dd319a178912751564471355d9019e220c20d7db3fb8307ed8582/lxml-6.0.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5179c60288204e6ddde3f774a93350177e08876eaf3ab78aa3a3649d43eb7d37", size = 5041061, upload-time = "2025-09-22T04:03:09.297Z" },
-    { url = "https://files.pythonhosted.org/packages/12/64/554eed290365267671fe001a20d72d14f468ae4e6acef1e179b039436967/lxml-6.0.2-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:967aab75434de148ec80597b75062d8123cadf2943fb4281f385141e18b21338", size = 5306233, upload-time = "2025-09-22T04:03:11.651Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/31/1d748aa275e71802ad9722df32a7a35034246b42c0ecdd8235412c3396ef/lxml-6.0.2-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d100fcc8930d697c6561156c6810ab4a508fb264c8b6779e6e61e2ed5e7558f9", size = 5604739, upload-time = "2025-09-22T04:03:13.592Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/41/2c11916bcac09ed561adccacceaedd2bf0e0b25b297ea92aab99fd03d0fa/lxml-6.0.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ca59e7e13e5981175b8b3e4ab84d7da57993eeff53c07764dcebda0d0e64ecd", size = 5225119, upload-time = "2025-09-22T04:03:15.408Z" },
-    { url = "https://files.pythonhosted.org/packages/99/05/4e5c2873d8f17aa018e6afde417c80cc5d0c33be4854cce3ef5670c49367/lxml-6.0.2-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:957448ac63a42e2e49531b9d6c0fa449a1970dbc32467aaad46f11545be9af1d", size = 4633665, upload-time = "2025-09-22T04:03:17.262Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/c9/dcc2da1bebd6275cdc723b515f93edf548b82f36a5458cca3578bc899332/lxml-6.0.2-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b7fc49c37f1786284b12af63152fe1d0990722497e2d5817acfe7a877522f9a9", size = 5234997, upload-time = "2025-09-22T04:03:19.14Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/e2/5172e4e7468afca64a37b81dba152fc5d90e30f9c83c7c3213d6a02a5ce4/lxml-6.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e19e0643cc936a22e837f79d01a550678da8377d7d801a14487c10c34ee49c7e", size = 5090957, upload-time = "2025-09-22T04:03:21.436Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/b3/15461fd3e5cd4ddcb7938b87fc20b14ab113b92312fc97afe65cd7c85de1/lxml-6.0.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1db01e5cf14345628e0cbe71067204db658e2fb8e51e7f33631f5f4735fefd8d", size = 4764372, upload-time = "2025-09-22T04:03:23.27Z" },
-    { url = "https://files.pythonhosted.org/packages/05/33/f310b987c8bf9e61c4dd8e8035c416bd3230098f5e3cfa69fc4232de7059/lxml-6.0.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:875c6b5ab39ad5291588aed6925fac99d0097af0dd62f33c7b43736043d4a2ec", size = 5634653, upload-time = "2025-09-22T04:03:25.767Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ff/51c80e75e0bc9382158133bdcf4e339b5886c6ee2418b5199b3f1a61ed6d/lxml-6.0.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cdcbed9ad19da81c480dfd6dd161886db6096083c9938ead313d94b30aadf272", size = 5233795, upload-time = "2025-09-22T04:03:27.62Z" },
-    { url = "https://files.pythonhosted.org/packages/56/4d/4856e897df0d588789dd844dbed9d91782c4ef0b327f96ce53c807e13128/lxml-6.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:80dadc234ebc532e09be1975ff538d154a7fa61ea5031c03d25178855544728f", size = 5257023, upload-time = "2025-09-22T04:03:30.056Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/85/86766dfebfa87bea0ab78e9ff7a4b4b45225df4b4d3b8cc3c03c5cd68464/lxml-6.0.2-cp314-cp314t-win32.whl", hash = "sha256:da08e7bb297b04e893d91087df19638dc7a6bb858a954b0cc2b9f5053c922312", size = 3911420, upload-time = "2025-09-22T04:03:32.198Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1a/b248b355834c8e32614650b8008c69ffeb0ceb149c793961dd8c0b991bb3/lxml-6.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:252a22982dca42f6155125ac76d3432e548a7625d56f5a273ee78a5057216eca", size = 4406837, upload-time = "2025-09-22T04:03:34.027Z" },
-    { url = "https://files.pythonhosted.org/packages/92/aa/df863bcc39c5e0946263454aba394de8a9084dbaff8ad143846b0d844739/lxml-6.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:bb4c1847b303835d89d785a18801a883436cdfd5dc3d62947f9c49e24f0f5a2c", size = 3822205, upload-time = "2025-09-22T04:03:36.249Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/9c/780c9a8fce3f04690b374f72f41306866b0400b9d0fdf3e17aaa37887eed/lxml-6.0.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:e748d4cf8fef2526bb2a589a417eba0c8674e29ffcb570ce2ceca44f1e567bf6", size = 3939264, upload-time = "2025-09-22T04:04:32.892Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/5a/1ab260c00adf645d8bf7dec7f920f744b032f69130c681302821d5debea6/lxml-6.0.2-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4ddb1049fa0579d0cbd00503ad8c58b9ab34d1254c77bc6a5576d96ec7853dba", size = 4216435, upload-time = "2025-09-22T04:04:34.907Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/37/565f3b3d7ffede22874b6d86be1a1763d00f4ea9fc5b9b6ccb11e4ec8612/lxml-6.0.2-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb233f9c95f83707dae461b12b720c1af9c28c2d19208e1be03387222151daf5", size = 4325913, upload-time = "2025-09-22T04:04:37.205Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ec/f3a1b169b2fb9d03467e2e3c0c752ea30e993be440a068b125fc7dd248b0/lxml-6.0.2-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc456d04db0515ce3320d714a1eac7a97774ff0849e7718b492d957da4631dd4", size = 4269357, upload-time = "2025-09-22T04:04:39.322Z" },
-    { url = "https://files.pythonhosted.org/packages/77/a2/585a28fe3e67daa1cf2f06f34490d556d121c25d500b10082a7db96e3bcd/lxml-6.0.2-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2613e67de13d619fd283d58bda40bff0ee07739f624ffee8b13b631abf33083d", size = 4412295, upload-time = "2025-09-22T04:04:41.647Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d9/a57dd8bcebd7c69386c20263830d4fa72d27e6b72a229ef7a48e88952d9a/lxml-6.0.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:24a8e756c982c001ca8d59e87c80c4d9dcd4d9b44a4cbeb8d9be4482c514d41d", size = 3516913, upload-time = "2025-09-22T04:04:43.602Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/11/29d08bc103a62c0eba8016e7ed5aeebbf1e4312e83b0b1648dd203b0e87d/lxml-6.0.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1c06035eafa8404b5cf475bb37a9f6088b0aca288d4ccc9d69389750d5543700", size = 3949829, upload-time = "2025-09-22T04:04:45.608Z" },
-    { url = "https://files.pythonhosted.org/packages/12/b3/52ab9a3b31e5ab8238da241baa19eec44d2ab426532441ee607165aebb52/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c7d13103045de1bdd6fe5d61802565f1a3537d70cd3abf596aa0af62761921ee", size = 4226277, upload-time = "2025-09-22T04:04:47.754Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/33/1eaf780c1baad88224611df13b1c2a9dfa460b526cacfe769103ff50d845/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a3c150a95fbe5ac91de323aa756219ef9cf7fde5a3f00e2281e30f33fa5fa4f", size = 4330433, upload-time = "2025-09-22T04:04:49.907Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/c1/27428a2ff348e994ab4f8777d3a0ad510b6b92d37718e5887d2da99952a2/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60fa43be34f78bebb27812ed90f1925ec99560b0fa1decdb7d12b84d857d31e9", size = 4272119, upload-time = "2025-09-22T04:04:51.801Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d0/3020fa12bcec4ab62f97aab026d57c2f0cfd480a558758d9ca233bb6a79d/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21c73b476d3cfe836be731225ec3421fa2f048d84f6df6a8e70433dff1376d5a", size = 4417314, upload-time = "2025-09-22T04:04:55.024Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/77/d7f491cbc05303ac6801651aabeb262d43f319288c1ea96c66b1d2692ff3/lxml-6.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:27220da5be049e936c3aca06f174e8827ca6445a4353a1995584311487fc4e3e", size = 3518768, upload-time = "2025-09-22T04:04:57.097Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6e/ee8fc0e01202eb3dd2b9e1ea4f0910d72425d35c66187c63931d7a3ea73f/lxml-6.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:41dcc4c7b10484257cbd6c37b83ddb26df2b0e5aff5ac00d095689015af868ec", size = 8540733, upload-time = "2026-04-18T04:27:33.185Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e8/325fe9b942824c773dffe1baf0c35b046a763851fdff4393af4450bceeb7/lxml-6.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a31286dbb5e74c8e9a5344465b77ab4c5bd511a253b355b5ca2fae7e579fafec", size = 4602805, upload-time = "2026-04-18T04:27:36.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/81/221aa3ea4a40370bb0358fa454cbe7e5a837e522f7630c24dfef3f9a73b0/lxml-6.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1bc4cc83fb7f66ffb16f74d6dd0162e144333fc36ebcce32246f80c8735b2551", size = 5002652, upload-time = "2026-04-18T04:27:30.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e1/fdbfb9019542f1875c093576df7f37adc2983c8ba7ecf17e5f14490bc107/lxml-6.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:20cf4d0651987c906a2f5cba4e3a8d6ba4bfdf973cfe2a96c0d6053888ea2ecd", size = 5155332, upload-time = "2026-04-18T04:27:33.507Z" },
+    { url = "https://files.pythonhosted.org/packages/56/b1/4087c782fff397cd03abf9c551069be59bb04a7e548c50fb7b9c4cdaca28/lxml-6.1.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffb34ea45a82dd637c2c97ae1bbb920850c1e59bcae79ce1c15af531d83e7215", size = 5057226, upload-time = "2026-04-18T04:27:37.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/66/516c79dec8417f3a972327330254c0b5fac93d5c3ecfd8a5b43650a5a4d9/lxml-6.1.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1d9b99e5b2597e4f5aed2484fef835256fa1b68a19e4265c97628ef4bf8bcf4", size = 5287588, upload-time = "2026-04-18T04:27:41.4Z" },
+    { url = "https://files.pythonhosted.org/packages/94/1d/e578f4cbeb42b9df9f29b0d44a45a7cdfa3a5ae300dd59ec68e3602d29bb/lxml-6.1.0-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:d43aa26dcda363f21e79afa0668f5029ed7394b3bb8c92a6927a3d34e8b610ea", size = 5412438, upload-time = "2026-04-18T04:27:45.589Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/2aa68307d6d15959e84d4882f9c04f2da63127eac463e1594166f681ef77/lxml-6.1.0-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:6262b87f9e5c1e5fe501d6c153247289af42eb44ad7660b9b3de17baaf92d6f6", size = 4770997, upload-time = "2026-04-18T04:27:49.853Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c9/3e51fc1228310a836b4eb32595ae00154ab12197fca944676a3ab3b163ea/lxml-6.1.0-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d1392c569c032f78a11a25d1de1c43fff13294c793b39e19d84fade3045cbbc3", size = 5359678, upload-time = "2026-04-18T04:31:56.184Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/91/ab8bc834f977fbbd310e697b120787c153db026f9151e02a88d2645d4e5b/lxml-6.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:045e387d1f4f42a418380930fa3f45c73c9b392faf67e495e58902e68e8f44a7", size = 5107890, upload-time = "2026-04-18T04:32:00.387Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/10/8a143cfa3ac99cb5b0523ff6d0429a9c9dddf25ffeae09caa3866c7964d9/lxml-6.1.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:9f93d5b8b07f73e8c77e3c6556a3db269918390c804b5e5fcdd4858232cc8f16", size = 4803977, upload-time = "2026-04-18T04:32:05.099Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fd/ee02faf52fa39c2fe32f824628958b9aa86dff21343dc3161f0e3c6ccd15/lxml-6.1.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:de550d129f18d8ab819651ffe4f38b1b713c7e116707de3c0c6400d0ef34fbc1", size = 5350277, upload-time = "2026-04-18T04:32:09.176Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8c/b3481364b8554b5d36d540189a87fc71e94b0b01c24f8f152bd662dd2e45/lxml-6.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c08da09dc003c9e8c70e06b53a11db6fb3b250c21c4236b03c7d7b443c318e7a", size = 5309717, upload-time = "2026-04-18T04:32:13.303Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e8/a6b21927077a9127afa17473b6576b322616f34ac50ee4f577e763b75ec0/lxml-6.1.0-cp310-cp310-win32.whl", hash = "sha256:37448bf9c7d7adfc5254763901e2bbd6bb876228dfc1fc7f66e58c06368a7544", size = 3598491, upload-time = "2026-04-18T04:27:24.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/82/14dea800d041274d96c07d49ff9191f011d1427450850de19bf541e2cc12/lxml-6.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:2593a0a6621545b9095b71ad74ed4226eba438a7d9fc3712a99bdb15508cf93a", size = 4020906, upload-time = "2026-04-18T04:27:27.53Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/d3539aaf4d9d21456b9a7b902816623227d05d63e7c5aafd8834c4b9bed6/lxml-6.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:e80807d72f96b96ad5588cb85c75616e4f2795a7737d4630784c51497beb7776", size = 3667787, upload-time = "2026-04-18T04:27:29.407Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/5d/3bccad330292946f97962df9d5f2d3ae129cce6e212732a781e856b91e07/lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9", size = 8526232, upload-time = "2026-04-18T04:27:40.389Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/51/adc8826570a112f83bb4ddb3a2ab510bbc2ccd62c1b9fe1f34fae2d90b57/lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50", size = 4595448, upload-time = "2026-04-18T04:27:44.208Z" },
+    { url = "https://files.pythonhosted.org/packages/54/84/5a9ec07cbe1d2334a6465f863b949a520d2699a755738986dcd3b6b89e3f/lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5", size = 4923771, upload-time = "2026-04-18T04:32:17.402Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/23/851cfa33b6b38adb628e45ad51fb27105fa34b2b3ba9d1d4aa7a9428dfe0/lxml-6.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d036ee7b99d5148072ac7c9b847193decdfeac633db350363f7bce4fff108f0e", size = 5068101, upload-time = "2026-04-18T04:32:21.437Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/38/41bf99c2023c6b79916ba057d83e9db21d642f473cac210201222882d38b/lxml-6.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ae5d8d5427f3cc317e7950f2da7ad276df0cfa37b8de2f5658959e618ea8512", size = 5002573, upload-time = "2026-04-18T04:32:25.373Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/053aa10bdc39747e1e923ce2d45413075e84f70a136045bb09e5eaca41d3/lxml-6.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:363e47283bde87051b821826e71dde47f107e08614e1aa312ba0c5711e77738c", size = 5202816, upload-time = "2026-04-18T04:32:29.393Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/da/bc710fad8bf04b93baee752c192eaa2210cd3a84f969d0be7830fea55802/lxml-6.1.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f504d861d9f2a8f94020130adac88d66de93841707a23a86244263d1e54682f5", size = 5329999, upload-time = "2026-04-18T04:32:34.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/bf035dedbdf7fab49411aa52e4236f3445e98d38647d85419e6c0d2806b9/lxml-6.1.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:23a5dc68e08ed13331d61815c08f260f46b4a60fdd1640bbeb82cf89a9d90289", size = 4659643, upload-time = "2026-04-18T04:32:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/22be31f33727a5e4c7b01b0a874503026e50329b259d3587e0b923cf964b/lxml-6.1.0-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f15401d8d3dbf239e23c818afc10c7207f7b95f9a307e092122b6f86dd43209a", size = 5265963, upload-time = "2026-04-18T04:32:41.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2b/d44d0e5c79226017f4ab8c87a802ebe4f89f97e6585a8e4166dffcdd7b6e/lxml-6.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fcf3da95e93349e0647d48d4b36a12783105bcc74cb0c416952f9988410846a3", size = 5045444, upload-time = "2026-04-18T04:32:44.512Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c3/3f034fec1594c331a6dbf9491238fdcc9d66f68cc529e109ec75b97197e1/lxml-6.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0d082495c5fcf426e425a6e28daaba1fcb6d8f854a4ff01effb1f1f381203eb9", size = 4712703, upload-time = "2026-04-18T04:32:47.16Z" },
+    { url = "https://files.pythonhosted.org/packages/12/16/0b83fccc158218aca75a7aa33e97441df737950734246b9fffa39301603d/lxml-6.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e3c4f84b24a1fcba435157d111c4b755099c6ff00a3daee1ad281817de75ed11", size = 5252745, upload-time = "2026-04-18T04:32:50.427Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ee/12e6c1b39a77666c02eaa77f94a870aaf63c4ac3a497b2d52319448b01c6/lxml-6.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:976a6b39b1b13e8c354ad8d3f261f3a4ac6609518af91bdb5094760a08f132c4", size = 5226822, upload-time = "2026-04-18T04:32:53.437Z" },
+    { url = "https://files.pythonhosted.org/packages/34/20/c7852904858b4723af01d2fc14b5d38ff57cb92f01934a127ebd9a9e51aa/lxml-6.1.0-cp311-cp311-win32.whl", hash = "sha256:857efde87d365706590847b916baff69c0bc9252dc5af030e378c9800c0b10e3", size = 3594026, upload-time = "2026-04-18T04:27:31.903Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/d60c732b56da5085175c07c74b2df4e6d181b0c9a61e1691474f06ef4b39/lxml-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:183bfb45a493081943be7ea2b5adfc2b611e1cf377cefa8b8a8be404f45ef9a7", size = 4025114, upload-time = "2026-04-18T04:27:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/df/c84dcc175fd690823436d15b41cb920cd5ba5e14cd8bfb00949d5903b320/lxml-6.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:19f4164243fc206d12ed3d866e80e74f5bc3627966520da1a5f97e42c32a3f39", size = 3667742, upload-time = "2026-04-18T04:27:38.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713, upload-time = "2026-04-18T04:32:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874, upload-time = "2026-04-18T04:32:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535, upload-time = "2026-04-18T04:34:06.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881, upload-time = "2026-04-18T04:34:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305, upload-time = "2026-04-18T04:34:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522, upload-time = "2026-04-18T04:34:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310, upload-time = "2026-04-18T04:34:17.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799, upload-time = "2026-04-18T04:34:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693, upload-time = "2026-04-18T04:34:23.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708, upload-time = "2026-04-18T04:34:26.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737, upload-time = "2026-04-18T04:34:28.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817, upload-time = "2026-04-18T04:34:30.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753, upload-time = "2026-04-18T04:34:33.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071, upload-time = "2026-04-18T04:34:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319, upload-time = "2026-04-18T04:34:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139, upload-time = "2026-04-18T04:32:20.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195, upload-time = "2026-04-18T04:32:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870, upload-time = "2026-04-18T04:32:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548, upload-time = "2026-04-18T04:32:15.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866, upload-time = "2026-04-18T04:32:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476, upload-time = "2026-04-18T04:34:41.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719, upload-time = "2026-04-18T04:34:44.797Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890, upload-time = "2026-04-18T04:34:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008, upload-time = "2026-04-18T04:34:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451, upload-time = "2026-04-18T04:34:54.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135, upload-time = "2026-04-18T04:34:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126, upload-time = "2026-04-18T04:34:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579, upload-time = "2026-04-18T04:35:02.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206, upload-time = "2026-04-18T04:35:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906, upload-time = "2026-04-18T04:35:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553, upload-time = "2026-04-18T04:35:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458, upload-time = "2026-04-18T04:35:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861, upload-time = "2026-04-18T04:35:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377, upload-time = "2026-04-18T04:32:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701, upload-time = "2026-04-18T04:32:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120, upload-time = "2026-04-18T04:32:15.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/88/55143966481409b1740a3ac669e611055f49efd68087a5ce41582325db3e/lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842", size = 3930134, upload-time = "2026-04-18T04:32:35.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/97/28b985c2983938d3cb696dd5501423afb90a8c3e869ef5d3c62569282c0f/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c", size = 4210749, upload-time = "2026-04-18T04:36:03.626Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/dfab2b7d58214921935ccea7ce9b3df9b7d46f305d12f0f532ac7cf6b804/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de", size = 4318463, upload-time = "2026-04-18T04:36:06.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a2/4ac7eb32a4d997dd352c32c32399aae27b3f268d440e6f9cfa405b575d2f/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07f98f5496f96bf724b1e3c933c107f0cbf2745db18c03d2e13a291c3afd2635", size = 4251124, upload-time = "2026-04-18T04:36:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/d6abd850bb4822f9b720cfe36b547a558e694881010ff7d012191e8769c6/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4642e04449a1e164b5ff71ffd901ddb772dfabf5c9adf1b7be5dffe1212bc037", size = 4401758, upload-time = "2026-04-18T04:36:11.803Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/3ee09a5b60cb44c4f2fbc1c9015cfd6ff5afc08f991cab295d3024dcbf2d/lxml-6.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:7da13bb6fbadfafb474e0226a30570a3445cfd47c86296f2446dafbd77079ace", size = 3508860, upload-time = "2026-04-18T04:32:48.619Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1234,41 +1341,64 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.10.0"
+name = "msgpack"
+version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b6/297734bb9f20ddf5e831cf4a83f422ddef5a29a33463999f0959d9cdc2df/mypy-1.10.0.tar.gz", hash = "sha256:3d087fcbec056c4ee34974da493a826ce316947485cef3901f511848e687c131", size = 3022145, upload-time = "2024-04-24T13:53:30.447Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/82/2081dbfbbf1071e1370e57f9e327adeda060113688ec0d6bf7bbf4d7a5ad/mypy-1.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:da1cbf08fb3b851ab3b9523a884c232774008267b1f83371ace57f412fe308c2", size = 10819193, upload-time = "2024-04-24T13:52:35.058Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/1b/b7c9caa89955a7d9c89eac79f31550f48f2c8233b5e12fe48ef55cd2e953/mypy-1.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:12b6bfc1b1a66095ab413160a6e520e1dc076a28f3e22f7fb25ba3b000b4ef99", size = 9970689, upload-time = "2024-04-24T13:53:22.727Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ae/03d3f767f1ca5576970720ea551b43b79254d12998484d8f3e63fc07561e/mypy-1.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e36fb078cce9904c7989b9693e41cb9711e0600139ce3970c6ef814b6ebc2b2", size = 12728098, upload-time = "2024-04-24T13:52:40.975Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ba/8f5db8bd94c18d86033d09bbe634d471c1e9d7014cc621585973183ad1d0/mypy-1.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2b0695d605ddcd3eb2f736cd8b4e388288c21e7de85001e9f85df9187f2b50f9", size = 12798838, upload-time = "2024-04-24T13:53:04.208Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/ad/d476f1055deea6e63a91e065ba046a7ee494705574c4f9730de439172810/mypy-1.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:cd777b780312ddb135bceb9bc8722a73ec95e042f911cc279e2ec3c667076051", size = 9365995, upload-time = "2024-04-24T13:53:07.25Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ec/64ffed9ea554845ff846bd1f6fc7b07ab507be1d2e1b0d58790d7ac2ca4c/mypy-1.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3be66771aa5c97602f382230165b856c231d1277c511c9a8dd058be4784472e1", size = 10739848, upload-time = "2024-04-24T13:52:58.596Z" },
-    { url = "https://files.pythonhosted.org/packages/03/ac/f4fcb9d7a349953be5f4e78157a48b5110343a0e5228f77b3f7d1a1b8479/mypy-1.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8b2cbaca148d0754a54d44121b5825ae71868c7592a53b7292eeb0f3fdae95ee", size = 9902362, upload-time = "2024-04-24T13:52:38.397Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/36/ca2b82d89828f484f1a068d9e25c08840c4cc6f6549e7ea755f4391e351f/mypy-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ec404a7cbe9fc0e92cb0e67f55ce0c025014e26d33e54d9e506a0f2d07fe5de", size = 12603712, upload-time = "2024-04-24T13:52:43.838Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/7a/54edb45a41de3bc66e5c3d2b7512a392b3f0f8b9c3d9465b9a2456b6a115/mypy-1.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e22e1527dc3d4aa94311d246b59e47f6455b8729f4968765ac1eacf9a4760bc7", size = 12676904, upload-time = "2024-04-24T13:53:16.518Z" },
-    { url = "https://files.pythonhosted.org/packages/39/a5/e5aad5567ace09fcb179fbc3047cc2a6173743d84447b1ff71413e1a9881/mypy-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:a87dbfa85971e8d59c9cc1fcf534efe664d8949e4c0b6b44e8ca548e746a8d53", size = 9355997, upload-time = "2024-04-24T13:53:25.379Z" },
-    { url = "https://files.pythonhosted.org/packages/30/30/6da95275426cfd21fc0c2e96d85a45d35fc4f7d37bd3286fa49f8f465447/mypy-1.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:a781f6ad4bab20eef8b65174a57e5203f4be627b46291f4589879bf4e257b97b", size = 10867123, upload-time = "2024-04-24T13:53:13.417Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/d3/61cf1fae3b79d264f9f27de97e6e8fab8a37c85fdada5a46b6de333319f8/mypy-1.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b808e12113505b97d9023b0b5e0c0705a90571c6feefc6f215c1df9381256e30", size = 9859921, upload-time = "2024-04-24T13:53:27.85Z" },
-    { url = "https://files.pythonhosted.org/packages/08/5d/a46e5222bd69a873a896ab4f0b5948979e03dce46c7712ccaa5204ca8d02/mypy-1.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f55583b12156c399dce2df7d16f8a5095291354f1e839c252ec6c0611e86e2e", size = 12647776, upload-time = "2024-04-24T13:52:49.635Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/6a/d8df60f2e48291f1a790ded56fd96421ac6a992f33c2571c0bdf0552d83a/mypy-1.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4cf18f9d0efa1b16478c4c129eabec36148032575391095f73cae2e722fcf9d5", size = 12726191, upload-time = "2024-04-24T13:53:19.413Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/93/9a015720bcf484d4202ea7fc5960c328c82d5eb1578950d586339ec15084/mypy-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:bc6ac273b23c6b82da3bb25f4136c4fd42665f17f2cd850771cb600bdd2ebeda", size = 9450377, upload-time = "2024-04-24T13:52:52.233Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/39/0148f7ee1b7f3a86d378a23b88cb85c432f83914ceb60364efa1769c598f/mypy-1.10.0-py3-none-any.whl", hash = "sha256:f8c083976eb530019175aabadb60921e73b4f45736760826aa1689dda8208aee", size = 2580084, upload-time = "2024-04-24T13:52:13.843Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a2/3b68a9e769db68668b25c6108444a35f9bd163bb848c0650d516761a59c0/msgpack-1.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0051fffef5a37ca2cd16978ae4f0aef92f164df86823871b5162812bebecd8e2", size = 81318, upload-time = "2025-10-08T09:14:38.722Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e1/2b720cc341325c00be44e1ed59e7cfeae2678329fbf5aa68f5bda57fe728/msgpack-1.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a605409040f2da88676e9c9e5853b3449ba8011973616189ea5ee55ddbc5bc87", size = 83786, upload-time = "2025-10-08T09:14:40.082Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e5/c2241de64bfceac456b140737812a2ab310b10538a7b34a1d393b748e095/msgpack-1.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b696e83c9f1532b4af884045ba7f3aa741a63b2bc22617293a2c6a7c645f251", size = 398240, upload-time = "2025-10-08T09:14:41.151Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/09/2a06956383c0fdebaef5aa9246e2356776f12ea6f2a44bd1368abf0e46c4/msgpack-1.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:365c0bbe981a27d8932da71af63ef86acc59ed5c01ad929e09a0b88c6294e28a", size = 406070, upload-time = "2025-10-08T09:14:42.821Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/74/2957703f0e1ef20637d6aead4fbb314330c26f39aa046b348c7edcf6ca6b/msgpack-1.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:41d1a5d875680166d3ac5c38573896453bbbea7092936d2e107214daf43b1d4f", size = 393403, upload-time = "2025-10-08T09:14:44.38Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/09/3bfc12aa90f77b37322fc33e7a8a7c29ba7c8edeadfa27664451801b9860/msgpack-1.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:354e81bcdebaab427c3df4281187edc765d5d76bfb3a7c125af9da7a27e8458f", size = 398947, upload-time = "2025-10-08T09:14:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4f/05fcebd3b4977cb3d840f7ef6b77c51f8582086de5e642f3fefee35c86fc/msgpack-1.1.2-cp310-cp310-win32.whl", hash = "sha256:e64c8d2f5e5d5fda7b842f55dec6133260ea8f53c4257d64494c534f306bf7a9", size = 64769, upload-time = "2025-10-08T09:14:47.334Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/3e/b4547e3a34210956382eed1c85935fff7e0f9b98be3106b3745d7dec9c5e/msgpack-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:db6192777d943bdaaafb6ba66d44bf65aa0e9c5616fa1d2da9bb08828c6b39aa", size = 71293, upload-time = "2025-10-08T09:14:48.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/97/560d11202bcd537abca693fd85d81cebe2107ba17301de42b01ac1677b69/msgpack-1.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2e86a607e558d22985d856948c12a3fa7b42efad264dca8a3ebbcfa2735d786c", size = 82271, upload-time = "2025-10-08T09:14:49.967Z" },
+    { url = "https://files.pythonhosted.org/packages/83/04/28a41024ccbd67467380b6fb440ae916c1e4f25e2cd4c63abe6835ac566e/msgpack-1.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:283ae72fc89da59aa004ba147e8fc2f766647b1251500182fac0350d8af299c0", size = 84914, upload-time = "2025-10-08T09:14:50.958Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/b817349db6886d79e57a966346cf0902a426375aadc1e8e7a86a75e22f19/msgpack-1.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61c8aa3bd513d87c72ed0b37b53dd5c5a0f58f2ff9f26e1555d3bd7948fb7296", size = 416962, upload-time = "2025-10-08T09:14:51.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e0/6cc2e852837cd6086fe7d8406af4294e66827a60a4cf60b86575a4a65ca8/msgpack-1.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:454e29e186285d2ebe65be34629fa0e8605202c60fbc7c4c650ccd41870896ef", size = 426183, upload-time = "2025-10-08T09:14:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/25/98/6a19f030b3d2ea906696cedd1eb251708e50a5891d0978b012cb6107234c/msgpack-1.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7bc8813f88417599564fafa59fd6f95be417179f76b40325b500b3c98409757c", size = 411454, upload-time = "2025-10-08T09:14:54.648Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/cd/9098fcb6adb32187a70b7ecaabf6339da50553351558f37600e53a4a2a23/msgpack-1.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bafca952dc13907bdfdedfc6a5f579bf4f292bdd506fadb38389afa3ac5b208e", size = 422341, upload-time = "2025-10-08T09:14:56.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ae/270cecbcf36c1dc85ec086b33a51a4d7d08fc4f404bdbc15b582255d05ff/msgpack-1.1.2-cp311-cp311-win32.whl", hash = "sha256:602b6740e95ffc55bfb078172d279de3773d7b7db1f703b2f1323566b878b90e", size = 64747, upload-time = "2025-10-08T09:14:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/79/309d0e637f6f37e83c711f547308b91af02b72d2326ddd860b966080ef29/msgpack-1.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:d198d275222dc54244bf3327eb8cbe00307d220241d9cec4d306d49a44e85f68", size = 71633, upload-time = "2025-10-08T09:14:59.177Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4d/7c4e2b3d9b1106cd0aa6cb56cc57c6267f59fa8bfab7d91df5adc802c847/msgpack-1.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:86f8136dfa5c116365a8a651a7d7484b65b13339731dd6faebb9a0242151c406", size = 64755, upload-time = "2025-10-08T09:15:00.48Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
+    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
+    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
+    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
+    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
+    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
 ]
 
 [[package]]
@@ -1649,6 +1779,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packageurl-python"
+version = "0.17.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/d6/3b5a4e3cfaef7a53869a26ceb034d1ff5e5c27c814ce77260a96d50ab7bb/packageurl_python-0.17.6.tar.gz", hash = "sha256:1252ce3a102372ca6f86eb968e16f9014c4ba511c5c37d95a7f023e2ca6e5c25", size = 50618, upload-time = "2025-11-24T15:20:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl", hash = "sha256:31a85c2717bc41dd818f3c62908685ff9eebcb68588213745b14a6ee9e7df7c9", size = 36776, upload-time = "2025-11-24T15:20:16.962Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1720,6 +1859,61 @@ wheels = [
 ]
 
 [[package]]
+name = "pip"
+version = "26.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+]
+
+[[package]]
+name = "pip-api"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pip" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl", hash = "sha256:8b2d7d7c37f2447373aa2cf8b1f60a2f2b27a84e1e9e0294a3f6ef10eb3ba6bb", size = 120369, upload-time = "2024-07-09T20:32:29.099Z" },
+]
+
+[[package]]
+name = "pip-audit"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/89/0e999b413facab81c33d118f3ac3739fd02c0622ccf7c4e82e37cebd8447/pip_audit-2.10.0.tar.gz", hash = "sha256:427ea5bf61d1d06b98b1ae29b7feacc00288a2eced52c9c58ceed5253ef6c2a4", size = 53776, upload-time = "2025-12-01T23:42:40.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/f3/4888f895c02afa085630a3a3329d1b18b998874642ad4c530e9a4d7851fe/pip_audit-2.10.0-py3-none-any.whl", hash = "sha256:16e02093872fac97580303f0848fa3ad64f7ecf600736ea7835a2b24de49613f", size = 61518, upload-time = "2025-12-01T23:42:39.193Z" },
+]
+
+[[package]]
+name = "pip-requirements-parser"
+version = "32.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl", hash = "sha256:4659bc2a667783e7a15d190f6fccf8b2486685b6dba4c19c3876314769c57526", size = 35648, upload-time = "2022-12-21T15:25:21.046Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1764,17 +1958,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "6.33.0"
+version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/ff/64a6c8f420818bb873713988ca5492cba3a7946be57e027ac63495157d97/protobuf-6.33.0.tar.gz", hash = "sha256:140303d5c8d2037730c548f8c7b93b20bb1dc301be280c378b82b8894589c954", size = 443463, upload-time = "2025-10-15T20:39:52.159Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/ee/52b3fa8feb6db4a833dfea4943e175ce645144532e8a90f72571ad85df4e/protobuf-6.33.0-cp310-abi3-win32.whl", hash = "sha256:d6101ded078042a8f17959eccd9236fb7a9ca20d3b0098bbcb91533a5680d035", size = 425593, upload-time = "2025-10-15T20:39:40.29Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/c6/7a465f1825872c55e0341ff4a80198743f73b69ce5d43ab18043699d1d81/protobuf-6.33.0-cp310-abi3-win_amd64.whl", hash = "sha256:9a031d10f703f03768f2743a1c403af050b6ae1f3480e9c140f39c45f81b13ee", size = 436882, upload-time = "2025-10-15T20:39:42.841Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/a9/b6eee662a6951b9c3640e8e452ab3e09f117d99fc10baa32d1581a0d4099/protobuf-6.33.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:905b07a65f1a4b72412314082c7dbfae91a9e8b68a0cc1577515f8df58ecf455", size = 427521, upload-time = "2025-10-15T20:39:43.803Z" },
-    { url = "https://files.pythonhosted.org/packages/10/35/16d31e0f92c6d2f0e77c2a3ba93185130ea13053dd16200a57434c882f2b/protobuf-6.33.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e0697ece353e6239b90ee43a9231318302ad8353c70e6e45499fa52396debf90", size = 324445, upload-time = "2025-10-15T20:39:44.932Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/eb/2a981a13e35cda8b75b5585aaffae2eb904f8f351bdd3870769692acbd8a/protobuf-6.33.0-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:e0a1715e4f27355afd9570f3ea369735afc853a6c3951a6afe1f80d8569ad298", size = 339159, upload-time = "2025-10-15T20:39:46.186Z" },
-    { url = "https://files.pythonhosted.org/packages/21/51/0b1cbad62074439b867b4e04cc09b93f6699d78fd191bed2bbb44562e077/protobuf-6.33.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:35be49fd3f4fefa4e6e2aacc35e8b837d6703c37a2168a55ac21e9b1bc7559ef", size = 323172, upload-time = "2025-10-15T20:39:47.465Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d1/0a28c21707807c6aacd5dc9c3704b2aa1effbf37adebd8caeaf68b17a636/protobuf-6.33.0-py3-none-any.whl", hash = "sha256:25c9e1963c6734448ea2d308cfa610e692b801304ba0908d7bfa564ac5132995", size = 170477, upload-time = "2025-10-15T20:39:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -2015,6 +2209,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/51/cc57175be197379a71a18780c67c1ce28af5c8706415f52b27c72b842b57/py_ed25519_zebra_bindings-1.3.0-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:584f6ba6c749b9aeb17f0d821667ed4368687cdcff479455d2cdbe0b459f24a9", size = 593770, upload-time = "2025-09-03T11:31:25.272Z" },
     { url = "https://files.pythonhosted.org/packages/b4/e3/77b6623575b1e4e92db1e9f55a1caa2b3dffbc90e2b14b86729700d67a45/py_ed25519_zebra_bindings-1.3.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:a5167fe53afe37cdf048938d073b6de51046edfc8ca95e6bbadb5a40844dd880", size = 519330, upload-time = "2025-09-03T11:31:35.483Z" },
     { url = "https://files.pythonhosted.org/packages/00/d7/5dbf23f3a2ec3404c33087cf45c9defa30b4f0239eab202beedb5e641f8c/py_ed25519_zebra_bindings-1.3.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:b0da8a3458c33afeaad5e465688704b2406496e0634333047b82c8ae8f512b48", size = 494082, upload-time = "2025-09-03T11:31:46.289Z" },
+]
+
+[[package]]
+name = "py-serializable"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl", hash = "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304", size = 23045, upload-time = "2025-07-21T09:56:46.848Z" },
 ]
 
 [[package]]
@@ -2346,44 +2552,51 @@ wheels = [
 
 [[package]]
 name = "pynacl"
-version = "1.6.0"
+version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/c6/a3124dee667a423f2c637cfd262a54d67d8ccf3e160f3c50f622a85b7723/pynacl-1.6.0.tar.gz", hash = "sha256:cb36deafe6e2bce3b286e5d1f3e1c246e0ccdb8808ddb4550bb2792f2df298f2", size = 3505641, upload-time = "2025-09-10T23:39:22.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/24/1b639176401255605ba7c2b93a7b1eb1e379e0710eca62613633eb204201/pynacl-1.6.0-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:f46386c24a65383a9081d68e9c2de909b1834ec74ff3013271f1bca9c2d233eb", size = 384141, upload-time = "2025-09-10T23:38:28.675Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/7b/874efdf57d6bf172db0df111b479a553c3d9e8bb4f1f69eb3ffff772d6e8/pynacl-1.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dea103a1afcbc333bc0e992e64233d360d393d1e63d0bc88554f572365664348", size = 808132, upload-time = "2025-09-10T23:38:38.995Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/61/9b53f5913f3b75ac3d53170cdb897101b2b98afc76f4d9d3c8de5aa3ac05/pynacl-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:04f20784083014e265ad58c1b2dd562c3e35864b5394a14ab54f5d150ee9e53e", size = 1407253, upload-time = "2025-09-10T23:38:40.492Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/0a/b138916b22bbf03a1bdbafecec37d714e7489dd7bcaf80cd17852f8b67be/pynacl-1.6.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbcc4452a1eb10cd5217318c822fde4be279c9de8567f78bad24c773c21254f8", size = 843719, upload-time = "2025-09-10T23:38:30.87Z" },
-    { url = "https://files.pythonhosted.org/packages/01/3b/17c368197dfb2c817ce033f94605a47d0cc27901542109e640cef263f0af/pynacl-1.6.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51fed9fe1bec9e7ff9af31cd0abba179d0e984a2960c77e8e5292c7e9b7f7b5d", size = 1445441, upload-time = "2025-09-10T23:38:33.078Z" },
-    { url = "https://files.pythonhosted.org/packages/35/3c/f79b185365ab9be80cd3cd01dacf30bf5895f9b7b001e683b369e0bb6d3d/pynacl-1.6.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:10d755cf2a455d8c0f8c767a43d68f24d163b8fe93ccfaabfa7bafd26be58d73", size = 825691, upload-time = "2025-09-10T23:38:34.832Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/1f/8b37d25e95b8f2a434a19499a601d4d272b9839ab8c32f6b0fc1e40c383f/pynacl-1.6.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:536703b8f90e911294831a7fbcd0c062b837f3ccaa923d92a6254e11178aaf42", size = 1410726, upload-time = "2025-09-10T23:38:36.893Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/93/5a4a4cf9913014f83d615ad6a2df9187330f764f606246b3a744c0788c03/pynacl-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6b08eab48c9669d515a344fb0ef27e2cbde847721e34bba94a343baa0f33f1f4", size = 801035, upload-time = "2025-09-10T23:38:42.109Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/60/40da6b0fe6a4d5fd88f608389eb1df06492ba2edca93fca0b3bebff9b948/pynacl-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5789f016e08e5606803161ba24de01b5a345d24590a80323379fc4408832d290", size = 1371854, upload-time = "2025-09-10T23:38:44.16Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b2/37ac1d65008f824cba6b5bf68d18b76d97d0f62d7a032367ea69d4a187c8/pynacl-1.6.0-cp314-cp314t-win32.whl", hash = "sha256:4853c154dc16ea12f8f3ee4b7e763331876316cc3a9f06aeedf39bcdca8f9995", size = 230345, upload-time = "2025-09-10T23:38:48.276Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/5a/9234b7b45af890d02ebee9aae41859b9b5f15fb4a5a56d88e3b4d1659834/pynacl-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:347dcddce0b4d83ed3f32fd00379c83c425abee5a9d2cd0a2c84871334eaff64", size = 243103, upload-time = "2025-09-10T23:38:45.503Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/2c/c1a0f19d720ab0af3bc4241af2bdf4d813c3ecdcb96392b5e1ddf2d8f24f/pynacl-1.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2d6cd56ce4998cb66a6c112fda7b1fdce5266c9f05044fa72972613bef376d15", size = 187778, upload-time = "2025-09-10T23:38:46.731Z" },
-    { url = "https://files.pythonhosted.org/packages/63/37/87c72df19857c5b3b47ace6f211a26eb862ada495cc96daa372d96048fca/pynacl-1.6.0-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:f4b3824920e206b4f52abd7de621ea7a44fd3cb5c8daceb7c3612345dfc54f2e", size = 382610, upload-time = "2025-09-10T23:38:49.459Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/64/3ce958a5817fd3cc6df4ec14441c43fd9854405668d73babccf77f9597a3/pynacl-1.6.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:16dd347cdc8ae0b0f6187a2608c0af1c8b7ecbbe6b4a06bff8253c192f696990", size = 798744, upload-time = "2025-09-10T23:38:58.531Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/8a/3f0dd297a0a33fa3739c255feebd0206bb1df0b44c52fbe2caf8e8bc4425/pynacl-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:16c60daceee88d04f8d41d0a4004a7ed8d9a5126b997efd2933e08e93a3bd850", size = 1397879, upload-time = "2025-09-10T23:39:00.44Z" },
-    { url = "https://files.pythonhosted.org/packages/41/94/028ff0434a69448f61348d50d2c147dda51aabdd4fbc93ec61343332174d/pynacl-1.6.0-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25720bad35dfac34a2bcdd61d9e08d6bfc6041bebc7751d9c9f2446cf1e77d64", size = 833907, upload-time = "2025-09-10T23:38:50.936Z" },
-    { url = "https://files.pythonhosted.org/packages/52/bc/a5cff7f8c30d5f4c26a07dfb0bcda1176ab8b2de86dda3106c00a02ad787/pynacl-1.6.0-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8bfaa0a28a1ab718bad6239979a5a57a8d1506d0caf2fba17e524dbb409441cf", size = 1436649, upload-time = "2025-09-10T23:38:52.783Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/20/c397be374fd5d84295046e398de4ba5f0722dc14450f65db76a43c121471/pynacl-1.6.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ef214b90556bb46a485b7da8258e59204c244b1b5b576fb71848819b468c44a7", size = 817142, upload-time = "2025-09-10T23:38:54.4Z" },
-    { url = "https://files.pythonhosted.org/packages/12/30/5efcef3406940cda75296c6d884090b8a9aad2dcc0c304daebb5ae99fb4a/pynacl-1.6.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:49c336dd80ea54780bcff6a03ee1a476be1612423010472e60af83452aa0f442", size = 1401794, upload-time = "2025-09-10T23:38:56.614Z" },
-    { url = "https://files.pythonhosted.org/packages/be/e1/a8fe1248cc17ccb03b676d80fa90763760a6d1247da434844ea388d0816c/pynacl-1.6.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:f3482abf0f9815e7246d461fab597aa179b7524628a4bc36f86a7dc418d2608d", size = 772161, upload-time = "2025-09-10T23:39:01.93Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/76/8a62702fb657d6d9104ce13449db221a345665d05e6a3fdefb5a7cafd2ad/pynacl-1.6.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:140373378e34a1f6977e573033d1dd1de88d2a5d90ec6958c9485b2fd9f3eb90", size = 1370720, upload-time = "2025-09-10T23:39:03.531Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/38/9e9e9b777a1c4c8204053733e1a0269672c0bd40852908c9ad6b6eaba82c/pynacl-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6b393bc5e5a0eb86bb85b533deb2d2c815666665f840a09e0aa3362bb6088736", size = 791252, upload-time = "2025-09-10T23:39:05.058Z" },
-    { url = "https://files.pythonhosted.org/packages/63/ef/d972ce3d92ae05c9091363cf185e8646933f91c376e97b8be79ea6e96c22/pynacl-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4a25cfede801f01e54179b8ff9514bd7b5944da560b7040939732d1804d25419", size = 1362910, upload-time = "2025-09-10T23:39:06.924Z" },
-    { url = "https://files.pythonhosted.org/packages/35/2c/ee0b373a1861f66a7ca8bdb999331525615061320dd628527a50ba8e8a60/pynacl-1.6.0-cp38-abi3-win32.whl", hash = "sha256:dcdeb41c22ff3c66eef5e63049abf7639e0db4edee57ba70531fc1b6b133185d", size = 226461, upload-time = "2025-09-10T23:39:11.894Z" },
-    { url = "https://files.pythonhosted.org/packages/75/f7/41b6c0b9dd9970173b6acc026bab7b4c187e4e5beef2756d419ad65482da/pynacl-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:cf831615cc16ba324240de79d925eacae8265b7691412ac6b24221db157f6bd1", size = 238802, upload-time = "2025-09-10T23:39:08.966Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/0f/462326910c6172fa2c6ed07922b22ffc8e77432b3affffd9e18f444dbfbb/pynacl-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:84709cea8f888e618c21ed9a0efdb1a59cc63141c403db8bf56c469b71ad56f2", size = 183846, upload-time = "2025-09-10T23:39:10.552Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2394,23 +2607,23 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -2440,12 +2653,25 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dotenv"
-version = "1.1.1"
+name = "python-discovery"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/cc5a8653e9a24f6cf84768f05064aa8ed5a83dcefd5e2a043db14a1c5f44/python_discovery-1.3.0.tar.gz", hash = "sha256:d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0", size = 63925, upload-time = "2026-05-05T14:38:39.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+    { url = "https://files.pythonhosted.org/packages/30/d4/24d543ab8b8158b7f5a97113c831205f5c900c92c8762b1e7f44b7ea0405/python_discovery-1.3.0-py3-none-any.whl", hash = "sha256:441d9ced3dfce36e113beb35ca302c71c7ef06f3c0f9c227a0b9bb3bd49b9e9f", size = 33124, upload-time = "2026-05-05T14:38:38.539Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -2541,6 +2767,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2593,6 +2832,24 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.59.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/e0/9bf5e5fc7442b10880f3ec0eff0ef4208b84a099606f343ec4f5445227fb/sentry_sdk-2.59.0.tar.gz", hash = "sha256:cd265808ef8bf3f3edf69b527c0a0b2b6b1322762679e55b8987db2e9584aec1", size = 447331, upload-time = "2026-05-04T12:19:06.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/00/b8cc413748fb6383d1582e7cda51314f99743351c462a92dc690d5b5853b/sentry_sdk-2.59.0-py2.py3-none-any.whl", hash = "sha256:abcf65ee9a9d9cdebf9ad369782408ecca9c1c792686ef06ba34f5ab233527fe", size = 468432, upload-time = "2026-05-04T12:19:04.741Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2621,15 +2878,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.48.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -2698,12 +2955,46 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
 name = "toolz"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8a/0b/d80dfa675bf592f636d1ea0b835eab4ec8df6e9415d8cfd766df54456123/toolz-1.0.0.tar.gz", hash = "sha256:2c86e3d9a04798ac556793bced838816296a2f085017664e4995cb40a1047a02", size = 66790, upload-time = "2024-10-04T16:17:04.001Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/98/eb27cc78ad3af8e302c9d8ff4977f5026676e130d28dd7578132a457170c/toolz-1.0.0-py3-none-any.whl", hash = "sha256:292c8f1c4e7516bf9086f8850935c799a874039c8bcf959d47b600e4c44a6236", size = 56383, upload-time = "2024-10-04T16:17:01.533Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.35"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/53/440e7b1212c4b0abbd4adb7aed93f4971aa1f8dca386ac5515930afa9172/ty-0.0.35.tar.gz", hash = "sha256:8375c240ab38138a19db07996c9808fb7a92047c1492e1ce587c2ef5112ad3a9", size = 5629237, upload-time = "2026-05-10T18:25:17.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/84/19662ee881675815b7fafff940a365be1985730465afd9b75cb2edd5f8b3/ty-0.0.35-py3-none-linux_armv6l.whl", hash = "sha256:85ae1e59b9fb0b40e9d84fe61b29653c5f2f5e78b487ece371a7a38c20c781cf", size = 11198741, upload-time = "2026-05-10T18:24:49.378Z" },
+    { url = "https://files.pythonhosted.org/packages/62/df/7e5b6f83d85b4d2e5b72b5dceb388f440acc10679417bd46f829b9200fab/ty-0.0.35-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:709dbb7af4fcadb1196863c00b8791bbbbcc9dacbe15a0ff17f0af82b35d415b", size = 10948304, upload-time = "2026-05-10T18:24:58.246Z" },
+    { url = "https://files.pythonhosted.org/packages/59/94/72d7263aca055cde427f0ebcf08d6a74e5a5fee1d1e7fdd553696089cecb/ty-0.0.35-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2cb0877419ab0c8708b6925cb0c2800b263842bd3c425113f200538772f3a0cc", size = 10407413, upload-time = "2026-05-10T18:24:37.422Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/23/fda6fae8a81ce0cb5f24cdfe63260e110c7af8844e31fa07d1e6e8ef0232/ty-0.0.35-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7afbcfc61904b7e82e7fe1a1db832a40d8f01e69dee1775f6594e552980536c", size = 10932614, upload-time = "2026-05-10T18:24:47.401Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3d/b98d8d4aa1a5ed6daaf15864e838f605ca7b1e8b93b7e17b96ed4bc4dfed/ty-0.0.35-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b61498cc3e4178031c079951257fbdb209a891b4feb10ad6c40f615a51846f41", size = 10962982, upload-time = "2026-05-10T18:24:44.88Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c4/2881aad71bf6fb2f8df17fc8e4bc89e904e54490a3ee747b5ef73f98ac85/ty-0.0.35-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:573b1eacda349fc8dba0d767b41631c3a6f66412363127c5bf2b1b40a1d898d2", size = 11476274, upload-time = "2026-05-10T18:24:42.4Z" },
+    { url = "https://files.pythonhosted.org/packages/34/0f/7717650adaeaddd23eea70470e2c26d3f0b9b18fdc7f26ec9552d6001f17/ty-0.0.35-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a7209746158d6393c1040aa64b3ca29622e212ea7d8bae22ba50dbcbb4f96f0a", size = 12012027, upload-time = "2026-05-10T18:25:00.752Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c9/1a16cb4aab6f4707d8f550772e91abc26d1c8870f19b5e2453ad10bb8209/ty-0.0.35-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4466a1470aa4418d49a9aa45d9da7de42033addd0a2837c5b2b0eb71d3c2bcd3", size = 11648894, upload-time = "2026-05-10T18:25:12.44Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a1/a977c0e07e9f88db9c67f90c6342a4dc4422c8091fa07bf26521870687c5/ty-0.0.35-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb44bb742d52c309dcaa6598bcf4d82eb4bf1241b9e4940461e522e30093fe8b", size = 11560482, upload-time = "2026-05-10T18:25:05.172Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c1/a5fb11227d5cc4ac3f29a115d8c8bc817578e8ef6907d1e4c914ddbf45ee/ty-0.0.35-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:34b219250736c989b2670a03782c61315f523f3a2be37f1f90b1207e2212c188", size = 11718495, upload-time = "2026-05-10T18:24:54.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/cb/e92e4317388b6d1fd821a46941b448a8a1ff0bf13e22147c5167d8fa1b00/ty-0.0.35-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:88e2ac497decc0940ef1a07571dee8a746112a93a09cdc7f8bca0099752e2e05", size = 10900815, upload-time = "2026-05-10T18:25:02.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/4f/03bd87388a92567f262f35ac64e10d2be047d258f2dfcf1405f500fa2b90/ty-0.0.35-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:02cae51b53e6ec17d5d827ff1a3a76fd119705b56a92156e04399eda6e911596", size = 10998051, upload-time = "2026-05-10T18:25:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/60/6edbc375ee6073973200096168f644e1081e5e55a7d42596826465b275de/ty-0.0.35-py3-none-musllinux_1_2_i686.whl", hash = "sha256:11871d730c9400d899ac0b9f3d660ed2e7e433377c8725549f8250a36a7f2620", size = 11148910, upload-time = "2026-05-10T18:24:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b1/a845d2066ed521c477450f436d4bd353d107e7c02dd6536a485944aaf892/ty-0.0.35-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1ad0a2f0530d0933dcc99ad36ac556c63e384ea72ab9a18d23ad2e2c9fd61c73", size = 11671005, upload-time = "2026-05-10T18:24:56.223Z" },
+    { url = "https://files.pythonhosted.org/packages/73/81/1d5912a54fb66b2f95ac828ae61d422ef5afeae1263e4d231e40796c229f/ty-0.0.35-py3-none-win32.whl", hash = "sha256:0e25d63ec4ab116e7f6757e44d16ca9216bca679d19ecc36d119cf80faada61a", size = 10481096, upload-time = "2026-05-10T18:24:39.976Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/36/1c7f8632bfec1c321f01581d4c940a3617b24bd3e8b37c8a7363d33fbfc4/ty-0.0.35-py3-none-win_amd64.whl", hash = "sha256:6a0a6d259f6f2f8f2f954c6f013d4e0b5eba68af6b353bf19a47d59ec254a3d5", size = 11555691, upload-time = "2026-05-10T18:25:07.792Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fb/59325221bce52f6e833d6865ce8360ef7d5e1e21151b38df6dc77c4327a7/ty-0.0.35-py3-none-win_arm64.whl", hash = "sha256:619c52c0fb2aa21961a848a1995135ad3b6d0a9aa54da0194e60f679cc200e13", size = 10925457, upload-time = "2026-05-10T18:25:10.352Z" },
 ]
 
 [[package]]
@@ -2820,14 +3111,14 @@ wheels = [
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.1"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]
@@ -2841,11 +3132,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -2907,17 +3198,18 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.34.0"
+version = "21.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
+    { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Production release rolling up bucket soft-delete (Phase 1 of \`delete-fix.md\`), the new S3 \`response-*\` query-param overrides, AWS-compat disambiguation of \`NoSuchBucket\` vs \`NoSuchKey\`, Starlette 1.0 / FastAPI 0.136 lifespan migration, and 11 transitive-dep CVE remediations. Soaked on staging since 2026-05-07.

The headline fix: \`DeleteBucket\` used to return \`InternalError\` after the API's 30s \`statement_timeout\` on any bucket with significant child-row residue (6-table FK cascade + cold heap I/O). Soft-delete now returns 204 in O(1); the eventual hard cleanup ships in Phase 2.

## Changes (biggest → smallest)

- **Bucket soft-delete migration** (\`hippius_s3/sql/migrations/20260507000000_add_buckets_deleted_at.sql\`) — adds \`deleted_at TIMESTAMPTZ\`, drops the global \`buckets_bucket_name_key UNIQUE(bucket_name)\` constraint and replaces it with the partial unique index \`buckets_bucket_name_active_key WHERE deleted_at IS NULL\` (S3 spec: name immediately reusable post-DELETE), and adds \`idx_buckets_deleted_at_pending\` for the future Phase 2 reaper.
- **20 SQL queries + 14 inline-SQL spots** all filter \`deleted_at IS NULL\` so soft-deleted buckets are invisible to every read path. Covers ACLService, ACLRepository, multipart, get_object, head_object, object_writer, acl_helper, sub_token_scope.
- **\`list_objects.sql\` rewritten with LATERAL join** (commit \`b19e973\`, misleadingly titled "Fixed bug in list-buckets query" — it actually fixes ListObjects). The previous correlated-subquery JOIN forced a full hash join over \`objects + object_versions\` on large buckets and was hitting asyncpg's 30s timeout on the hyperliquid bucket (~5+ min). LATERAL lets the planner use \`idx_objects_bucket_prefix\` as an ordered range scan and stop at LIMIT.
- **\`bucket_delete_endpoint.py\` rewritten** — soft-delete + idempotent \`404 NoSuchBucket\` (the legacy endpoint returned \`403 AccessDenied\` on the same path, conflating \"no permission\" with \"already deleted\" — AWS-incompat contract bug).
- **\`gateway/middlewares/cache_invalidation.py\` (new)** — purges \`redis-acl\` after a successful \`DELETE /<bucket>\` so anonymous public-bucket reads don't keep hitting cached grants for the 600s cache TTL (real authz hole). Best-effort: a Redis hiccup logs and continues so a successful 204 stays 204.
- **\`get_object_endpoint.py\` + \`head_object_endpoint.py\`** — disambiguate \`NoSuchBucket\` vs \`NoSuchKey\` (pre-existing AWS-incompat surfaced by the new e2e tests, fixed in 1ea2981).
- **Response \`response-*\` overrides on signed GET/HEAD** (from merged PR #168) — six query params honored on 200/206 GET and 200 HEAD: \`response-content-type\`, \`response-content-disposition\`, \`response-content-encoding\`, \`response-content-language\`, \`response-cache-control\`, \`response-expires\`. Anonymous traffic ignored (gated on \`account.id\`, the gateway-injected source of truth). CRLF in value → 400 InvalidArgument; cap at 4 KiB.
- **\`gateway/middlewares/cache_control.py\`** — honors \`response-cache-control\` on signed GET/HEAD (otherwise the gateway's bucket-ACL-driven policy would clobber the override).
- **Gateway lifespan migration** — \`gateway/main.py\` replaces \`@app.on_event\` (removed in Starlette 1.0) with \`@asynccontextmanager async def lifespan\`. Identical behaviour, no DeprecationWarning.
- **uv.lock CVE bumps** — urllib3 → 2.7.0, cryptography → 48.0.0, starlette → 1.0.0, fastapi → 0.136.1, pytest → 9.0.3, plus ecdsa, filelock, lxml, protobuf, pynacl, python-dotenv, virtualenv. pip-audit clean.
- **Tests** — 5 unit + 6 e2e for bucket soft-delete, 18 unit + 3 integration + 6 e2e for response-* overrides, 22 unit for \`cache_invalidation_middleware\`, 3 unit for \`cache_control_middleware\` override-honoring. **Unit count: 1364.**
- **\`.pre-commit-config.yaml\`** — adds CVE-2026-6357 to pip-audit ignore (false positive, pip 26.1 fixed).
- Removes dead \`delete_bucket.sql\` query (endpoint no longer hard-deletes).
- \`fs_cache_pressure_middleware\` simplification — drops the outer try/except per project convention.

## Pre-deploy checklist (operator)

- [ ] **Stuck bucket cleanup**: prod bucket \`pagination-test-40k-1777583359\` (\`799b6ccc-5aae-4db7-8e92-40c864165d70\`) carries 39,959 \`multipart_uploads\` rows from the original incident. If any have \`is_completed=FALSE\`, every \`DeleteBucket\` attempt on this bucket will return 409 BucketNotEmpty until the Phase 2 reaper ships. Pre-deploy:
  \`\`\`sql
  SELECT count(*) FILTER (WHERE is_completed = FALSE) AS open_mpus
    FROM multipart_uploads
   WHERE bucket_id = '799b6ccc-5aae-4db7-8e92-40c864165d70';
  \`\`\`
  If \`open_mpus > 0\`: flip them to TRUE pre-deploy, or accept the bucket stays stuck until Phase 2.
- [ ] **Migration timing** — prod deploy workflow does \`kubectl apply -k k8s/production\` (migration Job + new Deployments) → \`kubectl rollout status\` with no \`kubectl wait --for=condition=complete job/db-migrations\` between them. New API pods can come up before the migration runs and 500 with \`column \"deleted_at\" does not exist\`. Pre-existing pattern; worth a follow-up PR to harden.

## Known caveats (documented, not blockers)

- **No Phase 2 reaper yet.** Soft-deleted bucket rows accumulate in DB until Phase 2 ships. The per-object unpin pipeline still runs for objects deleted via DeleteObject. For buckets where no per-object deletes were issued, those objects' chunks stay on Arion until Phase 2.
- **ATS edge cache on warm public buckets.** \`is_cache_warm=true\` public buckets get \`Cache-Control: public, max-age=2592000\` (30d). The new middleware purges only \`redis-acl\`, not ATS — \`ats_purge_middleware\` explicitly states bucket-level purge is unsupported. After DeleteBucket on such a bucket, ATS could keep serving cached object bodies for up to 30 days. \`is_cache_warm\` landed 2026-05-06; quantify warm buckets in prod before this matters. Phase 2 follow-up.
- **Down-migration is one-way after any name reuse.** Re-creating a bucket with a previously-deleted name produces ≥2 rows sharing \`bucket_name\`; the down migration's restore of the global \`UNIQUE(bucket_name)\` constraint then fails. Documented rollback: revert app, leave the migration column.
- **TOCTOU between empty-check and soft-delete UPDATE** matches AWS eventual-consistency semantics; reaper handles orphan rows.
- **Audit log compliance**: \`204\` no longer means \"data is fully gone\" — it means \"soft-deleted, queued for cleanup\". GDPR / data-residency: Phase 2 should add a \`hard_delete_completed_at\` field.

## Test plan

- [x] \`ruff check\` + \`ruff format\` clean
- [x] \`ty check\` clean
- [x] **1364** unit tests pass
- [x] Full e2e suite passed on staging
- [x] Soaked on staging since 2026-05-07
- [x] Manual smoke against \`s3-staging.hippius.com\` (list / create / put / GET-with-overrides / HEAD-with-overrides / CRLF-rejection / delete / rb) — all green
- [ ] Run pre-deploy \`multipart_uploads\` query on prod (see checklist above)
- [ ] Watch \`column \"deleted_at\" does not exist\` errors in API logs during the rollout window
- [ ] Verify \`idx_buckets_deleted_at_pending\` count over the first 24h to confirm soft-delete is working as expected
