### PR TITLE
Fix meta-write race, ATS PURGE host, and pin toolchain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,16 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.0
     hooks:
+      # Lint + auto-fix in place. --fix means staged files get corrected
+      # automatically; only unfixable findings fail the commit.
       - id: ruff
         args: [--fix]
         stages: [pre-commit]
-        files: ^hippius_s3/
+        files: ^(hippius_s3|gateway|tests)/
+      # Format in place (no --check). Equivalent to `ruff format` on save.
       - id: ruff-format
-        args: [--check]
         stages: [pre-commit]
-        files: ^hippius_s3/
+        files: ^(hippius_s3|gateway|tests)/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -30,29 +32,23 @@ repos:
 
   - repo: local
     hooks:
+      # Use `.venv/bin/ty` (not PATH) so the version is the one pinned in
+      # pyproject.toml (ty==0.0.43). Scope matches CI:
+      # `.github/workflows/test-and-lint.yml` runs `ty check hippius_s3 gateway`.
       - id: ty
         name: ty (type check)
-        entry: ty check hippius_s3
+        entry: .venv/bin/ty check hippius_s3 gateway
         language: system
         stages: [pre-commit]
         pass_filenames: false
         types: [python]
 
+      # Audit the project venv (which we control via uv.lock) — NOT pip-audit's
+      # own tool env (which we don't). The `uv run` invocation ensures the
+      # audited interpreter is `.venv/bin/python`.
       - id: pip-audit
-        # CVE-2026-3219: pip concatenated tar/zip handling. Fix landed upstream (pypa/pip#13870)
-        # but pip 26.1 not yet released to PyPI as of 2026-04-24 — only 26.0.1 is up. Remove
-        # this ignore once 26.1 ships.
-        # CVE-2026-6357: pip self-update deferred imports ACE. Also fixed in pip 26.1
-        # (released 2026-04-26). Same situation — pip-audit's hook env still resolves
-        # 26.0.1 even though the project venv is on 26.1. Remove once the hook env
-        # picks up 26.1.
-        # CVE-2026-45409 (idna), PYSEC-2026-141 / PYSEC-2026-142 (urllib3):
-        # pip-audit's own tool env carries idna 3.11 and urllib3 2.6.3. Our project
-        # venv is already on idna 3.15 and urllib3 2.7.0 (clean). The hook scans the
-        # tool's env, not ours, so the only way to unblock the hook is to ignore.
-        # Remove once `uv tool upgrade pip-audit` lands fixed deps in the tool env.
         name: pip-audit (dependency scan)
-        entry: pip-audit --ignore-vuln CVE-2024-23342 --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357 --ignore-vuln CVE-2026-45409 --ignore-vuln PYSEC-2026-141 --ignore-vuln PYSEC-2026-142
+        entry: uv run --extra dev pip-audit
         language: system
         stages: [pre-commit]
         pass_filenames: false

--- a/gateway/middlewares/ats_purge.py
+++ b/gateway/middlewares/ats_purge.py
@@ -14,6 +14,27 @@ from gateway.services.ats_cache_client import schedule_purge
 DEFAULT_HOST = "s3.hippius.com"
 
 
