### PR TITLE
ops(postgres-nvme): pin image to digest to stop unattended rolling restarts

### DIFF
--- a/k8s/production/postgres-nvme-cluster.yaml
+++ b/k8s/production/postgres-nvme-cluster.yaml
@@ -3,6 +3,11 @@ kind: Cluster
 metadata:
   name: postgres-nvme
 spec:
+  # Pinned to the resolved digest of the (mutable) 18.1-system-trixie tag. CNPG re-resolves the tag
+  # and a digest drift auto-rolled the cluster overnight 2026-06-11 under primaryUpdateStrategy:
+  # unsupervised (graceful but unattended primary switchover). Pin = no surprise rolls; bump this
+  # digest deliberately to upgrade. This is the currently-running digest, so applying it is a no-op.
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie@sha256:51bc94428be3df3e234447278e33803544a93d27a57a4b6af737f218d6472d12
   affinity:
     enablePodAntiAffinity: true
     nodeSelector:


### PR DESCRIPTION
## Summary
Stops the **unattended overnight rolling restarts** of the `postgres-nvme` CNPG cluster by pinning its image to a digest.

## Background
On **2026-06-11 ~02:25 UTC** `postgres-nvme` did a rolling restart + primary switchover with no human action (and `postgres`/ceph followed at ~02:53). Investigation showed it was a **controlled CNPG roll, not a crash** (`"Switchover completed"`, `pg_controldata: shut down`, pods recreated with `restartCount=0`, nodes unchanged, operator unchanged). Trigger: `imageName` was the **mutable** tag `ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie` (operator-defaulted). CNPG re-resolves that tag's digest; when the upstream `system-trixie` image is rebuilt the digest drifts, and with `primaryUpdateStrategy: unsupervised` CNPG auto-rolls the cluster — a graceful but unattended primary switchover (~seconds of write unavailability).

## Change
- `k8s/production/postgres-nvme-cluster.yaml`: set `spec.imageName` to the **current resolved digest** — `…:18.1-system-trixie@sha256:51bc9442…` (CNPG best practice: pin by digest for immutability).

## Impact / safety
- The pinned digest **equals the digest the cluster is currently running**, so applying this is a **no-op — no rolling restart**.
- Future upstream rebuilds of the tag can no longer trigger a surprise unattended roll. To upgrade PostgreSQL, bump this digest deliberately in a PR + planned window.
- Scope: **nvme only** (the ceph `postgres` cluster is being deprecated, left as-is).

## Follow-up options (not in this PR)
- Consider `primaryUpdateStrategy: supervised` so even an intended image bump gates the primary switchover on approval.
- Consider a `ClusterImageCatalog` + Renovate to manage digests centrally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
