### PR TITLE
release(db): repoint prod to postgres-nvme-rw (Ceph→NVMe cutover)

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Update secrets
         run: |
-          DATABASE_URL="postgresql://postgres:${{ secrets.DATABASE_PASSWORD }}@postgres-rw:5432/hippius?sslmode=disable"
+          DATABASE_URL="postgresql://postgres:${{ secrets.DATABASE_PASSWORD }}@postgres-nvme-rw:5432/hippius?sslmode=disable"
 
           kubectl create secret generic hippius-s3-secrets \
             --from-literal=DATABASE_URL="${DATABASE_URL}" \
@@ -273,7 +273,7 @@ jobs:
         run: |
           CACHE_NS="${{ steps.ns.outputs.namespace }}"
           CLUSTER_URL="redis://redis-cluster.${CACHE_NS}.svc.cluster.local:6379?cluster=true"
-          DATABASE_URL="postgresql://postgres:${{ secrets.DATABASE_PASSWORD }}@postgres-rw.hippius-s3-prod.svc.cluster.local:5432/hippius?sslmode=disable"
+          DATABASE_URL="postgresql://postgres:${{ secrets.DATABASE_PASSWORD }}@postgres-nvme-rw.hippius-s3-prod.svc.cluster.local:5432/hippius?sslmode=disable"
 
           kubectl create secret generic hippius-s3-secrets \
             --from-literal=DATABASE_URL="${DATABASE_URL}" \

--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -20,6 +20,7 @@ patches:
   - path: services-patch.yaml
   - path: local-cache-patch.yaml
   - path: local-cache-configmap-patch.yaml
+  - path: postgres-nvme-initwait-patch.yaml
 
 images:
   - name: ghcr.io/thenervelab/hippius-s3/api

--- a/k8s/production/postgres-nvme-initwait-patch.yaml
+++ b/k8s/production/postgres-nvme-initwait-patch.yaml
@@ -1,0 +1,90 @@
+# Prod-only override: point the init-container DB readiness waits at the NVMe
+# cluster (postgres-nvme-rw) instead of the Ceph cluster (postgres-rw).
+#
+# Lives in the PRODUCTION overlay only. The shared base (k8s/base) keeps
+# `postgres-rw` so STAGING — which has no postgres-nvme cluster — is unaffected.
+# Required before decommissioning the Ceph `postgres` cluster, otherwise these
+# gates would hang once the postgres-rw Service is removed.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-for-postgres
+          command:
+            - sh
+            - -c
+            - until pg_isready -h postgres-nvme-rw -p 5432 -U postgres; do echo waiting for postgres; sleep 5; done
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: arion-uploader
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-for-services
+          command:
+            - sh
+            - -c
+            - until nc -z postgres-nvme-rw 5432 && nc -z redis 6379 && nc -z redis-queues 6379; do echo waiting for services; sleep 5; done
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: arion-downloader
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-for-services
+          command:
+            - sh
+            - -c
+            - until nc -z postgres-nvme-rw 5432 && nc -z redis 6379 && nc -z redis-queues 6379; do echo waiting for services; sleep 5; done
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: arion-unpinner
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-for-services
+          command:
+            - sh
+            - -c
+            - until nc -z postgres-nvme-rw 5432 && nc -z redis 6379 && nc -z redis-queues 6379; do echo waiting for services; sleep 5; done
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: janitor
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-for-services
+          command:
+            - sh
+            - -c
+            - until nc -z postgres-nvme-rw 5432 && nc -z redis 6379; do echo waiting for services; sleep 5; done
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-migrations
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-for-postgres
+          command:
+            - sh
+            - -c
+            - until pg_isready -h postgres-nvme-rw -p 5432 -U postgres; do echo waiting for postgres; sleep 5; done


### PR DESCRIPTION
**Maintenance-window release PR — DRAFT until cutover.** Merging this triggers the prod deploy that flips the app + workers from the Ceph Postgres cluster to the NVMe one.

## What it changes
- `.github/workflows/production-deploy.yaml`: `DATABASE_URL` host `postgres-rw` → `postgres-nvme-rw` (lines 135 main prod + 276 regional cache). Same value is stamped into `HIPPIUS_KEYSTORE_DATABASE_URL`.
- `k8s/production/postgres-nvme-initwait-patch.yaml`: **new** prod-overlay strategic-merge patch overriding init-container readiness waits (api + 4 workers + db-migrations Job) to `postgres-nvme-rw`. Shared `k8s/base` is **untouched**, so staging (no NVMe cluster) is unaffected.
- `k8s/production/kustomization.yaml`: wire the patch.

`s3-backup` deployments (`backup`, `hydrator`, `cleanup`) share the same `hippius-s3-secrets` — they get the NVMe DSN automatically when this deploy restarts them.

## When to merge
Only during the 2026-05-28 12:00 UTC maintenance window, **after** promoting the NVMe replica cluster (`kubectl patch cluster postgres-nvme replica.enabled=false`). Merging early would point the app at a still-read-only NVMe replica → write outage.

## Playbook
See [prod-big-release.md](./prod-big-release.md) (window step 4) — includes pre-checks, scenario-specific rollback (A–F), and the s3-backup repo's companion PR.

## Validation
- `kubectl kustomize k8s/production` builds clean.
- 6 NVMe init-waits applied (api + 4 workers + db-migrations Job); 0 remaining `postgres-rw` waits in the prod overlay.
- `staging` overlay untouched (verified: still on `postgres-rw`).