### PR TITLE
feat(gateway): warm-private bucket caching + CVE fixes

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -162,6 +162,7 @@ jobs:
             --from-literal=HIPPIUS_DOWNLOAD_BACKENDS="${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}" \
             --from-literal=HIPPIUS_DELETE_BACKENDS="${{ secrets.HIPPIUS_DELETE_BACKENDS }}" \
             --from-literal=ATS_CACHE_ENDPOINT="${{ secrets.ATS_CACHE_ENDPOINT }}" \
+            --from-literal=HIPPIUS_AUTH_PROBE_SECRET="${{ secrets.HIPPIUS_AUTH_PROBE_SECRET }}" \
             --namespace=hippius-s3-prod \
             --dry-run=client -o yaml | kubectl apply -f -
 
@@ -297,6 +298,7 @@ jobs:
             --from-literal=HIPPIUS_OVH_KMS_OKMS_ID="${{ secrets.HIPPIUS_OVH_KMS_OKMS_ID }}" \
             --from-literal=RESUBMISSION_SEED_PHRASE="${{ secrets.RESUBMISSION_SEED_PHRASE }}" \
             --from-literal=HIPPIUS_DOWNLOAD_BACKENDS="${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}" \
+            --from-literal=HIPPIUS_AUTH_PROBE_SECRET="${{ secrets.HIPPIUS_AUTH_PROBE_SECRET }}" \
             --namespace=${CACHE_NS} \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -162,6 +162,7 @@ jobs:
             --from-literal=HIPPIUS_DOWNLOAD_BACKENDS='${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}' \
             --from-literal=HIPPIUS_DELETE_BACKENDS='${{ secrets.HIPPIUS_DELETE_BACKENDS }}' \
             --from-literal=ATS_CACHE_ENDPOINT='${{ secrets.ATS_CACHE_ENDPOINT }}' \
+            --from-literal=HIPPIUS_AUTH_PROBE_SECRET='${{ secrets.HIPPIUS_AUTH_PROBE_SECRET }}' \
             --namespace=hippius-s3-staging \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,8 +46,13 @@ repos:
         # (released 2026-04-26). Same situation — pip-audit's hook env still resolves
         # 26.0.1 even though the project venv is on 26.1. Remove once the hook env
         # picks up 26.1.
+        # CVE-2026-45409 (idna), PYSEC-2026-141 / PYSEC-2026-142 (urllib3):
+        # pip-audit's own tool env carries idna 3.11 and urllib3 2.6.3. Our project
+        # venv is already on idna 3.15 and urllib3 2.7.0 (clean). The hook scans the
+        # tool's env, not ours, so the only way to unblock the hook is to ignore.
+        # Remove once `uv tool upgrade pip-audit` lands fixed deps in the tool env.
         name: pip-audit (dependency scan)
-        entry: pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357
+        entry: pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357 --ignore-vuln CVE-2026-45409 --ignore-vuln PYSEC-2026-141 --ignore-vuln PYSEC-2026-142
         language: system
         stages: [pre-commit]
         pass_filenames: false

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -139,6 +139,12 @@ class GatewayConfig:
         default_factory=lambda: _parse_csv(os.getenv("ATS_CACHE_ENDPOINT", ""))
     )
 
+    # Shared secret stamped on the X-Hippius-Auth-Probe header by an ATS header_rewrite
+    # rule on the auth-host remap. The gateway short-circuits with 200 OK when the
+    # header value matches (constant-time compare). Empty value disables the feature
+    # entirely — auth_probe_middleware becomes a pass-through. Required for prod use.
+    auth_probe_secret: str = dataclasses.field(default_factory=lambda: os.getenv("HIPPIUS_AUTH_PROBE_SECRET", ""))
+
 
 _config: GatewayConfig | None = None
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -143,7 +143,11 @@ class GatewayConfig:
     # rule on the auth-host remap. The gateway short-circuits with 200 OK when the
     # header value matches (constant-time compare). Empty value disables the feature
     # entirely — auth_probe_middleware becomes a pass-through. Required for prod use.
-    auth_probe_secret: str = dataclasses.field(default_factory=lambda: os.getenv("HIPPIUS_AUTH_PROBE_SECRET", ""))
+    # repr=False so a stray `str(config)` / `print(config)` doesn't leak the secret.
+    auth_probe_secret: str = dataclasses.field(
+        default_factory=lambda: os.getenv("HIPPIUS_AUTH_PROBE_SECRET", ""),
+        repr=False,
+    )
 
 
 _config: GatewayConfig | None = None

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -195,11 +195,18 @@ def factory() -> FastAPI:
         forward_service = request.app.state.forward_service
         return await forward_service.forward_request(request)
 
-    # Starlette executes middleware last-registered-first (last = outermost).
-    # The list below runs innermost → outermost on the request path.
-    # auth_probe short-circuits ATS authproxy subrequests with a 200 OK once
-    # auth_router + acl_middleware have validated; placing it innermost keeps
-    # ray_id / audit / metrics / tracing running on probe traffic.
+    # Starlette: last-registered = outermost. On the request path, outer
+    # middlewares run first; the handler runs last; the response unwinds back
+    # through them. The list below is ordered innermost → outermost, so
+    # auth_probe (first call) is the INNERMOST middleware and runs LAST on
+    # the request path — after auth_router + acl_middleware have already
+    # validated. A denied request is short-circuited by those with 401/403
+    # and never reaches the probe. Keeping the probe innermost also means
+    # ray_id / audit / metrics / tracing still execute on probe traffic.
+    #
+    # WARNING: do NOT move auth_probe_middleware later in this list. Doing so
+    # makes it OUTER to auth_router/acl, which would let unauthenticated
+    # callers short-circuit with 200 OK.
     app.middleware("http")(auth_probe_middleware)
     app.middleware("http")(ray_id_middleware)
     if config.enable_audit_logging:

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -14,6 +14,7 @@ from gateway.middlewares.account import account_middleware
 from gateway.middlewares.acl import acl_middleware
 from gateway.middlewares.ats_purge import ats_purge_middleware
 from gateway.middlewares.audit_log import audit_log_middleware
+from gateway.middlewares.auth_probe import auth_probe_middleware
 from gateway.middlewares.auth_router import auth_router_middleware
 from gateway.middlewares.cache_control import cache_control_middleware
 from gateway.middlewares.cache_invalidation import cache_invalidation_middleware
@@ -196,6 +197,10 @@ def factory() -> FastAPI:
 
     # Starlette executes middleware last-registered-first (last = outermost).
     # The list below runs innermost → outermost on the request path.
+    # auth_probe short-circuits ATS authproxy subrequests with a 200 OK once
+    # auth_router + acl_middleware have validated; placing it innermost keeps
+    # ray_id / audit / metrics / tracing running on probe traffic.
+    app.middleware("http")(auth_probe_middleware)
     app.middleware("http")(ray_id_middleware)
     if config.enable_audit_logging:
         app.middleware("http")(audit_log_middleware)

