### PR TITLE
Fix e2e download flakiness: survive transient redis read timeout in wait_for_chunk

### DIFF
--- a/hippius_s3/cache/notifier.py
+++ b/hippius_s3/cache/notifier.py
@@ -19,6 +19,9 @@ from typing import AsyncIterator
 from typing import Awaitable
 from typing import Callable
 
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +115,26 @@ class ChunkNotifier:
                     if msg["type"] == "message":
                         return
 
-            await asyncio.wait_for(_listen(), timeout=timeout)
+            # The pub/sub connection has its own (short) socket read timeout, so a
+            # blocking `listen()` can raise redis TimeoutError/ConnectionError long
+            # before `timeout` if the downloader is simply slower than that socket
+            # read window. Treat those as transient: re-check the FS (the chunk may
+            # have landed) and keep waiting up to the real `timeout` deadline rather
+            # than killing the stream. See the 5s-read-timeout incident.
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + timeout
+            while True:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    raise asyncio.TimeoutError(f"timed out waiting for chunk {chunk_key}")
+                try:
+                    await asyncio.wait_for(_listen(), timeout=remaining)
+                    break
+                except (RedisTimeoutError, RedisConnectionError) as exc:
+                    data = await fetch_fn(object_id, int(object_version), int(part_number), int(chunk_index))
+                    if data is not None:
+                        return data
+                    logger.debug("pubsub read interrupted for %s (%s); still waiting", chunk_key, exc)
 
         # Worker published — fetch it. Retry once on transient miss (e.g. a
         # janitor delete or CephFS replication lag).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "botocore>=1.38.25",
     "boto3>=1.40.61",
     "cachetools",
-    "redis",
+    "redis==6.4.0",
     "pyinstrument>=4.0.0",
     "PyNaCl>=1.6.0",
     "cryptography>=42.0.0",
@@ -53,7 +53,7 @@ proxy = [
     "uvicorn[standard]>=0.23.0",
     "httpx>=0.27.0",
     "asyncpg>=0.28.0",
-    "redis",
+    "redis==6.4.0",
     "python-dotenv>=1.0.0",
 ]
 dev = [

--- a/tests/unit/test_chunk_notifier.py
+++ b/tests/unit/test_chunk_notifier.py
@@ -11,6 +11,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from hippius_s3.cache.notifier import ChunkNotifier
 from hippius_s3.cache.notifier import build_chunk_key
@@ -182,6 +183,52 @@ async def test_wait_transient_miss_retries_once() -> None:
 
     assert result == b"retry-win"
     assert len(call_log) == 4
+
+
+@pytest.mark.asyncio
+async def test_wait_survives_transient_redis_read_timeout() -> None:
+    """A redis socket read timeout from listen() must NOT kill the wait.
+
+    Reproduces the incident where the pub/sub connection's short socket read
+    timeout fired (redis.exceptions.TimeoutError) before the slow downloader
+    delivered the chunk. The wait should swallow it, re-check the FS, and keep
+    waiting up to the real timeout — then succeed once the chunk lands.
+    """
+    redis = FakeRedis()
+    notifier = ChunkNotifier(redis)
+
+    # listen() raises a redis TimeoutError on its first call (the socket read
+    # window), then on the second call blocks until the worker injects a message.
+    listen_calls = 0
+
+    async def flaky_listen():
+        nonlocal listen_calls
+        listen_calls += 1
+        if listen_calls == 1:
+            raise RedisTimeoutError("Timeout reading from redis-queues:6379")
+        while True:
+            msg = await redis.pubsub_instance._messages.get()
+            yield msg
+
+    redis.pubsub_instance.listen = flaky_listen  # type: ignore[method-assign]
+
+    available = False
+
+    async def fetch(oid, v, pn, ci):
+        return b"late-chunk" if available else None
+
+    async def simulate_slow_worker():
+        nonlocal available
+        await asyncio.sleep(0.02)
+        available = True
+        redis.pubsub_instance.inject_message(f"notify:{build_chunk_key(OBJ, 1, 1, 0)}")
+
+    worker = asyncio.create_task(simulate_slow_worker())
+    result = await notifier.wait_for_chunk(OBJ, 1, 1, 0, fetch_fn=fetch, timeout=2.0)
+    await worker
+
+    assert result == b"late-chunk"
+    assert listen_calls >= 2  # proves we retried after the transient timeout
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

E2E `test_GetObject::test_get_object_downloads_and_matches_headers` started failing consistently on 2026-06-01 with `IncompleteRead(0 bytes read, 9437184 more expected)` on the pipeline-path GET — despite no read/write/cache code changing since the last green run.

### Root cause
`ChunkNotifier.wait_for_chunk` blocks on `pubsub.listen()` inside an intended `cache_ttl` (3600s) wait. But the redis pub/sub connection has a short socket **read timeout**, so `listen()` raises `redis.exceptions.TimeoutError` after ~5s when the downloader is slower than that window. That bubbled up as a **fatal** stream error → Starlette `Response content shorter than Content-Length` → client `IncompleteRead`. Under CI load the 9 MB cold-download crosses 5s, so it fails every time.

Pinning `redis` was tried first (theory: a floated redis-py 7.x changed pub/sub timeout behavior) — but `redis==6.4.0` reproduces the failure, **disproving the version theory**. The resilience gap is the real root cause, and it's a genuine **production** risk too: any cold-object GET where the backend fetch exceeds the socket read timeout fails the same way for real users.

### Fix
- `wait_for_chunk` now catches transient `redis.TimeoutError`/`ConnectionError` from `listen()`, re-checks the FS (the chunk may have landed), and keeps waiting up to the real `cache_ttl` deadline instead of dying.
- New unit test `test_wait_survives_transient_redis_read_timeout` reproduces the exact failure (listen() raises a redis TimeoutError, then the chunk lands) and asserts the wait survives + succeeds.
- Kept `redis==6.4.0` pin for deterministic CI image builds (the base image installs via `pip install -e .`, which otherwise floats deps run-to-run).

## Follow-ups (not in this PR)
- Make `Dockerfile.base` install from the lockfile so CI stops floating dependencies entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)