### PR TITLE
Public S3 benchmark + dashboard

### DIFF
--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -10,6 +10,9 @@ Top-level ops scripts. Smaller in scope than [hippius_s3/scripts/](../hippius_s3
 | [deploy_smoke.py](deploy_smoke.py) | Post-deploy smoke-test harness invoked from CI. Exercises a small matrix of PUT/GET/LIST against the deploy target. |
 | [retryable-mpu.py](retryable-mpu.py) | Multipart upload retry helper for manual use when a client lost an MPU mid-flight. Notes in [retryable-mpu.md](../retryable-mpu.md) (or wherever the doc landed — check git log). |
 | [bench_multipart.py](bench_multipart.py) | Benchmark MPU throughput against a target endpoint. Not part of CI. |
+| [s3-benchmark.py](s3-benchmark.py) | Single-PUT throughput + TTFB benchmark for cached vs uncached downloads. Reads `HIPPIUS_BENCH_ZONE` from `.aws.cli.env`, picks the regional endpoint, and publishes a JSON datapoint (schema 3, with the latest `k8s-production` commit SHA) to `s3://veggies/s3/<zone>/results/`. |
+| [benchmark.html](benchmark.html) | Static dashboard for `s3-benchmark.py` results. Loaded anonymously from `s3://veggies/s3/benchmark.html`; lists JSONs from the same bucket and renders Chart.js time-series for EU vs US (3 throughput + 3 latency charts). |
+| [favicon.svg](favicon.svg) | Hippius logo SVG used by `benchmark.html` for the page favicon and inline header logo. |
 
 ## Invocation
 

--- a/scripts/benchmark.html
+++ b/scripts/benchmark.html
@@ -1,0 +1,626 @@
+<!doctype html>
+<!--
+  Hippius S3 benchmark dashboard. Source for scripts/s3-benchmark.py output.
+  Hosted at https://s3.hippius.com/veggies/s3/benchmark.html (publicly readable).
+  Re-upload after edits:
+    aws s3 cp scripts/benchmark.html s3://veggies/s3/benchmark.html \
+      --endpoint-url https://s3.hippius.com \
+      --acl public-read \
+      --content-type "text/html; charset=utf-8" \
+      --cache-control "public, max-age=300"
+  Loads benchmark JSONs from s3://veggies/s3/{eu,us}/results/ via anonymous
+  ListBucket — no credentials are transmitted.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Hippius S3 Benchmarks</title>
+<meta name="theme-color" content="#3167DD">
+<link rel="icon" type="image/svg+xml" href="/veggies/favicon.svg">
+<style>
+  :root {
+    --bg: #F8FAFC;
+    --fg: #3F3F46;
+    --muted: #71717A;
+    --card: #FFFFFF;
+    --border: #E5E7EB;
+    --accent: #3167DD;
+    --eu: #3167DD;
+    --us: #DC2626;
+    --grid: rgba(0,0,0,0.05);
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+  .container { max-width: 1024px; margin: 0 auto; padding: 2.5rem 1rem; }
+  header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 2rem;
+  }
+  .brand { display: flex; align-items: center; gap: 0.75rem; }
+  .brand img { height: 32px; width: auto; display: block; }
+  .brand h1 {
+    margin: 0; font-size: 1.25rem; font-weight: 600; color: #18181B;
+    letter-spacing: -0.01em;
+  }
+  .pill {
+    display: inline-block; padding: 0.5rem 0.75rem;
+    background: var(--accent); color: #fff;
+    text-decoration: none; border-radius: 0.25rem;
+    font-size: 0.875rem; font-weight: 600;
+  }
+  .pill:hover { background: #2553C3; }
+  .pill-secondary {
+    background: #FFFFFF; color: var(--accent);
+    border: 1px solid var(--accent);
+  }
+  .pill-secondary:hover { background: rgba(49, 103, 221, 0.06); }
+  .header-links { display: flex; gap: 0.5rem; align-items: center; }
+  .lede {
+    color: var(--muted); font-size: 0.95rem; margin: 0 0 0.5rem 0;
+    max-width: 720px;
+  }
+  .quickstart-link {
+    color: #A1A1AA; font-size: 0.85rem; margin: 0 0 2rem 0;
+    max-width: 720px;
+  }
+  .quickstart-link a { color: inherit; text-decoration: underline; }
+  .quickstart-link a:hover { color: var(--accent); }
+  .card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    margin-bottom: 0;
+  }
+  .charts {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.25rem;
+    margin-bottom: 1.25rem;
+  }
+  @media (max-width: 720px) {
+    .charts { grid-template-columns: 1fr; }
+  }
+  .card h2 {
+    margin: 0 0 0.25rem 0; font-size: 1rem; font-weight: 600; color: #18181B;
+  }
+  .card .subtitle { color: var(--muted); font-size: 0.85rem; margin: 0 0 1rem 0; min-height: 2.4em; }
+  .chart-wrap { position: relative; height: 280px; }
+  .chart-wrap-sm { height: 180px; }
+  .card-compact { margin-top: 1.25rem; }
+  .chart-legend {
+    list-style: none; padding: 0;
+    margin: 0 0 0.5rem 0;
+    display: flex; flex-wrap: wrap;
+    gap: 0.25rem 1.25rem;
+    font-size: 12px; color: #52525B;
+  }
+  .chart-legend li {
+    display: inline-flex; align-items: center; gap: 0.55rem;
+    cursor: pointer; user-select: none;
+    padding: 0.35rem 0.6rem;
+    margin: -0.35rem -0.6rem;
+    border-radius: 4px;
+    transition: background 0.12s, opacity 0.12s;
+  }
+  .chart-legend li:hover { background: rgba(0, 0, 0, 0.04); }
+  .chart-legend li.is-hidden { opacity: 0.4; }
+  .chart-legend li.is-hidden:hover { opacity: 0.6; }
+  .chart-legend li.is-hidden .legend-text { text-decoration: line-through; }
+  .chart-legend .legend-marker {
+    display: inline-block; width: 28px; height: 3px;
+    border-radius: 1px; flex-shrink: 0;
+  }
+  .empty {
+    color: var(--muted); font-size: 0.9rem; text-align: center;
+    padding: 4rem 0;
+  }
+  footer {
+    margin-top: 2rem; padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+    color: var(--muted); font-size: 0.8rem;
+    line-height: 1.6;
+  }
+  footer pre {
+    margin: 0.5rem 0 0 0; padding: 0.75rem 1rem;
+    background: #F1F5F9; border-radius: 6px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.75rem; color: #475569;
+    overflow-x: auto; line-height: 1.5;
+  }
+  footer a { color: var(--accent); text-decoration: none; }
+  footer a:hover { text-decoration: underline; }
+  .tt {
+    position: absolute; pointer-events: auto;
+    background: #fff; border: 1px solid var(--border);
+    border-radius: 6px; padding: 0.5rem 0.75rem;
+    font-size: 0.85rem; color: var(--fg);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+    opacity: 0; transition: opacity 0.12s;
+    z-index: 50; min-width: 180px;
+    transform: translate(-50%, calc(-100% - 12px));
+  }
+  .tt-title { font-size: 0.72rem; color: var(--muted); margin-bottom: 0.35rem; }
+  .tt-table { border-collapse: collapse; margin: 0; width: 100%; }
+  .tt-table td { padding: 0.05rem 0; border: 0; vertical-align: middle; line-height: 1.4; }
+  .tt-bar-cell { padding-right: 0.55rem !important; width: 14px; }
+  .tt-bar { display: block; width: 14px; height: 2px; border-radius: 1px; }
+  .tt-label { white-space: nowrap; }
+  .tt-value { padding-left: 0.9rem !important; text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+  .tt-faint { color: #A1A1AA; }
+  .tt-sep td { padding: 0.45rem 0 0.35rem 0 !important; }
+  .tt-hr { border: 0; border-top: 1px solid rgba(0, 0, 0, 0.06); margin: 0 0 0.25rem 0; }
+  .tt-sha {
+    display: inline-block; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.7rem; color: #A1A1AA; text-decoration: none; letter-spacing: -0.02em;
+  }
+  .tt-sha:hover { color: var(--accent); text-decoration: underline; }
+  footer code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: #F1F5F9; padding: 0.05rem 0.3rem; border-radius: 3px;
+    color: #475569;
+  }
+</style>
+</head>
+<body>
+<div class="container">
+  <header>
+    <div class="brand">
+      <img src="/veggies/favicon.svg" alt="Hippius">
+      <h1>S3 Benchmarks</h1>
+    </div>
+    <div class="header-links">
+      <a class="pill pill-secondary" href="https://status.hippius.com/">Status</a>
+      <a class="pill" href="https://docs.hippius.com/use/quickstart">Quickstart &rarr;</a>
+    </div>
+  </header>
+
+  <p class="lede">
+    Throughput benchmarks for our two supported regions:
+    <strong>eu-central-1.hippius.com</strong> (also reachable as
+    <strong>s3.hippius.com</strong>) and <strong>us-east-1.hippius.com</strong>.
+    Each datapoint is one run, recording min/max/avg over 3 trials.
+  </p>
+  <p class="quickstart-link">
+    See <a href="https://docs.hippius.com/use/quickstart">https://docs.hippius.com/use/quickstart</a> to try out Hippius S3 and store your first file.
+  </p>
+
+  <div class="charts">
+    <div class="card">
+      <h2>Upload throughput</h2>
+      <p class="subtitle">How fast clients can upload a 2&nbsp;GB object to each region.</p>
+      <ul class="chart-legend" id="legend-chart-upload"></ul>
+      <div class="chart-wrap"><canvas id="chart-upload"></canvas></div>
+    </div>
+
+    <div class="card">
+      <h2>Upload latency</h2>
+      <p class="subtitle">End-to-end time to PUT a 2&nbsp;GB object.</p>
+      <ul class="chart-legend" id="legend-chart-upload-lat"></ul>
+      <div class="chart-wrap"><canvas id="chart-upload-lat"></canvas></div>
+    </div>
+
+    <div class="card">
+      <h2>Download throughput</h2>
+      <p class="subtitle">Typical download &mdash; content served from the regional cache.</p>
+      <ul class="chart-legend" id="legend-chart-cached"></ul>
+      <div class="chart-wrap"><canvas id="chart-cached"></canvas></div>
+    </div>
+
+    <div class="card">
+      <h2>Download TTFB</h2>
+      <p class="subtitle">Time to first byte for typical downloads served from the regional cache.</p>
+      <ul class="chart-legend" id="legend-chart-cached-ttfb"></ul>
+      <div class="chart-wrap"><canvas id="chart-cached-ttfb"></canvas></div>
+    </div>
+
+    <div class="card">
+      <h2>Uncached download throughput</h2>
+      <p class="subtitle">First-time download of a fresh object &mdash; content fetched from origin storage.</p>
+      <ul class="chart-legend" id="legend-chart-uncached"></ul>
+      <div class="chart-wrap"><canvas id="chart-uncached"></canvas></div>
+    </div>
+
+    <div class="card">
+      <h2>Uncached download TTFB</h2>
+      <p class="subtitle">Time to first byte on first-time downloads.</p>
+      <ul class="chart-legend" id="legend-chart-uncached-ttfb"></ul>
+      <div class="chart-wrap"><canvas id="chart-uncached-ttfb"></canvas></div>
+    </div>
+  </div>
+
+  <div class="card card-compact">
+    <h2>Benchmark runtime</h2>
+    <p class="subtitle">Active S3 time per run — first upload to last download, excluding file generation and setup.</p>
+    <ul class="chart-legend" id="legend-chart-runtime"></ul>
+    <div class="chart-wrap chart-wrap-sm"><canvas id="chart-runtime"></canvas></div>
+  </div>
+
+  <footer>
+    All benchmarks use 2&nbsp;GB test files via a single PUT request (no multipart upload). Each run records 3 trials.
+    All timestamps are in UTC.
+    Equivalent AWS CLI invocations:
+<pre># Upload — single PUT, no multipart
+aws s3api put-object --bucket BUCKET --key KEY --body ./file.bin \
+  --endpoint-url https://eu-central-1.hippius.com
+
+# Download
+aws s3 cp s3://BUCKET/KEY ./file.bin \
+  --endpoint-url https://eu-central-1.hippius.com</pre>
+    <p style="margin-top: 1rem;">
+      Source: <a href="https://github.com/thenervelab/hippius-s3/blob/main/scripts/s3-benchmark.py">scripts/s3-benchmark.py</a> in the <a href="https://github.com/thenervelab/hippius-s3">hippius-s3</a> repo.
+    </p>
+  </footer>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/date-fns@3.6.0/cdn.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+<script>
+(() => {
+  // HTML legend plugin — renders the legend as real DOM elements outside the canvas
+  // so the browser handles cursor:pointer, click hit boxes, and hover styles natively.
+  // Chart.js v4's canvas-drawn legend has finicky hit detection and no built-in cursor.
+  const htmlLegendPlugin = {
+    id: "htmlLegend",
+    afterUpdate(chart, args, options) {
+      const containerID = options.containerID;
+      const ul = containerID ? document.getElementById(containerID) : null;
+      if (!ul) return;
+      while (ul.firstChild) ul.firstChild.remove();
+      const labels = chart.options.plugins.legend.labels;
+      let items = labels.generateLabels ? labels.generateLabels(chart) : Chart.defaults.plugins.legend.labels.generateLabels(chart);
+      if (labels.filter) items = items.filter((it) => labels.filter(it, chart.data));
+      items.forEach((item) => {
+        const li = document.createElement("li");
+        const ds = chart.data.datasets[item.datasetIndex];
+        const zone = ds && ds.zone;
+        const isHidden = zone
+          ? chart.data.datasets.some((d, i) => d.zone === zone && chart.getDatasetMeta(i).hidden === true)
+          : chart.getDatasetMeta(item.datasetIndex).hidden === true;
+        if (isHidden) li.classList.add("is-hidden");
+        const marker = document.createElement("span");
+        marker.className = "legend-marker";
+        marker.style.background = item.strokeStyle || item.fillStyle;
+        const text = document.createElement("span");
+        text.className = "legend-text";
+        text.innerHTML = item.text;
+        li.appendChild(marker);
+        li.appendChild(text);
+        li.addEventListener("click", () => {
+          if (zone) {
+            const anyHidden = chart.data.datasets.some(
+              (d, i) => d.zone === zone && chart.getDatasetMeta(i).hidden === true,
+            );
+            chart.data.datasets.forEach((d, i) => {
+              if (d.zone === zone) chart.getDatasetMeta(i).hidden = !anyHidden;
+            });
+          } else {
+            const meta = chart.getDatasetMeta(item.datasetIndex);
+            meta.hidden = !meta.hidden;
+          }
+          chart.update();
+        });
+        ul.appendChild(li);
+      });
+    },
+  };
+  Chart.register(htmlLegendPlugin);
+
+  // Custom interaction mode. For each zone, we treat the area between min and max
+  // (the visible band) as the hover region. Cursor y inside that band at the cursor's
+  // nearest x = hit. Multiple zones can match simultaneously (overlap) and all are
+  // returned, so the tooltip groups both into one panel.
+  Chart.Interaction.modes.byZone = function (chart, e) {
+    const pos = Chart.helpers.getRelativePosition(e, chart);
+    const xScale = chart.scales.x;
+    const yScale = chart.scales.y;
+    if (!xScale || !yScale) return [];
+    const Y_TOL = 6;       // extra y-pixel tolerance around band edges
+    const SCALAR_TOL = 22; // y-pixel tolerance for single-line (runtime) charts
+
+    const byZone = {};
+    chart.data.datasets.forEach((ds, dsIdx) => {
+      if (!ds.zone) return;
+      (byZone[ds.zone] ||= []).push({ ds, dsIdx });
+    });
+
+    const items = [];
+    for (const zone of Object.keys(byZone)) {
+      const group = byZone[zone];
+      const sample = group[0].ds;
+      if (!sample.data || sample.data.length === 0) continue;
+      // pick the data index whose x is nearest to the cursor x
+      let nearestIdx = 0;
+      let nearestDist = Infinity;
+      for (let i = 0; i < sample.data.length; i++) {
+        const px = xScale.getPixelForValue(sample.data[i].x);
+        const d = Math.abs(px - pos.x);
+        if (d < nearestDist) { nearestDist = d; nearestIdx = i; }
+      }
+      const minEntry = group.find(g => g.ds.role === "min");
+      const maxEntry = group.find(g => g.ds.role === "max");
+      const avgEntry = group.find(g => g.ds.role === "avg");
+
+      let inBand = false;
+      if (minEntry && maxEntry) {
+        const pY1 = yScale.getPixelForValue(minEntry.ds.data[nearestIdx].y);
+        const pY2 = yScale.getPixelForValue(maxEntry.ds.data[nearestIdx].y);
+        const top = Math.min(pY1, pY2) - Y_TOL;
+        const bottom = Math.max(pY1, pY2) + Y_TOL;
+        if (pos.y >= top && pos.y <= bottom) inBand = true;
+      } else if (avgEntry) {
+        const pY = yScale.getPixelForValue(avgEntry.ds.data[nearestIdx].y);
+        if (Math.abs(pos.y - pY) <= SCALAR_TOL) inBand = true;
+      }
+      if (!inBand) continue;
+
+      group.forEach(({ ds, dsIdx }) => {
+        const meta = chart.getDatasetMeta(dsIdx);
+        if (meta.hidden) return;
+        if (meta.data && meta.data[nearestIdx]) {
+          items.push({ element: meta.data[nearestIdx], datasetIndex: dsIdx, index: nearestIdx });
+        }
+      });
+    }
+    return items;
+  };
+
+  const BUCKET_ENDPOINT = "https://s3.hippius.com/veggies";
+  const GH_COMMIT_BASE = "https://github.com/thenervelab/hippius-s3/commit/";
+  const ZONE_PALETTE = {
+    eu: { min: "#6B8DD6", avg: "#3167DD", max: "#1E3A8A", fill: "rgba(49, 103, 221, 0.14)" },
+    us: { min: "#F87171", avg: "#DC2626", max: "#7F1D1D", fill: "rgba(220, 38, 38, 0.14)" },
+  };
+  const ZONE_LABELS = {
+    eu: "eu-central-1.hippius.com",
+    us: "us-east-1.hippius.com",
+  };
+  const ROLE_ORDER = ["max", "avg", "min"];
+  const METRICS = [
+    { id: "chart-upload",        field: "upload_mb_s",                     unit: "MB/s", decimals: 1 },
+    { id: "chart-uncached",      field: "download_uncached_mb_s",          unit: "MB/s", decimals: 1 },
+    { id: "chart-cached",        field: "download_cached_mb_s",            unit: "MB/s", decimals: 1 },
+    { id: "chart-upload-lat",    field: "upload_seconds",                  unit: "s",    decimals: 2 },
+    { id: "chart-uncached-ttfb", field: "download_uncached_ttfb_seconds",  unit: "s",    decimals: 3 },
+    { id: "chart-cached-ttfb",   field: "download_cached_ttfb_seconds",    unit: "s",    decimals: 3 },
+    { id: "chart-runtime",       field: "total_runtime_seconds",           unit: "s",    decimals: 1, scalar: true },
+  ];
+
+  async function listResults() {
+    const res = await fetch(`${BUCKET_ENDPOINT}/?list-type=2&prefix=s3/`, { cache: "no-store" });
+    if (!res.ok) throw new Error(`list failed: ${res.status}`);
+    const xml = new DOMParser().parseFromString(await res.text(), "application/xml");
+    const keys = [];
+    for (const node of xml.getElementsByTagName("Key")) {
+      const k = node.textContent || "";
+      if (/^s3\/(eu|us)\/results\/benchmark_.+\.json$/.test(k)) keys.push(k);
+    }
+    return keys;
+  }
+
+  async function loadResult(key) {
+    const r = await fetch(`${BUCKET_ENDPOINT}/${key}`, { cache: "no-store" });
+    if (!r.ok) return null;
+    const j = await r.json();
+    if (!j || !j.zone || !j.timestamp) return null;
+    return j;
+  }
+
+  function datasetsFor(metricField, results, scalar) {
+    const byZone = {};
+    for (const r of results) {
+      const v = r[metricField];
+      if (v === undefined || v === null) continue;
+      (byZone[r.zone] ||= []).push({ t: r.timestamp, s: v, sha: r.commit_sha || null });
+    }
+    const datasets = [];
+    for (const [zone, points] of Object.entries(byZone)) {
+      const palette = ZONE_PALETTE[zone] || ZONE_PALETTE.eu;
+      const label = ZONE_LABELS[zone] || zone.toUpperCase();
+      points.sort((a, b) => a.t.localeCompare(b.t));
+      const xs = points.map(p => p.t);
+      const shas = points.map(p => p.sha);
+      if (scalar) {
+        datasets.push({
+          label,
+          data: xs.map((t, i) => ({ x: t, y: points[i].s })),
+          borderColor: palette.avg, backgroundColor: palette.avg,
+          borderWidth: 2.5, pointRadius: 3, tension: 0.2, fill: false,
+          pointBackgroundColor: palette.avg, pointBorderColor: palette.avg,
+          pointStyle: "line",
+          zone, role: "avg", commitShas: shas, scalar: true,
+        });
+        continue;
+      }
+      datasets.push({
+        label: `${label} min`,
+        data: xs.map((t, i) => ({ x: t, y: points[i].s.min })),
+        borderColor: palette.min, backgroundColor: palette.min,
+        borderWidth: 0.75, pointRadius: 0, tension: 0.2, fill: false,
+        pointStyle: "line",
+        zone, role: "min",
+      });
+      datasets.push({
+        label: `${label} max`,
+        data: xs.map((t, i) => ({ x: t, y: points[i].s.max })),
+        borderColor: palette.max, backgroundColor: palette.fill,
+        borderWidth: 0.75, pointRadius: 0, tension: 0.2, fill: "-1",
+        pointStyle: "line",
+        zone, role: "max",
+      });
+      datasets.push({
+        label: `${label} avg`,
+        data: xs.map((t, i) => ({ x: t, y: points[i].s.avg })),
+        borderColor: palette.avg, backgroundColor: palette.avg,
+        borderWidth: 2.5, pointRadius: 3, tension: 0.2, fill: false,
+        pointBackgroundColor: palette.avg, pointBorderColor: palette.avg,
+        pointStyle: "line",
+        zone, role: "avg", commitShas: shas,
+      });
+    }
+    return datasets;
+  }
+
+  let tooltipHideTimer = null;
+  function ensureTooltipEl() {
+    let el = document.getElementById("cjs-tt");
+    if (el) return el;
+    el = document.createElement("div");
+    el.id = "cjs-tt";
+    el.className = "tt";
+    el.addEventListener("mouseenter", () => {
+      if (tooltipHideTimer) { clearTimeout(tooltipHideTimer); tooltipHideTimer = null; }
+    });
+    el.addEventListener("mouseleave", () => { el.style.opacity = 0; });
+    document.body.appendChild(el);
+    return el;
+  }
+
+  function externalTooltipHandler(unit, decimals) {
+    return function (context) {
+      const el = ensureTooltipEl();
+      const { tooltip, chart } = context;
+      if (tooltip.opacity === 0) {
+        if (tooltipHideTimer) clearTimeout(tooltipHideTimer);
+        tooltipHideTimer = setTimeout(() => { el.style.opacity = 0; }, 180);
+        return;
+      }
+      if (tooltipHideTimer) { clearTimeout(tooltipHideTimer); tooltipHideTimer = null; }
+
+      const title = (tooltip.title && tooltip.title[0]) || "";
+      const byZone = {};
+      for (const dp of tooltip.dataPoints) {
+        const ds = dp.dataset;
+        if (!ds.zone || !ds.role) continue;
+        (byZone[ds.zone] ||= {})[ds.role] = dp;
+      }
+
+      const zones = Object.keys(byZone);
+      let bodyHtml = "";
+      zones.forEach((zone, zoneIdx) => {
+        const group = byZone[zone];
+        const zoneLabel = ZONE_LABELS[zone] || zone;
+        let zoneSha = null;
+        for (const role of ROLE_ORDER) {
+          const dp = group[role];
+          if (!dp) continue;
+          const color = dp.dataset.borderColor;
+          const value = dp.parsed.y.toFixed(decimals);
+          if (role === "avg" && dp.dataset.commitShas) {
+            zoneSha = dp.dataset.commitShas[dp.dataIndex] || null;
+          }
+          const roleLabel = dp.dataset.scalar ? "" : ` ${role}`;
+          const faint = role === "avg" ? "" : " tt-faint";
+          bodyHtml += `<tr><td class="tt-bar-cell"><span class="tt-bar" style="background:${color}"></span></td><td class="tt-label${faint}">${zoneLabel}${roleLabel}</td><td class="tt-value${faint}">${value} ${unit}</td></tr>`;
+        }
+        if (zoneSha) {
+          const short = zoneSha.slice(0, 7);
+          const sepClass = zoneIdx === zones.length - 1 ? "tt-sep tt-sep-last" : "tt-sep";
+          bodyHtml += `<tr class="${sepClass}"><td colspan="3"><hr class="tt-hr"><a class="tt-sha" href="${GH_COMMIT_BASE}${zoneSha}" target="_blank" rel="noopener">@${short}</a></td></tr>`;
+        }
+      });
+      el.innerHTML = `<div class="tt-title">${title}</div><table class="tt-table">${bodyHtml}</table>`;
+
+      const canvasRect = chart.canvas.getBoundingClientRect();
+      el.style.left = (canvasRect.left + window.scrollX + tooltip.caretX) + "px";
+      el.style.top = (canvasRect.top + window.scrollY + tooltip.caretY) + "px";
+      el.style.opacity = 1;
+    };
+  }
+
+  function renderChart(canvasId, datasets, unit, decimals, scalar) {
+    const ctx = document.getElementById(canvasId);
+    if (!ctx) return;
+    if (datasets.length === 0) {
+      const parent = ctx.parentElement;
+      parent.innerHTML = '<div class="empty">No benchmark runs available yet.</div>';
+      return;
+    }
+    new Chart(ctx, {
+      type: "line",
+      data: { datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: "byZone", intersect: false, axis: "xy" },
+        plugins: {
+          legend: {
+            display: false,
+            labels: {
+              filter: (item) => scalar ? true : / avg$/.test(item.text),
+            },
+          },
+          htmlLegend: { containerID: `legend-${canvasId}` },
+          tooltip: {
+            enabled: false,
+            external: externalTooltipHandler(unit, decimals),
+            mode: "byZone",
+            intersect: false,
+            axis: "xy",
+          },
+        },
+        scales: {
+          x: {
+            type: "time",
+            time: {
+              tooltipFormat: "dd/MM/yy HH:mm 'UTC'",
+              minUnit: "minute",
+              displayFormats: {
+                minute: "dd/MM/yy HH:mm",
+                hour: "dd/MM/yy HH:mm",
+                day: "dd/MM/yy",
+                week: "dd/MM/yy",
+                month: "MM/yy",
+              },
+            },
+            ticks: {
+              source: "auto",
+              autoSkip: true,
+              autoSkipPadding: 24,
+              maxRotation: 45,
+              minRotation: 45,
+              color: "#71717A",
+              font: { size: 11 },
+            },
+            grid: { color: "rgba(0,0,0,0.05)" },
+          },
+          y: {
+            title: { display: true, text: unit, color: "#71717A", font: { size: 11 } },
+            beginAtZero: true,
+            ticks: { color: "#71717A", font: { size: 11 } },
+            grid: { color: "rgba(0,0,0,0.05)" },
+            afterFit: function (scale) { scale.width = 56; },
+          },
+        },
+      },
+    });
+  }
+
+  async function main() {
+    const keys = await listResults();
+    const results = (await Promise.all(keys.map(loadResult))).filter(Boolean);
+    for (const m of METRICS) {
+      renderChart(m.id, datasetsFor(m.field, results, m.scalar), m.unit, m.decimals, m.scalar);
+    }
+  }
+
+  main().catch(err => {
+    console.error(err);
+    for (const m of METRICS) {
+      const el = document.getElementById(m.id);
+      if (el) el.parentElement.innerHTML = `<div class="empty">Failed to load results: ${err.message}</div>`;
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/scripts/benchmark.html
+++ b/scripts/benchmark.html
@@ -33,7 +33,10 @@
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; }
   body {
-    background: var(--bg);
+    background-color: var(--bg);
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'><path d='M 64 0 L 0 0 L 0 64' fill='none' stroke='rgba(15,23,42,0.05)' stroke-width='1'/></svg>");
+    background-repeat: repeat;
+    background-size: 64px 64px;
     color: var(--fg);
     font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     line-height: 1.5;
@@ -64,12 +67,10 @@
   .pill-secondary:hover { background: rgba(49, 103, 221, 0.06); }
   .header-links { display: flex; gap: 0.5rem; align-items: center; }
   .lede {
-    color: var(--muted); font-size: 0.95rem; margin: 0 0 0.5rem 0;
-    max-width: 720px;
+    color: var(--muted); font-size: 0.95rem; margin: 0 0 1.5rem 0;
   }
   .quickstart-link {
     color: #A1A1AA; font-size: 0.85rem; margin: 0 0 2rem 0;
-    max-width: 720px;
   }
   .quickstart-link a { color: inherit; text-decoration: underline; }
   .quickstart-link a:hover { color: var(--accent); }
@@ -96,26 +97,24 @@
   .chart-wrap { position: relative; height: 280px; }
   .chart-wrap-sm { height: 180px; }
   .card-compact { margin-top: 1.25rem; }
-  .chart-legend {
+  .global-legend {
     list-style: none; padding: 0;
-    margin: 0 0 0.5rem 0;
-    display: flex; flex-wrap: wrap;
-    gap: 0.25rem 1.25rem;
-    font-size: 12px; color: #52525B;
+    margin: 0 0 1.5rem 0;
+    display: flex; flex-wrap: wrap; gap: 0.5rem 1.5rem;
+    font-size: 13px; color: var(--fg);
   }
-  .chart-legend li {
-    display: inline-flex; align-items: center; gap: 0.55rem;
+  .global-legend li {
+    display: inline-flex; align-items: center; gap: 0.6rem;
     cursor: pointer; user-select: none;
-    padding: 0.35rem 0.6rem;
-    margin: -0.35rem -0.6rem;
-    border-radius: 4px;
+    padding: 0.45rem 0.7rem;
+    border-radius: 6px;
     transition: background 0.12s, opacity 0.12s;
   }
-  .chart-legend li:hover { background: rgba(0, 0, 0, 0.04); }
-  .chart-legend li.is-hidden { opacity: 0.4; }
-  .chart-legend li.is-hidden:hover { opacity: 0.6; }
-  .chart-legend li.is-hidden .legend-text { text-decoration: line-through; }
-  .chart-legend .legend-marker {
+  .global-legend li:hover { background: rgba(0, 0, 0, 0.05); }
+  .global-legend li.is-hidden { opacity: 0.4; }
+  .global-legend li.is-hidden:hover { opacity: 0.6; }
+  .global-legend li.is-hidden .legend-text { text-decoration: line-through; }
+  .global-legend .legend-marker {
     display: inline-block; width: 28px; height: 3px;
     border-radius: 1px; flex-shrink: 0;
   }
@@ -139,22 +138,24 @@
   footer a { color: var(--accent); text-decoration: none; }
   footer a:hover { text-decoration: underline; }
   .tt {
-    position: absolute; pointer-events: auto;
+    position: absolute; pointer-events: none;
     background: #fff; border: 1px solid var(--border);
     border-radius: 6px; padding: 0.5rem 0.75rem;
     font-size: 0.85rem; color: var(--fg);
     box-shadow: 0 2px 8px rgba(0,0,0,0.06);
     opacity: 0; transition: opacity 0.12s;
     z-index: 50; min-width: 180px;
-    transform: translate(-50%, calc(-100% - 12px));
+    transform: translate(-50%, calc(-100% - 4px));
   }
+  .tt.is-active { pointer-events: auto; opacity: 1; }
   .tt-title { font-size: 0.72rem; color: var(--muted); margin-bottom: 0.35rem; }
   .tt-table { border-collapse: collapse; margin: 0; width: 100%; }
   .tt-table td { padding: 0.05rem 0; border: 0; vertical-align: middle; line-height: 1.4; }
   .tt-bar-cell { padding-right: 0.55rem !important; width: 14px; }
   .tt-bar { display: block; width: 14px; height: 2px; border-radius: 1px; }
-  .tt-label { white-space: nowrap; }
-  .tt-value { padding-left: 0.9rem !important; text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+  .tt-host-cell { white-space: nowrap; padding-right: 0.45rem !important; }
+  .tt-type-cell { white-space: nowrap; padding-right: 0.6rem !important; }
+  .tt-value { padding-left: 0.4rem !important; text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
   .tt-faint { color: #A1A1AA; }
   .tt-sep td { padding: 0.45rem 0 0.35rem 0 !important; }
   .tt-hr { border: 0; border-top: 1px solid rgba(0, 0, 0, 0.06); margin: 0 0 0.25rem 0; }
@@ -162,12 +163,22 @@
     display: inline-block; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     font-size: 0.7rem; color: #A1A1AA; text-decoration: none; letter-spacing: -0.02em;
   }
-  .tt-sha:hover { color: var(--accent); text-decoration: underline; }
-  footer code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-    background: #F1F5F9; padding: 0.05rem 0.3rem; border-radius: 3px;
-    color: #475569;
+  .tt-sha:hover {
+    color: var(--accent); text-decoration: underline;
+    animation: tt-sha-pulse 0.9s ease-in-out infinite;
   }
+  @keyframes tt-sha-pulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.45; }
+  }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: #F1F5F9; padding: 0.08rem 0.4rem; border-radius: 4px;
+    font-size: 0.9em; color: #475569; white-space: nowrap;
+  }
+  .tt-table code { padding: 0.04rem 0.3rem; font-size: 0.92em; }
+  .global-legend code { padding: 0.05rem 0.35rem; font-size: 0.95em; }
+  .tt-faint code { color: #94A3B8; background: #F5F7FA; }
 </style>
 </head>
 <body>
@@ -185,54 +196,54 @@
 
   <p class="lede">
     Throughput benchmarks for our two supported regions:
-    <strong>eu-central-1.hippius.com</strong> (also reachable as
-    <strong>s3.hippius.com</strong>) and <strong>us-east-1.hippius.com</strong>.
-    Each datapoint is one run, recording min/max/avg over 3 trials.
+    <code>eu-central-1.hippius.com</code> (also reachable as
+    <code>s3.hippius.com</code>) and <code>us-east-1.hippius.com</code>.
   </p>
-  <p class="quickstart-link">
-    See <a href="https://docs.hippius.com/use/quickstart">https://docs.hippius.com/use/quickstart</a> to try out Hippius S3 and store your first file.
-  </p>
+  <ul class="global-legend" id="global-legend">
+    <li data-zone="eu">
+      <span class="legend-marker" style="background: #3167DD"></span>
+      <code class="legend-text">eu-central-1.hippius.com</code>
+    </li>
+    <li data-zone="us">
+      <span class="legend-marker" style="background: #DC2626"></span>
+      <code class="legend-text">us-east-1.hippius.com</code>
+    </li>
+  </ul>
 
   <div class="charts">
     <div class="card">
       <h2>Upload throughput</h2>
       <p class="subtitle">How fast clients can upload a 2&nbsp;GB object to each region.</p>
-      <ul class="chart-legend" id="legend-chart-upload"></ul>
       <div class="chart-wrap"><canvas id="chart-upload"></canvas></div>
     </div>
 
     <div class="card">
       <h2>Upload latency</h2>
       <p class="subtitle">End-to-end time to PUT a 2&nbsp;GB object.</p>
-      <ul class="chart-legend" id="legend-chart-upload-lat"></ul>
       <div class="chart-wrap"><canvas id="chart-upload-lat"></canvas></div>
     </div>
 
     <div class="card">
       <h2>Download throughput</h2>
       <p class="subtitle">Typical download &mdash; content served from the regional cache.</p>
-      <ul class="chart-legend" id="legend-chart-cached"></ul>
       <div class="chart-wrap"><canvas id="chart-cached"></canvas></div>
     </div>
 
     <div class="card">
       <h2>Download TTFB</h2>
       <p class="subtitle">Time to first byte for typical downloads served from the regional cache.</p>
-      <ul class="chart-legend" id="legend-chart-cached-ttfb"></ul>
       <div class="chart-wrap"><canvas id="chart-cached-ttfb"></canvas></div>
     </div>
 
     <div class="card">
       <h2>Uncached download throughput</h2>
       <p class="subtitle">First-time download of a fresh object &mdash; content fetched from origin storage.</p>
-      <ul class="chart-legend" id="legend-chart-uncached"></ul>
       <div class="chart-wrap"><canvas id="chart-uncached"></canvas></div>
     </div>
 
     <div class="card">
       <h2>Uncached download TTFB</h2>
       <p class="subtitle">Time to first byte on first-time downloads.</p>
-      <ul class="chart-legend" id="legend-chart-uncached-ttfb"></ul>
       <div class="chart-wrap"><canvas id="chart-uncached-ttfb"></canvas></div>
     </div>
   </div>
@@ -240,7 +251,6 @@
   <div class="card card-compact">
     <h2>Benchmark runtime</h2>
     <p class="subtitle">Active S3 time per run — first upload to last download, excluding file generation and setup.</p>
-    <ul class="chart-legend" id="legend-chart-runtime"></ul>
     <div class="chart-wrap chart-wrap-sm"><canvas id="chart-runtime"></canvas></div>
   </div>
 
@@ -315,63 +325,26 @@ aws s3 cp s3://BUCKET/KEY ./file.bin \
   };
   Chart.register(htmlLegendPlugin);
 
-  // Custom interaction mode. For each zone, we treat the area between min and max
-  // (the visible band) as the hover region. Cursor y inside that band at the cursor's
-  // nearest x = hit. Multiple zones can match simultaneously (overlap) and all are
-  // returned, so the tooltip groups both into one panel.
-  Chart.Interaction.modes.byZone = function (chart, e) {
-    const pos = Chart.helpers.getRelativePosition(e, chart);
-    const xScale = chart.scales.x;
-    const yScale = chart.scales.y;
-    if (!xScale || !yScale) return [];
-    const Y_TOL = 6;       // extra y-pixel tolerance around band edges
-    const SCALAR_TOL = 22; // y-pixel tolerance for single-line (runtime) charts
-
-    const byZone = {};
+  // Tooltip fires only when the cursor is intersecting an avg point's hit area
+  // (point pointRadius + pointHitRadius). On a hit, we expand to all datasets in
+  // that point's zone so the tooltip shows min/max/avg together.
+  Chart.Interaction.modes.byZone = function (chart, e, options, useFinalPosition) {
+    const hits = Chart.Interaction.modes.point(chart, e, { intersect: true }, useFinalPosition);
+    if (hits.length === 0) return [];
+    const baseDs = chart.data.datasets[hits[0].datasetIndex];
+    if (!baseDs || !baseDs.zone) return hits;
+    const zone = baseDs.zone;
+    const idx = hits[0].index;
+    const expanded = [];
     chart.data.datasets.forEach((ds, dsIdx) => {
-      if (!ds.zone) return;
-      (byZone[ds.zone] ||= []).push({ ds, dsIdx });
+      if (ds.zone !== zone) return;
+      const meta = chart.getDatasetMeta(dsIdx);
+      if (meta.hidden) return;
+      if (meta.data && meta.data[idx]) {
+        expanded.push({ element: meta.data[idx], datasetIndex: dsIdx, index: idx });
+      }
     });
-
-    const items = [];
-    for (const zone of Object.keys(byZone)) {
-      const group = byZone[zone];
-      const sample = group[0].ds;
-      if (!sample.data || sample.data.length === 0) continue;
-      // pick the data index whose x is nearest to the cursor x
-      let nearestIdx = 0;
-      let nearestDist = Infinity;
-      for (let i = 0; i < sample.data.length; i++) {
-        const px = xScale.getPixelForValue(sample.data[i].x);
-        const d = Math.abs(px - pos.x);
-        if (d < nearestDist) { nearestDist = d; nearestIdx = i; }
-      }
-      const minEntry = group.find(g => g.ds.role === "min");
-      const maxEntry = group.find(g => g.ds.role === "max");
-      const avgEntry = group.find(g => g.ds.role === "avg");
-
-      let inBand = false;
-      if (minEntry && maxEntry) {
-        const pY1 = yScale.getPixelForValue(minEntry.ds.data[nearestIdx].y);
-        const pY2 = yScale.getPixelForValue(maxEntry.ds.data[nearestIdx].y);
-        const top = Math.min(pY1, pY2) - Y_TOL;
-        const bottom = Math.max(pY1, pY2) + Y_TOL;
-        if (pos.y >= top && pos.y <= bottom) inBand = true;
-      } else if (avgEntry) {
-        const pY = yScale.getPixelForValue(avgEntry.ds.data[nearestIdx].y);
-        if (Math.abs(pos.y - pY) <= SCALAR_TOL) inBand = true;
-      }
-      if (!inBand) continue;
-
-      group.forEach(({ ds, dsIdx }) => {
-        const meta = chart.getDatasetMeta(dsIdx);
-        if (meta.hidden) return;
-        if (meta.data && meta.data[nearestIdx]) {
-          items.push({ element: meta.data[nearestIdx], datasetIndex: dsIdx, index: nearestIdx });
-        }
-      });
-    }
-    return items;
+    return expanded;
   };
 
   const BUCKET_ENDPOINT = "https://s3.hippius.com/veggies";
@@ -434,9 +407,11 @@ aws s3 cp s3://BUCKET/KEY ./file.bin \
           label,
           data: xs.map((t, i) => ({ x: t, y: points[i].s })),
           borderColor: palette.avg, backgroundColor: palette.avg,
-          borderWidth: 2.5, pointRadius: 3, tension: 0.2, fill: false,
-          pointBackgroundColor: palette.avg, pointBorderColor: palette.avg,
-          pointStyle: "line",
+          borderWidth: 2.5, tension: 0.2, fill: false,
+          pointRadius: 4, pointHoverRadius: 7, pointHitRadius: 12,
+          pointBackgroundColor: palette.avg, pointBorderColor: "#fff", pointBorderWidth: 1.5,
+          pointHoverBackgroundColor: palette.avg, pointHoverBorderColor: "#fff", pointHoverBorderWidth: 2,
+          pointStyle: "circle",
           zone, role: "avg", commitShas: shas, scalar: true,
         });
         continue;
@@ -444,16 +419,16 @@ aws s3 cp s3://BUCKET/KEY ./file.bin \
       datasets.push({
         label: `${label} min`,
         data: xs.map((t, i) => ({ x: t, y: points[i].s.min })),
-        borderColor: palette.min, backgroundColor: palette.min,
-        borderWidth: 0.75, pointRadius: 0, tension: 0.2, fill: false,
+        borderColor: "rgba(0,0,0,0)", backgroundColor: palette.min,
+        borderWidth: 0, pointRadius: 0, tension: 0.2, fill: false,
         pointStyle: "line",
         zone, role: "min",
       });
       datasets.push({
         label: `${label} max`,
         data: xs.map((t, i) => ({ x: t, y: points[i].s.max })),
-        borderColor: palette.max, backgroundColor: palette.fill,
-        borderWidth: 0.75, pointRadius: 0, tension: 0.2, fill: "-1",
+        borderColor: "rgba(0,0,0,0)", backgroundColor: palette.fill,
+        borderWidth: 0, pointRadius: 0, tension: 0.2, fill: "-1",
         pointStyle: "line",
         zone, role: "max",
       });
@@ -461,26 +436,24 @@ aws s3 cp s3://BUCKET/KEY ./file.bin \
         label: `${label} avg`,
         data: xs.map((t, i) => ({ x: t, y: points[i].s.avg })),
         borderColor: palette.avg, backgroundColor: palette.avg,
-        borderWidth: 2.5, pointRadius: 3, tension: 0.2, fill: false,
-        pointBackgroundColor: palette.avg, pointBorderColor: palette.avg,
-        pointStyle: "line",
+        borderWidth: 2.5, tension: 0.2, fill: false,
+        pointRadius: 4, pointHoverRadius: 7, pointHitRadius: 12,
+        pointBackgroundColor: palette.avg, pointBorderColor: "#fff", pointBorderWidth: 1.5,
+        pointHoverBackgroundColor: palette.avg, pointHoverBorderColor: "#fff", pointHoverBorderWidth: 2,
+        pointStyle: "circle",
         zone, role: "avg", commitShas: shas,
       });
     }
     return datasets;
   }
 
-  let tooltipHideTimer = null;
+  let pinnedTooltip = null; // { chart } when tooltip is pinned by a dot click
   function ensureTooltipEl() {
     let el = document.getElementById("cjs-tt");
     if (el) return el;
     el = document.createElement("div");
     el.id = "cjs-tt";
     el.className = "tt";
-    el.addEventListener("mouseenter", () => {
-      if (tooltipHideTimer) { clearTimeout(tooltipHideTimer); tooltipHideTimer = null; }
-    });
-    el.addEventListener("mouseleave", () => { el.style.opacity = 0; });
     document.body.appendChild(el);
     return el;
   }
@@ -489,12 +462,11 @@ aws s3 cp s3://BUCKET/KEY ./file.bin \
     return function (context) {
       const el = ensureTooltipEl();
       const { tooltip, chart } = context;
+      if (pinnedTooltip) return; // ignore hover updates while pinned
       if (tooltip.opacity === 0) {
-        if (tooltipHideTimer) clearTimeout(tooltipHideTimer);
-        tooltipHideTimer = setTimeout(() => { el.style.opacity = 0; }, 180);
+        el.classList.remove("is-active");
         return;
       }
-      if (tooltipHideTimer) { clearTimeout(tooltipHideTimer); tooltipHideTimer = null; }
 
       const title = (tooltip.title && tooltip.title[0]) || "";
       const byZone = {};
@@ -518,14 +490,17 @@ aws s3 cp s3://BUCKET/KEY ./file.bin \
           if (role === "avg" && dp.dataset.commitShas) {
             zoneSha = dp.dataset.commitShas[dp.dataIndex] || null;
           }
-          const roleLabel = dp.dataset.scalar ? "" : ` ${role}`;
-          const faint = role === "avg" ? "" : " tt-faint";
-          bodyHtml += `<tr><td class="tt-bar-cell"><span class="tt-bar" style="background:${color}"></span></td><td class="tt-label${faint}">${zoneLabel}${roleLabel}</td><td class="tt-value${faint}">${value} ${unit}</td></tr>`;
+          const isAvg = role === "avg";
+          const faint = isAvg ? "" : " tt-faint";
+          const barHtml = isAvg ? `<span class="tt-bar" style="background:${color}"></span>` : "";
+          const hostCell = isAvg ? `<code>${zoneLabel}</code>` : "";
+          const typeCell = dp.dataset.scalar ? "" : role;
+          bodyHtml += `<tr><td class="tt-bar-cell">${barHtml}</td><td class="tt-host-cell">${hostCell}</td><td class="tt-type-cell${faint}">${typeCell}</td><td class="tt-value${faint}">${value} ${unit}</td></tr>`;
         }
         if (zoneSha) {
           const short = zoneSha.slice(0, 7);
           const sepClass = zoneIdx === zones.length - 1 ? "tt-sep tt-sep-last" : "tt-sep";
-          bodyHtml += `<tr class="${sepClass}"><td colspan="3"><hr class="tt-hr"><a class="tt-sha" href="${GH_COMMIT_BASE}${zoneSha}" target="_blank" rel="noopener">@${short}</a></td></tr>`;
+          bodyHtml += `<tr class="${sepClass}"><td colspan="4"><hr class="tt-hr"><a class="tt-sha" href="${GH_COMMIT_BASE}${zoneSha}" target="_blank" rel="noopener">@${short}</a></td></tr>`;
         }
       });
       el.innerHTML = `<div class="tt-title">${title}</div><table class="tt-table">${bodyHtml}</table>`;
@@ -533,38 +508,48 @@ aws s3 cp s3://BUCKET/KEY ./file.bin \
       const canvasRect = chart.canvas.getBoundingClientRect();
       el.style.left = (canvasRect.left + window.scrollX + tooltip.caretX) + "px";
       el.style.top = (canvasRect.top + window.scrollY + tooltip.caretY) + "px";
-      el.style.opacity = 1;
+      el.classList.add("is-active");
     };
   }
 
   function renderChart(canvasId, datasets, unit, decimals, scalar) {
     const ctx = document.getElementById(canvasId);
-    if (!ctx) return;
+    if (!ctx) return null;
     if (datasets.length === 0) {
       const parent = ctx.parentElement;
       parent.innerHTML = '<div class="empty">No benchmark runs available yet.</div>';
-      return;
+      return null;
     }
-    new Chart(ctx, {
+    return new Chart(ctx, {
       type: "line",
       data: { datasets },
       options: {
         responsive: true,
         maintainAspectRatio: false,
-        interaction: { mode: "byZone", intersect: false, axis: "xy" },
+        interaction: { mode: "byZone", intersect: true, axis: "xy" },
+        onHover: (e, activeElements) => {
+          if (e && e.native && e.native.target) {
+            e.native.target.style.cursor = activeElements && activeElements.length > 0 ? "pointer" : "default";
+          }
+        },
+        onClick: (e, activeElements, chart) => {
+          const el = document.getElementById("cjs-tt");
+          if (pinnedTooltip) {
+            pinnedTooltip = null;
+            if (el) el.classList.remove("is-active");
+            return;
+          }
+          if (activeElements && activeElements.length > 0) {
+            pinnedTooltip = { chart };
+          }
+        },
         plugins: {
-          legend: {
-            display: false,
-            labels: {
-              filter: (item) => scalar ? true : / avg$/.test(item.text),
-            },
-          },
-          htmlLegend: { containerID: `legend-${canvasId}` },
+          legend: { display: false },
           tooltip: {
             enabled: false,
             external: externalTooltipHandler(unit, decimals),
             mode: "byZone",
-            intersect: false,
+            intersect: true,
             axis: "xy",
           },
         },
@@ -605,12 +590,45 @@ aws s3 cp s3://BUCKET/KEY ./file.bin \
     });
   }
 
+  function setupGlobalLegend(charts) {
+    const root = document.getElementById("global-legend");
+    if (!root) return;
+    const hiddenZones = new Set();
+    root.querySelectorAll("li").forEach((li) => {
+      const zone = li.dataset.zone;
+      if (!zone) return;
+      li.addEventListener("click", () => {
+        const willHide = !hiddenZones.has(zone);
+        if (willHide) hiddenZones.add(zone); else hiddenZones.delete(zone);
+        li.classList.toggle("is-hidden", willHide);
+        for (const chart of charts) {
+          chart.data.datasets.forEach((d, i) => {
+            if (d.zone === zone) chart.getDatasetMeta(i).hidden = willHide;
+          });
+          chart.update();
+        }
+      });
+    });
+  }
+
+  document.addEventListener("click", (e) => {
+    if (!pinnedTooltip) return;
+    const el = document.getElementById("cjs-tt");
+    if (el && el.contains(e.target)) return; // click inside tooltip — keep open (e.g. SHA link)
+    if (pinnedTooltip.chart && pinnedTooltip.chart.canvas.contains(e.target)) return; // chart's onClick handles toggling
+    pinnedTooltip = null;
+    if (el) el.classList.remove("is-active");
+  });
+
   async function main() {
     const keys = await listResults();
     const results = (await Promise.all(keys.map(loadResult))).filter(Boolean);
+    const charts = [];
     for (const m of METRICS) {
-      renderChart(m.id, datasetsFor(m.field, results, m.scalar), m.unit, m.decimals, m.scalar);
+      const c = renderChart(m.id, datasetsFor(m.field, results, m.scalar), m.unit, m.decimals, m.scalar);
+      if (c) charts.push(c);
     }
+    setupGlobalLegend(charts);
   }
 
   main().catch(err => {

--- a/scripts/s3-benchmark.py
+++ b/scripts/s3-benchmark.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+# Benchmark hippius-s3 upload + download against two buckets:
+#   - private bucket: gateway emits Cache-Control: private,no-store → ATS forwards every GET
+#   - public bucket:  gateway emits Cache-Control: public,max-age=300 → ATS caches
+# First anon GET on a freshly-uploaded public object is TCP_MISS (cold); subsequent GETs
+# hit TCP_HIT / TCP_MEM_HIT. We classify warm/cold from the Age header and
+# x-hippius-ray-id continuity. Source .aws.cli.env before running.
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import secrets
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import boto3
+import requests
+from botocore.client import Config as BotoConfig
+from dotenv import load_dotenv
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RESULTS_BUCKET = "veggies"
+RESULTS_ENDPOINT = "https://s3.hippius.com"
+ENDPOINT_BY_ZONE = {
+    "eu": "https://eu-central-1.hippius.com",
+    "us": "https://us-east-1.hippius.com",
+}
+GITHUB_REPO = "thenervelab/hippius-s3"
+GITHUB_TRACKED_BRANCH = "k8s-production"
+
+
+@dataclass
+class GetResult:
+    label: str
+    bucket: str
+    key: str
+    status: int
+    bytes_received: int
+    ttfb_seconds: float
+    total_seconds: float
+    age: int | None
+    ats_hit: bool  # set later, based on ray-id continuity per URL
+    x_hippius_source: str | None
+    x_hippius_ray_id: str | None
+    md5: str
+
+
+def make_s3_client(endpoint: str):
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        config=BotoConfig(signature_version="s3v4", retries={"max_attempts": 3, "mode": "standard"}),
+    )
+
+
+def ensure_bucket(s3, bucket: str, public: bool) -> None:
+    existing = {b["Name"] for b in s3.list_buckets().get("Buckets", [])}
+    if bucket not in existing:
+        s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_acl(Bucket=bucket, ACL="public-read" if public else "private")
+
+
+def generate_random_file(path: Path, size_mb: int) -> str:
+    h = hashlib.md5()
+    remaining = size_mb * 1024 * 1024
+    chunk = 1024 * 1024
+    with path.open("wb") as f:
+        while remaining > 0:
+            n = min(chunk, remaining)
+            buf = secrets.token_bytes(n)
+            f.write(buf)
+            h.update(buf)
+            remaining -= n
+    return h.hexdigest()
+
+
+def upload(s3, bucket: str, key: str, path: Path) -> float:
+    t0 = time.monotonic()
+    with path.open("rb") as f:
+        s3.put_object(Bucket=bucket, Key=key, Body=f)
+    return time.monotonic() - t0
+
+
+def download(label: str, bucket: str, key: str, url: str, session: requests.Session) -> GetResult:
+    h = hashlib.md5()
+    bytes_in = 0
+    ttfb: float | None = None
+    t0 = time.monotonic()
+    with session.get(url, stream=True, timeout=300) as r:
+        for chunk in r.iter_content(chunk_size=1024 * 1024):
+            if ttfb is None:
+                ttfb = time.monotonic() - t0
+            if chunk:
+                h.update(chunk)
+                bytes_in += len(chunk)
+        if ttfb is None:
+            ttfb = time.monotonic() - t0
+        total = time.monotonic() - t0
+        age_raw = r.headers.get("age")
+        age = int(age_raw) if age_raw is not None and age_raw.isdigit() else None
+        return GetResult(
+            label=label,
+            bucket=bucket,
+            key=key,
+            status=r.status_code,
+            bytes_received=bytes_in,
+            ttfb_seconds=ttfb,
+            total_seconds=total,
+            age=age,
+            ats_hit=False,
+            x_hippius_source=r.headers.get("x-hippius-source"),
+            x_hippius_ray_id=r.headers.get("x-hippius-ray-id"),
+            md5=h.hexdigest(),
+        )
+
+
+def presign(s3, bucket: str, key: str) -> str:
+    return s3.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=3600)
+
+
+def public_url(endpoint: str, bucket: str, key: str) -> str:
+    parts = urlsplit(endpoint)
+    return f"{parts.scheme}://{parts.netloc}/{bucket}/{key}"
+
+
+def cleanup(s3, bucket: str, keys: list[str], remove_bucket: bool) -> None:
+    for k in keys:
+        s3.delete_object(Bucket=bucket, Key=k)
+    if remove_bucket:
+        s3.delete_bucket(Bucket=bucket)
+
+
+def stats(values: list[float]) -> dict:
+    if not values:
+        return {"n": 0, "min": 0.0, "mean": 0.0, "p50": 0.0, "p95": 0.0, "max": 0.0}
+    s = sorted(values)
+    n = len(s)
+    return {
+        "n": n,
+        "min": s[0],
+        "mean": statistics.fmean(s),
+        "p50": s[n // 2],
+        "p95": s[min(n - 1, int(n * 0.95))],
+        "max": s[-1],
+    }
+
+
+def _series(values: list[float]) -> dict:
+    if not values:
+        return {"min": 0.0, "max": 0.0, "avg": 0.0, "n": 0}
+    return {
+        "min": round(min(values), 2),
+        "max": round(max(values), 2),
+        "avg": round(statistics.fmean(values), 2),
+        "n": len(values),
+    }
+
+
+def fetch_tracked_commit_sha() -> str | None:
+    url = f"https://api.github.com/repos/{GITHUB_REPO}/commits/{GITHUB_TRACKED_BRANCH}"
+    r = requests.get(url, headers={"Accept": "application/vnd.github+json"}, timeout=10)
+    if r.status_code != 200:
+        print(f"WARN: github sha lookup returned {r.status_code}; recording null", file=sys.stderr)
+        return None
+    return r.json().get("sha")
+
+
+def build_result_payload(
+    zone: str,
+    endpoint: str,
+    size_mb: int,
+    trials: int,
+    warm_replays: int,
+    upload_speeds: list[float],
+    upload_times: list[float],
+    rows: list[GetResult],
+    commit_sha: str | None,
+    total_runtime_seconds: float,
+) -> dict:
+    speeds_by_label: dict[str, list[float]] = {}
+    ttfb_by_label: dict[str, list[float]] = {}
+    for r in rows:
+        if r.total_seconds > 0:
+            speeds_by_label.setdefault(r.label, []).append(size_mb / r.total_seconds)
+        ttfb_by_label.setdefault(r.label, []).append(r.ttfb_seconds)
+    uncached_speed = speeds_by_label.get("private", []) + speeds_by_label.get("public-cold", [])
+    cached_speed = speeds_by_label.get("public-warm", [])
+    uncached_ttfb = ttfb_by_label.get("private", []) + ttfb_by_label.get("public-cold", [])
+    cached_ttfb = ttfb_by_label.get("public-warm", [])
+    return {
+        "schema": 3,
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "zone": zone,
+        "endpoint": endpoint,
+        "file_size_mb": size_mb,
+        "trials": trials,
+        "warm_replays": warm_replays,
+        "commit_sha": commit_sha,
+        "commit_repo": GITHUB_REPO,
+        "commit_branch": GITHUB_TRACKED_BRANCH,
+        "total_runtime_seconds": round(total_runtime_seconds, 2),
+        "upload_mb_s": _series(upload_speeds),
+        "download_uncached_mb_s": _series(uncached_speed),
+        "download_cached_mb_s": _series(cached_speed),
+        "upload_seconds": _series(upload_times),
+        "download_uncached_ttfb_seconds": _series(uncached_ttfb),
+        "download_cached_ttfb_seconds": _series(cached_ttfb),
+    }
+
+
+def publish_results(payload: dict) -> str:
+    s3 = make_s3_client(RESULTS_ENDPOINT)
+    existing = {b["Name"] for b in s3.list_buckets().get("Buckets", [])}
+    if RESULTS_BUCKET not in existing:
+        s3.create_bucket(Bucket=RESULTS_BUCKET)
+        s3.put_bucket_acl(Bucket=RESULTS_BUCKET, ACL="public-read")
+    ts_compact = payload["timestamp"].replace("-", "").replace(":", "")
+    key = f"s3/{payload['zone']}/results/benchmark_{ts_compact}.json"
+    body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+    s3.put_object(
+        Bucket=RESULTS_BUCKET,
+        Key=key,
+        Body=body,
+        ACL="public-read",
+        ContentType="application/json",
+        CacheControl="public, max-age=60",
+    )
+    return f"{RESULTS_ENDPOINT}/{RESULTS_BUCKET}/{key}"
+
+
+def summarize(rows: list[GetResult], size_mb: int) -> None:
+    by_label: dict[str, list[GetResult]] = {}
+    for r in rows:
+        by_label.setdefault(r.label, []).append(r)
+
+    print()
+    header = f"{'label':<14} {'n':>3} {'ttfb_p50':>9} {'ttfb_p95':>9} {'tot_p50':>9} {'tot_p95':>9} {'MBs_p50':>8} {'MBs_p95':>8} {'age_p50':>7} {'hit%':>5}"
+    print(header)
+    print("-" * len(header))
+    for label in ("private", "public-cold", "public-warm"):
+        if label not in by_label:
+            continue
+        items = by_label[label]
+        ttfbs = [it.ttfb_seconds for it in items]
+        totals = [it.total_seconds for it in items]
+        speeds = [size_mb / it.total_seconds for it in items if it.total_seconds > 0]
+        ages = sorted(it.age for it in items if it.age is not None)
+        hits = sum(1 for it in items if it.ats_hit)
+        s_t = stats(totals)
+        s_ttfb = stats(ttfbs)
+        s_s = stats(speeds)
+        age_p50 = ages[len(ages) // 2] if ages else None
+        hit_pct = 100.0 * hits / len(items)
+        age_str = str(age_p50) if age_p50 is not None else "-"
+        print(
+            f"{label:<14} {len(items):>3} {s_ttfb['p50']:>9.3f} {s_ttfb['p95']:>9.3f} "
+            f"{s_t['p50']:>9.3f} {s_t['p95']:>9.3f} {s_s['p50']:>8.1f} {s_s['p95']:>8.1f} "
+            f"{age_str:>7} {hit_pct:>4.0f}%"
+        )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="hippius-s3 ATS cold/warm download benchmark")
+    p.add_argument("--endpoint", help="override endpoint URL (default: derived from zone)")
+    p.add_argument("--zone", help="override HIPPIUS_BENCH_ZONE from .aws.cli.env (eu | us)")
+    p.add_argument("--private-bucket", default=f"bench-private-{int(time.time())}")
+    p.add_argument("--public-bucket", default=f"bench-public-{int(time.time())}")
+    p.add_argument("--size", type=int, default=2048, help="object size in MB")
+    p.add_argument("--trials", type=int, default=3)
+    p.add_argument("--warm-replays", type=int, default=3, help="warm GETs per trial after the cold GET")
+    p.add_argument("--keep", action="store_true", help="don't delete benchmark buckets/keys at the end")
+    p.add_argument("--csv", help="write per-request rows to this CSV path (NEVER uploaded; local debug only)")
+    p.add_argument("--no-publish", action="store_true", help="skip uploading the JSON summary to the results bucket")
+    args = p.parse_args()
+
+    # .aws.cli.env is a bash script with `aws configure set ...` and `echo` lines
+    # that dotenv warns about per-line. Silence those — credentials still load.
+    import logging
+    logging.getLogger("dotenv.main").setLevel(logging.ERROR)
+    load_dotenv(REPO_ROOT / ".aws.cli.env", override=False)
+
+    if not (os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY")):
+        print("ERROR: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY missing — populate .aws.cli.env", file=sys.stderr)
+        return 2
+
+    zone = (args.zone or os.environ.get("HIPPIUS_BENCH_ZONE", "")).strip().lower()
+    if zone not in ENDPOINT_BY_ZONE:
+        print(
+            f"ERROR: HIPPIUS_BENCH_ZONE must be one of {sorted(ENDPOINT_BY_ZONE)} "
+            "(set in .aws.cli.env or pass --zone)",
+            file=sys.stderr,
+        )
+        return 2
+
+    endpoint = args.endpoint or ENDPOINT_BY_ZONE[zone]
+
+    commit_sha = fetch_tracked_commit_sha()
+    s3 = make_s3_client(endpoint)
+    print(f"Zone:            {zone}")
+    print(f"Endpoint:        {endpoint}")
+    print(f"Tracked SHA:     {commit_sha[:12] + '…' if commit_sha else 'unavailable'} ({GITHUB_REPO}@{GITHUB_TRACKED_BRANCH})")
+    print(f"Private bucket:  {args.private_bucket}  (Cache-Control: private,no-store → ATS bypass)")
+    print(f"Public bucket:   {args.public_bucket}  (Cache-Control: public,max-age=300 → ATS caches)")
+    print(f"Size: {args.size} MB | Trials: {args.trials} | Warm replays per trial: {args.warm_replays}")
+    print()
+
+    ensure_bucket(s3, args.private_bucket, public=False)
+    ensure_bucket(s3, args.public_bucket, public=True)
+
+    tmp = Path(f"/tmp/s3-bench-{os.getpid()}.bin")
+    rows: list[GetResult] = []
+    upload_speeds: list[float] = []
+    upload_times: list[float] = []
+    keys_private: list[str] = []
+    keys_public: list[str] = []
+    session_signed = requests.Session()
+    session_anon = requests.Session()
+    # Per-URL first ray-id seen — subsequent GETs that report the same ray-id are
+    # serving from a prior origin response, i.e. ATS cache hits.
+    first_ray_by_url: dict[str, str] = {}
+    # Measure only active S3 time — first upload to last download, excluding
+    # file generation, bucket setup, github SHA lookup, and cleanup.
+    s3_active_start: float | None = None
+
+    def classify(url: str, result: GetResult) -> None:
+        rid = result.x_hippius_ray_id
+        if rid is None:
+            return
+        prior = first_ray_by_url.get(url)
+        if prior is None:
+            first_ray_by_url[url] = rid
+            return
+        result.ats_hit = rid == prior
+
+    for trial in range(1, args.trials + 1):
+        key = f"bench/trial-{trial}-{int(time.time() * 1000)}.bin"
+        print(f"=== Trial {trial}/{args.trials} (key={key}) ===")
+        expected_md5 = generate_random_file(tmp, args.size)
+        print(f"  Generated {args.size}MB md5={expected_md5}")
+
+        if s3_active_start is None:
+            s3_active_start = time.monotonic()
+        priv_elapsed = upload(s3, args.private_bucket, key, tmp)
+        pub_elapsed = upload(s3, args.public_bucket, key, tmp)
+        keys_private.append(key)
+        keys_public.append(key)
+        upload_speeds.append(args.size / priv_elapsed)
+        upload_speeds.append(args.size / pub_elapsed)
+        upload_times.append(priv_elapsed)
+        upload_times.append(pub_elapsed)
+        print(f"  Upload private: {priv_elapsed:.2f}s ({args.size / priv_elapsed:.1f} MB/s)")
+        print(f"  Upload public:  {pub_elapsed:.2f}s ({args.size / pub_elapsed:.1f} MB/s)")
+
+        url_priv = presign(s3, args.private_bucket, key)
+        r = download("private", args.private_bucket, key, url_priv, session_signed)
+        assert r.status == 200, f"private GET status {r.status}"
+        assert r.md5 == expected_md5, "private GET md5 mismatch"
+        classify(url_priv, r)
+        rows.append(r)
+        print(
+            f"  Private DL:     ttfb={r.ttfb_seconds:.3f}s total={r.total_seconds:.3f}s "
+            f"age={r.age} src={r.x_hippius_source} ray={r.x_hippius_ray_id}"
+        )
+
+        url_pub = public_url(endpoint, args.public_bucket, key)
+        r_cold = download("public-cold", args.public_bucket, key, url_pub, session_anon)
+        assert r_cold.status == 200, f"public cold GET status {r_cold.status}"
+        assert r_cold.md5 == expected_md5, "public cold GET md5 mismatch"
+        classify(url_pub, r_cold)
+        rows.append(r_cold)
+        print(
+            f"  Public cold DL: ttfb={r_cold.ttfb_seconds:.3f}s total={r_cold.total_seconds:.3f}s "
+            f"age={r_cold.age} src={r_cold.x_hippius_source} ray={r_cold.x_hippius_ray_id}"
+        )
+
+        for i in range(1, args.warm_replays + 1):
+            r_warm = download("public-warm", args.public_bucket, key, url_pub, session_anon)
+            assert r_warm.status == 200, f"public warm GET status {r_warm.status}"
+            classify(url_pub, r_warm)
+            rows.append(r_warm)
+            print(
+                f"  Public warm #{i}: ttfb={r_warm.ttfb_seconds:.3f}s total={r_warm.total_seconds:.3f}s "
+                f"age={r_warm.age} ats_hit={r_warm.ats_hit}"
+            )
+
+    s3_active_end = time.monotonic()
+    total_runtime_seconds = s3_active_end - (s3_active_start or s3_active_end)
+
+    summarize(rows, args.size)
+    s_up = stats(upload_speeds)
+    print()
+    print(f"Upload throughput (MB/s): p50={s_up['p50']:.1f}  p95={s_up['p95']:.1f}  max={s_up['max']:.1f}")
+    print(f"Active S3 runtime:        {total_runtime_seconds:.2f}s (first upload → last download)")
+    payload = build_result_payload(
+        zone=zone,
+        endpoint=endpoint,
+        size_mb=args.size,
+        trials=args.trials,
+        warm_replays=args.warm_replays,
+        upload_speeds=upload_speeds,
+        upload_times=upload_times,
+        rows=rows,
+        commit_sha=commit_sha,
+        total_runtime_seconds=total_runtime_seconds,
+    )
+    print()
+    print("Result summary:")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+    if args.no_publish:
+        print("Skipped publish (--no-publish)")
+    else:
+        public_url_out = publish_results(payload)
+        print(f"Published: {public_url_out}")
+
+    if args.csv:
+        with open(args.csv, "w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(
+                [
+                    "label", "bucket", "key", "status", "bytes",
+                    "ttfb_s", "total_s", "age", "ats_hit", "source", "ray_id", "md5",
+                ]
+            )
+            for r in rows:
+                w.writerow(
+                    [
+                        r.label, r.bucket, r.key, r.status, r.bytes_received,
+                        f"{r.ttfb_seconds:.4f}", f"{r.total_seconds:.4f}",
+                        r.age if r.age is not None else "",
+                        int(r.ats_hit), r.x_hippius_source or "", r.x_hippius_ray_id or "", r.md5,
+                    ]
+                )
+        print(f"CSV written to {args.csv}")
+
+    tmp.unlink(missing_ok=True)
+
+    if not args.keep:
+        cleanup(s3, args.private_bucket, keys_private, remove_bucket=True)
+        cleanup(s3, args.public_bucket, keys_public, remove_bucket=True)
+        print("Cleaned up buckets and keys")
+    else:
+        print("Skipped cleanup (--keep)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Single-PUT throughput / TTFB benchmark for EU + US regions, plus a public Chart.js dashboard fed by per-run JSON datapoints.

## Changes
- `scripts/s3-benchmark.py` — bench script. Picks endpoint by `HIPPIUS_BENCH_ZONE` (eu / us) loaded from `.aws.cli.env`, publishes JSON to `s3://veggies/s3/<zone>/results/`, embeds the latest `k8s-production` commit SHA via the GitHub API.
- `scripts/benchmark.html` — static dashboard. 7 Chart.js panels (upload + download × throughput / latency / TTFB + runtime), EU vs US, global-legend zone toggle, click-to-pin tooltip with the GitHub commit link.
- `scripts/CLAUDE.md` — inventory entries for the two new files.

## Conclusion
Live at https://s3.hippius.com/veggies/s3/benchmark.html. Daily crons on `s3-bench` (EU 03:00 UTC) and `s3-bench-us` (US 03:30 UTC) publish a fresh datapoint each day.
