### PR TITLE
Per-pod arion-unpinner concurrency (both axes) + shared Arion-DELETE semaphore

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -164,6 +164,7 @@ jobs:
             --from-literal=ATS_CACHE_ENDPOINT="${{ secrets.ATS_CACHE_ENDPOINT }}" \
             --from-literal=HIPPIUS_AUTH_PROBE_SECRET="${{ secrets.HIPPIUS_AUTH_PROBE_SECRET }}" \
             --from-literal=HIPPIUS_UPLOADER_MAX_INFLIGHT="${{ secrets.HIPPIUS_UPLOADER_MAX_INFLIGHT || '4' }}" \
+            --from-literal=HIPPIUS_UNPINNER_MAX_INFLIGHT="${{ secrets.HIPPIUS_UNPINNER_MAX_INFLIGHT || '4' }}" \
             --namespace=hippius-s3-prod \
             --dry-run=client -o yaml | kubectl apply -f -
 
@@ -303,6 +304,7 @@ jobs:
             --from-literal=HIPPIUS_DOWNLOAD_BACKENDS="${{ secrets.HIPPIUS_DOWNLOAD_BACKENDS }}" \
             --from-literal=HIPPIUS_AUTH_PROBE_SECRET="${{ secrets.HIPPIUS_AUTH_PROBE_SECRET }}" \
             --from-literal=HIPPIUS_UPLOADER_MAX_INFLIGHT="${{ secrets.HIPPIUS_UPLOADER_MAX_INFLIGHT || '4' }}" \
+            --from-literal=HIPPIUS_UNPINNER_MAX_INFLIGHT="${{ secrets.HIPPIUS_UNPINNER_MAX_INFLIGHT || '4' }}" \
             --namespace=${CACHE_NS} \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -164,6 +164,7 @@ jobs:
             --from-literal=ATS_CACHE_ENDPOINT='${{ secrets.ATS_CACHE_ENDPOINT }}' \
             --from-literal=HIPPIUS_AUTH_PROBE_SECRET='${{ secrets.HIPPIUS_AUTH_PROBE_SECRET }}' \
             --from-literal=HIPPIUS_UPLOADER_MAX_INFLIGHT='${{ secrets.HIPPIUS_UPLOADER_MAX_INFLIGHT || '4' }}' \
+            --from-literal=HIPPIUS_UNPINNER_MAX_INFLIGHT='${{ secrets.HIPPIUS_UNPINNER_MAX_INFLIGHT || '4' }}' \
             --namespace=hippius-s3-staging \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -174,7 +174,15 @@ class Config:
     fs_meta_wait_seconds: float = env("HIPPIUS_FS_META_WAIT_SECONDS:30", convert=float)
 
     # Unpinner configuration
+    # How many unpin requests one unpinner pod processes concurrently (outer bounded-dispatch,
+    # mirroring the uploader). The old loop was a serial consumer.
+    unpinner_max_inflight: int = env("HIPPIUS_UNPINNER_MAX_INFLIGHT:4", convert=int)
+    # Single shared per-pod bound on concurrent Arion DELETEs across ALL in-flight requests — one
+    # fat request expands to ~N chunk identifiers, so this is what actually unlocks delete throughput.
     unpinner_parallelism: int = env("HIPPIUS_UNPINNER_PARALLELISM:5", convert=int)
+    # Per-pod unpinner DB pool size (concurrent soft-deletes). Multiplied by replica count against
+    # Postgres max_connections — keep modest and raise alongside parallelism.
+    unpinner_db_pool_max: int = env("HIPPIUS_UNPINNER_DB_POOL_MAX:12", convert=int)
     unpinner_max_attempts: int = env("HIPPIUS_UNPINNER_MAX_ATTEMPTS:5", convert=int)
     unpinner_backoff_base_ms: int = env("HIPPIUS_UNPINNER_BACKOFF_BASE_MS:1000", convert=int)
     unpinner_backoff_max_ms: int = env("HIPPIUS_UNPINNER_BACKOFF_MAX_MS:60000", convert=int)

