### PR TITLE
NVMe cache-node failure: disk canary + 1-command evacuate-to-ceph

### DIFF
--- a/disk-failure-playbook.md
+++ b/disk-failure-playbook.md
@@ -1,0 +1,162 @@
+# Disk Failure Playbook — FS cache (NVMe ⇄ Ceph)
+
+What to do when the cache node (`k8s-v3-node6-cache`) or its disks act up. Written after the
+2026-06-11 incident (stale CephFS mounts → api 0/5 for ~3h).
+
+---
+
+## 1. How the cache is set up
+
+Two cache volumes, one mode switch:
+
+| | NVMe (normal mode) | Ceph (evacuated mode) |
+|---|---|---|
+| Volume | `local-cache-pvc` → `local-cache-pv` (40Ti **local** disk, RWO) | `object-cache-pvc` (CephFS, RWX, ~9.7Ti) |
+| Mount path | `/var/lib/hippius/local_object_cache` | `/var/lib/hippius/object_cache` |
+| Reachable from | **only** `k8s-v3-node6-cache` | every node |
+| Primary cache env | `HIPPIUS_OBJECT_CACHE_DIR=/var/lib/hippius/local_object_cache` (+ ceph as `FALLBACK_DIR`, read-only) | `HIPPIUS_OBJECT_CACHE_DIR=/var/lib/hippius/object_cache` (no fallback) |
+
+**Six workloads use the cache and live or die together** (they must all see the same chunks +
+`meta.json`): `api`, `arion-uploader`, `arion-downloader`, `janitor` (hippius-s3) and `backup`,
+`hydrator` (s3-backup). In NVMe mode all six are **hard-pinned to node6** — that's the SPOF.
+Everything else (gateway, unpinner, cleanup, redis, postgres) runs elsewhere and is unaffected.
+
+How the modes are constructed:
+- **NVMe mode** = base manifests + `k8s/production/local-cache-patch.yaml` (pin + nvme volume +
+  ceph demoted to RO) + `k8s/production/local-cache-configmap-patch.yaml` (env). s3-backup mirrors
+  this with its own `k8s/production/local-cache-patch.yaml` + kustomization env literals.
+- **Ceph mode** = exactly what the **base manifests already are** (ceph RWX mounted RW, no pin,
+  default env). The evacuation just strips the production patches from the live objects.
+
+**Detection**: the `disk-canary` deployment (pinned to node6) probes both mounts every 30s and
+exports `disk_canary_mount_healthy{mount=…}`. Grafana pages on unhealthy (2m) **and on metric
+absence** (5m — node too broken to run the canary, e.g. pods stuck in `Init` on bad mounts).
+
+---
+
+## 2. Decision tree when paged
+
+```
+canary page / pods stuck Init on node6
+│
+├─ Stale CephFS staging mount?  (pod events show: MountVolume.SetUp failed ... lstat ...
+│  globalmount: permission denied)
+│     → try the 10-minute fix first: §3 (stale-mount remediation)
+│
+├─ NVMe device errors / disk dead / node unresponsive, not fixable quickly?
+│     → evacuate to ceph: §4
+│
+└─ Transient blip (canary recovered on its own)?
+      → watch; no action.
+```
+
+Rule of thumb: if S3 is hard-down and the node fix isn't obviously < 30 minutes, **evacuate** —
+it's reversible and rehearsed; a long outage is not.
+
+---
+
+## 3. Stale-mount remediation (the 2026-06-11 fix, ~10 min)
+
+Symptoms: pods stuck `Init:0/1` on node6, events show `lstat ... globalmount: permission denied`.
+The kernel CephFS session died; the staging mount is a zombie. CSI-pod restarts do NOT help.
+
+```bash
+# 1. Find the broken globalmount paths from the pod events
+kubectl -n hippius-s3-prod describe pod <stuck-pod> | grep globalmount
+
+# 2. Force-unmount them on the node via a privileged nsenter pod
+kubectl debug node/k8s-v3-node6-cache -it --image=busybox -- chroot /host sh
+  umount -f /var/lib/kubelet/plugins/kubernetes.io/csi/rook-ceph.cephfs.csi.ceph.com/<hash1>/globalmount
+  umount -f /var/lib/kubelet/plugins/kubernetes.io/csi/rook-ceph.cephfs.csi.ceph.com/<hash2>/globalmount
+
+# 3. Kubelet still thinks the volume is staged ("staging path is not a mountpoint"):
+#    scale the consumers to 0 so kubelet unstages, then back up for a fresh NodeStageVolume.
+kubectl -n hippius-s3-prod scale deploy/api --replicas=0
+kubectl -n hippius-s3-prod scale deploy/api --replicas=5
+# (repeat for any other deployment using the broken PVC)
+
+# 4. Check dmesg for the root cause while you're there
+kubectl debug node/k8s-v3-node6-cache -it --image=busybox -- chroot /host dmesg | grep -i ceph | tail
+```
+
+---
+
+## 4. Redeploy everything on CEPH ONLY (evacuate)
+
+One command. It preflights (proves the ceph PVC mounts from a non-cache node), patches the cache
+env ConfigMaps, strips the pin + NVMe volume from all six deployments, mounts ceph read-write, and
+rolls everything together:
+
+```bash
+cd ~/projects/hippius-s3
+
+# see where things stand (read-only)
+./scripts/evacuate_status.sh
+
+# validate everything server-side without changing anything
+./scripts/evacuate_cache.sh --dry-run
+
+# DO IT
+./scripts/evacuate_cache.sh --yes
+```
+
+What it changes (all reversible by a normal deploy):
+- ConfigMap `hippius-s3-defaults`: `HIPPIUS_OBJECT_CACHE_DIR=/var/lib/hippius/object_cache`,
+  `FALLBACK_DIR=""` — and the live hash-suffixed `s3-backup-config-*`: `OBJECT_CACHE_DIR` likewise.
+- Deployments `api`, `arion-uploader`, `arion-downloader`, `janitor`, `backup`, `hydrator`:
+  `nodeSelector` removed, `local-cache` volume removed (mandatory — the local PV's nodeAffinity
+  would otherwise still force node6), `object-cache` mounted RW.
+  (Patch files: `k8s/evacuate/*.yaml`.)
+
+Afterwards:
+```bash
+# 1. verify spread + mode
+./scripts/evacuate_status.sh
+
+# 2. verify a PUT/GET round-trip via s3.hippius.com (any client)
+
+# 3. if the NVMe data is gone for good: mark never-uploaded objects failed so GETs 404
+#    instead of hanging (dry-run first, then --apply)
+python -m hippius_s3.scripts.reconcile_lost_uploads
+python -m hippius_s3.scripts.reconcile_lost_uploads --apply
+```
+
+Expectations while evacuated: ceph-speed cache (slower than NVMe), cold cache (GET misses refill
+from Arion — expect elevated Arion download traffic for a while), and **no single node can take
+S3 down**.
+
+## 5. Redeploy everything on NVME ONLY (failback)
+
+Failback is deliberately **just the normal production deploy** — CI re-renders the manifests with
+the local-cache patches, which restores the pin, the NVMe volume, and the env:
+
+```bash
+# after node6/disk is repaired and verified healthy (canary green):
+# hippius-s3 — push/merge the current release to the prod deploy branch:
+git push origin <release>:k8s-production        # or merge via PR as usual
+# s3-backup — same:
+git push origin <release>:k8s-production
+```
+
+Notes:
+- Do NOT hand-revert the evacuate patches — the deploy pipeline owns failback.
+- Chunks written to ceph **during** the evacuation stay readable after failback: normal NVMe-mode
+  config keeps ceph as `HIPPIUS_OBJECT_CACHE_FALLBACK_DIR` (read fallback) by design.
+- Verify with `./scripts/evacuate_status.sh` → `MODE: NVME (normal)` and pods back on node6.
+
+---
+
+## 6. Quick reference
+
+| Action | Command |
+|---|---|
+| Which mode are we in? | `./scripts/evacuate_status.sh` |
+| Validate the flip w/o changes | `./scripts/evacuate_cache.sh --dry-run` |
+| **Evacuate to ceph** | `./scripts/evacuate_cache.sh --yes` |
+| Reconcile lost uploads | `python -m hippius_s3.scripts.reconcile_lost_uploads [--apply]` |
+| **Failback to nvme** | normal production deploys (both repos) |
+| Stale-mount quick fix | §3 above (`umount -f` + scale-cycle) |
+| Canary health | Grafana: `disk_canary_mount_healthy`; logs: `DISK_CANARY_FAIL` |
+
+Related docs: `proposal-1.md` (this design), `proposal-2.md` (standby alternative, rejected),
+`proposal-3.md` (tiered-cache redesign, the long-term fix), `k8s/evacuate/README.md`.

