### PR TITLE
ops(postgres-nvme): manual-only image upgrades — pin digest + supervised switchover

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,38 @@ Pre-built Grafana dashboards: Hippius S3 Overview (API performance, request rate
 
 Performance benchmarks live in the separate [`hippius-benchmarks`](https://github.com/thenervelab/hippius-benchmarks) repo. The public S3 dashboard is at <https://s3.hippius.com/veggies/s3/benchmark.html>.
 
+## Operations
+
+### Upgrading PostgreSQL (`postgres-nvme`)
+
+The production `postgres-nvme` CNPG cluster ([k8s/production/postgres-nvme-cluster.yaml](k8s/production/postgres-nvme-cluster.yaml)) is configured for **manual-only** image upgrades — nothing rolls automatically:
+
+- `spec.imageName` is pinned to an **immutable digest** (`…@sha256:…`), so upstream rebuilds of the `18.1-system-trixie` tag can never trigger a surprise roll.
+- `primaryUpdateStrategy: supervised`, so any roll updates the replicas but **stops before the primary** — the write-serving primary only switches over when a human promotes a replica.
+
+**To do a deliberate minor upgrade, in a planned maintenance window:**
+
+1. Find the digest of the target image (e.g. after bumping the base tag):
+   ```bash
+   docker manifest inspect ghcr.io/cloudnative-pg/postgresql:<tag> -v \
+     | grep -m1 digest
+   ```
+2. Update `spec.imageName` in `k8s/production/postgres-nvme-cluster.yaml` to `…:<tag>@sha256:<digest>` and merge/apply.
+3. CNPG rolls the **replicas** automatically, then pauses (cluster reports "waiting for the user to request a switchover"). No primary disruption yet.
+4. Complete the roll by promoting a replica — this performs the (brief) primary switchover:
+   ```bash
+   kubectl -n hippius-s3-prod cnpg promote postgres-nvme <replica-pod>
+   ```
+5. Verify every instance is on the new digest:
+   ```bash
+   kubectl -n hippius-s3-prod get pods -l cnpg.io/cluster=postgres-nvme \
+     -o custom-columns='NAME:.metadata.name,ROLE:.metadata.labels.cnpg\.io/instanceRole,DIGEST:.status.containerStatuses[0].imageID'
+   ```
+
+> **Important:** because of `supervised`, step 4 is not optional. If you skip it, the replicas run the new image while the primary stays on the old one (version skew) until you promote.
+
+For major version upgrades (`pg_upgrade`, offline) see the [CloudNativePG docs](https://cloudnative-pg.io/docs/current/postgres_upgrades/) — those are out of scope for the routine minor bump above.
+
 ## License
 
 See [LICENSE](LICENSE) file.

--- a/k8s/production/postgres-nvme-cluster.yaml
+++ b/k8s/production/postgres-nvme-cluster.yaml
@@ -3,6 +3,11 @@ kind: Cluster
 metadata:
   name: postgres-nvme
 spec:
+  # Pinned to the resolved digest of the (mutable) 18.1-system-trixie tag. CNPG re-resolves the tag
+  # and a digest drift auto-rolled the cluster overnight 2026-06-11 under primaryUpdateStrategy:
+  # unsupervised (graceful but unattended primary switchover). Pin = no surprise rolls; bump this
+  # digest deliberately to upgrade. This is the currently-running digest, so applying it is a no-op.
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.1-system-trixie@sha256:51bc94428be3df3e234447278e33803544a93d27a57a4b6af737f218d6472d12
   affinity:
     enablePodAntiAffinity: true
     nodeSelector:

--- a/k8s/production/postgres-nvme-cluster.yaml
+++ b/k8s/production/postgres-nvme-cluster.yaml
@@ -51,7 +51,11 @@ spec:
       wal_buffers: 64MB
       wal_level: replica
       work_mem: 128MB
-  primaryUpdateStrategy: unsupervised
+  # supervised: on any roll (deliberate digest bump, or an operator upgrade) CNPG updates the
+  # replicas but STOPS before the primary — the write-serving primary is only switched over when a
+  # human runs `kubectl cnpg promote postgres-nvme <replica>`. No unattended primary disruption.
+  # Trade-off: you must manually finish the roll or replicas/primary sit on skewed images.
+  primaryUpdateStrategy: supervised
   replicationSlots:
     highAvailability:
       enabled: true


### PR DESCRIPTION
## Summary
Makes `postgres-nvme` image upgrades **manual, never automatic**, by closing both CNPG auto-roll paths: pin the image to an immutable digest, and require a human to complete any primary switchover.

## Background
On **2026-06-11 ~02:25 UTC** `postgres-nvme` did a rolling restart + primary switchover with no human action. Investigation showed a **controlled CNPG roll, not a crash** (`"Switchover completed"`, `pg_controldata: shut down`, pods recreated with `restartCount=0`). Trigger: `imageName` was the **mutable** tag `18.1-system-trixie`; CNPG re-resolves that tag's digest, and when the upstream image is rebuilt the digest drifts. With `primaryUpdateStrategy: unsupervised`, CNPG then auto-rolled the cluster — a graceful but unattended primary switchover (~seconds of write unavailability).

There are **two independent triggers** for an automatic roll in CNPG: (1) the image content changing, and (2) an operator upgrade. Pinning the digest closes (1); `supervised` ensures that even if a roll fires from either trigger, the write-serving primary never flips without a human.

## Changes
- **Pin `spec.imageName` to the resolved digest** — `…:18.1-system-trixie@sha256:51bc9442…` (CNPG best practice: pin by digest for immutability). Upstream tag rebuilds can no longer trigger a surprise roll.
- **`primaryUpdateStrategy: unsupervised → supervised`** — on any roll, CNPG updates the replicas but **stops before the primary**; the switchover only happens when an operator runs `kubectl cnpg promote postgres-nvme <replica>`. Requires ≥2 instances (cluster runs 3).

## Impact / safety
- **Verified against the live cluster (2026-07-02):** all three instances (`postgres-nvme-1/2/4`) are still running the pinned digest `sha256:51bc9442…`, and `primaryUpdateStrategy` is currently `unsupervised`. So applying this PR is a **no-op — no rolling restart**; it only changes *future* behavior.
- To upgrade PostgreSQL from now on: bump the digest deliberately in a PR + planned window, then complete the primary switchover manually.
- **Trade-off of supervised:** you must remember to finish a roll (`kubectl cnpg promote`), or replicas and the primary sit on skewed images until you do.
- Scope: **nvme only** (the ceph `postgres` cluster is being deprecated, left as-is).

## Follow-up (not in this PR — operator-level, `cnpg-system`)
- Set `ENABLE_INSTANCE_MANAGER_INPLACE_UPDATES=true` on the CNPG operator to also avoid rolling restarts on *operator* upgrades (caveat: pod-spec/probe changes in a release still force a one-time roll — but `supervised` keeps even that off the primary).
- We evaluated `ImageCatalog`/`ClusterImageCatalog` and rejected it: editing a catalog entry auto-propagates to referencing clusters, so it gives no more manual control than editing `imageName` directly — overkill for a single cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)