--- a/hippius_s3/workers/CLAUDE.md
+++ b/hippius_s3/workers/CLAUDE.md
@@ -73,6 +73,8 @@ Key config ([../config.py](../config.py)):
 
 Delete pin on backend → mark `chunk_backend.deleted = true, deleted_at = now()` (soft delete). Retries with backoff (`HIPPIUS_UNPINNER_MAX_ATTEMPTS=5`, `HIPPIUS_UNPINNER_BACKOFF_BASE_MS=1000`, `_MAX_MS=60000`). Failures go to [../dlq/unpin_dlq.py](../dlq/unpin_dlq.py).
 
+**Concurrency model**: runs many replicas; each pod processes up to `HIPPIUS_UNPINNER_MAX_INFLIGHT` unpin requests concurrently (bounded-dispatch loop mirroring the uploader). One request expands to N chunk identifiers — their backend DELETEs run concurrently bounded by a single shared per-pod `HIPPIUS_UNPINNER_PARALLELISM` semaphore (the one throttle on Arion DELETEs). Atomic dequeue + idempotent DELETE (404 tolerated) + idempotent soft-delete make cross-pod/cross-request concurrency safe. Scale via `MAX_INFLIGHT` + `PARALLELISM`, not just replicas.
+
 ## Tracing
 
 All worker operations emit OTel spans with `hippius.ray_id`, `hippius.account.main`, and backend-specific attributes. See [downloader.py:114-123](downloader.py) for the standard span shape.

--- a/hippius_s3/workers/unpinner.py
+++ b/hippius_s3/workers/unpinner.py
@@ -54,9 +54,17 @@ async def process_unpin_request(
     worker_logger: logging.LoggerAdapter,
     dlq_manager: UnpinDLQManager,
     db_pool: asyncpg.Pool,
+    sem: asyncio.Semaphore | None = None,
 ) -> None:
-    """Process a single unpin request for a specific backend."""
+    """Process a single unpin request for a specific backend.
+
+    A request expands to N chunk identifiers; their backend DELETEs run concurrently bounded by the
+    shared per-pod `sem` (passed by the loop so all in-flight requests share one Arion-DELETE budget).
+    Falls back to a per-request semaphore when called standalone (e.g. tests).
+    """
     config = get_config()