--- a/hippius_s3/scripts/reconcile_lost_uploads.py
+++ b/hippius_s3/scripts/reconcile_lost_uploads.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Reconcile uploads lost with the NVMe cache after an evacuation.
+
+When the cache node dies, chunks staged on its node-local NVMe that were never uploaded to any
+backend die with it. The affected object_versions sit in 'publishing'/'pinning' forever and their
+GETs hang waiting on chunks that will never arrive. This script finds versions whose part_chunks
+have ZERO live chunk_backend rows (nothing ever reached a backend) and marks them 'failed' — the
+same transition the uploader applies on permanent failure — so clients get a clean 404/error
+instead of a hang.
+
+Notes:
+- Queued upload requests for these versions also self-resolve via the uploader's meta-wait
+  deadline -> permanent -> DLQ path; this script is the accelerator + covers versions no longer
+  in any queue.
+- Versions with SOME chunk_backend rows (partially uploaded) are intentionally skipped: the
+  uploader/backup retry machinery may still complete them — triage those via the DLQ.
+
+Usage:
+    python -m hippius_s3.scripts.reconcile_lost_uploads                # dry-run (default)
+    python -m hippius_s3.scripts.reconcile_lost_uploads --apply
+    python -m hippius_s3.scripts.reconcile_lost_uploads --min-age-minutes 30 --apply
+"""
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import asyncpg
+
+from hippius_s3.config import get_config
+
+
+CANDIDATES_SQL = """
+SELECT
+    ov.object_id,
+    ov.object_version,
+    ov.status,
+    ov.created_at,
+    COUNT(pc.id) AS chunk_count
+FROM object_versions ov
+JOIN parts p
+  ON p.object_id = ov.object_id AND p.object_version = ov.object_version
+JOIN part_chunks pc
+  ON pc.part_id = p.part_id
+WHERE ov.status IN ('publishing', 'pinning')
+  AND ov.created_at < now() - make_interval(mins => $1)
+  AND NOT EXISTS (
+      SELECT 1
+      FROM parts p2
+      JOIN part_chunks pc2 ON pc2.part_id = p2.part_id
+      JOIN chunk_backend cb ON cb.chunk_id = pc2.id AND NOT cb.deleted
+      WHERE p2.object_id = ov.object_id AND p2.object_version = ov.object_version
+  )
+GROUP BY ov.object_id, ov.object_version, ov.status, ov.created_at
+ORDER BY ov.created_at
+"""
+
+MARK_FAILED_SQL = """
+UPDATE object_versions SET status = 'failed'
+WHERE object_id = $1 AND object_version = $2 AND status IN ('publishing', 'pinning')
+"""
+
+
+async def find_candidates(conn: Any, min_age_minutes: int) -> list[Any]:
+    return await conn.fetch(CANDIDATES_SQL, min_age_minutes)
+
+
+async def mark_failed(conn: Any, candidates: list[Any]) -> int:
+    marked = 0
+    for row in candidates:
+        result = await conn.execute(MARK_FAILED_SQL, row["object_id"], row["object_version"])
+        # asyncpg returns e.g. "UPDATE 1"; the status re-check guards against races with a
+        # concurrently-recovering uploader.
+        if result.endswith("1"):
+            marked += 1
+    return marked
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="Mark never-uploaded object_versions failed after NVMe cache loss")
+    parser.add_argument("--apply", action="store_true", help="actually mark candidates failed (default: dry-run)")
+    parser.add_argument(
+        "--min-age-minutes",
+        type=int,
+        default=60,
+        help="only consider versions older than this (avoid racing in-flight PUTs; default 60)",
+    )
+    args = parser.parse_args()
+
+    config = get_config()
+    conn = await asyncpg.connect(dsn=config.database_url)
+    try:
+        candidates = await find_candidates(conn, args.min_age_minutes)
+        if not candidates:
+            print(
+                f"No lost uploads found (status publishing/pinning, older than {args.min_age_minutes}m, "
+                f"zero live chunk_backend rows)."
+            )
+            return 0
+
+        print(f"{len(candidates)} candidate object_versions (never reached any backend):")
+        for row in candidates[:50]:
+            print(
+                f"  object_id={row['object_id']} v={row['object_version']} status={row['status']} "
+                f"created={row['created_at']} chunks={row['chunk_count']}"
+            )
+        if len(candidates) > 50:
+            print(f"  ... and {len(candidates) - 50} more")
+
+        if not args.apply:
+            print("\nDRY RUN — nothing changed. Re-run with --apply to mark these failed.")
+            return 0
+
+        marked = await mark_failed(conn, candidates)
+        print(f"\nMarked {marked}/{len(candidates)} object_versions failed.")
+        return 0
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/k8s/evacuate/README.md
+++ b/k8s/evacuate/README.md
@@ -1,0 +1,20 @@
+# Evacuate-to-ceph patches
+
+Strategic-merge patches applied to the **live** prod deployments by `scripts/evacuate_cache.sh`
+when the NVMe cache node (`k8s-v3-node6-cache`) is failing. Each patch is the exact inverse of
+`k8s/production/local-cache-patch.yaml`:
+
+- remove the `kubernetes.io/hostname` node pin (`nodeSelector: null`),
+- remove the `local-cache` volume + mount (mandatory: the local PV's nodeAffinity would otherwise
+  still force scheduling onto the broken node),
+- mount the ceph `object-cache` volume read-write (it is read-only in nvme mode).
+
+`configmap-ceph.yaml` flips the cache env (`HIPPIUS_OBJECT_CACHE_DIR` → ceph path, fallback
+cleared). ConfigMap changes do not restart pods — the script issues `rollout restart` after
+patching.
+
+**Failback is the normal production deploy**: CI re-renders the manifests with the local-cache
+patches, `kubectl apply` restores the pin/volumes/env (all fields here exist in the rendered
+config, so three-way apply reverts them cleanly). Do not hand-revert these patches.
+
+See `disk-failure-playbook.md` at the repo root.

--- a/k8s/evacuate/api.yaml
+++ b/k8s/evacuate/api.yaml
@@ -1,0 +1,17 @@
+# Evacuate-to-ceph patch for api: unpin from the cache node, drop the node-local NVMe volume,
+# mount the ceph cache read-write. Applied live by scripts/evacuate_cache.sh.
+spec:
+  template:
+    spec:
+      nodeSelector: null
+      containers:
+        - name: api
+          volumeMounts:
+            - $patch: delete
+              mountPath: /var/lib/hippius/local_object_cache
+            - name: object-cache
+              mountPath: /var/lib/hippius/object_cache
+              readOnly: false
+      volumes:
+        - $patch: delete
+          name: local-cache

--- a/k8s/evacuate/arion-downloader.yaml
+++ b/k8s/evacuate/arion-downloader.yaml
@@ -1,0 +1,17 @@
+# Evacuate-to-ceph patch for arion-downloader: unpin from the cache node, drop the node-local NVMe volume,
+# mount the ceph cache read-write. Applied live by scripts/evacuate_cache.sh.
+spec:
+  template:
+    spec:
+      nodeSelector: null
+      containers:
+        - name: arion-downloader
+          volumeMounts:
+            - $patch: delete
+              mountPath: /var/lib/hippius/local_object_cache
+            - name: object-cache
+              mountPath: /var/lib/hippius/object_cache
+              readOnly: false
+      volumes:
+        - $patch: delete
+          name: local-cache

--- a/k8s/evacuate/arion-uploader.yaml
+++ b/k8s/evacuate/arion-uploader.yaml
@@ -1,0 +1,17 @@
+# Evacuate-to-ceph patch for arion-uploader: unpin from the cache node, drop the node-local NVMe volume,
+# mount the ceph cache read-write. Applied live by scripts/evacuate_cache.sh.
+spec:
+  template:
+    spec:
+      nodeSelector: null
+      containers:
+        - name: arion-uploader
+          volumeMounts:
+            - $patch: delete
+              mountPath: /var/lib/hippius/local_object_cache
+            - name: object-cache
+              mountPath: /var/lib/hippius/object_cache
+              readOnly: false
+      volumes:
+        - $patch: delete
+          name: local-cache

--- a/k8s/evacuate/backup.yaml
+++ b/k8s/evacuate/backup.yaml
@@ -1,0 +1,17 @@
+# Evacuate-to-ceph patch for backup: unpin from the cache node, drop the node-local NVMe volume,
+# mount the ceph cache read-write. Applied live by hippius-s3's scripts/evacuate_cache.sh.
+spec:
+  template:
+    spec:
+      nodeSelector: null
+      containers:
+        - name: backup
+          volumeMounts:
+            - $patch: delete
+              mountPath: /var/lib/hippius/local_object_cache
+            - name: object-cache
+              mountPath: /var/lib/hippius/object_cache
+              readOnly: false
+      volumes:
+        - $patch: delete
+          name: local-cache

--- a/k8s/evacuate/configmap-ceph.yaml
+++ b/k8s/evacuate/configmap-ceph.yaml
@@ -1,0 +1,5 @@
+# Evacuate-to-ceph env flip: ceph becomes the primary (and only) cache.
+# Failback: the normal production deploy re-applies local-cache-configmap-patch.yaml.
+data:
+  HIPPIUS_OBJECT_CACHE_DIR: "/var/lib/hippius/object_cache"
+  HIPPIUS_OBJECT_CACHE_FALLBACK_DIR: ""

--- a/k8s/evacuate/hydrator.yaml
+++ b/k8s/evacuate/hydrator.yaml
@@ -1,0 +1,17 @@
+# Evacuate-to-ceph patch for hydrator: unpin from the cache node, drop the node-local NVMe volume,
+# mount the ceph cache read-write. Applied live by hippius-s3's scripts/evacuate_cache.sh.
+spec:
+  template:
+    spec:
+      nodeSelector: null
+      containers:
+        - name: hydrator
+          volumeMounts:
+            - $patch: delete
+              mountPath: /var/lib/hippius/local_object_cache
+            - name: object-cache
+              mountPath: /var/lib/hippius/object_cache
+              readOnly: false
+      volumes:
+        - $patch: delete
+          name: local-cache

--- a/k8s/evacuate/janitor.yaml
+++ b/k8s/evacuate/janitor.yaml
@@ -1,0 +1,17 @@
+# Evacuate-to-ceph patch for janitor: unpin from the cache node, drop the node-local NVMe volume,
+# mount the ceph cache read-write. Applied live by scripts/evacuate_cache.sh.
+spec:
+  template:
+    spec:
+      nodeSelector: null
+      containers:
+        - name: janitor
+          volumeMounts:
+            - $patch: delete
+              mountPath: /var/lib/hippius/local_object_cache
+            - name: object-cache
+              mountPath: /var/lib/hippius/object_cache
+              readOnly: false
+      volumes:
+        - $patch: delete
+          name: local-cache

--- a/k8s/production/disk-canary-deployment.yaml
+++ b/k8s/production/disk-canary-deployment.yaml
@@ -1,0 +1,76 @@
+# Disk canary: probes the NVMe + ceph cache mounts on the cache node every 30s and exports
+# disk_canary_mount_healthy{mount=...} gauges. Pages fire on unhealthy AND on metric absence
+# (node too broken to run the canary — the 2026-06-11 pods-stuck-in-Init case).
+# Deliberately pinned to the cache node: its whole job is to be the early-warning sensor there.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: disk-canary
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: disk-canary
+  template:
+    metadata:
+      labels:
+        app: disk-canary
+        worker-type: canary
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: k8s-v3-node6-cache
+      containers:
+        - name: disk-canary
+          image: ghcr.io/thenervelab/hippius-s3/workers:latest
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: hippius-s3-defaults
+            - configMapRef:
+                name: hippius-s3-environment
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment=$(ENVIRONMENT),service.namespace=$(K8S_NAMESPACE),service.instance.id=$(POD_NAME)"
+            - name: WORKER_SCRIPT
+              value: "workers/run_disk_canary_in_loop.py"
+            - name: DISK_CANARY_MOUNTS
+              value: "/var/lib/hippius/local_object_cache,/var/lib/hippius/object_cache"
+          volumeMounts:
+            - name: local-cache
+              mountPath: /var/lib/hippius/local_object_cache
+            - name: object-cache
+              mountPath: /var/lib/hippius/object_cache
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "test -d /proc/1 && grep -q python /proc/1/cmdline"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+      volumes:
+        - name: local-cache
+          persistentVolumeClaim:
+            claimName: local-cache-pvc
+        - name: object-cache
+          persistentVolumeClaim:
+            claimName: object-cache-pvc

--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - gateway-nodeport.yaml
   - pv-local-cache.yaml
   - pvc-local-cache.yaml
+  - disk-canary-deployment.yaml
 
 patches:
   - path: namespace-patch.yaml

--- a/monitoring/grafana/provisioning/alerting/alert-rules.yml
+++ b/monitoring/grafana/provisioning/alerting/alert-rules.yml
@@ -240,3 +240,100 @@ groups:
           summary: API response times severely degraded during user activity
         labels:
           severity: high
+
+  - orgId: 1
+    name: hippius-s3-disk-canary
+    folder: Hippius S3 Alerts
+    interval: 1m
+    rules:
+      - uid: disk-canary-mount-unhealthy
+        title: Cache mount unhealthy on cache node
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'min(disk_canary_mount_healthy) by (mount)'
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator:
+                    params:
+                      - 1
+                    type: lt
+                  type: query
+              refId: C
+        noDataState: OK
+        execErrState: Error
+        for: 2m
+        annotations:
+          description: 'disk-canary reports mount {{ $labels.mount }} unhealthy on k8s-v3-node6-cache — stale mount or disk failure. Runbook: disk-failure-playbook.md (evacuate to ceph if not quickly fixable).'
+          summary: FS cache mount failing canary probes on the cache node
+        labels:
+          severity: critical
+
+      - uid: disk-canary-metrics-absent
+        title: Disk canary metrics absent (cache node may be down)
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'absent(disk_canary_mount_healthy)'
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  type: query
+              refId: C
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        annotations:
+          description: 'No disk_canary_mount_healthy metrics for 5m — the canary cannot run on k8s-v3-node6-cache (node-level failure, e.g. pods stuck in Init on broken mounts). Runbook: disk-failure-playbook.md.'
+          summary: Disk canary silent — cache node likely unable to schedule/run pods
+        labels:
+          severity: critical

--- a/scripts/evacuate_cache.sh
+++ b/scripts/evacuate_cache.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# evacuate_cache.sh — flip ALL cache-dependent prod workloads from the node-local NVMe cache to
+# the shared ceph cache and unpin them from k8s-v3-node6-cache. Run when the cache node (NVMe
+# device, mounts, or the node itself) is failing and not quickly fixable.
+#
+# What it does, in order:
+#   1. Preflight: prove the ceph cache PVC is mountable from a NON-cache node (probe pod).
+#   2. Patch the cache env ConfigMaps (hippius-s3-defaults + the live hash-suffixed
+#      s3-backup-config) so the primary cache dir becomes /var/lib/hippius/object_cache (ceph).
+#   3. Patch 6 deployments (api, arion-uploader, arion-downloader, janitor, backup, hydrator)
+#      from k8s/evacuate/*.yaml: drop the node pin, drop the local-cache NVMe volume, mount the
+#      ceph cache read-write.
+#   4. Rollout-restart all 6 together and wait; print final pod placement.
+#
+# FAILBACK = run the normal production deploy (hippius-s3 push to k8s-production + s3-backup push
+# to k8s-production). CI re-applies the local-cache patches and the nvme env values. Do NOT
+# hand-revert. See disk-failure-playbook.md.
+#
+# Usage:
+#   ./scripts/evacuate_cache.sh --dry-run          # validate everything, change nothing
+#   ./scripts/evacuate_cache.sh --yes              # execute
+#   ./scripts/evacuate_cache.sh --yes -n <ns>      # non-default namespace
+
+set -euo pipefail
+
+NS="hippius-s3-prod"
+DRY_RUN=false
+CONFIRM=false
+CACHE_NODE="k8s-v3-node6-cache"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EVAC_DIR="$SCRIPT_DIR/../k8s/evacuate"
+
+HIPPIUS_DEPLOYS=(api arion-uploader arion-downloader janitor)
+S3BACKUP_DEPLOYS=(backup hydrator)
+ALL_DEPLOYS=("${HIPPIUS_DEPLOYS[@]}" "${S3BACKUP_DEPLOYS[@]}")
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    --yes) CONFIRM=true; shift ;;
+    -n|--namespace) NS="$2"; shift 2 ;;
+    *) echo "unknown arg: $1"; exit 2 ;;
+  esac
+done
+
+log() { printf '\n==> %s\n' "$*"; }
+
+log "EVACUATE CACHE -> CEPH (namespace=$NS, dry_run=$DRY_RUN)"
+log "Current state"
+"$SCRIPT_DIR/evacuate_status.sh" -n "$NS" || true
+
+# ---------------------------------------------------------------- 1. preflight
+log "Preflight: probing ceph PVC mount from a non-cache node"
+if $DRY_RUN; then
+  echo "(dry-run: skipping probe pod creation)"
+else
+  kubectl -n "$NS" delete pod evacuate-preflight --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl -n "$NS" apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: evacuate-preflight
+spec:
+  restartPolicy: Never
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values: ["$CACHE_NODE"]
+  containers:
+    - name: probe
+      image: busybox:1.35
+      command: ["sh", "-c", "touch /cache/.evacuate-preflight && rm /cache/.evacuate-preflight && echo CEPH_MOUNT_OK"]
+      volumeMounts:
+        - name: object-cache
+          mountPath: /cache
+  volumes:
+    - name: object-cache
+      persistentVolumeClaim:
+        claimName: object-cache-pvc
+EOF
+  for i in $(seq 1 24); do
+    phase=$(kubectl -n "$NS" get pod evacuate-preflight -o jsonpath='{.status.phase}' 2>/dev/null || echo Pending)
+    [[ "$phase" == "Succeeded" ]] && break
+    [[ "$phase" == "Failed" ]] && { echo "PREFLIGHT FAILED — ceph cache not mountable off-node. Aborting."; kubectl -n "$NS" logs evacuate-preflight | tail -5; exit 1; }
+    sleep 5
+  done
+  [[ "$phase" == "Succeeded" ]] || { echo "PREFLIGHT TIMED OUT after 120s. Aborting."; exit 1; }
+  kubectl -n "$NS" delete pod evacuate-preflight --wait=false >/dev/null
+  echo "preflight OK — ceph cache mountable from non-cache nodes"
+fi
+
+if ! $DRY_RUN && ! $CONFIRM; then
+  echo
+  read -r -p "Proceed with evacuation of ${ALL_DEPLOYS[*]} in $NS? [type 'evacuate'] " ans
+  [[ "$ans" == "evacuate" ]] || { echo "aborted"; exit 1; }
+fi
+
+PATCH_FLAGS=()
+$DRY_RUN && PATCH_FLAGS+=(--dry-run=server)
+
+# ------------------------------------------------------- 2. configmap env flip
+log "Patching hippius-s3-defaults ConfigMap (cache env -> ceph)"
+kubectl -n "$NS" patch configmap hippius-s3-defaults "${PATCH_FLAGS[@]}" \
+  --patch-file "$EVAC_DIR/configmap-ceph.yaml"
+
+log "Patching live s3-backup-config ConfigMap (OBJECT_CACHE_DIR -> ceph)"
+S3B_CM=$(kubectl -n "$NS" get deploy backup \
+  -o jsonpath='{.spec.template.spec.containers[0].envFrom[0].configMapRef.name}' 2>/dev/null || true)
+if [[ -n "$S3B_CM" ]]; then
+  kubectl -n "$NS" patch configmap "$S3B_CM" "${PATCH_FLAGS[@]}" --type merge -p \
+    '{"data":{"OBJECT_CACHE_DIR":"/var/lib/hippius/object_cache","OBJECT_CACHE_FALLBACK_DIR":""}}'
+else
+  echo "WARNING: could not resolve s3-backup-config from deploy/backup — skipping (check manually)"
+fi
+
+# ------------------------------------------------------ 3. deployment patches
+for d in "${ALL_DEPLOYS[@]}"; do
+  log "Patching deployment/$d (unpin + drop local-cache + ceph RW)"
+  kubectl -n "$NS" patch deployment "$d" "${PATCH_FLAGS[@]}" --patch-file "$EVAC_DIR/$d.yaml"
+done
+
+$DRY_RUN && { log "DRY RUN complete — all patches validated server-side, nothing changed."; exit 0; }
+
+# ------------------------------------------------------------- 4. roll + wait
+log "Rolling all deployments (configmap changes need restarts)"
+for d in "${ALL_DEPLOYS[@]}"; do
+  kubectl -n "$NS" rollout restart "deployment/$d"
+done
+
+log "Waiting for rollouts"
+for d in "${ALL_DEPLOYS[@]}"; do
+  kubectl -n "$NS" rollout status "deployment/$d" --timeout=10m || echo "WARNING: $d rollout not complete"
+done
+
+log "Final placement (expect spread across nodes, none on $CACHE_NODE)"
+kubectl -n "$NS" get pods -o wide | grep -E "$(IFS='|'; echo "${ALL_DEPLOYS[*]}")" | awk '{print $1, $3, $7}' | sort -k3
+
+log "DONE. Next steps:"
+echo "  1. Verify a PUT/GET round-trip against the public endpoint."
+echo "  2. If the NVMe data is lost, run:  python -m hippius_s3.scripts.reconcile_lost_uploads --apply"
+echo "  3. Failback after node repair: normal production deploys (both repos). See disk-failure-playbook.md."

--- a/scripts/evacuate_status.sh
+++ b/scripts/evacuate_status.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# evacuate_status.sh — read-only: report whether the cache workloads are in NVME mode (pinned to
+# the cache node, local cache primary) or CEPH mode (evacuated), and where the pods are running.
+set -euo pipefail
+
+NS="hippius-s3-prod"
+CACHE_NODE="k8s-v3-node6-cache"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--namespace) NS="$2"; shift 2 ;;
+    *) echo "unknown arg: $1"; exit 2 ;;
+  esac
+done
+
+DEPLOYS=(api arion-uploader arion-downloader janitor backup hydrator)
+
+dir=$(kubectl -n "$NS" get configmap hippius-s3-defaults \
+  -o jsonpath='{.data.HIPPIUS_OBJECT_CACHE_DIR}' 2>/dev/null || echo "?")
+echo "HIPPIUS_OBJECT_CACHE_DIR = $dir"
+
+nvme=0; ceph=0
+for d in "${DEPLOYS[@]}"; do
+  sel=$(kubectl -n "$NS" get deploy "$d" \
+    -o jsonpath='{.spec.template.spec.nodeSelector.kubernetes\.io/hostname}' 2>/dev/null || echo "")
+  vols=$(kubectl -n "$NS" get deploy "$d" \
+    -o jsonpath='{.spec.template.spec.volumes[*].name}' 2>/dev/null || echo "")
+  if [[ "$sel" == "$CACHE_NODE" && "$vols" == *local-cache* ]]; then
+    mode="NVME (pinned)"; nvme=$((nvme+1))
+  elif [[ -z "$sel" && "$vols" != *local-cache* ]]; then
+    mode="CEPH (evacuated)"; ceph=$((ceph+1))
+  else
+    mode="MIXED/UNKNOWN (selector='$sel' volumes='$vols')"
+  fi
+  printf '  %-18s %s\n' "$d" "$mode"
+done
+
+echo
+if [[ $nvme -eq ${#DEPLOYS[@]} ]]; then echo "MODE: NVME (normal)"
+elif [[ $ceph -eq ${#DEPLOYS[@]} ]]; then echo "MODE: CEPH (evacuated)"
+else echo "MODE: MIXED — investigate (a flip may be half-applied)"; fi
+
+echo
+echo "Pod placement:"
+kubectl -n "$NS" get pods -o wide 2>/dev/null \
+  | grep -E "^($(IFS='|'; echo "${DEPLOYS[*]}"))-" \
+  | awk '{print $7}' | sort | uniq -c | sort -rn | sed 's/^/  /'

--- a/tests/unit/test_disk_canary.py
+++ b/tests/unit/test_disk_canary.py
@@ -1,0 +1,44 @@
+"""Tests for the disk-canary mount probe (workers/run_disk_canary_in_loop.py check_mount)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from workers.run_disk_canary_in_loop import check_mount
+
+
+def test_healthy_mount_passes_and_cleans_up(tmp_path):
+    elapsed = check_mount(str(tmp_path))
+    assert elapsed >= 0
+    canary_dir = tmp_path / ".canary"
+    assert canary_dir.is_dir()
+    assert list(canary_dir.glob("heartbeat.*")) == [], "heartbeat must be deleted after the probe"
+    assert list(canary_dir.glob(".tmp.*")) == [], "tmp file must be renamed away"
+
+
+def test_missing_mount_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        check_mount(str(tmp_path / "does-not-exist"))
+
+
+def test_unwritable_mount_raises(tmp_path):
+    if os.geteuid() == 0:
+        pytest.skip("root bypasses permission bits")
+    target = tmp_path / "ro"
+    target.mkdir()
+    canary_dir = target / ".canary"
+    canary_dir.mkdir()
+    canary_dir.chmod(0o555)
+    try:
+        with pytest.raises(PermissionError):
+            check_mount(str(target))
+    finally:
+        canary_dir.chmod(0o755)
+
+
+def test_repeated_probes_are_idempotent(tmp_path):
+    for _ in range(3):
+        check_mount(str(tmp_path))
+    assert list((tmp_path / ".canary").iterdir()) == []