--- a/gateway/middlewares/acl.py
+++ b/gateway/middlewares/acl.py
@@ -5,6 +5,7 @@ from fastapi import Request
 from fastapi import Response
 
 from gateway.config import get_config
+from gateway.middlewares.auth_probe import is_valid_auth_probe
 from gateway.services.sub_token_scope import OP_LIST_BUCKETS
 from gateway.services.sub_token_scope import OP_READ_OBJECT
 from gateway.services.sub_token_scope import bucket_in_scope
@@ -118,6 +119,13 @@ async def acl_middleware(
         return await call_next(request)
 
     if request.method == "OPTIONS":
+        return await call_next(request)
+
+    # PURGE from gateway → ATS authproxy → here. The probe secret is the
+    # trust boundary. acl can't compute a required permission for PURGE
+    # anyway (get_required_permission raises). Skip; auth_probe (innermost)
+    # returns 200 so ATS proceeds with the actual cache invalidation.
+    if request.method == "PURGE" and is_valid_auth_probe(request):
         return await call_next(request)
 
     bucket, key = parse_s3_path(path)

--- a/gateway/middlewares/auth_probe.py
+++ b/gateway/middlewares/auth_probe.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import hmac
+from typing import Awaitable
+from typing import Callable
+
+from fastapi import Request
+from fastapi import Response
+
+from gateway.config import get_config
+
+
+AUTH_PROBE_HEADER = "x-hippius-auth-probe"
+
+
+async def auth_probe_middleware(
+    request: Request,
+    call_next: Callable[[Request], Awaitable[Response]],
+) -> Response:
+    # When ATS's authproxy plugin asks "is this request authorized?", the
+    # subrequest carries X-Hippius-Auth-Probe: <secret> (stamped by header_rewrite
+    # on a dedicated auth-host remap, which is the ONLY ATS rule that emits the
+    # header). By the time we get here, auth_router and acl_middleware have
+    # already validated — they would have returned 401/403 otherwise. Return an
+    # empty 200 so ATS proceeds with cache lookup / origin fetch; skip the
+    # catch-all forward that would otherwise round-trip to the internal API for
+    # no reason.
+    #
+    # Defense against client-supplied header injection: the value must match the
+    # configured HIPPIUS_AUTH_PROBE_SECRET via constant-time compare. A client
+    # sending the header (intentionally or accidentally) without the secret falls
+    # through to normal request handling. When the secret is unset (dev / not
+    # rolled out yet), the middleware is fully disabled (fail-closed).
+    #
+    # Registered as the innermost middleware so observability (ray_id, audit,
+    # metrics, tracing) still runs for probe requests.
+    secret = get_config().auth_probe_secret
+    if secret:
+        provided = request.headers.get(AUTH_PROBE_HEADER, "")
+        if provided and hmac.compare_digest(provided, secret):
+            # Flag for outer middlewares (cache_control, etc.) on the response
+            # path so they can skip mutating a probe response. Set BEFORE
+            # returning so the state is visible to every middleware as the
+            # response bubbles out.
+            request.state.is_auth_probe = True
+            return Response(status_code=200, content=b"")
+
+    return await call_next(request)

--- a/gateway/middlewares/auth_probe.py
+++ b/gateway/middlewares/auth_probe.py
@@ -10,7 +10,25 @@ from fastapi import Response
 from gateway.config import get_config
 
 
+__all__ = ["AUTH_PROBE_HEADER", "auth_probe_middleware", "is_valid_auth_probe"]
+
+
 AUTH_PROBE_HEADER = "x-hippius-auth-probe"
+
+
+def is_valid_auth_probe(request: Request) -> bool:
+    """Constant-time compare X-Hippius-Auth-Probe header against the configured
+    secret. Returns False when the secret is unset (fail-closed) or the header
+    is missing/wrong. Used by auth_probe_middleware (innermost short-circuit)
+    AND by auth_router + acl to early-exempt PURGE traffic that ATS bounces
+    back via authproxy."""
+    secret = get_config().auth_probe_secret
+    if not secret:
+        return False
+    provided = request.headers.get(AUTH_PROBE_HEADER, "")
+    if not provided:
+        return False
+    return hmac.compare_digest(provided, secret)
 
 
 async def auth_probe_middleware(
@@ -34,15 +52,12 @@ async def auth_probe_middleware(
     #
     # Registered as the innermost middleware so observability (ray_id, audit,
     # metrics, tracing) still runs for probe requests.
-    secret = get_config().auth_probe_secret
-    if secret:
-        provided = request.headers.get(AUTH_PROBE_HEADER, "")
-        if provided and hmac.compare_digest(provided, secret):
-            # Flag for outer middlewares (cache_control, etc.) on the response
-            # path so they can skip mutating a probe response. Set BEFORE
-            # returning so the state is visible to every middleware as the
-            # response bubbles out.
-            request.state.is_auth_probe = True
-            return Response(status_code=200, content=b"")
+    if is_valid_auth_probe(request):
+        # Flag for outer middlewares (cache_control, etc.) on the response
+        # path so they can skip mutating a probe response. Set BEFORE
+        # returning so the state is visible to every middleware as the
+        # response bubbles out.
+        request.state.is_auth_probe = True
+        return Response(status_code=200, content=b"")
 
     return await call_next(request)

--- a/gateway/middlewares/auth_router.py
+++ b/gateway/middlewares/auth_router.py
@@ -4,6 +4,7 @@ from typing import Callable
 from fastapi import Request
 from fastapi import Response
 
+from gateway.middlewares.auth_probe import is_valid_auth_probe
 from gateway.services.auth_orchestrator import authenticate_request
 from hippius_s3.services.ray_id_service import get_logger_with_ray_id
 
@@ -27,6 +28,14 @@ async def auth_router_middleware(
 
     path = request.url.path
     if any(path.startswith(exempt_path) or path == exempt_path for exempt_path in exempt_paths):
+        return await call_next(request)
+
+    # PURGE from the gateway → ATS bounces back here via authproxy. There is
+    # no Authorization header on internal PURGE traffic; the probe secret is
+    # the trust boundary (same defense-in-depth as auth_probe_middleware uses
+    # for cached reads). Without this bypass, auth_router would 403 every
+    # PURGE and ats_purge_middleware's invalidation-on-write would break.
+    if request.method == "PURGE" and is_valid_auth_probe(request):
         return await call_next(request)
 
     auth_result = await authenticate_request(request)

--- a/gateway/middlewares/cache_control.py
+++ b/gateway/middlewares/cache_control.py
@@ -14,11 +14,16 @@ PUBLIC_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=60"
 # the cache-control service has flagged as is_cache_warm. Combined with PURGE on
 # write, ATS holds bodies until either the next write or LRU eviction.
 #
-# Only emitted when anonymous_read_allowed is also True — a private object in a
-# warm bucket still gets PRIVATE_CACHE_CONTROL because object-level ACL grants
-# can override bucket-level public-read.
+# Emitted in two scenarios:
+#  - warm bucket, anonymous-readable (browsers + ATS may cache).
+#  - warm bucket, NOT anonymous-readable. In this case ATS stores under this
+#    cache-friendly directive but header_rewrite on the ATS side rewrites the
+#    response to "private, no-store" before egress to the client (based on the
+#    X-Hippius-Visibility: private sentinel set below). Per-request access is
+#    gated by ATS authproxy → gateway /__authcheck probe.
 WARM_PUBLIC_CACHE_CONTROL = "public, max-age=2592000, stale-while-revalidate=86400"
 PRIVATE_CACHE_CONTROL = "private, no-store"
+VISIBILITY_HEADER = "X-Hippius-Visibility"
 
 
 async def cache_control_middleware(
@@ -26,6 +31,13 @@ async def cache_control_middleware(
     call_next: Callable[[Request], Awaitable[Response]],
 ) -> Response:
     response = await call_next(request)
+
+    # ATS authproxy subrequests are short-circuited by auth_probe_middleware
+    # (innermost) which marks the request before returning. Their response
+    # isn't stored in the ATS cache and never reaches the real client, so
+    # leave it untouched.
+    if getattr(request.state, "is_auth_probe", False):
+        return response
 
     if request.method not in ("GET", "HEAD"):
         return response
@@ -53,11 +65,23 @@ async def cache_control_middleware(
         response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
         return response
 
-    if not getattr(request.state, "anonymous_read_allowed", False):
+    bucket_is_cache_warm = getattr(request.state, "bucket_is_cache_warm", False)
+    anonymous_read_allowed = getattr(request.state, "anonymous_read_allowed", False)
+
+    if not anonymous_read_allowed:
+        if bucket_is_cache_warm:
+            # Warm-private: emit cache-friendly directives so ATS stores the
+            # response for 30d, plus a sentinel that triggers ATS header_rewrite
+            # to demote Cache-Control to "private, no-store" on egress to the
+            # real client. Per-request authorization is enforced by ATS
+            # authproxy subrequests carrying X-Hippius-Auth-Probe.
+            response.headers["Cache-Control"] = WARM_PUBLIC_CACHE_CONTROL
+            response.headers[VISIBILITY_HEADER] = "private"
+            return response
         response.headers["Cache-Control"] = PRIVATE_CACHE_CONTROL
         return response
 
-    if getattr(request.state, "bucket_is_cache_warm", False):
+    if bucket_is_cache_warm:
         response.headers["Cache-Control"] = WARM_PUBLIC_CACHE_CONTROL
         return response
 

--- a/gateway/middlewares/cache_control.py
+++ b/gateway/middlewares/cache_control.py
@@ -6,6 +6,7 @@ from typing import Callable
 from fastapi import Request
 from fastapi import Response
 
+from gateway.config import get_config
 from gateway.middlewares.acl import parse_s3_path
 
 
@@ -69,12 +70,13 @@ async def cache_control_middleware(
     anonymous_read_allowed = getattr(request.state, "anonymous_read_allowed", False)
 
     if not anonymous_read_allowed:
-        if bucket_is_cache_warm:
-            # Warm-private: emit cache-friendly directives so ATS stores the
-            # response for 30d, plus a sentinel that triggers ATS header_rewrite
-            # to demote Cache-Control to "private, no-store" on egress to the
-            # real client. Per-request authorization is enforced by ATS
-            # authproxy subrequests carrying X-Hippius-Auth-Probe.
+        # Warm-private only makes sense with ATS in front: the cache-friendly
+        # Cache-Control + X-Hippius-Visibility sentinel pair relies on ATS
+        # header_rewrite to demote the response to "private, no-store" on
+        # egress. With no ATS configured, the sentinel is meaningless and
+        # `public, max-age=30d` would leak straight to browsers, letting them
+        # cache and serve private bodies. Fall back to PRIVATE_CACHE_CONTROL.
+        if bucket_is_cache_warm and get_config().ats_cache_endpoints:
             response.headers["Cache-Control"] = WARM_PUBLIC_CACHE_CONTROL
             response.headers[VISIBILITY_HEADER] = "private"
             return response

--- a/k8s/base/gateway-deployment.yaml
+++ b/k8s/base/gateway-deployment.yaml
@@ -136,6 +136,11 @@ spec:
                 secretKeyRef:
                   name: hippius-s3-secrets
                   key: ATS_CACHE_ENDPOINT
+            - name: HIPPIUS_AUTH_PROBE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_AUTH_PROBE_SECRET
           startupProbe:
             httpGet:
               path: /health

--- a/k8s/cache/base/gateway-deployment.yaml
+++ b/k8s/cache/base/gateway-deployment.yaml
@@ -118,6 +118,11 @@ spec:
                 secretKeyRef:
                   name: hippius-s3-secrets
                   key: HIPPIUS_OVH_KMS_OKMS_ID
+            - name: HIPPIUS_AUTH_PROBE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_AUTH_PROBE_SECRET
           startupProbe:
             httpGet:
               path: /health

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "substrate-interface==1.7.11",
     "watchfiles>=1.1.0",
     "pandas>=2.3.3",
-    "pyarrow>=18.0.0",
     "opentelemetry-api>=1.37.0",
     "opentelemetry-sdk>=1.37.0",
     "opentelemetry-distro>=0.58b0",

--- a/tests/unit/gateway/test_auth_probe_middleware.py
+++ b/tests/unit/gateway/test_auth_probe_middleware.py
@@ -1,0 +1,140 @@
+"""Tests for auth_probe_middleware — short-circuits ATS authproxy subrequests with 200 OK
+when the request carries X-Hippius-Auth-Probe = <shared secret>."""
+
+from typing import Any
+from typing import Generator
+
+import pytest
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi import Response
+from httpx import ASGITransport
+from httpx import AsyncClient
+
+from gateway.config import GatewayConfig
+from gateway.middlewares import auth_probe as auth_probe_mod
+from gateway.middlewares.auth_probe import AUTH_PROBE_HEADER
+from gateway.middlewares.auth_probe import auth_probe_middleware
+
+
+TEST_SECRET = "fake-test-probe-secret-not-real"
+
+
+@pytest.fixture  # type: ignore[misc]
+def configured_secret(monkeypatch: pytest.MonkeyPatch) -> Generator[str, None, None]:
+    """Force the middleware's get_config() to return a config with the test secret.
+    Patching the cached singleton avoids any os.environ-vs-cache races."""
+    cfg = GatewayConfig(auth_probe_secret=TEST_SECRET)
+    monkeypatch.setattr(auth_probe_mod, "get_config", lambda: cfg)
+    yield TEST_SECRET
+
+
+@pytest.fixture  # type: ignore[misc]
+def empty_secret(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    """get_config().auth_probe_secret == "" → middleware disabled (fail-closed)."""
+    cfg = GatewayConfig(auth_probe_secret="")
+    monkeypatch.setattr(auth_probe_mod, "get_config", lambda: cfg)
+    yield
+
+
+@pytest.fixture  # type: ignore[misc]
+def app() -> Any:
+    """An app where the catch-all handler counts how many times it ran."""
+    app = FastAPI()
+    app.state.handler_calls = 0
+    app.state.handler_body = b"forwarded-payload"
+
+    app.middleware("http")(auth_probe_middleware)
+
+    @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"])
+    async def catch_all(request: Request) -> Response:
+        request.app.state.handler_calls += 1
+        return Response(status_code=200, content=request.app.state.handler_body)
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_correct_secret_short_circuits_with_200(app: Any, configured_secret: str) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/warm-private/foo.txt", headers={AUTH_PROBE_HEADER: configured_secret})
+    assert r.status_code == 200
+    assert r.content == b""
+    assert app.state.handler_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_correct_secret_short_circuits_head(app: Any, configured_secret: str) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.head("/warm-private/foo.txt", headers={AUTH_PROBE_HEADER: configured_secret})
+    assert r.status_code == 200
+    assert app.state.handler_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_no_probe_header_runs_handler(app: Any, configured_secret: str) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/regular/foo.txt")
+    assert r.status_code == 200
+    assert r.content == b"forwarded-payload"
+    assert app.state.handler_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_wrong_secret_does_not_short_circuit(app: Any, configured_secret: str) -> None:
+    """A client guessing or smuggling the header must NOT trigger the short-circuit.
+    The legacy literal '1' value is rejected — this is the main security property."""
+    for value in ("1", "0", "true", "", TEST_SECRET[:-1], TEST_SECRET + "x", "guess"):
+        app.state.handler_calls = 0
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            r = await client.get("/regular/foo.txt", headers={AUTH_PROBE_HEADER: value})
+        assert r.status_code == 200, f"value={value!r}"
+        assert r.content == b"forwarded-payload", f"value={value!r}"
+        assert app.state.handler_calls == 1, f"value={value!r}"
+
+
+@pytest.mark.asyncio
+async def test_empty_secret_disables_middleware(app: Any, empty_secret: None) -> None:
+    """When HIPPIUS_AUTH_PROBE_SECRET is unset, even a client sending the header
+    (regardless of value, including '') must go through the handler — the middleware
+    is fully disabled. Fail-closed default for un-rolled-out environments."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/regular/foo.txt", headers={AUTH_PROBE_HEADER: "any-value"})
+    assert r.status_code == 200
+    assert r.content == b"forwarded-payload"
+    assert app.state.handler_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_secret_disables_middleware_even_with_empty_value(app: Any, empty_secret: None) -> None:
+    """Guard against the trap of '' == '' short-circuiting when secret is empty."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/regular/foo.txt", headers={AUTH_PROBE_HEADER: ""})
+    assert r.status_code == 200
+    assert r.content == b"forwarded-payload"
+    assert app.state.handler_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_probe_header_is_case_insensitive(app: Any, configured_secret: str) -> None:
+    """HTTP headers are case-insensitive — Starlette lowercases them on lookup,
+    so an ATS rule that emits 'X-Hippius-Auth-Probe' must work the same as the
+    lowercase form."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/warm-private/foo.txt", headers={"X-Hippius-Auth-Probe": configured_secret})
+    assert r.status_code == 200
+    assert r.content == b""
+    assert app.state.handler_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_probe_response_has_empty_body_for_all_methods(app: Any, configured_secret: str) -> None:
+    """authproxy subrequest is HEAD by default but REDIRECT mode preserves the
+    method. Either way the gateway should return an empty 200; ATS only consults
+    the status code."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for method in ("GET", "HEAD", "PUT", "POST", "DELETE"):
+            r = await client.request(method, "/any/path", headers={AUTH_PROBE_HEADER: configured_secret})
+            assert r.status_code == 200, method
+            assert r.content == b"", method
+    assert app.state.handler_calls == 0

--- a/tests/unit/gateway/test_auth_router_middleware.py
+++ b/tests/unit/gateway/test_auth_router_middleware.py
@@ -43,6 +43,10 @@ def auth_router_app() -> Any:
     async def put_test_endpoint(request: Request) -> dict[str, str]:
         return {"message": "ok"}
 
+    @app.api_route("/purge-target/{bucket}/{key:path}", methods=["PURGE"])
+    async def purge_endpoint(request: Request, bucket: str, key: str) -> dict[str, str]:
+        return {"message": "purged", "bucket": bucket, "key": key}
+
     @app.get("/health")
     async def health_endpoint() -> dict[str, str]:
         return {"status": "healthy"}
@@ -281,3 +285,82 @@ async def test_presigned_get_with_non_hip_credential_rejected(auth_router_app: A
     # v1 behavior: non-hip credentials in presigned URLs should be treated as invalid access keys
     assert response.status_code == 403
     assert b"InvalidAccessKeyId" in response.content
+
+
+# ---------------------------------------------------------------------------
+# PURGE-from-ATS-authproxy bypass
+# ---------------------------------------------------------------------------
+#
+# When ATS authproxy is in front of the gateway, gateway-initiated PURGEs to
+# ATS get bounced back to the gateway as auth subrequests carrying a stamped
+# X-Hippius-Auth-Probe header. Those PURGEs have no Authorization header, so
+# the regular auth_router rule (PUT/POST/DELETE/PURGE without Authorization →
+# 403) would block them and ats_purge_middleware's invalidation-on-write
+# would break. Bypass auth when method == PURGE AND the probe secret matches.
+PURGE_PROBE_SECRET = "fake-test-probe-secret-not-real"
+
+
+@pytest.fixture  # type: ignore[misc]
+def configured_probe_secret(monkeypatch: pytest.MonkeyPatch) -> str:
+    from gateway.config import GatewayConfig
+    from gateway.middlewares import auth_probe as auth_probe_mod
+
+    cfg = GatewayConfig(auth_probe_secret=PURGE_PROBE_SECRET)
+    monkeypatch.setattr(auth_probe_mod, "get_config", lambda: cfg)
+    return PURGE_PROBE_SECRET
+
+
+@pytest.mark.asyncio
+async def test_purge_with_valid_probe_secret_bypasses_auth(
+    auth_router_app: Any, configured_probe_secret: str
+) -> None:
+    """PURGE with the matching probe secret skips auth_router validation
+    (no Authorization header needed)."""
+    async with AsyncClient(transport=ASGITransport(app=auth_router_app), base_url="http://test") as client:
+        response = await client.request(
+            "PURGE",
+            "/purge-target/some-bucket/some/key.txt",
+            headers={"x-hippius-auth-probe": configured_probe_secret},
+        )
+    assert response.status_code == 200
+    assert response.json()["message"] == "purged"
+
+
+@pytest.mark.asyncio
+async def test_purge_without_probe_header_returns_403(
+    auth_router_app: Any, configured_probe_secret: str
+) -> None:
+    """PURGE without the probe header still gets the existing 403 — only the
+    ATS authproxy bounce-back can bypass."""
+    async with AsyncClient(transport=ASGITransport(app=auth_router_app), base_url="http://test") as client:
+        response = await client.request("PURGE", "/purge-target/some-bucket/some/key.txt")
+    assert response.status_code == 403
+    assert b"InvalidAccessKeyId" in response.content
+
+
+@pytest.mark.asyncio
+async def test_purge_with_wrong_probe_value_returns_403(
+    auth_router_app: Any, configured_probe_secret: str
+) -> None:
+    """Constant-time compare protects against guessed probe values."""
+    for bad in ("", "1", "wrong-secret", PURGE_PROBE_SECRET[:-1], PURGE_PROBE_SECRET + "x"):
+        async with AsyncClient(transport=ASGITransport(app=auth_router_app), base_url="http://test") as client:
+            response = await client.request(
+                "PURGE",
+                "/purge-target/some-bucket/some/key.txt",
+                headers={"x-hippius-auth-probe": bad},
+            )
+        assert response.status_code == 403, f"value={bad!r}"
+
+
+@pytest.mark.asyncio
+async def test_purge_with_probe_when_secret_unset_returns_403(auth_router_app: Any) -> None:
+    """Fail-closed: if HIPPIUS_AUTH_PROBE_SECRET is unset, the bypass is
+    disabled and PURGE without auth gets the standard 403."""
+    async with AsyncClient(transport=ASGITransport(app=auth_router_app), base_url="http://test") as client:
+        response = await client.request(
+            "PURGE",
+            "/purge-target/some-bucket/some/key.txt",
+            headers={"x-hippius-auth-probe": "anything"},
+        )
+    assert response.status_code == 403

--- a/tests/unit/gateway/test_cache_control_middleware.py
+++ b/tests/unit/gateway/test_cache_control_middleware.py
@@ -11,6 +11,7 @@ from httpx import AsyncClient
 
 from gateway.middlewares.cache_control import PRIVATE_CACHE_CONTROL
 from gateway.middlewares.cache_control import PUBLIC_CACHE_CONTROL
+from gateway.middlewares.cache_control import VISIBILITY_HEADER
 from gateway.middlewares.cache_control import WARM_PUBLIC_CACHE_CONTROL
 from gateway.middlewares.cache_control import cache_control_middleware
 
@@ -28,6 +29,10 @@ def app() -> Any:
         request.state.bucket_is_cache_warm = request.headers.get("x-test-warm") == "true"
         # Simulate auth_router wiring
         request.state.auth_method = request.headers.get("x-test-auth-method", "anonymous")
+        # Simulate auth_probe_middleware wiring (it sets this when the probe
+        # secret matches; real flow would short-circuit before reaching here)
+        if request.headers.get("x-test-is-auth-probe") == "true":
+            request.state.is_auth_probe = True
         upstream_cc = request.headers.get("x-test-upstream-cc")
         headers = {"Cache-Control": upstream_cc} if upstream_cc else None
         return Response(status_code=status, content=b"ok", headers=headers)
@@ -151,14 +156,17 @@ async def test_warm_bucket_gets_long_max_age(app: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_warm_flag_ignored_when_not_anon_readable(app: Any) -> None:
-    """Warm flag must NOT override the private default when the bucket isn't anon-readable."""
+async def test_warm_private_emits_warm_policy_with_visibility_sentinel(app: Any) -> None:
+    """warm=true + anon_read=false: ATS stores under WARM_PUBLIC, header_rewrite
+    demotes Cache-Control on egress based on the X-Hippius-Visibility sentinel.
+    Per-request auth gating is handled by ATS authproxy."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         r = await client.get(
             "/warm-but-private/foo.txt",
-            headers={"x-test-warm": "true"},  # warm=true but no anon-read
+            headers={"x-test-warm": "true"},
         )
-    assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL
+    assert r.headers["Cache-Control"] == WARM_PUBLIC_CACHE_CONTROL
+    assert r.headers[VISIBILITY_HEADER] == "private"
 
 
 @pytest.mark.asyncio
@@ -288,14 +296,16 @@ async def test_warm_bucket_listing_gets_private(app: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_warm_bucket_anon_disallowed_gets_private(app: Any) -> None:
-    """Defensive: warm flag set but anon_read_allowed=False (e.g. private overlay) → PRIVATE."""
+async def test_warm_bucket_anon_disallowed_gets_warm_with_visibility(app: Any) -> None:
+    """warm=true + private (per-object ACL or otherwise): cacheable for ATS,
+    egress-demoted to private by ATS header_rewrite based on the sentinel."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         r = await client.get(
             "/warm-bucket/foo.txt",
-            headers={"x-test-warm": "true"},  # warm but no anon-read
+            headers={"x-test-warm": "true"},
         )
-    assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL
+    assert r.headers["Cache-Control"] == WARM_PUBLIC_CACHE_CONTROL
+    assert r.headers[VISIBILITY_HEADER] == "private"
 
 
 @pytest.mark.asyncio
@@ -311,3 +321,133 @@ async def test_missing_warm_flag_defaults_to_public(app: Any) -> None:
             headers={"x-test-anon-read": "true"},
         )
     assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
+
+
+@pytest.mark.asyncio
+async def test_warm_private_head_emits_warm_with_visibility(app: Any) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.head(
+            "/warm-bucket/foo.txt",
+            headers={"x-test-warm": "true"},
+        )
+    assert r.headers["Cache-Control"] == WARM_PUBLIC_CACHE_CONTROL
+    assert r.headers[VISIBILITY_HEADER] == "private"
+
+
+@pytest.mark.asyncio
+async def test_warm_private_206_emits_warm_with_visibility(app: Any) -> None:
+    """Range requests on warm-private must carry the same demotion sentinel."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/warm-bucket/foo.txt",
+            headers={"x-test-status": "206", "x-test-warm": "true"},
+        )
+    assert r.status_code == 206
+    assert r.headers["Cache-Control"] == WARM_PUBLIC_CACHE_CONTROL
+    assert r.headers[VISIBILITY_HEADER] == "private"
+
+
+@pytest.mark.asyncio
+async def test_warm_private_304_emits_warm_with_visibility(app: Any) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/warm-bucket/foo.txt",
+            headers={"x-test-status": "304", "x-test-warm": "true"},
+        )
+    assert r.status_code == 304
+    assert r.headers["Cache-Control"] == WARM_PUBLIC_CACHE_CONTROL
+    assert r.headers[VISIBILITY_HEADER] == "private"
+
+
+@pytest.mark.asyncio
+async def test_warm_private_404_no_visibility(app: Any) -> None:
+    """Negative-caching protection wins: 404 on warm-private → no-store, no sentinel."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/warm-bucket/missing.txt",
+            headers={"x-test-status": "404", "x-test-warm": "true"},
+        )
+    assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL
+    assert VISIBILITY_HEADER not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_warm_private_put_no_visibility_header(app: Any) -> None:
+    """Writes never carry the visibility sentinel — ATS can't cache writes anyway."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.put(
+            "/warm-bucket/foo.txt",
+            content=b"x",
+            headers={"x-test-warm": "true"},
+        )
+    assert "Cache-Control" not in r.headers
+    assert VISIBILITY_HEADER not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_warm_public_no_visibility_header(app: Any) -> None:
+    """Public warm responses must NOT carry the sentinel — clients should be able to cache."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/warm-public/foo.txt",
+            headers={"x-test-anon-read": "true", "x-test-warm": "true"},
+        )
+    assert r.headers["Cache-Control"] == WARM_PUBLIC_CACHE_CONTROL
+    assert VISIBILITY_HEADER not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_cold_private_no_visibility_header(app: Any) -> None:
+    """Cold private (default branch) stays no-store with no sentinel."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/cold-private/foo.txt")
+    assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL
+    assert VISIBILITY_HEADER not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_cold_public_no_visibility_header(app: Any) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/cold-public/foo.txt",
+            headers={"x-test-anon-read": "true"},
+        )
+    assert r.headers["Cache-Control"] == PUBLIC_CACHE_CONTROL
+    assert VISIBILITY_HEADER not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_auth_probe_response_left_untouched(app: Any) -> None:
+    """When auth_probe_middleware has flagged the request as a probe (state set
+    after secret-match), cache_control_middleware must NOT mutate the response.
+    ATS doesn't cache subrequest responses; stray headers would just pollute logs."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/warm-bucket/foo.txt",
+            headers={
+                "x-test-is-auth-probe": "true",
+                "x-test-anon-read": "true",
+                "x-test-warm": "true",
+            },
+        )
+    assert "Cache-Control" not in r.headers
+    assert VISIBILITY_HEADER not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_non_probe_request_with_smuggled_header_still_gets_warm_treatment(app: Any) -> None:
+    """The cache_control skip is keyed off request.state.is_auth_probe (set
+    only by auth_probe_middleware after secret-match), NOT off the raw header.
+    A client smuggling X-Hippius-Auth-Probe with a guess value never flips
+    is_auth_probe, so cache_control treats the request normally."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/warm-bucket/foo.txt",
+            headers={
+                "x-hippius-auth-probe": "1",  # smuggled — no secret matches
+                "x-test-warm": "true",
+            },
+        )
+    # Normal warm-private treatment applies — auth_probe state was never set.
+    assert r.headers["Cache-Control"] == WARM_PUBLIC_CACHE_CONTROL
+    assert r.headers[VISIBILITY_HEADER] == "private"

--- a/tests/unit/gateway/test_cache_control_middleware.py
+++ b/tests/unit/gateway/test_cache_control_middleware.py
@@ -9,11 +9,21 @@ from fastapi import Response
 from httpx import ASGITransport
 from httpx import AsyncClient
 
+from gateway.config import GatewayConfig
+from gateway.middlewares import cache_control as cache_control_mod
 from gateway.middlewares.cache_control import PRIVATE_CACHE_CONTROL
 from gateway.middlewares.cache_control import PUBLIC_CACHE_CONTROL
 from gateway.middlewares.cache_control import VISIBILITY_HEADER
 from gateway.middlewares.cache_control import WARM_PUBLIC_CACHE_CONTROL
 from gateway.middlewares.cache_control import cache_control_middleware
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def ats_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """All warm-* tests assume ATS is in front (which gates the warm-private
+    branch). Tests that need ATS unset opt out by re-patching themselves."""
+    cfg = GatewayConfig(ats_cache_endpoints=["http://ats.test"])
+    monkeypatch.setattr(cache_control_mod, "get_config", lambda: cfg)
 
 
 @pytest.fixture  # type: ignore[misc]
@@ -431,6 +441,24 @@ async def test_auth_probe_response_left_untouched(app: Any) -> None:
             },
         )
     assert "Cache-Control" not in r.headers
+    assert VISIBILITY_HEADER not in r.headers
+
+
+@pytest.mark.asyncio
+async def test_warm_private_falls_back_to_private_when_ats_not_configured(
+    app: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Defense-in-depth: warm-private relies on ATS header_rewrite to demote
+    Cache-Control on egress. If ATS isn't configured, emitting `public,max-age=30d`
+    would leak private bodies into client / browser caches. Fall back to no-store."""
+    cfg = GatewayConfig(ats_cache_endpoints=[])
+    monkeypatch.setattr(cache_control_mod, "get_config", lambda: cfg)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get(
+            "/warm-bucket/foo.txt",
+            headers={"x-test-warm": "true"},  # warm=true, anon_read=false (no ATS)
+        )
+    assert r.headers["Cache-Control"] == PRIVATE_CACHE_CONTROL
     assert VISIBILITY_HEADER not in r.headers
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -932,7 +932,6 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "pandas" },
     { name = "prometheus-client" },
-    { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pyinstrument" },
     { name = "pynacl" },
@@ -1007,7 +1006,6 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "prometheus-client", specifier = ">=0.23.1" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'dev'", specifier = ">=3.1" },
-    { name = "pyarrow", specifier = ">=18.0.0" },
     { name = "pydantic", specifier = ">=2.3.0" },
     { name = "pyinstrument", specifier = ">=4.0.0" },
     { name = "pynacl", specifier = ">=1.6.0" },
@@ -1109,11 +1107,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -2295,48 +2293,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/9b/9dec4ae43d307b56053d2a593dee7db3c3d257d46a311d7867c09c142eb9/py_sr25519_bindings-0.2.2-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:a26b1add87dc6086463975aa1d889f39f90b0d22949d4de52e8a53e516bd2ac4", size = 634353, upload-time = "2025-03-12T20:35:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/40/42/026b5379b5240ec1c2b295a185e0679ae1afe6f23c585fdc33ef15be8cfd/py_sr25519_bindings-0.2.2-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:84cb2c645ce60a04688dedf61ed289d4fb716aef4129313814be1a2d47e268e7", size = 565750, upload-time = "2025-03-12T20:35:33.345Z" },
     { url = "https://files.pythonhosted.org/packages/5a/a6/f45343b20aa622c70870aa038a69097e109d93fed06a81a48b8cdcfc9c77/py_sr25519_bindings-0.2.2-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:76e660007dd415de22b1d99a884ee39cb6abf03f24377f58e4498533856c2bac", size = 539941, upload-time = "2025-03-12T20:35:46.722Z" },
-]
-
-[[package]]
-name = "pyarrow"
-version = "19.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7f/09/a9046344212690f0632b9c709f9bf18506522feb333c894d0de81d62341a/pyarrow-19.0.1.tar.gz", hash = "sha256:3bf266b485df66a400f282ac0b6d1b500b9d2ae73314a153dbe97d6d5cc8a99e", size = 1129437, upload-time = "2025-02-18T18:55:57.027Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/01/b23b514d86b839956238d3f8ef206fd2728eee87ff1b8ce150a5678d9721/pyarrow-19.0.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:fc28912a2dc924dddc2087679cc8b7263accc71b9ff025a1362b004711661a69", size = 30688914, upload-time = "2025-02-18T18:51:37.575Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/68/218ff7cf4a0652a933e5f2ed11274f724dd43b9813cb18dd72c0a35226a2/pyarrow-19.0.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:fca15aabbe9b8355800d923cc2e82c8ef514af321e18b437c3d782aa884eaeec", size = 32102866, upload-time = "2025-02-18T18:51:44.358Z" },
-    { url = "https://files.pythonhosted.org/packages/98/01/c295050d183014f4a2eb796d7d2bbfa04b6cccde7258bb68aacf6f18779b/pyarrow-19.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad76aef7f5f7e4a757fddcdcf010a8290958f09e3470ea458c80d26f4316ae89", size = 41147682, upload-time = "2025-02-18T18:51:49.481Z" },
-    { url = "https://files.pythonhosted.org/packages/40/17/a6c3db0b5f3678f33bbb552d2acbc16def67f89a72955b67b0109af23eb0/pyarrow-19.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d03c9d6f2a3dffbd62671ca070f13fc527bb1867b4ec2b98c7eeed381d4f389a", size = 42179192, upload-time = "2025-02-18T18:51:56.265Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/75/c7c8e599300d8cebb6cb339014800e1c720c9db2a3fcb66aa64ec84bac72/pyarrow-19.0.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:65cf9feebab489b19cdfcfe4aa82f62147218558d8d3f0fc1e9dea0ab8e7905a", size = 40517272, upload-time = "2025-02-18T18:52:02.969Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/c9/68ab123ee1528699c4d5055f645ecd1dd68ff93e4699527249d02f55afeb/pyarrow-19.0.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:41f9706fbe505e0abc10e84bf3a906a1338905cbbcf1177b71486b03e6ea6608", size = 42069036, upload-time = "2025-02-18T18:52:10.173Z" },
-    { url = "https://files.pythonhosted.org/packages/54/e3/d5cfd7654084e6c0d9c3ce949e5d9e0ccad569ae1e2d5a68a3ec03b2be89/pyarrow-19.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:c6cb2335a411b713fdf1e82a752162f72d4a7b5dbc588e32aa18383318b05866", size = 25277951, upload-time = "2025-02-18T18:52:15.459Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/55/f1a8d838ec07fe3ca53edbe76f782df7b9aafd4417080eebf0b42aab0c52/pyarrow-19.0.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:cc55d71898ea30dc95900297d191377caba257612f384207fe9f8293b5850f90", size = 30713987, upload-time = "2025-02-18T18:52:20.463Z" },
-    { url = "https://files.pythonhosted.org/packages/13/12/428861540bb54c98a140ae858a11f71d041ef9e501e6b7eb965ca7909505/pyarrow-19.0.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:7a544ec12de66769612b2d6988c36adc96fb9767ecc8ee0a4d270b10b1c51e00", size = 32135613, upload-time = "2025-02-18T18:52:25.29Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/8a/23d7cc5ae2066c6c736bce1db8ea7bc9ac3ef97ac7e1c1667706c764d2d9/pyarrow-19.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0148bb4fc158bfbc3d6dfe5001d93ebeed253793fff4435167f6ce1dc4bddeae", size = 41149147, upload-time = "2025-02-18T18:52:30.975Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/7a/845d151bb81a892dfb368bf11db584cf8b216963ccce40a5cf50a2492a18/pyarrow-19.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f24faab6ed18f216a37870d8c5623f9c044566d75ec586ef884e13a02a9d62c5", size = 42178045, upload-time = "2025-02-18T18:52:36.859Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/31/e7282d79a70816132cf6cae7e378adfccce9ae10352d21c2fecf9d9756dd/pyarrow-19.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:4982f8e2b7afd6dae8608d70ba5bd91699077323f812a0448d8b7abdff6cb5d3", size = 40532998, upload-time = "2025-02-18T18:52:42.578Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/82/20f3c290d6e705e2ee9c1fa1d5a0869365ee477e1788073d8b548da8b64c/pyarrow-19.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:49a3aecb62c1be1d822f8bf629226d4a96418228a42f5b40835c1f10d42e4db6", size = 42084055, upload-time = "2025-02-18T18:52:48.749Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/77/e62aebd343238863f2c9f080ad2ef6ace25c919c6ab383436b5b81cbeef7/pyarrow-19.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:008a4009efdb4ea3d2e18f05cd31f9d43c388aad29c636112c2966605ba33466", size = 25283133, upload-time = "2025-02-18T18:52:54.549Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b4/94e828704b050e723f67d67c3535cf7076c7432cd4cf046e4bb3b96a9c9d/pyarrow-19.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:80b2ad2b193e7d19e81008a96e313fbd53157945c7be9ac65f44f8937a55427b", size = 30670749, upload-time = "2025-02-18T18:53:00.062Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/3b/4692965e04bb1df55e2c314c4296f1eb12b4f3052d4cf43d29e076aedf66/pyarrow-19.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:ee8dec072569f43835932a3b10c55973593abc00936c202707a4ad06af7cb294", size = 32128007, upload-time = "2025-02-18T18:53:06.581Z" },
-    { url = "https://files.pythonhosted.org/packages/22/f7/2239af706252c6582a5635c35caa17cb4d401cd74a87821ef702e3888957/pyarrow-19.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d5d1ec7ec5324b98887bdc006f4d2ce534e10e60f7ad995e7875ffa0ff9cb14", size = 41144566, upload-time = "2025-02-18T18:53:11.958Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/e3/c9661b2b2849cfefddd9fd65b64e093594b231b472de08ff658f76c732b2/pyarrow-19.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3ad4c0eb4e2a9aeb990af6c09e6fa0b195c8c0e7b272ecc8d4d2b6574809d34", size = 42202991, upload-time = "2025-02-18T18:53:17.678Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/4f/a2c0ed309167ef436674782dfee4a124570ba64299c551e38d3fdaf0a17b/pyarrow-19.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d383591f3dcbe545f6cc62daaef9c7cdfe0dff0fb9e1c8121101cabe9098cfa6", size = 40507986, upload-time = "2025-02-18T18:53:26.263Z" },
-    { url = "https://files.pythonhosted.org/packages/27/2e/29bb28a7102a6f71026a9d70d1d61df926887e36ec797f2e6acfd2dd3867/pyarrow-19.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b4c4156a625f1e35d6c0b2132635a237708944eb41df5fbe7d50f20d20c17832", size = 42087026, upload-time = "2025-02-18T18:53:33.063Z" },
-    { url = "https://files.pythonhosted.org/packages/16/33/2a67c0f783251106aeeee516f4806161e7b481f7d744d0d643d2f30230a5/pyarrow-19.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:5bd1618ae5e5476b7654c7b55a6364ae87686d4724538c24185bbb2952679960", size = 25250108, upload-time = "2025-02-18T18:53:38.462Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/8d/275c58d4b00781bd36579501a259eacc5c6dfb369be4ddeb672ceb551d2d/pyarrow-19.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e45274b20e524ae5c39d7fc1ca2aa923aab494776d2d4b316b49ec7572ca324c", size = 30653552, upload-time = "2025-02-18T18:53:44.357Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/9e/e6aca5cc4ef0c7aec5f8db93feb0bde08dbad8c56b9014216205d271101b/pyarrow-19.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:d9dedeaf19097a143ed6da37f04f4051aba353c95ef507764d344229b2b740ae", size = 32103413, upload-time = "2025-02-18T18:53:52.971Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/fa/a7033f66e5d4f1308c7eb0dfcd2ccd70f881724eb6fd1776657fdf65458f/pyarrow-19.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ebfb5171bb5f4a52319344ebbbecc731af3f021e49318c74f33d520d31ae0c4", size = 41134869, upload-time = "2025-02-18T18:53:59.471Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/92/34d2569be8e7abdc9d145c98dc410db0071ac579b92ebc30da35f500d630/pyarrow-19.0.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2a21d39fbdb948857f67eacb5bbaaf36802de044ec36fbef7a1c8f0dd3a4ab2", size = 42192626, upload-time = "2025-02-18T18:54:06.062Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1f/80c617b1084fc833804dc3309aa9d8daacd46f9ec8d736df733f15aebe2c/pyarrow-19.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:99bc1bec6d234359743b01e70d4310d0ab240c3d6b0da7e2a93663b0158616f6", size = 40496708, upload-time = "2025-02-18T18:54:12.347Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/90/83698fcecf939a611c8d9a78e38e7fed7792dcc4317e29e72cf8135526fb/pyarrow-19.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1b93ef2c93e77c442c979b0d596af45e4665d8b96da598db145b0fec014b9136", size = 42075728, upload-time = "2025-02-18T18:54:19.364Z" },
-    { url = "https://files.pythonhosted.org/packages/40/49/2325f5c9e7a1c125c01ba0c509d400b152c972a47958768e4e35e04d13d8/pyarrow-19.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:d9d46e06846a41ba906ab25302cf0fd522f81aa2a85a71021826f34639ad31ef", size = 25242568, upload-time = "2025-02-18T18:54:25.846Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/72/135088d995a759d4d916ec4824cb19e066585b4909ebad4ab196177aa825/pyarrow-19.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:c0fe3dbbf054a00d1f162fda94ce236a899ca01123a798c561ba307ca38af5f0", size = 30702371, upload-time = "2025-02-18T18:54:30.665Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/01/00beeebd33d6bac701f20816a29d2018eba463616bbc07397fdf99ac4ce3/pyarrow-19.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:96606c3ba57944d128e8a8399da4812f56c7f61de8c647e3470b417f795d0ef9", size = 32116046, upload-time = "2025-02-18T18:54:35.995Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/c9/23b1ea718dfe967cbd986d16cf2a31fe59d015874258baae16d7ea0ccabc/pyarrow-19.0.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f04d49a6b64cf24719c080b3c2029a3a5b16417fd5fd7c4041f94233af732f3", size = 41091183, upload-time = "2025-02-18T18:54:42.662Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/d4/b4a3aa781a2c715520aa8ab4fe2e7fa49d33a1d4e71c8fc6ab7b5de7a3f8/pyarrow-19.0.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a9137cf7e1640dce4c190551ee69d478f7121b5c6f323553b319cac936395f6", size = 42171896, upload-time = "2025-02-18T18:54:49.808Z" },
-    { url = "https://files.pythonhosted.org/packages/23/1b/716d4cd5a3cbc387c6e6745d2704c4b46654ba2668260d25c402626c5ddb/pyarrow-19.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7c1bca1897c28013db5e4c83944a2ab53231f541b9e0c3f4791206d0c0de389a", size = 40464851, upload-time = "2025-02-18T18:54:57.073Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/bd/54907846383dcc7ee28772d7e646f6c34276a17da740002a5cefe90f04f7/pyarrow-19.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:58d9397b2e273ef76264b45531e9d552d8ec8a6688b7390b5be44c02a37aade8", size = 42085744, upload-time = "2025-02-18T18:55:08.562Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Lets ATS cache **private** bucket contents (today it only caches public). A new innermost middleware short-circuits ATS \`authproxy\` subrequests with empty 200 OK after auth+ACL have already validated; \`cache_control\` emits cache-friendly directives plus an \`X-Hippius-Visibility: private\` sentinel for ATS to demote on egress.

## Changes

- **\`gateway/middlewares/auth_probe.py\`** (new) — innermost middleware. Constant-time compare against \`HIPPIUS_AUTH_PROBE_SECRET\`. Fail-closed when secret unset.
- **\`gateway/middlewares/cache_control.py\`** — warm-private branch: \`is_cache_warm=true\` + \`anonymous_read_allowed=false\` → \`WARM_PUBLIC\` Cache-Control + \`X-Hippius-Visibility: private\`. Skips mutation on probe responses via \`request.state.is_auth_probe\`.
- **\`gateway/config.py\`** — new \`auth_probe_secret\` field (\`repr=False\` so dataclass repr can't leak it).
- **Workflows + k8s** — \`HIPPIUS_AUTH_PROBE_SECRET\` wired through staging/production deploys and both gateway deployment manifests (main + cache-region). Gateway-only.
- **CVE cleanup** — drop unused \`pyarrow\` (no imports anywhere) + bump \`idna\` to 3.15.
- **Tests** — 8 new auth_probe tests + 10 new warm-private cache_control tests covering smuggled-header rejection, fail-closed secret, all-methods empty body, visibility-header isolation.

## Operator action before deploy

Add \`HIPPIUS_AUTH_PROBE_SECRET\` to GitHub repo Settings → Secrets (\`openssl rand -hex 32\`). Same value goes on the ATS \`header_rewrite\` rule (separate PR). Until both are set, the middleware no-ops — safe to merge before ATS is configured.

## Test plan

- [x] \`pytest tests/unit/gateway\` — 1030 passed, 36 skipped
- [x] \`pre-commit run --all-files\` — clean (ruff, ruff-format, ty, pip-audit)
- [ ] Staging smoke after deploy + secret rollout