+    if sem is None:
+        sem = asyncio.Semaphore(max(1, int(config.unpinner_parallelism)))
 
     with tracer.start_as_current_span(
         "unpinner.process_unpin",
@@ -114,24 +122,34 @@ async def process_unpin_request(
             span.set_attribute("num_identifiers", len(rows))
 
             async with backend_client_factory() as client:
-                for row in rows:
+                # Unpin each identifier concurrently, bounded by the shared per-pod `sem`. Each
+                # identifier is best-effort (a failed DELETE/soft-delete logs a warning but must not
+                # fail the whole request), mirroring the original serial behavior.
+                async def _unpin_one(row: Any) -> None:
                     identifier = row["backend_identifier"]
                     chunk_id = row["chunk_id"]
-                    try:
-                        await client.unpin_file(identifier, account_ss58=request.address)
-                        worker_logger.info(f"Unpinned {backend_name} identifier={identifier}")
-                    except Exception as unpin_err:
-                        worker_logger.warning(f"Failed to unpin {backend_name} identifier={identifier}: {unpin_err}")
-
-                    try:
-                        async with db_pool.acquire() as conn:
-                            await conn.fetchval(
-                                get_query("soft_delete_chunk_backend_by_chunk_id"),
-                                backend_name,
-                                chunk_id,
+                    async with sem:
+                        try:
+                            await client.unpin_file(identifier, account_ss58=request.address)
+                            worker_logger.info(f"Unpinned {backend_name} identifier={identifier}")
+                        except Exception as unpin_err:
+                            worker_logger.warning(
+                                f"Failed to unpin {backend_name} identifier={identifier}: {unpin_err}"
                             )
-                    except Exception as db_err:
-                        worker_logger.warning(f"Failed to soft-delete chunk_backend row chunk_id={chunk_id}: {db_err}")
+
+                        try:
+                            async with db_pool.acquire() as conn:
+                                await conn.fetchval(
+                                    get_query("soft_delete_chunk_backend_by_chunk_id"),
+                                    backend_name,
+                                    chunk_id,
+                                )
+                        except Exception as db_err:
+                            worker_logger.warning(
+                                f"Failed to soft-delete chunk_backend row chunk_id={chunk_id}: {db_err}"
+                            )
+
+                await asyncio.gather(*[_unpin_one(row) for row in rows])
 
             get_metrics_collector().record_unpinner_operation(
                 main_account=request.address,
@@ -198,10 +216,11 @@ async def run_unpinner_loop(
 
     redis_client = create_redis_client(config.redis_url)
     redis_queues_client = async_redis.from_url(config.redis_queues_url)
+    pool_max = max(2, int(config.unpinner_db_pool_max))
     db_pool = await asyncpg.create_pool(
         dsn=config.database_url,
-        min_size=1,
-        max_size=3,
+        min_size=2,
+        max_size=pool_max,
     )
 
     from hippius_s3.queue import initialize_queue_client
@@ -213,12 +232,68 @@ async def run_unpinner_loop(
 
     dlq_manager = UnpinDLQManager(redis_queues_client)
 
-    logger.info(f"Starting {backend_name} unpinner service...")
-    logger.info(f"Queue: {queue_name}")
+    delete_sem = asyncio.Semaphore(max(1, int(config.unpinner_parallelism)))
+    max_inflight = max(1, int(config.unpinner_max_inflight))
+    logger.info(
+        f"Starting {backend_name} unpinner service (queue={queue_name} max_inflight={max_inflight} "
+        f"delete_concurrency={config.unpinner_parallelism} db_pool_max={pool_max})"
+    )
 
+    async def _handle_unpin(request: UnpinChainRequest) -> None:
+        ray_id = request.ray_id or "no-ray-id"
+        ray_id_context.set(ray_id)
+        worker_logger = get_logger_with_ray_id(__name__, ray_id)
+        with tracer.start_as_current_span(
+            "unpinner.job",
+            attributes={
+                "object_id": request.object_id,
+                "hippius.ray_id": ray_id,
+                "backend": backend_name,
+                "hippius.account.main": request.address,
+                "attempts": request.attempts or 0,
+            },
+        ):
+            await process_unpin_request(
+                request,
+                backend_name=backend_name,
+                backend_client_factory=backend_client_factory,
+                worker_logger=worker_logger,
+                dlq_manager=dlq_manager,
+                db_pool=db_pool,
+                sem=delete_sem,
+            )
+
+    # Periodic retry-mover — one per pod, off the per-request hot path (running it per dequeue across
+    # N concurrent workers would multiply Redis load).
+    async def _retry_mover() -> None:
+        while True:
+            try:
+                await move_due_unpin_retries(backend_name=backend_name)
+            except Exception as e:
+                logger.error(f"Error moving {backend_name} unpin retries: {e}")
+            await asyncio.sleep(2.0)
+
+    inflight: set[asyncio.Task[None]] = set()
+
+    def _reap(tasks: set[asyncio.Task[None]]) -> None:
+        # Per-request failures are already routed to retry/DLQ inside process_unpin_request (which
+        # never re-raises), so a task raises here only on a routing-path failure (rare).
+        for t in tasks:
+            inflight.discard(t)
+            err = t.exception()
+            if err is not None and not isinstance(err, asyncio.CancelledError):
+                logger.error(f"inflight {backend_name} unpinner task error: {err}")
+
+    mover_task = asyncio.create_task(_retry_mover())
     try:
         while True:
-            await move_due_unpin_retries(backend_name=backend_name)
+            _reap({t for t in inflight if t.done()})
+
+            # Capacity gate — keep at most max_inflight requests processing at once.
+            if len(inflight) >= max_inflight:
+                done_wait, _ = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
+                _reap(done_wait)
+                continue
 
             unpin_request, redis_queues_client = await with_redis_retry(
                 lambda rc: dequeue_unpin_request(queue_name),
@@ -228,31 +303,21 @@ async def run_unpinner_loop(
             )
 
             if not unpin_request:
-                await asyncio.sleep(1)
+                if inflight:
+                    done_wait, _ = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED, timeout=0.5)
+                    _reap(done_wait)
+                else:
+                    await asyncio.sleep(0.1)
                 continue
 
-            ray_id = unpin_request.ray_id or "no-ray-id"
-            ray_id_context.set(ray_id)
-            worker_logger = get_logger_with_ray_id(__name__, ray_id)
-
-            with tracer.start_as_current_span(
-                "unpinner.job",
-                attributes={
-                    "object_id": unpin_request.object_id,
-                    "hippius.ray_id": ray_id,
-                    "backend": backend_name,
-                    "hippius.account.main": unpin_request.address,
-                    "attempts": unpin_request.attempts or 0,
-                },
-            ):
-                await process_unpin_request(
-                    unpin_request,
-                    backend_name=backend_name,
-                    backend_client_factory=backend_client_factory,
-                    worker_logger=worker_logger,
-                    dlq_manager=dlq_manager,
-                    db_pool=db_pool,
-                )
+            inflight.add(asyncio.create_task(_handle_unpin(unpin_request)))
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        logger.info(f"{backend_name} unpinner stopping…")
     finally:
+        mover_task.cancel()
+        for t in inflight:
+            t.cancel()
+        # gather (not suppress) so cancelled tasks' CancelledError is absorbed here.
+        await asyncio.gather(mover_task, *inflight, return_exceptions=True)
         if db_pool:
             await db_pool.close()

--- a/k8s/base/workers-deployments.yaml
+++ b/k8s/base/workers-deployments.yaml
@@ -351,7 +351,7 @@ metadata:
   name: arion-unpinner
 
 spec:
-  replicas: 1
+  replicas: 3
   strategy:
     type: Recreate
   selector:
@@ -393,6 +393,11 @@ spec:
               value: "deployment.environment=$(ENVIRONMENT),service.namespace=$(K8S_NAMESPACE),service.instance.id=$(POD_NAME)"
             - name: WORKER_SCRIPT
               value: "workers/run_arion_unpinner_in_loop.py"
+            - name: HIPPIUS_UNPINNER_MAX_INFLIGHT
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_UNPINNER_MAX_INFLIGHT
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/tests/unit/test_unpinner_loop.py
+++ b/tests/unit/test_unpinner_loop.py
@@ -1,0 +1,287 @@
+"""Tests for run_unpinner_loop's bounded-concurrent dispatch + the shared per-pod Arion-DELETE
+semaphore.
+
+The unpinner used to be serial on two axes: a serial outer consume loop AND a serial inner
+`for row in rows` loop that awaited each of an object's N chunk DELETEs one at a time. It now (a)
+dispatches up to `unpinner_max_inflight` requests concurrently, and (b) within each request runs the
+identifier DELETEs concurrently bounded by a single shared per-pod semaphore. These tests verify both
+axes plus graceful shutdown and best-effort per-identifier semantics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from hippius_s3.workers import unpinner as un
+
+
+def _make_config(*, max_inflight: int, parallelism: int = 5) -> MagicMock:
+    cfg = MagicMock()
+    cfg.unpinner_max_inflight = max_inflight
+    cfg.unpinner_parallelism = parallelism
+    cfg.unpinner_db_pool_max = 12
+    cfg.unpinner_max_attempts = 5
+    cfg.unpinner_backoff_base_ms = 1
+    cfg.unpinner_backoff_max_ms = 10
+    cfg.redis_url = "redis://localhost:6379"
+    cfg.redis_queues_url = "redis://localhost:6382"
+    cfg.database_url = "postgresql://localhost/test"
+    return cfg
+
+
+def _req(name: str) -> MagicMock:
+    r = MagicMock()
+    r.ray_id = f"ray-{name}"
+    r.object_id = name
+    r.object_version = 1
+    r.address = "5Addr"
+    r.attempts = 0
+    r.name = name
+    return r
+
+
+class _Harness:
+    def __init__(self, *, max_inflight: int) -> None:
+        self.config = _make_config(max_inflight=max_inflight)
+        self.dequeue_sequence: list = []
+        self.process_calls: list = []
+        self.process_fn = None  # type: ignore[var-annotated]
+
+    async def _dequeue(self, queue_name: str):
+        await asyncio.sleep(0)  # yield so spawned tasks get scheduled
+        if not self.dequeue_sequence:
+            raise KeyboardInterrupt()
+        item = self.dequeue_sequence.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def _with_redis_retry(self, func, client, url, name, **kw):
+        return await func(client), client
+
+    async def _process(self, request, **kwargs):
+        self.process_calls.append(request)
+        assert self.process_fn is not None
+        return await self.process_fn(request)
+
+    async def run(self) -> None:
+        with (
+            patch.object(un, "get_config", return_value=self.config),
+            patch.object(un, "asyncpg") as mock_asyncpg,
+            patch.object(un, "create_redis_client", return_value=MagicMock()),
+            patch.object(un, "async_redis") as mock_async_redis,
+            patch.object(un, "with_redis_retry", side_effect=self._with_redis_retry),
+            patch.object(un, "dequeue_unpin_request", side_effect=self._dequeue),
+            patch.object(un, "move_due_unpin_retries", new=AsyncMock(return_value=0)),
+            patch.object(un, "initialize_metrics_collector"),
+            patch.object(un, "UnpinDLQManager", return_value=MagicMock()),
+            patch.object(un, "get_logger_with_ray_id", return_value=MagicMock()),
+            patch("hippius_s3.queue.initialize_queue_client"),
+            patch("hippius_s3.redis_cache.initialize_cache_client"),
+            patch.object(un, "process_unpin_request", side_effect=self._process),
+        ):
+            pool = MagicMock()
+            pool.close = AsyncMock()
+            mock_asyncpg.create_pool = AsyncMock(return_value=pool)
+            mock_async_redis.from_url = MagicMock(return_value=MagicMock())
+            await un.run_unpinner_loop(
+                backend_name="arion",
+                backend_client_factory=MagicMock(),
+                queue_name="arion_unpin_requests",
+            )
+
+
+@pytest.mark.asyncio
+async def test_dispatches_requests_concurrently():
+    """With max_inflight >= N, all N requests are in process_unpin_request at once."""
+    h = _Harness(max_inflight=5)
+    h.dequeue_sequence = [_req("a"), _req("b"), _req("c")]
+
+    cur = 0
+    peak = 0
+    all_active = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow(_req):
+        nonlocal cur, peak
+        cur += 1
+        peak = max(peak, cur)
+        if peak >= 3:
+            all_active.set()
+        await release.wait()
+        cur -= 1
+
+    h.process_fn = _slow
+
+    async def controller():
+        await asyncio.wait_for(all_active.wait(), timeout=2.0)
+        release.set()
+
+    await asyncio.gather(h.run(), controller())
+    assert peak == 3, f"expected 3 concurrent, saw {peak}"
+    assert len(h.process_calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_respects_max_inflight_capacity():
+    """When over capacity, concurrent process_unpin_request never exceeds max_inflight."""
+    h = _Harness(max_inflight=2)
+    h.dequeue_sequence = [_req(f"r{i}") for i in range(6)]
+
+    cur = 0
+    peak = 0
+
+    async def _slow(_req):
+        nonlocal cur, peak
+        cur += 1
+        peak = max(peak, cur)
+        await asyncio.sleep(0.03)
+        cur -= 1
+
+    h.process_fn = _slow
+    await asyncio.wait_for(h.run(), timeout=5.0)
+    assert peak <= 2, f"inflight cap breached: saw {peak}"
+    assert len(h.process_calls) == 6
+
+
+@pytest.mark.asyncio
+async def test_graceful_shutdown_cancels_inflight():
+    """KeyboardInterrupt while tasks are in flight must cancel + drain them and return — not hang."""
+    h = _Harness(max_inflight=4)
+    h.dequeue_sequence = [_req("x"), _req("y")]  # then dequeue raises KeyboardInterrupt
+
+    cancelled = {"n": 0}
+
+    async def _block(_req):
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled["n"] += 1
+            raise
+
+    h.process_fn = _block
+    await asyncio.wait_for(h.run(), timeout=5.0)
+    assert len(h.process_calls) == 2
+    assert cancelled["n"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# Inner axis: the shared per-pod semaphore bounds concurrent Arion DELETEs
+# across a request's identifiers AND across multiple in-flight requests.
+# --------------------------------------------------------------------------- #
+
+
+class _DeleteTracker:
+    def __init__(self) -> None:
+        self.cur = 0
+        self.peak = 0
+        self.calls: list = []
+
+    def enter(self, ident: str) -> None:
+        self.cur += 1
+        self.peak = max(self.peak, self.cur)
+        self.calls.append(ident)
+
+    def leave(self) -> None:
+        self.cur -= 1
+
+
+def _fake_db_pool(rows: list) -> MagicMock:
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=rows)
+    conn.fetchval = AsyncMock(return_value=1)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(return_value=conn), __aexit__=AsyncMock()))
+    return pool
+
+
+def _client_factory(tracker: _DeleteTracker, *, fail_on: str | None = None):
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def unpin_file(self, identifier, **kw):
+            tracker.enter(identifier)
+            try:
+                await asyncio.sleep(0.02)
+                if fail_on is not None and identifier == fail_on:
+                    raise RuntimeError("arion delete blip")
+            finally:
+                tracker.leave()
+
+    return _FakeClient
+
+
+@pytest.mark.asyncio
+async def test_delete_semaphore_bounds_arion_deletes_across_requests():
+    """One shared semaphore caps concurrent Arion DELETEs across MULTIPLE concurrent fat requests —
+    the throttle that lets outer request-concurrency scale without stampeding the backend."""
+    tracker = _DeleteTracker()
+    shared = asyncio.Semaphore(3)
+    rows_a = [{"backend_identifier": f"a-{i}", "chunk_id": i} for i in range(4)]
+    rows_b = [{"backend_identifier": f"b-{i}", "chunk_id": 100 + i} for i in range(4)]
+
+    common = {
+        "backend_name": "arion",
+        "worker_logger": MagicMock(),
+        "dlq_manager": MagicMock(),
+    }
+    with (
+        patch.object(un, "get_config", return_value=_make_config(max_inflight=4, parallelism=3)),
+        patch.object(un, "get_query", return_value="SQL"),
+        patch.object(un, "get_metrics_collector", return_value=MagicMock()),
+    ):
+        await asyncio.gather(
+            un.process_unpin_request(
+                _req("oa"),
+                backend_client_factory=_client_factory(tracker),
+                db_pool=_fake_db_pool(rows_a),
+                sem=shared,
+                **common,
+            ),
+            un.process_unpin_request(
+                _req("ob"),
+                backend_client_factory=_client_factory(tracker),
+                db_pool=_fake_db_pool(rows_b),
+                sem=shared,
+                **common,
+            ),
+        )
+
+    assert len(tracker.calls) == 8, "every identifier across both requests must be deleted once"
+    assert tracker.peak > 1, "no overlap — shared semaphore not parallelizing"
+    assert tracker.peak <= 3, "shared per-pod Arion-DELETE bound breached"
+
+
+@pytest.mark.asyncio
+async def test_failing_identifier_does_not_fail_request():
+    """A single identifier's DELETE failure is best-effort (logged) — it must not fail the whole
+    request, and the other identifiers still get processed."""
+    tracker = _DeleteTracker()
+    rows = [{"backend_identifier": f"id-{i}", "chunk_id": i} for i in range(4)]
+
+    with (
+        patch.object(un, "get_config", return_value=_make_config(max_inflight=4, parallelism=4)),
+        patch.object(un, "get_query", return_value="SQL"),
+        patch.object(un, "get_metrics_collector", return_value=MagicMock()),
+    ):
+        # Must not raise even though id-2's DELETE blows up.
+        await un.process_unpin_request(
+            _req("o"),
+            backend_name="arion",
+            backend_client_factory=_client_factory(tracker, fail_on="id-2"),
+            worker_logger=MagicMock(),
+            dlq_manager=MagicMock(),
+            db_pool=_fake_db_pool(rows),
+            sem=asyncio.Semaphore(4),
+        )
+
+    assert len(tracker.calls) == 4, "all identifiers attempted despite one failing"

--- a/workers/CLAUDE.md
+++ b/workers/CLAUDE.md
@@ -8,7 +8,7 @@ Worker entry points — the `run_*.py` scripts that actually run as pod processe
 |---|---|---|
 | [run_arion_uploader_in_loop.py](run_arion_uploader_in_loop.py) | Drains `arion_upload_requests`, uploads chunks to Arion, publishes to chain. | Single instance (rate-limited; scale via parallelism config) |
 | [run_arion_downloader_in_loop.py](run_arion_downloader_in_loop.py) | Drains `arion_download_requests`, fetches chunks from Arion, fills FS cache, notifies streamers. | Horizontally scalable |
-| [run_arion_unpinner_in_loop.py](run_arion_unpinner_in_loop.py) | Drains `unpin_requests`, soft-deletes `chunk_backend` rows, calls Arion delete. | Single instance |
+| [run_arion_unpinner_in_loop.py](run_arion_unpinner_in_loop.py) | Drains `unpin_requests`, soft-deletes `chunk_backend` rows, calls Arion delete. | Horizontally scalable; per-pod request concurrency (`HIPPIUS_UNPINNER_MAX_INFLIGHT`) + shared Arion-DELETE semaphore (`HIPPIUS_UNPINNER_PARALLELISM`) |
 | [run_janitor_in_loop.py](run_janitor_in_loop.py) | FS cache GC with replication gate, hot retention, and pressure modes. | Single instance |
 | [run_orphan_checker_in_loop.py](run_orphan_checker_in_loop.py) | Periodically scans the Hippius chain for orphaned files and enqueues cleanup. | Single instance |
 | [run_account_cacher_in_loop.py](run_account_cacher_in_loop.py) | Warms account credit cache from Substrate. | Single instance |


### PR DESCRIPTION
## Summary
The arion-uploader rework drained the upload backlog; the **unpin** side is now the bottleneck —
`arion_unpin_requests` was growing ~+300/min in prod (573k+). Root cause: the unpinner was serial on
**two** axes — a serial outer consume loop AND a serial inner `for row in rows` loop that awaited each
of an object's ~80 chunk DELETEs one at a time. Scaling replicas only multiplied the outer axis.

This applies the proven uploader pattern to **both** axes.

## Changes (largest → smallest)
- **Inner axis (the big win)** — `process_unpin_request`'s serial identifier loop becomes a bounded
  `asyncio.gather` under a single shared per-pod semaphore on concurrent Arion DELETEs (reuses the
  previously-dead `HIPPIUS_UNPINNER_PARALLELISM` knob). Per-identifier DELETE/soft-delete stays
  best-effort (one failure doesn't fail the request).
- **Outer axis** — `run_unpinner_loop` becomes a bounded-dispatch loop (`HIPPIUS_UNPINNER_MAX_INFLIGHT`,
  default 4) with a periodic retry-mover and graceful shutdown (cancel + gather), mirroring the uploader.
- **DB pool** config-driven (`HIPPIUS_UNPINNER_DB_POOL_MAX`, default 12, min 2; was hardcoded min1/max3).
- **Replicas** `1 → 3` so the live prod `kubectl scale` is persisted by the manifest.
- **`HIPPIUS_UNPINNER_MAX_INFLIGHT` wired as a deploy secret** (default 4) — ramp without a code change,
  like `HIPPIUS_UPLOADER_MAX_INFLIGHT`.
- **Tests**: bounded dispatch, capacity gate, graceful shutdown, shared-DELETE-semaphore bound across
  concurrent fat requests, and best-effort per-identifier failure.

## Safety
Atomic dequeue (no double-processing), idempotent Arion DELETE (404 tolerated) + idempotent soft-delete
make cross-pod/cross-request concurrency safe. No behavior change to error routing (transient→retry,
permanent→DLQ).

## Rollout
Merge at default `max_inflight=4` (+ replicas 3). Ramp `HIPPIUS_UNPINNER_MAX_INFLIGHT` /
`HIPPIUS_UNPINNER_PARALLELISM` via the secret/env while watching Arion DELETE 429/5xx, the
`arion_unpin_requests` drain slope, and `redis-queues` slowlog.

## Conclusion
Restores the unpinner's ability to keep up with bulk-delete / migration unpin floods by parallelizing
the work that was previously serial end-to-end.