--- a/tests/unit/test_reconcile_lost_uploads.py
+++ b/tests/unit/test_reconcile_lost_uploads.py
@@ -1,0 +1,43 @@
+"""Tests for the post-evacuation reconcile script (hippius_s3/scripts/reconcile_lost_uploads.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hippius_s3.scripts.reconcile_lost_uploads import CANDIDATES_SQL
+from hippius_s3.scripts.reconcile_lost_uploads import find_candidates
+from hippius_s3.scripts.reconcile_lost_uploads import mark_failed
+
+
+def _row(object_id: str, version: int = 1) -> dict:
+    return {"object_id": object_id, "object_version": version, "status": "publishing", "chunk_count": 3}
+
+
+@pytest.mark.asyncio
+async def test_find_candidates_passes_min_age():
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=[_row("a")])
+    rows = await find_candidates(conn, 45)
+    conn.fetch.assert_awaited_once_with(CANDIDATES_SQL, 45)
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_counts_only_actual_updates():
+    """The status re-check in MARK_FAILED_SQL means a concurrently-recovered version updates 0
+    rows — it must not be counted as marked."""
+    conn = AsyncMock()
+    conn.execute = AsyncMock(side_effect=["UPDATE 1", "UPDATE 0", "UPDATE 1"])
+    marked = await mark_failed(conn, [_row("a"), _row("b"), _row("c")])
+    assert marked == 2
+    assert conn.execute.await_count == 3
+
+
+def test_candidates_sql_guards():
+    """The query must only target pre-upload statuses and require zero LIVE backend rows."""
+    assert "'publishing', 'pinning'" in CANDIDATES_SQL
+    assert "NOT EXISTS" in CANDIDATES_SQL
+    assert "NOT cb.deleted" in CANDIDATES_SQL, "soft-deleted backend rows must not count as replicated"
+    assert "make_interval" in CANDIDATES_SQL, "min-age guard must be parameterized"

--- a/workers/run_disk_canary_in_loop.py
+++ b/workers/run_disk_canary_in_loop.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Disk canary: per-mount health probe for the FS cache volumes on the cache node.
+
+Every interval, for each configured mount: lstat the root, then write -> read -> delete a
+heartbeat file under <mount>/.canary/. Each check runs in a thread with a hard timeout because a
+stale CephFS kernel mount HANGS IO syscalls (it doesn't error) — the 2026-06-11 incident surfaced
+as `permission denied` on lstat, but the hang case must page too.
+
+Emits OTel observable gauges (same pipeline as the janitor):
+  disk_canary_mount_healthy{mount=...}  1 healthy / 0 unhealthy
+  disk_canary_op_seconds{mount=...}     duration of the last successful check
+and logs `DISK_CANARY_FAIL mount=... reason=...` at ERROR for Loki-side visibility.
+
+Grafana pages on `disk_canary_mount_healthy < 1` AND on metric absence (node too broken to run
+the canary at all — the pods-stuck-in-Init case).
+"""
+
+import asyncio
+import logging
+import os
+import socket
+import sys
+import time
+import uuid
+from pathlib import Path
+
+from opentelemetry import metrics as otel_metrics
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from hippius_s3.config import get_config
+from hippius_s3.logging_config import setup_loki_logging
+from hippius_s3.sentry import init_sentry
+
+
+config = get_config()
+
+setup_loki_logging(config, "disk-canary", include_ray_id=False)
+logger = logging.getLogger(__name__)
+init_sentry("disk-canary", is_worker=True)
+
+CHECK_INTERVAL_SECONDS = float(os.getenv("DISK_CANARY_INTERVAL_SECONDS", "30"))
+# A healthy local write+fsync is milliseconds; a stale mount hangs forever. 10s is unambiguous.
+CHECK_TIMEOUT_SECONDS = float(os.getenv("DISK_CANARY_TIMEOUT_SECONDS", "10"))
+MOUNTS = [
+    m.strip()
+    for m in os.getenv(
+        "DISK_CANARY_MOUNTS",
+        "/var/lib/hippius/local_object_cache,/var/lib/hippius/object_cache",
+    ).split(",")
+    if m.strip()
+]
+
+_mount_healthy: dict[str, int] = dict.fromkeys(MOUNTS, 1)
+_mount_op_seconds: dict[str, float] = dict.fromkeys(MOUNTS, 0.0)
+
+
+def _obs_healthy(_: object) -> list[otel_metrics.Observation]:
+    return [otel_metrics.Observation(v, {"mount": m}) for m, v in _mount_healthy.items()]
+
+
+def _obs_op_seconds(_: object) -> list[otel_metrics.Observation]:
+    return [otel_metrics.Observation(v, {"mount": m}) for m, v in _mount_op_seconds.items()]
+
+
+def _setup_metrics() -> None:
+    existing = otel_metrics.get_meter_provider()
+    if not isinstance(existing, MeterProvider):
+        endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4317")
+        service_name = os.getenv("OTEL_SERVICE_NAME", "hippius-s3")
+        resource = Resource.create({"service.name": service_name, "service.instance.id": socket.gethostname()})
+        metric_reader = PeriodicExportingMetricReader(
+            OTLPMetricExporter(endpoint=endpoint, insecure=True),
+            export_interval_millis=10000,
+        )
+        otel_metrics.set_meter_provider(MeterProvider(resource=resource, metric_readers=[metric_reader]))
+
+    meter = otel_metrics.get_meter("disk-canary")
+    meter.create_observable_gauge(
+        name="disk_canary_mount_healthy",
+        callbacks=[_obs_healthy],
+        description="1 if the mount passed the last write/read/delete probe, 0 otherwise",
+    )
+    meter.create_observable_gauge(
+        name="disk_canary_op_seconds",
+        callbacks=[_obs_op_seconds],
+        description="Duration of the last successful probe per mount",
+    )
+
+
+def check_mount(mount: str) -> float:
+    """Synchronous probe of one mount: lstat root, write -> read -> delete a heartbeat file.
+
+    Returns the elapsed seconds on success; raises on any failure. Runs inside a thread with an
+    outer timeout because stale network mounts hang rather than error.
+    """
+    started = time.monotonic()
+    root = Path(mount)
+    os.lstat(root)  # stale CephFS staging mounts fail exactly here (permission denied)
+
+    canary_dir = root / ".canary"
+    canary_dir.mkdir(exist_ok=True)
+    payload = uuid.uuid4().bytes
+    heartbeat = canary_dir / f"heartbeat.{socket.gethostname()}"
+    tmp = canary_dir / f".tmp.{uuid.uuid4().hex}"
+    with tmp.open("wb") as fp:
+        fp.write(payload)
+        fp.flush()
+        os.fsync(fp.fileno())
+    tmp.replace(heartbeat)
+    read_back = heartbeat.read_bytes()
+    if read_back != payload:
+        raise RuntimeError(f"read-back mismatch ({len(read_back)} bytes)")
+    heartbeat.unlink()
+    return time.monotonic() - started
+
+
+async def _check_one(mount: str) -> None:
+    try:
+        elapsed = await asyncio.wait_for(asyncio.to_thread(check_mount, mount), timeout=CHECK_TIMEOUT_SECONDS)
+        if _mount_healthy[mount] == 0:
+            logger.info(f"DISK_CANARY_RECOVERED mount={mount} op_seconds={elapsed:.3f}")
+        _mount_healthy[mount] = 1
+        _mount_op_seconds[mount] = elapsed
+    except TimeoutError:
+        _mount_healthy[mount] = 0
+        logger.error(f"DISK_CANARY_FAIL mount={mount} reason=timeout_after_{CHECK_TIMEOUT_SECONDS}s (stale mount?)")
+    except Exception as e:
+        _mount_healthy[mount] = 0
+        logger.error(f"DISK_CANARY_FAIL mount={mount} reason={type(e).__name__}: {e}")
+
+
+async def run_disk_canary_loop() -> None:
+    _setup_metrics()
+    logger.info(
+        f"Starting disk canary (mounts={MOUNTS} interval={CHECK_INTERVAL_SECONDS}s timeout={CHECK_TIMEOUT_SECONDS}s)"
+    )
+    while True:
+        # NOTE: a hung to_thread check leaks its worker thread past the timeout; that is acceptable
+        # — the gauge flips to 0 and the pod gets recycled when the node is remediated.
+        await asyncio.gather(*[_check_one(m) for m in MOUNTS])
+        await asyncio.sleep(CHECK_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    asyncio.run(run_disk_canary_loop())


### PR DESCRIPTION
## Summary
Implements **proposal-1** after the 2026-06-11 cache-node incident (stale CephFS mounts on `k8s-v3-node6-cache` → api 0/5 for ~3h, undiscovered for hours; the hard node pin gave the scheduler no escape). This adds **detect + page + 1-command evacuate-to-ceph**: a disk canary that pages within ~2 minutes, and a rehearsable script that flips all six cache workloads off the broken node onto the shared ceph cache.

## Changes (largest → smallest)
- **`scripts/evacuate_cache.sh`** — the 1-command flip: preflights ceph mountability from a non-cache node (probe pod), patches the cache env ConfigMaps (incl. resolving the hash-suffixed live `s3-backup-config-*`), strips the node pin + `local-cache` NVMe volume from `api`/`arion-uploader`/`arion-downloader`/`janitor`/`backup`/`hydrator` via `k8s/evacuate/*.yaml` strategic-merge patches (removing the volume is mandatory — the local PV's nodeAffinity would otherwise still force node6), mounts ceph RW, rolls everything together and prints the final spread. `--dry-run` does full server-side validation — **already exercised against live prod: all 8 patches valid, nothing changed**. `evacuate_status.sh` reports NVME/CEPH/MIXED mode (works against prod).
- **`disk-canary` worker + alerts** — pinned to the cache node, probes both cache mounts every 30s (lstat + write/read/delete heartbeat; hang-proof via thread timeout — stale CephFS mounts *hang*, they don't error), exports `disk_canary_mount_healthy{mount=…}` through the standard OTel pipeline. Two Grafana rules: unhealthy ≥2m, and **metric absence ≥5m** (node too broken to run the canary — exactly the pods-stuck-in-Init case).
- **`reconcile_lost_uploads.py`** — post-evacuation: marks object_versions that never reached any backend `failed` so GETs 404 cleanly instead of hanging (dry-run default; status re-check guards racing recoveries; SQL EXPLAIN-validated against the prod schema).
- **`disk-failure-playbook.md`** — setup summary, decision tree, the `umount -f` + scale-cycle stale-mount quick fix from the incident, and the exact ceph-only / nvme-only redeploy commands.

## Failback
Deliberately the **normal production deploy** — CI re-applies the local-cache patches (pin + NVMe env return). Evacuation-era ceph chunks stay readable afterwards because NVMe-mode config keeps ceph as the read `FALLBACK_DIR`.

## Verification
- 8 new unit tests pass (canary probe + reconcile logic); ruff/ty clean; kustomize base/staging/production build.
- `evacuate_cache.sh --dry-run` validated server-side against the live prod objects.
- Sister PR (patch mirrors): thenervelab/s3-backup `feature/nvme-evacuation`.

## Conclusion
The next node6 failure pages in ~2 minutes and is recoverable with one rehearsable command instead of a 3-hour outage. Recommend a quiet-window game-day (evacuate janitor alone → full evacuate → failback) before relying on it.