+def _public_host(request: Request) -> str:
+    # The cache key in ATS is built from the inbound URL the GET hit, so the
+    # PURGE must carry the same public Host. By the time the request reaches
+    # the gateway pod, the on-wire `Host` has been rewritten by ATS to the
+    # upstream NodePort (or by in-cluster callers to the k8s service DNS),
+    # which would produce a different cache key. The original public host is
+    # preserved on `x-forwarded-host` / `x-original-host` — same fallback
+    # chain SigV4 uses (gateway/middlewares/sigv4.py).
+    host = (
+        request.headers.get("x-forwarded-host")
+        or request.headers.get("x-original-host")
+        or request.headers.get("host")
+        or DEFAULT_HOST
+    )
+    # cachekey.so includes scheme://host[:port]/path; default ports are
+    # implicit so '<host>:80' and '<host>:443' must collapse to '<host>'.
+    if host.endswith(":80") or host.endswith(":443"):
+        host = host.rsplit(":", 1)[0]
+    return host
+
+
 async def ats_purge_middleware(
     request: Request,
     call_next: Callable[[Request], Awaitable[Response]],
@@ -45,7 +66,7 @@ async def ats_purge_middleware(
         # MPU part upload — not visible until CompleteMultipartUpload, skip.
         return response
 
-    host = request.headers.get("host", DEFAULT_HOST)
+    host = _public_host(request)
     is_complete_mpu = method == "POST" and "uploadId" in qs and "partNumber" not in qs
     if method in ("PUT", "DELETE") or is_complete_mpu:
         schedule_purge(host, f"{bucket}/{key}")

--- a/gateway/middlewares/banhammer.py
+++ b/gateway/middlewares/banhammer.py
@@ -190,7 +190,7 @@ class BanHammerService:
             end
             return ttl
             """
-            with_ttl = await self.redis.eval(script, 1, block_key, value, str(ban_seconds))
+            with_ttl = await self.redis.eval(script, 1, block_key, value, str(ban_seconds))  # ty: ignore[invalid-await]
             logger.warning(
                 "banhammer_ban ip=%s profile=%s ban_seconds=%s effective_ttl=%s count=%s reason=%s",
                 ip,

--- a/hippius_s3/api/user.py
+++ b/hippius_s3/api/user.py
@@ -254,7 +254,7 @@ async def recent_uploads(
 ) -> JSONResponse:
     cache_key = f"recent_uploads:{main_account_id}"
 
-    cached = await redis.get(cache_key)  # ty: ignore[unresolved-attribute]
+    cached = await redis.get(cache_key)
     if cached is not None:
         return JSONResponse(json.loads(cached))
 
@@ -284,7 +284,7 @@ async def recent_uploads(
         "uploads": uploads,
     }
 
-    await redis.setex(cache_key, RECENT_UPLOADS_CACHE_TTL_SECONDS, json.dumps(payload))  # ty: ignore[unresolved-attribute]
+    await redis.setex(cache_key, RECENT_UPLOADS_CACHE_TTL_SECONDS, json.dumps(payload))
 
     return JSONResponse(payload)
 

--- a/hippius_s3/cache/fs_store.py
+++ b/hippius_s3/cache/fs_store.py
@@ -386,6 +386,32 @@ class FileSystemPartsStore:
             logger.warning(f"FS meta read failed: object_id={object_id} v={object_version} part={part_number}: {e}")
             return None
 
+    async def get_meta_with_wait(
+        self,
+        object_id: str,
+        object_version: int,
+        part_number: int,
+        deadline_seconds: float = 30.0,
+    ) -> Optional[dict]:
+        # Poll get_meta with exponential backoff. The uploader writes meta last
+        # (after all chunks), and the consumer may dequeue before the writer's
+        # fsync has propagated across the shared cache mount. Within the
+        # deadline, "missing" = "writer hasn't finished" = wait. After the
+        # deadline, "missing" = genuine fault (writer crashed / FS-evicted /
+        # never written) = let the caller raise an after-deadline error so the
+        # classifier can route it as permanent.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + deadline_seconds
+        backoff = 0.1
+        while True:
+            meta = await self.get_meta(object_id, object_version, part_number)
+            if meta is not None:
+                return meta
+            if loop.time() >= deadline:
+                return None
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 2.0)
+
     async def delete_part(self, object_id: str, object_version: int, part_number: int) -> None:
         """Delete a part directory and attempt to prune empty parent directories.
 

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -149,6 +149,16 @@ class Config:
     uploader_pin_parallelism: int = env("HIPPIUS_UPLOADER_PIN_PARALLELISM:5", convert=int)
     # Heavy validation gating (legacy PINNER_VALIDATE_COVERAGE supported for compat)
     uploader_validate_coverage: bool = env("UPLOADER_VALIDATE_COVERAGE:false", convert=lambda x: x.lower() == "true")
+    # Deadline (seconds) for polling meta.json on the shared FS cache before
+    # giving up. The api pod writes meta last after fsync. On prod the api and
+    # consumer workers are co-located on the cache node so reads see meta
+    # immediately. On staging (and as defence-in-depth on prod) the worker
+    # may live on a different node from the producer, so meta visibility can
+    # lag the producer's fsync by ~hundreds of ms on a RWX CephFS mount.
+    # Within this window a missing meta = "writer hasn't propagated yet" =
+    # poll. After the window = genuine fault → raise (classifier routes
+    # to DLQ as permanent).
+    fs_meta_wait_seconds: float = env("HIPPIUS_FS_META_WAIT_SECONDS:30", convert=float)
 
     # Unpinner configuration
     unpinner_parallelism: int = env("HIPPIUS_UNPINNER_PARALLELISM:5", convert=int)

--- a/hippius_s3/dlq/base.py
+++ b/hippius_s3/dlq/base.py
@@ -51,7 +51,7 @@ class BaseDLQManager(Generic[T]):
         """Release lock only if token matches (atomic compare-and-delete)."""
         script = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
         with contextlib.suppress(Exception):
-            await self.redis_client.eval(script, 1, self._lock_key(identifier), token)
+            await self.redis_client.eval(script, 1, self._lock_key(identifier), token)  # ty: ignore[invalid-await]
 
     async def push(self, payload: T, last_error: str, error_type: str) -> None:
         """Push a failed request to the Dead-Letter Queue."""
@@ -61,7 +61,7 @@ class BaseDLQManager(Generic[T]):
 
         dlq_entry = self._create_entry(payload, last_error, etype)
 
-        await self.redis_client.lpush(self.dlq_key, json.dumps(dlq_entry))
+        await self.redis_client.lpush(self.dlq_key, json.dumps(dlq_entry))  # ty: ignore[invalid-await]
         identifier = self._get_identifier(payload)
         logger.warning(
             f"Pushed to DLQ ({self.dlq_key}): identifier={identifier}, error_type={etype}, error={last_error}"
@@ -84,7 +84,7 @@ class BaseDLQManager(Generic[T]):
 
     async def peek(self, limit: int = 10) -> List[Dict[str, Any]]:
         """Peek at DLQ entries without removing them."""
-        raw = await self.redis_client.lrange(self.dlq_key, -limit, -1)
+        raw = await self.redis_client.lrange(self.dlq_key, -limit, -1)  # ty: ignore[invalid-await]
         out: List[Dict[str, Any]] = []
         for entry_json in raw:
             try:
@@ -95,11 +95,11 @@ class BaseDLQManager(Generic[T]):
 
     async def stats(self) -> Dict[str, Any]:
         """Get DLQ statistics."""
-        count = await self.redis_client.llen(self.dlq_key)
+        count = await self.redis_client.llen(self.dlq_key)  # ty: ignore[invalid-await]
         error_types = {"transient": 0, "permanent": 0, "unknown": 0}
 
         if count > 0:
-            all_entries = await self.redis_client.lrange(self.dlq_key, 0, -1)
+            all_entries = await self.redis_client.lrange(self.dlq_key, 0, -1)  # ty: ignore[invalid-await]
             for entry_json in all_entries:
                 try:
                     entry = json.loads(entry_json)
@@ -131,7 +131,7 @@ class BaseDLQManager(Generic[T]):
                 logger.error(
                     f"Refusing to requeue permanent error for identifier: {identifier}. Use --force to override."
                 )
-                await self.redis_client.lpush(self.dlq_key, json.dumps(entry))
+                await self.redis_client.lpush(self.dlq_key, json.dumps(entry))  # ty: ignore[invalid-await]
                 return False
 
             payload_data = entry["payload"]
@@ -151,7 +151,7 @@ class BaseDLQManager(Generic[T]):
             logger.error(f"Failed to requeue identifier: {identifier}, error: {e}")
             with contextlib.suppress(Exception):
                 if "entry" in locals() and entry:
-                    await self.redis_client.lpush(self.dlq_key, json.dumps(entry))
+                    await self.redis_client.lpush(self.dlq_key, json.dumps(entry))  # ty: ignore[invalid-await]
             return False
         finally:
             with contextlib.suppress(Exception):
@@ -180,7 +180,7 @@ class BaseDLQManager(Generic[T]):
                 entry = json.loads(entry_json)
                 if entry.get("error_type") == "permanent" and not force:
                     # Put permanent errors back
-                    await self.redis_client.lpush(self.dlq_key, entry_json)
+                    await self.redis_client.lpush(self.dlq_key, entry_json)  # ty: ignore[invalid-await]
                     total_skipped += 1
                     continue
                 payload_data = entry["payload"]
@@ -219,14 +219,14 @@ class BaseDLQManager(Generic[T]):
         if identifier:
             entry = await self._find_and_remove_entry(identifier)
             return 1 if entry else 0
-        count = int(await self.redis_client.llen(self.dlq_key))
+        count = int(await self.redis_client.llen(self.dlq_key))  # ty: ignore[invalid-await]
         await self.redis_client.delete(self.dlq_key)
         return count
 
     async def export(self, file_path: str) -> bool:
         """Export DLQ contents to a JSON file."""
         try:
-            all_entries = await self.redis_client.lrange(self.dlq_key, 0, -1)
+            all_entries = await self.redis_client.lrange(self.dlq_key, 0, -1)  # ty: ignore[invalid-await]
             entries = []
             for entry_json in all_entries:
                 try:
@@ -257,7 +257,7 @@ class BaseDLQManager(Generic[T]):
             entries = await asyncio.to_thread(_read_json)
 
             for entry in entries:
-                await self.redis_client.lpush(self.dlq_key, json.dumps(entry))
+                await self.redis_client.lpush(self.dlq_key, json.dumps(entry))  # ty: ignore[invalid-await]
 
             logger.info(f"Imported {len(entries)} entries from {file_path}")
             return True

--- a/hippius_s3/dlq/unpin_dlq.py
+++ b/hippius_s3/dlq/unpin_dlq.py
@@ -35,7 +35,7 @@ class UnpinDLQManager(BaseDLQManager[UnpinChainRequest]):
 
     async def _find_and_remove_entry(self, identifier: str) -> Optional[Dict[str, Any]]:
         """Find and remove entry by CID or object_id."""
-        all_entries = await self.redis_client.lrange(self.dlq_key, 0, -1)
+        all_entries = await self.redis_client.lrange(self.dlq_key, 0, -1)  # ty: ignore[invalid-await]
         target_entry: Optional[Dict[str, Any]] = None
 
         for entry_json in all_entries:
@@ -45,7 +45,7 @@ class UnpinDLQManager(BaseDLQManager[UnpinChainRequest]):
                 continue
 
             if entry.get("cid") == identifier or entry.get("object_id") == identifier:
-                removed = await self.redis_client.lrem(self.dlq_key, 1, entry_json)
+                removed = await self.redis_client.lrem(self.dlq_key, 1, entry_json)  # ty: ignore[invalid-await]
                 if removed:
                     target_entry = entry
                     break

--- a/hippius_s3/dlq/upload_dlq.py
+++ b/hippius_s3/dlq/upload_dlq.py
@@ -22,7 +22,7 @@ class UploadDLQManager(BaseDLQManager[UploadChainRequest]):
             """Enqueue upload request to specific backend queue."""
             client = get_queue_client()
             raw = payload.model_dump_json()
-            await client.lpush(self._queue_name, raw)
+            await client.lpush(self._queue_name, raw)  # ty: ignore[invalid-await]
 
         super().__init__(
             redis_client=redis_client,
@@ -52,7 +52,7 @@ class UploadDLQManager(BaseDLQManager[UploadChainRequest]):
 
     async def _find_and_remove_entry(self, identifier: str) -> Optional[Dict[str, Any]]:
         """Find and remove entry by object_id."""
-        all_entries = await self.redis_client.lrange(self.dlq_key, 0, -1)
+        all_entries = await self.redis_client.lrange(self.dlq_key, 0, -1)  # ty: ignore[invalid-await]
         target_entry: Optional[Dict[str, Any]] = None
 
         for entry_json in all_entries:
@@ -61,7 +61,7 @@ class UploadDLQManager(BaseDLQManager[UploadChainRequest]):
             except json.JSONDecodeError:
                 continue
             if entry.get("object_id") == identifier:
-                removed = await self.redis_client.lrem(self.dlq_key, 1, entry_json)
+                removed = await self.redis_client.lrem(self.dlq_key, 1, entry_json)  # ty: ignore[invalid-await]
                 if removed:
                     target_entry = entry
                     break

--- a/hippius_s3/metrics_collector_task.py
+++ b/hippius_s3/metrics_collector_task.py
@@ -88,10 +88,10 @@ class BackgroundMetricsCollector:
                 self.metrics_collector.set_queue_length(queue_name, length)
 
             for queue_name in self.ZSET_QUEUES:
-                length = int(await rc.zcard(queue_name) or 0)  # ty: ignore
+                length = int(await rc.zcard(queue_name) or 0)
                 self.metrics_collector.set_queue_length(queue_name, length)
 
-            info = await self.redis_client.info("memory")  # ty: ignore
+            info = await self.redis_client.info("memory")
             self.metrics_collector._used_mem = info.get("used_memory", 0)
             self.metrics_collector._max_mem = info.get("maxmemory", 0)
 

--- a/hippius_s3/queue.py
+++ b/hippius_s3/queue.py
@@ -154,7 +154,7 @@ async def enqueue_upload_to_backends(request: UploadChainRequest) -> None:
     raw = request.model_dump_json()
     for backend in request.upload_backends:
         queue_name = f"{backend}_upload_requests"
-        await client.lpush(queue_name, raw)
+        await client.lpush(queue_name, raw)  # ty: ignore[invalid-await]
     logger.info(f"Enqueued upload request {request.name=} backends={request.upload_backends}")
 
 
@@ -167,7 +167,7 @@ async def dequeue_upload_request(queue_name: str) -> UploadChainRequest | None:
     """Get the next upload request from the Redis queue."""
     client = get_queue_client()
 
-    result = await client.brpop(_normalize_queue_name(queue_name), timeout=0.5)
+    result = await client.brpop(_normalize_queue_name(queue_name), timeout=0.5)  # ty: ignore[invalid-await, invalid-argument-type]
     if result:
         _, queue_data = result
         queue_data = json.loads(queue_data)
@@ -248,7 +248,7 @@ async def enqueue_unpin_request(payload: UnpinChainRequest, *, queue_name: str |
     raw = payload.model_dump_json()
 
     if queue_name is not None:
-        await client.lpush(_normalize_queue_name(queue_name), raw)
+        await client.lpush(_normalize_queue_name(queue_name), raw)  # ty: ignore[invalid-await]
         logger.info(f"Enqueued unpin request {payload.name=} queue={queue_name}")
     else:
         config = get_config()
@@ -277,14 +277,14 @@ async def enqueue_unpin_request(payload: UnpinChainRequest, *, queue_name: str |
         backends = effective or config.delete_backends
         queue_names = [f"{b}_unpin_requests" for b in backends]
         for qname in queue_names:
-            await client.lpush(qname, raw)
+            await client.lpush(qname, raw)  # ty: ignore[invalid-await]
         logger.info(f"Enqueued unpin request {payload.name=} queues={queue_names}")
 
 
 async def dequeue_unpin_request(queue_name: str = "unpin_requests") -> UnpinChainRequest | None:
     """Get the next unpin request from the Redis queue."""
     client = get_queue_client()
-    result = await client.brpop(_normalize_queue_name(queue_name), timeout=3)
+    result = await client.brpop(_normalize_queue_name(queue_name), timeout=3)  # ty: ignore[invalid-await, invalid-argument-type]
     if result:
         _, queue_data = result
         return UnpinChainRequest.model_validate_json(queue_data)
@@ -379,7 +379,7 @@ async def enqueue_download_request(payload: DownloadChainRequest) -> None:
     queue_names = [f"{b}_download_requests" for b in payload.download_backends]
 
     for qname in queue_names:
-        await client.lpush(qname, raw)
+        await client.lpush(qname, raw)  # ty: ignore[invalid-await]
 
     logger.info(f"Enqueued download request {payload.name=} queues={queue_names}")
 
@@ -387,7 +387,7 @@ async def enqueue_download_request(payload: DownloadChainRequest) -> None:
 async def dequeue_download_request(queue_name: str) -> DownloadChainRequest | None:
     """Get the next download request from a backend-specific download queue."""
     client = get_queue_client()
-    result = await client.brpop(_normalize_queue_name(queue_name), timeout=5)
+    result = await client.brpop(_normalize_queue_name(queue_name), timeout=5)  # ty: ignore[invalid-await, invalid-argument-type]
     if result:
         _, queue_data = result
         return DownloadChainRequest.model_validate_json(queue_data)

--- a/hippius_s3/redis_utils.py
+++ b/hippius_s3/redis_utils.py
@@ -17,8 +17,14 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+# Public type alias: every code path treats the Redis client polymorphically
+# (we never reach into cluster-only or standalone-only attributes). Exposing
+# a named union here is what lets call sites annotate cleanly without
+# importing both classes separately.
+RedisClient = Union[Redis, RedisCluster]
 
-def create_redis_client(redis_url: str) -> Union[Redis, RedisCluster]:
+
+def create_redis_client(redis_url: str) -> RedisClient:
     """
     Create a Redis client from URL, automatically detecting cluster vs standalone.
 
@@ -39,7 +45,7 @@ def create_redis_client(redis_url: str) -> Union[Redis, RedisCluster]:
             socket_timeout=5,
             health_check_interval=30,
             socket_keepalive=True,
-            retry_on_error=[RedisConnectionError, RedisTimeoutError],  # ty: ignore[invalid-argument-type]
+            retry_on_error=[RedisConnectionError, RedisTimeoutError],
         )
     logger.info("Creating Redis client")
     return Redis.from_url(redis_url)

--- a/hippius_s3/workers/downloader.py
+++ b/hippius_s3/workers/downloader.py
@@ -442,7 +442,7 @@ async def run_downloader_loop(
             if needs_redis_reconnect:
                 logger.warning(f"[{backend_name}] Rebuilding cache redis client after task error")
                 with contextlib.suppress(Exception):
-                    await redis_client.aclose()  # ty: ignore[unresolved-attribute]
+                    await redis_client.aclose()
                 redis_client = create_redis_client(config.redis_url)  # ty: ignore[invalid-assignment]
                 initialize_cache_client(redis_client)
                 obj_cache = RedisObjectPartsCache(redis_client, queues_client=redis_queues_client, fs_store=fs_store)
@@ -465,7 +465,7 @@ async def run_downloader_loop(
             except (BusyLoadingError, RedisConnectionError, RedisTimeoutError) as exc:
                 logger.warning(f"[{backend_name}] Redis error dequeuing: {exc}. Reconnecting…")
                 with contextlib.suppress(Exception):
-                    await redis_queues_client.aclose()  # ty: ignore[unresolved-attribute]
+                    await redis_queues_client.aclose()
                 await asyncio.sleep(2)
                 redis_queues_client = async_redis.from_url(config.redis_queues_url)
                 initialize_queue_client(redis_queues_client)
@@ -503,6 +503,6 @@ async def run_downloader_loop(
         logger.error(f"[{backend_name}] Fatal loop error: {exc}", exc_info=True)
         raise
     finally:
-        await redis_client.aclose()  # ty: ignore[unresolved-attribute]
-        await redis_queues_client.aclose()  # ty: ignore[unresolved-attribute]
+        await redis_client.aclose()
+        await redis_queues_client.aclose()
         await db_pool.close()

--- a/hippius_s3/workers/errors.py
+++ b/hippius_s3/workers/errors.py
@@ -228,6 +228,11 @@ _TRANSIENT_KEYWORDS = (
     "429",
     "part_meta_not_ready",
     "part_row_missing",
+    # Defense-in-depth for the meta-write/race-window error shape — the
+    # consumer (arion-uploader, s3-backup) now polls meta within a bounded
+    # deadline before raising, so this string should not appear in practice.
+    # Kept here so any stray race-window raise still classifies as transient.
+    "missing meta in filesystem cache for",
 )
 
 _PERMANENT_KEYWORDS = (
@@ -253,7 +258,14 @@ _PERMANENT_KEYWORDS = (
     "nosuchbucket",
     "invalid token",
     "expired token",
-    "filesystem cache",  # FS evicted source bytes between enqueue and processing
+    # Source bytes are genuinely gone — the data is unrecoverable. These two
+    # cover (a) the after-deadline raise from arion-uploader / s3-backup once
+    # the meta-poll deadline expires (writer crashed or chunks evicted) and
+    # (b) the operator misconfig case where the cache root is unmounted. The
+    # transient race-window form ("missing meta in filesystem cache for ...")
+    # is intentionally NOT covered by these — it gets retried.
+    "missing meta in filesystem cache after",
+    "filesystem cache directory missing",
     "key too long",
     "hippius api",  # explicit Hippius API failures don't self-heal (the
     # client's @retry_on_error decorator already burned its budget)

--- a/hippius_s3/workers/uploader.py
+++ b/hippius_s3/workers/uploader.py
@@ -268,7 +268,15 @@ class Uploader:
             },
         ) as span:
             logger.debug(f"Uploading chunk object_id={object_id} part={part_number}")
-            meta = await self.fs_store.get_meta(object_id, int(object_version), part_number)
+            meta_wait_s = float(getattr(self.config, "fs_meta_wait_seconds", 30.0))
+            meta = await self.fs_store.get_meta_with_wait(
+                object_id, int(object_version), part_number, deadline_seconds=meta_wait_s
+            )
+            if meta is None:
+                raise RuntimeError(
+                    f"Missing meta in filesystem cache after {meta_wait_s}s for upload: "
+                    f"object_id={object_id} version={int(object_version)} part={part_number}"
+                )
             num_chunks_meta = int(meta.get("num_chunks", 0)) if isinstance(meta, dict) else 0
 
             resolved_upload_id: Optional[str] = upload_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,11 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.21.0",
     "ruff>=0.12.0",
-    "ty>=0.0.16",
+    # ty must be pinned exactly: the same code can be "clean" on one version
+    # and "broken" on the next. Keep this in lockstep with
+    # .github/workflows/test-and-lint.yml `uv tool install ty==X.Y.Z` and
+    # .pre-commit-config.yaml (which runs `.venv/bin/ty` so it inherits this pin).
+    "ty==0.0.43",
     "pip-audit>=2.10.0",
     "pre-commit>=3.5.0",
     "minio>=7.1.15",
@@ -69,7 +73,11 @@ dev = [
     "types-boto3",
     "types-botocore",
     "types-requests",
-    "types-redis",
+    # types-redis intentionally NOT pinned here: the `redis` package ships its
+    # own inline stubs (`redis-stubs/` in site-packages) since 5.x, and adding
+    # the standalone types-redis (4.6.x) confuses ty by stacking two stub sets
+    # — one of them missing methods like aclose, the other inconsistent on
+    # close() signatures. Bundled stubs only.
     "requests>=2.31.0",
     "psycopg[binary]>=3.1",
     "fakeredis>=2.23.0",

--- a/tests/unit/CLAUDE.md
+++ b/tests/unit/CLAUDE.md
@@ -64,11 +64,12 @@ Put them under the matching subdirectory. Naming: `test_<module>_<behavior>.py`.
 
 | ID | Time | T | Title | Read |
 |----|------|---|-------|------|
-| #6741 | 12:26 PM | 🔄 | Downloader tests migrated to FileSystemPartsStore | ~296 |
+| #6801 | 1:01 PM | 🟣 | Committed comprehensive PR #146 code review fixes addressing critical safety issues | ~1390 |
+| #6798 | 12:58 PM | 🔄 | Deleted obsolete download cache dual-read test file | ~271 |
 
-### May 27, 2026
+### Apr 23, 2026
 
 | ID | Time | T | Title | Read |
 |----|------|---|-------|------|
-| #8225 | 10:49 AM | ✅ | Performance optimization suite completed and verified | ~570 |
+| #6965 | 2:08 PM | 🔵 | Code reuse analysis identifies test fixture duplication and typing improvements | ~864 |
 </claude-mem-context>

--- a/tests/unit/gateway/test_ats_purge_middleware.py
+++ b/tests/unit/gateway/test_ats_purge_middleware.py
@@ -112,9 +112,7 @@ async def test_batch_delete_does_not_purge_in_v1(app: Any, captured_purges: list
 
 
 @pytest.mark.asyncio
-async def test_bucket_acl_flip_does_not_fire_wildcard_purge(
-    app: Any, captured_purges: list[tuple[str, str]]
-) -> None:
+async def test_bucket_acl_flip_does_not_fire_wildcard_purge(app: Any, captured_purges: list[tuple[str, str]]) -> None:
     """Stock ATS HTTP PURGE doesn't support globs — bucket-level invalidation is a no-op.
 
     Objects age out within the 5-min TTL; regex_revalidate plugin could close this gap later.
@@ -126,9 +124,7 @@ async def test_bucket_acl_flip_does_not_fire_wildcard_purge(
 
 
 @pytest.mark.asyncio
-async def test_bucket_delete_does_not_fire_wildcard_purge(
-    app: Any, captured_purges: list[tuple[str, str]]
-) -> None:
+async def test_bucket_delete_does_not_fire_wildcard_purge(app: Any, captured_purges: list[tuple[str, str]]) -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://s3.hippius.com") as client:
         r = await client.delete("/mybucket")
     assert r.status_code == 200
@@ -181,6 +177,80 @@ async def test_host_header_propagated(app: Any, captured_purges: list[tuple[str,
         r = await client.put("/mybucket/k", content=b"x")
     assert r.status_code == 200
     assert captured_purges == [("s3-staging.hippius.com", "mybucket/k")]
+
+
+@pytest.mark.asyncio
+async def test_x_forwarded_host_wins_over_inbound_host(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    """In prod the on-wire Host is the upstream rewritten by ATS — the public
+    Host that built the cache key lives on x-forwarded-host. Must use that."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://192.168.1.199:30081") as client:
+        r = await client.put(
+            "/mybucket/k",
+            content=b"x",
+            headers={"x-forwarded-host": "s3.hippius.com"},
+        )
+    assert r.status_code == 200
+    assert captured_purges == [("s3.hippius.com", "mybucket/k")]
+
+
+@pytest.mark.asyncio
+async def test_x_original_host_used_when_no_x_forwarded_host(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://192.168.1.199:30081") as client:
+        r = await client.put(
+            "/mybucket/k",
+            content=b"x",
+            headers={"x-original-host": "eu-central-1.hippius.com"},
+        )
+    assert r.status_code == 200
+    assert captured_purges == [("eu-central-1.hippius.com", "mybucket/k")]
+
+
+@pytest.mark.asyncio
+async def test_default_port_stripped_from_host(app: Any, captured_purges: list[tuple[str, str]]) -> None:
+    """`s3.hippius.com:80` and `s3.hippius.com` must produce the same cache
+    key — the cachekey.so plugin keys on the URL including port, but HTTP
+    clients omit default ports in the URL the GET uses."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://x") as client:
+        r = await client.put(
+            "/mybucket/k",
+            content=b"x",
+            headers={"x-forwarded-host": "s3.hippius.com:80"},
+        )
+    assert r.status_code == 200
+    assert captured_purges == [("s3.hippius.com", "mybucket/k")]
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_default_host_when_no_headers(
+    app: Any, captured_purges: list[tuple[str, str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """For requests with no usable Host hint (in-cluster service DNS that
+    doesn't map cleanly), fall back to s3.hippius.com so PURGEs at least hit
+    a remap-mapped name instead of being rejected as ERR_INVALID_URL."""
+    # ASGITransport always sends a Host header; simulate the no-host case by
+    # invoking the middleware directly with a constructed scope.
+    from fastapi import Request as _Request
+
+    captured_purges.clear()
+    scope = {
+        "type": "http",
+        "method": "PUT",
+        "path": "/mybucket/k",
+        "raw_path": b"/mybucket/k",
+        "query_string": b"",
+        "headers": [],  # no host at all
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 1234),
+        "state": {},
+    }
+    request = _Request(scope)
+
+    async def _next(req: _Request) -> Response:
+        return Response(status_code=200, content=b"ok")
+
+    await ats_purge_middleware(request, _next)
+    assert captured_purges == [("s3.hippius.com", "mybucket/k")]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_classify_errors.py
+++ b/tests/unit/test_classify_errors.py
@@ -33,6 +33,7 @@ from hippius_s3.workers.errors import is_retryable
 # Helpers — small fakes that match real exception shapes
 # --------------------------------------------------------------------------- #
 
+
 class _HTTPLikeError(Exception):
     """Mimics httpx.HTTPStatusError: ``error.response.status_code`` is set."""
 
@@ -69,6 +70,7 @@ class _HippiusAuthenticationError(_HippiusAPIError):
 # extract_http_status_code
 # =========================================================================== #
 
+
 def test_extract_from_httpx_like() -> None:
     assert extract_http_status_code(_HTTPLikeError(503)) == "503"
 
@@ -103,6 +105,7 @@ def test_extract_walks_into_chained_cause() -> None:
 # extract_boto_error_code
 # =========================================================================== #
 
+
 def test_extract_boto_code_present() -> None:
     assert extract_boto_error_code(_client_error(503, code="SlowDown")) == "SlowDown"
 
@@ -114,6 +117,7 @@ def test_extract_boto_code_absent_on_httpx_like() -> None:
 # =========================================================================== #
 # is_billing_error
 # =========================================================================== #
+
 
 def test_is_billing_402_status() -> None:
     assert is_billing_error(_HTTPLikeError(402)) is True
@@ -132,6 +136,7 @@ def test_is_billing_false_on_other_codes() -> None:
 # classify_upload_error — status-code layer
 # =========================================================================== #
 
+
 @pytest.mark.parametrize(
     "error, expected",
     [
@@ -141,15 +146,15 @@ def test_is_billing_false_on_other_codes() -> None:
         (_HTTPLikeError(503), "transient"),
         (_HTTPLikeError(504), "transient"),
         # special codes
-        (_HTTPLikeError(408), "transient"),   # request timeout
-        (_HTTPLikeError(429), "transient"),   # too many requests
-        (_HTTPLikeError(507), "permanent"),   # disk full upstream
-        (_HTTPLikeError(402), "billing"),     # out of credit (upload-only bucket)
+        (_HTTPLikeError(408), "transient"),  # request timeout
+        (_HTTPLikeError(429), "transient"),  # too many requests
+        (_HTTPLikeError(507), "permanent"),  # disk full upstream
+        (_HTTPLikeError(402), "billing"),  # out of credit (upload-only bucket)
         # 4xx (non-special) → permanent
-        (_HTTPLikeError(400), "permanent"),   # bad request
-        (_HTTPLikeError(401), "permanent"),   # unauthorized
-        (_HTTPLikeError(403), "permanent"),   # forbidden
-        (_HTTPLikeError(404), "permanent"),   # bad URL on upload
+        (_HTTPLikeError(400), "permanent"),  # bad request
+        (_HTTPLikeError(401), "permanent"),  # unauthorized
+        (_HTTPLikeError(403), "permanent"),  # forbidden
+        (_HTTPLikeError(404), "permanent"),  # bad URL on upload
         (_HTTPLikeError(409), "permanent"),
         (_HTTPLikeError(413), "permanent"),
         (_HTTPLikeError(415), "permanent"),
@@ -163,6 +168,7 @@ def test_upload_status_codes(error: Exception, expected: str) -> None:
 # =========================================================================== #
 # classify_upload_error — botocore error code layer
 # =========================================================================== #
+
 
 @pytest.mark.parametrize(
     "code, http_status, expected",
@@ -193,6 +199,7 @@ def test_upload_boto_codes(code: str, http_status: int, expected: str) -> None:
 # classify_upload_error — exception class layer
 # =========================================================================== #
 
+
 def test_upload_asyncio_timeout_is_transient() -> None:
     assert classify_upload_error(asyncio.TimeoutError()) == "transient"
 
@@ -205,15 +212,18 @@ def test_upload_builtin_timeout_error_is_transient() -> None:
     assert classify_upload_error(TimeoutError("deadline")) == "transient"
 
 
-@pytest.mark.parametrize("errno_value", [
-    errno.ECONNRESET,
-    errno.ECONNREFUSED,
-    errno.ETIMEDOUT,
-    errno.EHOSTUNREACH,
-    errno.ENETUNREACH,
-    errno.EPIPE,
-    errno.EAGAIN,
-])
+@pytest.mark.parametrize(
+    "errno_value",
+    [
+        errno.ECONNRESET,
+        errno.ECONNREFUSED,
+        errno.ETIMEDOUT,
+        errno.EHOSTUNREACH,
+        errno.ENETUNREACH,
+        errno.EPIPE,
+        errno.EAGAIN,
+    ],
+)
 def test_upload_oserror_errno_is_transient(errno_value: int) -> None:
     exc = OSError(errno_value, "broken")
     assert classify_upload_error(exc) == "transient"
@@ -251,40 +261,47 @@ def test_upload_botocore_param_validation_is_not_transient() -> None:
 # classify_upload_error — keyword fallback layer
 # =========================================================================== #
 
-@pytest.mark.parametrize("error, expected", [
-    # Transient keywords
-    (Exception("connection refused"), "transient"),
-    (Exception("read timed out"), "transient"),
-    (Exception("network is unreachable"), "transient"),
-    (Exception("503 Service Unavailable"), "transient"),
-    (Exception("429 Too Many Requests"), "transient"),
-    (Exception("rate limit exceeded"), "transient"),
-    (Exception("request was throttled"), "transient"),
-    (Exception("could not connect to host"), "transient"),
-    (Exception("connection pool is exhausted"), "transient"),
-    (Exception("remote disconnected without sending response"), "transient"),
-    (Exception("deadline exceeded"), "transient"),
-    (Exception("part_meta_not_ready"), "transient"),
-    (Exception("part_row_missing"), "transient"),
-    # Permanent keywords
-    (Exception("Malformed request body"), "permanent"),
-    (Exception("invalid chunk index"), "permanent"),
-    (Exception("validation error: bad field"), "permanent"),
-    (Exception("integrity check failed"), "permanent"),
-    (Exception("insufficient storage on device"), "permanent"),
-    (Exception("SignatureDoesNotMatch"), "permanent"),
-    (Exception("Hippius API rejected publish"), "permanent"),
-    (Exception("forbidden by policy"), "permanent"),
-    (Exception("unauthorized"), "permanent"),
-    (Exception("access denied"), "permanent"),
-    (Exception("filesystem cache missing"), "permanent"),  # FS evicted
-    # Custom exception classes
-    (_HippiusAPIError("publish failed"), "permanent"),
-    (_HippiusAuthenticationError("token expired"), "permanent"),
-    # Nothing matches → unknown (these go to DLQ flagged for review)
-    (Exception("totally novel failure"), "unknown"),
-    (Exception(""), "unknown"),
-])
+
+@pytest.mark.parametrize(
+    "error, expected",
+    [
+        # Transient keywords
+        (Exception("connection refused"), "transient"),
+        (Exception("read timed out"), "transient"),
+        (Exception("network is unreachable"), "transient"),
+        (Exception("503 Service Unavailable"), "transient"),
+        (Exception("429 Too Many Requests"), "transient"),
+        (Exception("rate limit exceeded"), "transient"),
+        (Exception("request was throttled"), "transient"),
+        (Exception("could not connect to host"), "transient"),
+        (Exception("connection pool is exhausted"), "transient"),
+        (Exception("remote disconnected without sending response"), "transient"),
+        (Exception("deadline exceeded"), "transient"),
+        (Exception("part_meta_not_ready"), "transient"),
+        (Exception("part_row_missing"), "transient"),
+        # Permanent keywords
+        (Exception("Malformed request body"), "permanent"),
+        (Exception("invalid chunk index"), "permanent"),
+        (Exception("validation error: bad field"), "permanent"),
+        (Exception("integrity check failed"), "permanent"),
+        (Exception("insufficient storage on device"), "permanent"),
+        (Exception("SignatureDoesNotMatch"), "permanent"),
+        (Exception("Hippius API rejected publish"), "permanent"),
+        (Exception("forbidden by policy"), "permanent"),
+        (Exception("unauthorized"), "permanent"),
+        (Exception("access denied"), "permanent"),
+        (
+            Exception("Missing meta in filesystem cache after 30s for upload: object_id=abc"),
+            "permanent",
+        ),  # after-deadline = FS evicted / writer crashed
+        # Custom exception classes
+        (_HippiusAPIError("publish failed"), "permanent"),
+        (_HippiusAuthenticationError("token expired"), "permanent"),
+        # Nothing matches → unknown (these go to DLQ flagged for review)
+        (Exception("totally novel failure"), "unknown"),
+        (Exception(""), "unknown"),
+    ],
+)
 def test_upload_keyword_and_class_fallbacks(error: Exception, expected: str) -> None:
     assert classify_upload_error(error) == expected
 
@@ -292,6 +309,7 @@ def test_upload_keyword_and_class_fallbacks(error: Exception, expected: str) -> 
 # =========================================================================== #
 # classify_upload_error — chained __cause__ walk-through
 # =========================================================================== #
+
 
 def test_upload_walks_chained_cause_for_transient() -> None:
     inner = ConnectionError("upstream dropped")
@@ -319,6 +337,7 @@ def test_upload_walks_chained_cause_for_permanent() -> None:
 # classify_upload_error — disk full 507 wins over the billing check
 # =========================================================================== #
 
+
 def test_507_wins_over_billing() -> None:
     # Pathological: a 507 with "Payment Required" in the message. 507 wins because
     # the status-code layer runs before the billing keyword fallback in is_billing_error.
@@ -328,6 +347,7 @@ def test_507_wins_over_billing() -> None:
 # =========================================================================== #
 # classify_error backward-compat alias
 # =========================================================================== #
+
 
 def test_classify_error_alias_matches_upload() -> None:
     # Several call sites still import classify_error; it must equal classify_upload_error.
@@ -339,6 +359,7 @@ def test_classify_error_alias_matches_upload() -> None:
 # =========================================================================== #
 # classify_download_error — the 404 divergence is the headline behaviour
 # =========================================================================== #
+
 
 @pytest.mark.parametrize(
     "error, expected",
@@ -371,6 +392,7 @@ def test_download_never_returns_billing() -> None:
 # =========================================================================== #
 # classify_unpin_error — 404 transient, everything else same as upload
 # =========================================================================== #
+
 
 def test_unpin_404_is_transient_not_permanent() -> None:
     """The headline difference from upload/download: 404 means the pin commit
@@ -412,6 +434,7 @@ def test_three_classifiers_diverge_on_404() -> None:
 # is_retryable — wraps classify_upload_error + attempt budget
 # =========================================================================== #
 
+
 def test_retryable_true_for_transient_under_budget() -> None:
     assert is_retryable(_HTTPLikeError(503), attempts=0, max_attempts=5) is True
     assert is_retryable(_HTTPLikeError(503), attempts=3, max_attempts=5) is True
@@ -435,11 +458,15 @@ def test_retryable_false_for_billing() -> None:
 # compute_backoff_ms — exponential with jitter, capped
 # =========================================================================== #
 
-@pytest.mark.parametrize("attempt, base_floor, base_ceiling", [
-    (1, 1000, 1100),
-    (2, 2000, 2200),
-    (3, 4000, 4400),
-])
+
+@pytest.mark.parametrize(
+    "attempt, base_floor, base_ceiling",
+    [
+        (1, 1000, 1100),
+        (2, 2000, 2200),
+        (3, 4000, 4400),
+    ],
+)
 def test_backoff_within_bounds(attempt: int, base_floor: int, base_ceiling: int) -> None:
     for _ in range(40):
         v = compute_backoff_ms(attempt, base_ms=1000, max_ms=10**9)
@@ -462,28 +489,78 @@ def test_backoff_grows_per_attempt() -> None:
 # Real-world DLQ-shaped failure messages (regression coverage for "unknown" leak)
 # =========================================================================== #
 
-@pytest.mark.parametrize("real_message, expected", [
-    # ----- patterns observed in the 2026-06-04 prod arion_upload_requests:dlq sample -----
-    ("all connection attempts failed", "transient"),                # 137× / 200 sample
-    ("Server disconnected without sending a response.", "transient"),  # 22× / 200
-    ("[Errno -5] No address associated with hostname", "transient"),  # 2× — DNS resolver blip
-    (
-        "Authentication failed: Client error '401 Unauthorized' for url 'https://arion.hippius.com/upload' "
-        "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401",
-        "permanent",
-    ),
-    # ----- additional real-world shapes (httpx, boto, generic transport) -----
-    ("Connection reset by peer", "transient"),
-    ("HTTPConnectionPool(host='arion.hippius.com', port=443): Max retries exceeded", "transient"),
-    ("upstream request timeout", "transient"),
-    ("HTTP/1.1 502 Bad Gateway", "transient"),
-    ("Temporary failure in name resolution", "transient"),
-    # Real arion-unpinner validation rejection (what we saw in the day-2 digest)
-    ("Failed to unpin arion identifier=abc123: 1 validation error", "permanent"),
-    # Real api STREAM fetch failed (the PR #177 territory)
-    ("STREAM fetch failed object_id=... v=1 part=14 chunk=2", "unknown"),
-    # boto SlowDown verbose form
-    ("An error occurred (SlowDown) when calling the PutObject operation: Please reduce your request rate.", "transient"),
-])
+
+@pytest.mark.parametrize(
+    "real_message, expected",
+    [
+        # ----- patterns observed in the 2026-06-04 prod arion_upload_requests:dlq sample -----
+        ("all connection attempts failed", "transient"),  # 137× / 200 sample
+        ("Server disconnected without sending a response.", "transient"),  # 22× / 200
+        ("[Errno -5] No address associated with hostname", "transient"),  # 2× — DNS resolver blip
+        (
+            "Authentication failed: Client error '401 Unauthorized' for url 'https://arion.hippius.com/upload' "
+            "For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401",
+            "permanent",
+        ),
+        # ----- additional real-world shapes (httpx, boto, generic transport) -----
+        ("Connection reset by peer", "transient"),
+        ("HTTPConnectionPool(host='arion.hippius.com', port=443): Max retries exceeded", "transient"),
+        ("upstream request timeout", "transient"),
+        ("HTTP/1.1 502 Bad Gateway", "transient"),
+        ("Temporary failure in name resolution", "transient"),
+        # Real arion-unpinner validation rejection (what we saw in the day-2 digest)
+        ("Failed to unpin arion identifier=abc123: 1 validation error", "permanent"),
+        # Real api STREAM fetch failed (the PR #177 territory)
+        ("STREAM fetch failed object_id=... v=1 part=14 chunk=2", "unknown"),
+        # boto SlowDown verbose form
+        (
+            "An error occurred (SlowDown) when calling the PutObject operation: Please reduce your request rate.",
+            "transient",
+        ),
+    ],
+)
 def test_real_world_error_messages(real_message: str, expected: str) -> None:
     assert classify_upload_error(Exception(real_message)) == expected
+
+
+# =========================================================================== #
+# Meta-write race: must NOT permanently DLQ the race-window message
+# =========================================================================== #
+
+
+@pytest.mark.parametrize(
+    "msg, expected",
+    [
+        # Pre-deadline race-window message — defense-in-depth: arion-uploader /
+        # s3-backup now polls and only raises after the deadline, but if this
+        # string is ever raised it MUST classify as transient and retry.
+        (
+            "Missing meta in filesystem cache for backup: object_id=abc-123 version=1 part=1",
+            "transient",
+        ),
+        (
+            "Missing meta in filesystem cache for upload: object_id=abc-123 version=1 part=1",
+            "transient",
+        ),
+        # After-deadline raise — writer crashed, data evicted, etc. Permanent.
+        (
+            "Missing meta in filesystem cache after 30.0s for upload: object_id=abc-123 version=1 part=1",
+            "permanent",
+        ),
+        (
+            "Missing meta in filesystem cache after 30.0s for backup: object_id=abc-123 version=1 part=1",
+            "permanent",
+        ),
+        # Operator misconfig (cache root unmounted) — permanent.
+        ("Filesystem cache directory missing: /var/lib/hippius/object_cache", "permanent"),
+    ],
+)
+def test_filesystem_cache_race_classification(msg: str, expected: str) -> None:
+    assert classify_upload_error(Exception(msg)) == expected
+    # Same expectation for download / unpin classifiers — the race shape is
+    # consumer-agnostic.
+    from hippius_s3.workers.errors import classify_download_error
+    from hippius_s3.workers.errors import classify_unpin_error
+
+    assert classify_download_error(Exception(msg)) == expected
+    assert classify_unpin_error(Exception(msg)) == expected

--- a/tests/unit/test_fs_store.py
+++ b/tests/unit/test_fs_store.py
@@ -76,6 +76,42 @@ async def test_get_meta_missing_returns_none(fs: FileSystemPartsStore) -> None:
     assert await fs.get_meta(OBJ, 1, 99) is None
 
 
+@pytest.mark.asyncio
+async def test_get_meta_with_wait_returns_immediately_when_present(fs: FileSystemPartsStore) -> None:
+    await fs.set_meta(OBJ, 1, 1, chunk_size=4096, num_chunks=2, size_bytes=8192)
+    t0 = time.monotonic()
+    meta = await fs.get_meta_with_wait(OBJ, 1, 1, deadline_seconds=5.0)
+    elapsed = time.monotonic() - t0
+    assert meta == {"chunk_size": 4096, "num_chunks": 2, "size_bytes": 8192}
+    # Fast-path: should not wait at all when meta is already present.
+    assert elapsed < 0.05
+
+
+@pytest.mark.asyncio
+async def test_get_meta_with_wait_returns_none_after_deadline(fs: FileSystemPartsStore) -> None:
+    t0 = time.monotonic()
+    meta = await fs.get_meta_with_wait(OBJ, 1, 99, deadline_seconds=0.3)
+    elapsed = time.monotonic() - t0
+    assert meta is None
+    # Should have actually waited for the deadline (not returned immediately).
+    assert 0.25 <= elapsed <= 1.5
+
+
+@pytest.mark.asyncio
+async def test_get_meta_with_wait_picks_up_late_write(fs: FileSystemPartsStore) -> None:
+    """Simulates the producer-consumer race: consumer starts polling first,
+    producer writes meta partway through, consumer should return the meta."""
+
+    async def write_after(delay: float) -> None:
+        await asyncio.sleep(delay)
+        await fs.set_meta(OBJ, 1, 1, chunk_size=4096, num_chunks=1, size_bytes=4096)
+
+    writer = asyncio.create_task(write_after(0.2))
+    meta = await fs.get_meta_with_wait(OBJ, 1, 1, deadline_seconds=5.0)
+    await writer
+    assert meta == {"chunk_size": 4096, "num_chunks": 1, "size_bytes": 4096}
+
+
 # -------- atomic writes ----------
 
 

--- a/tests/unit/test_uploader_upload.py
+++ b/tests/unit/test_uploader_upload.py
@@ -420,3 +420,162 @@ async def test_process_upload_no_longer_calls_pin_on_api(mock_config, mock_db_po
 
         assert "QmCID1" in result
         assert not hasattr(uploader, "pin_on_api")
+
+
+# ============================================================================ #
+# Meta-write race: end-to-end chain that the original DLQ pileup hinged on.
+#
+# The chain we MUST keep working:
+#   _upload_single_chunk
+#     → fs_store.get_meta_with_wait(...) returns None  (poll deadline expired)
+#     → raise RuntimeError("Missing meta in filesystem cache after Ns ...")
+#     → classify_upload_error(error) == "permanent"
+#     → uploader's main loop routes to DLQ as permanent (no infinite retry)
+#
+# Unit tests already cover each link in isolation (get_meta_with_wait polling
+# in test_fs_store.py; the classifier in test_classify_errors.py). The
+# regression risk is in the SEAM between them — that the upload code raises
+# the EXACT message shape the classifier recognises.
+# ============================================================================ #
+
+
+@pytest.mark.asyncio
+async def test_upload_raises_after_deadline_message_when_meta_missing(
+    mock_config, mock_db_pool, mock_fs_store
+):
+    """The uploader must raise the after-deadline message (not the pre-deadline
+    one) when get_meta_with_wait returns None — otherwise the classifier would
+    mark it transient and the worker would retry the failing slot forever."""
+    redis = FakeRedis()
+    redis_queues = FakeRedis()
+    mock_config.fs_meta_wait_seconds = 0.1
+
+    # The whole point of the race fix: get_meta_with_wait returns None when
+    # the writer hasn't propagated meta within the deadline.
+    mock_fs_store.get_meta_with_wait = AsyncMock(return_value=None)
+
+    uploader = Uploader(
+        mock_db_pool, redis, redis_queues, mock_config, backend_name="arion", backend_client=MagicMock()
+    )
+    uploader.fs_store = mock_fs_store
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await uploader._upload_single_chunk(
+            object_id="obj-race-1",
+            object_key="test-key",
+            chunk=Chunk(id=1),
+            upload_id="upload-race-1",
+            object_version=1,
+            account_ss58="5FakeTestAccountAddress123456789012345678901234",
+        )
+
+    msg = str(excinfo.value)
+    # The exact substring the classifier's _PERMANENT_KEYWORDS keys on. If this
+    # ever drifts, the classifier will mis-route the failure (back to
+    # transient) and we will retry until DLQ — re-creating the original bug.
+    assert "missing meta in filesystem cache after" in msg.lower()
+    assert "object_id=obj-race-1" in msg
+    assert "version=1" in msg
+    assert "part=1" in msg
+
+    # And the deadline-poll must have been awaited with the configured value,
+    # not skipped or hardcoded.
+    mock_fs_store.get_meta_with_wait.assert_awaited_once()
+    _, kwargs = mock_fs_store.get_meta_with_wait.call_args
+    assert kwargs.get("deadline_seconds") == 0.1
+
+
+@pytest.mark.asyncio
+async def test_uploader_after_deadline_message_classifies_as_permanent(
+    mock_config, mock_db_pool, mock_fs_store
+):
+    """End-to-end seam check: take the EXACT exception the uploader produces
+    on a stuck meta and run it through the actual classifier. The original
+    bug was a mismatch between the message string and the keyword list — this
+    test exists to make any future drift between them an immediate red CI."""
+    from hippius_s3.workers.errors import classify_upload_error
+
+    redis = FakeRedis()
+    redis_queues = FakeRedis()
+    mock_config.fs_meta_wait_seconds = 0.05
+    mock_fs_store.get_meta_with_wait = AsyncMock(return_value=None)
+
+    uploader = Uploader(
+        mock_db_pool, redis, redis_queues, mock_config, backend_name="arion", backend_client=MagicMock()
+    )
+    uploader.fs_store = mock_fs_store
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await uploader._upload_single_chunk(
+            object_id="obj-race-2",
+            object_key="test-key",
+            chunk=Chunk(id=1),
+            upload_id="upload-race-2",
+            object_version=1,
+            account_ss58="5FakeTestAccountAddress123456789012345678901234",
+        )
+
+    # The whole reason we changed the message string and the keyword list
+    # together: this exception, raised by THIS code path, must be permanent.
+    # If the classifier returns "transient" we'd retry forever on a fault.
+    # If it returns "unknown" we'd land in DLQ but mark it for human review
+    # (also wrong — this IS a genuine permanent failure).
+    assert classify_upload_error(excinfo.value) == "permanent"
+
+
+@pytest.mark.asyncio
+async def test_uploader_does_not_raise_when_meta_lands_within_deadline(
+    mock_config, mock_db_pool, mock_fs_store
+):
+    """The race-fix sibling assertion: when get_meta_with_wait succeeds (the
+    common case in production, where api + workers share a node), the upload
+    path takes the normal happy path with no error and no retry overhead."""
+    redis = FakeRedis()
+    redis_queues = FakeRedis()
+    mock_config.fs_meta_wait_seconds = 30.0
+
+    # Meta returns normally — this is the steady-state production behavior.
+    mock_fs_store.get_meta_with_wait = AsyncMock(
+        return_value={"num_chunks": 1, "chunk_size": 1024}
+    )
+
+    chunk_uuid = "aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+    mock_conn = AsyncMock()
+    mock_conn.fetchrow = AsyncMock(return_value=MockRow({"part_id": "part-uuid"}))
+    mock_conn.fetchval = AsyncMock(side_effect=[chunk_uuid, 1])
+    mock_db_pool.acquire = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_conn)))
+
+    mock_upload_response = UploadResponse(
+        id="file-uuid-happy",
+        original_name="test.part1.chunk0",
+        content_type="application/octet-stream",
+        size_bytes=1024,
+        sha256_hex="abc",
+        cid="QmHappy",
+        status="completed",
+        file_url="https://example.com/file",
+        created_at="2025-11-27T12:00:00Z",
+        updated_at="2025-11-27T12:00:00Z",
+    )
+    mock_api_instance = AsyncMock()
+    mock_api_instance.upload_file_and_get_cid = AsyncMock(return_value=mock_upload_response)
+    mock_api_instance.__aenter__ = AsyncMock(return_value=mock_api_instance)
+    mock_api_instance.__aexit__ = AsyncMock()
+
+    uploader = Uploader(
+        mock_db_pool, redis, redis_queues, mock_config, backend_name="arion", backend_client=mock_api_instance
+    )
+    uploader.fs_store = mock_fs_store
+
+    # Should NOT raise.
+    await uploader._upload_single_chunk(
+        object_id="obj-happy",
+        object_key="test-key",
+        chunk=Chunk(id=1),
+        upload_id="upload-happy",
+        object_version=1,
+        account_ss58="5FakeTestAccountAddress123456789012345678901234",
+    )
+
+    # And the upload actually proceeded — no early bail-out hiding a regression.
+    assert mock_api_instance.upload_file_and_get_cid.call_count == 1

--- a/tests/unit/test_uploader_upload.py
+++ b/tests/unit/test_uploader_upload.py
@@ -43,6 +43,7 @@ def mock_fs_store():
     store = MagicMock(spec=FileSystemPartsStore)
     store.get_chunk = AsyncMock(return_value=b"encrypted_chunk_data_123")
     store.get_meta = AsyncMock(return_value={"num_chunks": 1, "chunk_size": 1024})
+    store.get_meta_with_wait = AsyncMock(return_value={"num_chunks": 1, "chunk_size": 1024})
     return store
 
 
@@ -96,7 +97,7 @@ async def test_upload_single_chunk_calls_new_api(mock_config, mock_db_pool, mock
     mock_api_instance.__aexit__ = AsyncMock()
     uploader.backend_client = mock_api_instance
 
-    result = await uploader._upload_single_chunk(
+    await uploader._upload_single_chunk(
         object_id="obj-123",
         object_key="test-key",
         chunk=Chunk(id=1),

--- a/uv.lock
+++ b/uv.lock
@@ -960,7 +960,6 @@ dev = [
     { name = "ty" },
     { name = "types-boto3" },
     { name = "types-botocore" },
-    { name = "types-redis" },
     { name = "types-requests" },
 ]
 proxy = [
@@ -1014,17 +1013,16 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-dotenv", marker = "extra == 'proxy'", specifier = ">=1.0.0" },
-    { name = "redis" },
-    { name = "redis", marker = "extra == 'proxy'" },
+    { name = "redis", specifier = "==6.4.0" },
+    { name = "redis", marker = "extra == 'proxy'", specifier = "==6.4.0" },
     { name = "requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0.0" },
     { name = "substrate-interface", specifier = "==1.7.11" },
-    { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.16" },
+    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.43" },
     { name = "types-boto3", marker = "extra == 'dev'" },
     { name = "types-botocore", marker = "extra == 'dev'" },
-    { name = "types-redis", marker = "extra == 'dev'" },
     { name = "types-requests", marker = "extra == 'dev'" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.23.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'proxy'", specifier = ">=0.23.0" },
@@ -1858,11 +1856,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]
@@ -2443,11 +2441,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -2697,7 +2695,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2705,9 +2703,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -2930,27 +2928,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.35"
+version = "0.0.43"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/53/440e7b1212c4b0abbd4adb7aed93f4971aa1f8dca386ac5515930afa9172/ty-0.0.35.tar.gz", hash = "sha256:8375c240ab38138a19db07996c9808fb7a92047c1492e1ce587c2ef5112ad3a9", size = 5629237, upload-time = "2026-05-10T18:25:17.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/37/4ec04de0659b93be37d956dfceca13b1ecab9c959f28d8a1d5e514603f36/ty-0.0.43.tar.gz", hash = "sha256:ea4cff50548f2a1877e848d3abe9e293cde8ab94757a7eb93fc0d4013f98be8e", size = 5798429, upload-time = "2026-06-04T00:52:10.013Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/84/19662ee881675815b7fafff940a365be1985730465afd9b75cb2edd5f8b3/ty-0.0.35-py3-none-linux_armv6l.whl", hash = "sha256:85ae1e59b9fb0b40e9d84fe61b29653c5f2f5e78b487ece371a7a38c20c781cf", size = 11198741, upload-time = "2026-05-10T18:24:49.378Z" },
-    { url = "https://files.pythonhosted.org/packages/62/df/7e5b6f83d85b4d2e5b72b5dceb388f440acc10679417bd46f829b9200fab/ty-0.0.35-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:709dbb7af4fcadb1196863c00b8791bbbbcc9dacbe15a0ff17f0af82b35d415b", size = 10948304, upload-time = "2026-05-10T18:24:58.246Z" },
-    { url = "https://files.pythonhosted.org/packages/59/94/72d7263aca055cde427f0ebcf08d6a74e5a5fee1d1e7fdd553696089cecb/ty-0.0.35-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2cb0877419ab0c8708b6925cb0c2800b263842bd3c425113f200538772f3a0cc", size = 10407413, upload-time = "2026-05-10T18:24:37.422Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/23/fda6fae8a81ce0cb5f24cdfe63260e110c7af8844e31fa07d1e6e8ef0232/ty-0.0.35-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7afbcfc61904b7e82e7fe1a1db832a40d8f01e69dee1775f6594e552980536c", size = 10932614, upload-time = "2026-05-10T18:24:47.401Z" },
-    { url = "https://files.pythonhosted.org/packages/72/3d/b98d8d4aa1a5ed6daaf15864e838f605ca7b1e8b93b7e17b96ed4bc4dfed/ty-0.0.35-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b61498cc3e4178031c079951257fbdb209a891b4feb10ad6c40f615a51846f41", size = 10962982, upload-time = "2026-05-10T18:24:44.88Z" },
-    { url = "https://files.pythonhosted.org/packages/18/c4/2881aad71bf6fb2f8df17fc8e4bc89e904e54490a3ee747b5ef73f98ac85/ty-0.0.35-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:573b1eacda349fc8dba0d767b41631c3a6f66412363127c5bf2b1b40a1d898d2", size = 11476274, upload-time = "2026-05-10T18:24:42.4Z" },
-    { url = "https://files.pythonhosted.org/packages/34/0f/7717650adaeaddd23eea70470e2c26d3f0b9b18fdc7f26ec9552d6001f17/ty-0.0.35-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a7209746158d6393c1040aa64b3ca29622e212ea7d8bae22ba50dbcbb4f96f0a", size = 12012027, upload-time = "2026-05-10T18:25:00.752Z" },
-    { url = "https://files.pythonhosted.org/packages/22/c9/1a16cb4aab6f4707d8f550772e91abc26d1c8870f19b5e2453ad10bb8209/ty-0.0.35-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4466a1470aa4418d49a9aa45d9da7de42033addd0a2837c5b2b0eb71d3c2bcd3", size = 11648894, upload-time = "2026-05-10T18:25:12.44Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a1/a977c0e07e9f88db9c67f90c6342a4dc4422c8091fa07bf26521870687c5/ty-0.0.35-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb44bb742d52c309dcaa6598bcf4d82eb4bf1241b9e4940461e522e30093fe8b", size = 11560482, upload-time = "2026-05-10T18:25:05.172Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/c1/a5fb11227d5cc4ac3f29a115d8c8bc817578e8ef6907d1e4c914ddbf45ee/ty-0.0.35-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:34b219250736c989b2670a03782c61315f523f3a2be37f1f90b1207e2212c188", size = 11718495, upload-time = "2026-05-10T18:24:54.12Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/cb/e92e4317388b6d1fd821a46941b448a8a1ff0bf13e22147c5167d8fa1b00/ty-0.0.35-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:88e2ac497decc0940ef1a07571dee8a746112a93a09cdc7f8bca0099752e2e05", size = 10900815, upload-time = "2026-05-10T18:25:02.941Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/4f/03bd87388a92567f262f35ac64e10d2be047d258f2dfcf1405f500fa2b90/ty-0.0.35-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:02cae51b53e6ec17d5d827ff1a3a76fd119705b56a92156e04399eda6e911596", size = 10998051, upload-time = "2026-05-10T18:25:14.68Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/60/6edbc375ee6073973200096168f644e1081e5e55a7d42596826465b275de/ty-0.0.35-py3-none-musllinux_1_2_i686.whl", hash = "sha256:11871d730c9400d899ac0b9f3d660ed2e7e433377c8725549f8250a36a7f2620", size = 11148910, upload-time = "2026-05-10T18:24:51.842Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/b1/a845d2066ed521c477450f436d4bd353d107e7c02dd6536a485944aaf892/ty-0.0.35-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1ad0a2f0530d0933dcc99ad36ac556c63e384ea72ab9a18d23ad2e2c9fd61c73", size = 11671005, upload-time = "2026-05-10T18:24:56.223Z" },
-    { url = "https://files.pythonhosted.org/packages/73/81/1d5912a54fb66b2f95ac828ae61d422ef5afeae1263e4d231e40796c229f/ty-0.0.35-py3-none-win32.whl", hash = "sha256:0e25d63ec4ab116e7f6757e44d16ca9216bca679d19ecc36d119cf80faada61a", size = 10481096, upload-time = "2026-05-10T18:24:39.976Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/36/1c7f8632bfec1c321f01581d4c940a3617b24bd3e8b37c8a7363d33fbfc4/ty-0.0.35-py3-none-win_amd64.whl", hash = "sha256:6a0a6d259f6f2f8f2f954c6f013d4e0b5eba68af6b353bf19a47d59ec254a3d5", size = 11555691, upload-time = "2026-05-10T18:25:07.792Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/fb/59325221bce52f6e833d6865ce8360ef7d5e1e21151b38df6dc77c4327a7/ty-0.0.35-py3-none-win_arm64.whl", hash = "sha256:619c52c0fb2aa21961a848a1995135ad3b6d0a9aa54da0194e60f679cc200e13", size = 10925457, upload-time = "2026-05-10T18:25:10.352Z" },
+    { url = "https://files.pythonhosted.org/packages/db/74/1916026a78f20019a2f03adbd6fb4430ddb7ce1e52c2e17a90856a6d192e/ty-0.0.43-py3-none-linux_armv6l.whl", hash = "sha256:3bf70f5446480562bf6c9f639df4b5cb60716b8f8d1a6b8e5811d5c7eccd8bf2", size = 11598153, upload-time = "2026-06-04T00:52:20.646Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/af/58bb0089d2635216c8fa6612dd486a3f986d0ab1c46a41527ab95e57f0e3/ty-0.0.43-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7184741f8b15425a1bc64b950ad005cb353573288ac0e8a04f5481ceb3832596", size = 11357811, upload-time = "2026-06-04T00:52:24.683Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/9c/32c6b14f3feddf87b59c7a50709e2b3da408258f2f583f05575f77bc8f7b/ty-0.0.43-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8c306379ca9a35f6ae5270fe9bda7af4b46d91822725a2586d78c8b9b5493b62", size = 10772024, upload-time = "2026-06-04T00:52:14.312Z" },
+    { url = "https://files.pythonhosted.org/packages/09/fa/98aa4a74bd00cd5efc424923cd1daffbf1e40a0338041cafb203379d746f/ty-0.0.43-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d624b884c9c1fd244ad2a5f026364e7162a22b3f537025941ada2e363e676414", size = 11291034, upload-time = "2026-06-04T00:52:37.249Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/db/4de086c38ce96dcada2bd451f43171d2c237f96d8ed19a1ea8fe51bb8ef4/ty-0.0.43-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:281fc4c00fbc196045141faa085055bddc58846b04a2800204701415a1b9c6aa", size = 11364724, upload-time = "2026-06-04T00:52:33.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d3/e3cd8e3233a6fd8362a49aa025b79e9f40151a2a86d811ace154c6eb7445/ty-0.0.43-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f57d6cc28de89024b48d1788e4758c05299d5749d4a51c02e71ac655ec23d9a5", size = 11890555, upload-time = "2026-06-04T00:52:22.711Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7b/6f46d444e8241606bbde098df3dca93f2ec0b834a42055db85ee7d33646f/ty-0.0.43-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0a1d6ad6c5e7792c7eac0a01e550f2c2004462e01a64a91ea1636aba6fef6e71", size = 12450968, upload-time = "2026-06-04T00:52:28.94Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e1/79fbe51f2e4b9d8347f2013cd7ed0b63f3b499038c02dc0357e9b28a3a47/ty-0.0.43-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:66d474395d7635fb618bdbb58b4e3360259a2056d0a5621b82754b9da2cd8a04", size = 12064187, upload-time = "2026-06-04T00:52:12.039Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3f/c758a3a8df5b90d331f2b60c8f16021ee64d75e78f99d67cc4efc9bf5f4b/ty-0.0.43-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2663a0003a8b60fb98db7f6f6e673df80b21d0fe3a9868a26fb06b4e049b6fc4", size = 11943208, upload-time = "2026-06-04T00:52:31.14Z" },
+    { url = "https://files.pythonhosted.org/packages/54/5f/f516442749cf1b45ca6720a5d41df2738a486ed9ace774c03d515db89084/ty-0.0.43-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:d5a6c352d374d889189d5ec82b54b26a5885f769f7b7787f7f875500dcb8673e", size = 12143572, upload-time = "2026-06-04T00:52:18.457Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/0d83c7f43bf4c10f3678bfe7d938e51c445298c7b923f155c5204730c2df/ty-0.0.43-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e7dbbeedfad3ca250d74fcc355fa9ab6b38d2a17f22d6304f615716939dbbb27", size = 11279355, upload-time = "2026-06-04T00:52:26.726Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/de/a6c978bef6d9e949f79f4782d9e4ee4df0893713e73b055d84c1a5116b9a/ty-0.0.43-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:24b18a0273ee46154996cfcfa27438f851f440c925587ec200df6f98dffe67d3", size = 11408412, upload-time = "2026-06-04T00:52:35.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b1/d13857c23867f0f76b92e38e5841c64ca5e76dc5d4bf27f52cb81d8ab685/ty-0.0.43-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2ef681951520d692b7e9c0b5e56aacf4f98ccae47cf6ffccaf2c7b6b33dc226e", size = 11541709, upload-time = "2026-06-04T00:52:16.451Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f1/cd6afc6f6a687e238bf5e12189f7920e81a0bdef6c3dba4c784ef140f7d9/ty-0.0.43-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2af105de7437143aa4676b28016b5bee661aaaa4eff52be5867fb25119641ceb", size = 12041266, upload-time = "2026-06-04T00:52:43.541Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ba/51ca7c3335da2b8d0a3e477fa4986be9f4a53b05bfab862967d8d2e6ca60/ty-0.0.43-py3-none-win32.whl", hash = "sha256:e4773115b0d6486ee30f1657fc8bdffe7e3a3f5300ab77ef2495da6e83e4694f", size = 10858724, upload-time = "2026-06-04T00:52:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/29/5d80453e5f7c520145fa058851da87230dbd7ca761a7675447a9fe504e0b/ty-0.0.43-py3-none-win_amd64.whl", hash = "sha256:48d3545094a4ae6395492c7e6ac90550fce969e0ed2815fbf8c5da9756676b7d", size = 11976157, upload-time = "2026-06-04T00:52:41.438Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ed/befe5a543e5b95e754ed38ee95239e44efda9bc5f578db4ac1bc8dd758d6/ty-0.0.43-py3-none-win_arm64.whl", hash = "sha256:740ca33d7f75f655a4e7d475bc42dfb825c13219bb073fad30fcc04d35790c74", size = 11308680, upload-time = "2026-06-04T00:52:39.233Z" },
 ]
 
 [[package]]
@@ -2989,44 +2987,6 @@ wheels = [
 ]
 
 [[package]]
-name = "types-cffi"
-version = "1.17.0.20250915"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "types-setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/98/ea454cea03e5f351323af6a482c65924f3c26c515efd9090dede58f2b4b6/types_cffi-1.17.0.20250915.tar.gz", hash = "sha256:4362e20368f78dabd5c56bca8004752cc890e07a71605d9e0d9e069dbaac8c06", size = 17229, upload-time = "2025-09-15T03:01:25.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/ec/092f2b74b49ec4855cdb53050deb9699f7105b8fda6fe034c0781b8687f3/types_cffi-1.17.0.20250915-py3-none-any.whl", hash = "sha256:cef4af1116c83359c11bb4269283c50f0688e9fc1d7f0eeb390f3661546da52c", size = 20112, upload-time = "2025-09-15T03:01:24.187Z" },
-]
-
-[[package]]
-name = "types-pyopenssl"
-version = "24.1.0.20240722"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "types-cffi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/93/29/47a346550fd2020dac9a7a6d033ea03fccb92fa47c726056618cc889745e/types-pyOpenSSL-24.1.0.20240722.tar.gz", hash = "sha256:47913b4678a01d879f503a12044468221ed8576263c1540dcb0484ca21b08c39", size = 8458, upload-time = "2024-07-22T02:32:22.558Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/05/c868a850b6fbb79c26f5f299b768ee0adc1f9816d3461dcf4287916f655b/types_pyOpenSSL-24.1.0.20240722-py3-none-any.whl", hash = "sha256:6a7a5d2ec042537934cfb4c9d4deb0e16c4c6250b09358df1f083682fe6fda54", size = 7499, upload-time = "2024-07-22T02:32:21.232Z" },
-]
-
-[[package]]
-name = "types-redis"
-version = "4.6.0.20241004"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "types-pyopenssl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/95/c054d3ac940e8bac4ca216470c80c26688a0e79e09f520a942bb27da3386/types-redis-4.6.0.20241004.tar.gz", hash = "sha256:5f17d2b3f9091ab75384153bfa276619ffa1cf6a38da60e10d5e6749cc5b902e", size = 49679, upload-time = "2024-10-04T02:43:59.224Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/82/7d25dce10aad92d2226b269bce2f85cfd843b4477cd50245d7d40ecf8f89/types_redis-4.6.0.20241004-py3-none-any.whl", hash = "sha256:ef5da68cb827e5f606c8f9c0b49eeee4c2669d6d97122f301d3a55dc6a63f6ed", size = 58737, upload-time = "2024-10-04T02:43:57.968Z" },
-]
-
-[[package]]
 name = "types-requests"
 version = "2.32.4.20250913"
 source = { registry = "https://pypi.org/simple" }
@@ -3045,15 +3005,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/c5/23946fac96c9dd5815ec97afd1c8ad6d22efa76c04a79a4823f2f67692a5/types_s3transfer-0.13.1.tar.gz", hash = "sha256:ce488d79fdd7d3b9d39071939121eca814ec65de3aa36bdce1f9189c0a61cc80", size = 14181, upload-time = "2025-08-31T16:57:06.93Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/dc/b3f9b5c93eed6ffe768f4972661250584d5e4f248b548029026964373bcd/types_s3transfer-0.13.1-py3-none-any.whl", hash = "sha256:4ff730e464a3fd3785b5541f0f555c1bd02ad408cf82b6b7a95429f6b0d26b4a", size = 19617, upload-time = "2025-08-31T16:57:05.73Z" },
-]
-
-[[package]]
-name = "types-setuptools"
-version = "80.9.0.20250822"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/bd/1e5f949b7cb740c9f0feaac430e301b8f1c5f11a81e26324299ea671a237/types_setuptools-80.9.0.20250822.tar.gz", hash = "sha256:070ea7716968ec67a84c7f7768d9952ff24d28b65b6594797a464f1b3066f965", size = 41296, upload-time = "2025-08-22T03:02:08.771Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/2d/475bf15c1cdc172e7a0d665b6e373ebfb1e9bf734d3f2f543d668b07a142/types_setuptools-80.9.0.20250822-py3-none-any.whl", hash = "sha256:53bf881cb9d7e46ed12c76ef76c0aaf28cfe6211d3fab12e0b83620b1a8642c3", size = 63179, upload-time = "2025-08-22T03:02:07.643Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Three coordinated fixes bundled in one PR:

1. **Meta-write race condition** on the shared FS cache that was sending uploader requests straight to DLQ as `permanent` instead of letting them retry. The arion-uploader now polls `meta.json` with a bounded deadline; the error-string convention lets the classifier distinguish a race-window miss (transient) from an after-deadline raise (genuine fault → permanent).
2. **ATS PURGE host-resolution bug** that caused every cache invalidation to silently miss because the Host header reaching the gateway is the ATS upstream rewrite, not the public name that built the cache key. PURGE now mirrors SigV4's fallback chain (`x-forwarded-host` → `x-original-host` → `host` → `s3.hippius.com`) and collapses default ports.
3. **Toolchain pin sweep** to stop ty/stubs version drift that was causing the same code to oscillate between \"clean\" and \"36 diagnostics\" depending on which surface ran the check.

## Changes (biggest → smallest)

- **`hippius_s3/cache/fs_store.py`**: new `get_meta_with_wait(deadline_seconds=30.0)` — polls `get_meta` with exponential backoff (100ms → 2s capped) until deadline. Inherited by `DualFileSystemPartsStore` via polymorphism.
- **`hippius_s3/workers/uploader.py`**: `_upload_single_chunk` now uses `get_meta_with_wait` and raises a distinct `\"Missing meta in filesystem cache after Ns for upload\"` string on deadline expiry, so the classifier can route after-deadline failures as permanent and race-window failures as transient.
- **`hippius_s3/workers/errors.py`**: removed the over-broad `\"filesystem cache\"` permanent keyword (was catching the transient race); added precise `\"missing meta in filesystem cache after\"` and `\"filesystem cache directory missing\"` to permanent; added `\"missing meta in filesystem cache for\"` to transient as defense-in-depth.
- **`gateway/middlewares/ats_purge.py`**: new `_public_host(request)` resolves the cache-key-aligned host. Replaces the previous `request.headers.get(\"host\", DEFAULT_HOST)` that always hit the upstream rewrite.
- **`hippius_s3/config.py`**: `HIPPIUS_FS_META_WAIT_SECONDS` (default 30) — tunable per-pod for the meta-poll deadline.
- **`.pre-commit-config.yaml`**:
  - ty hook now runs `.venv/bin/ty check hippius_s3 gateway` (was `ty check hippius_s3` via PATH — picked up an arbitrary `uv tool` version).
  - ruff auto-formats in place (was `--check`-only).
  - ruff scope widened to `(hippius_s3|gateway|tests)/`.
  - pip-audit runs `uv run --extra dev pip-audit` against the project venv, not pip-audit's own tool env. All stale `--ignore-vuln` flags removed.
- **`pyproject.toml`**: pinned `ty==0.0.43` to match CI. Removed `types-redis` (4.6.x stubs were stacking with redis 6.4.0's bundled stubs and producing inconsistent method signatures).
- **`uv.lock`**: bumped pygments → 2.20.0 and requests → 2.34.2 (surfaced by the now-honest pip-audit).
- **`hippius_s3/redis_utils.py`**: exposed `RedisClient = Union[Redis, RedisCluster]` type alias for cleaner downstream annotations.
- **Narrow `# ty: ignore` cleanup across `dlq/`, `queue.py`, `workers/downloader.py`, `api/user.py`, `metrics_collector_task.py`, `gateway/middlewares/banhammer.py`** — replaced shotgun ignores with narrow ones (or none) under the pinned toolchain.

### Tests

- `tests/unit/test_fs_store.py` — three tests for `get_meta_with_wait`: returns immediately when meta exists, returns `None` after deadline, picks up a late write (producer-consumer race simulation).
- `tests/unit/test_classify_errors.py` — parametrized regression for the race-window vs after-deadline vs operator-misconfig shapes across all three classifiers.
- `tests/unit/gateway/test_ats_purge_middleware.py` — `x-forwarded-host` priority, `x-original-host` fallback, default-port stripping, no-header fallback to `DEFAULT_HOST`.

## Conclusion

Closes the meta-race DLQ-pileup we observed on staging without changing PUT-path latency on the happy path (`get_meta_with_wait` returns on the first iteration when meta is already on disk, which is the common case in production where api + workers share a node). The PURGE fix is independent of the race fix and prepares the gateway for working ATS cache invalidation once `ATS_CACHE_ENDPOINT` is set per-region. The toolchain pin ends the ty-version drift.

**Follow-up not in this PR:** s3-backup repo's `backup.py` needs the mirror change (poll + after-deadline error string + matching classifier keywords). Without that, the ovh-side worker still hits the race; only arion-side is covered here.