### PR TITLE
Fix drain stall: node-scoped claim (G1) + rate-control (F1/F7) [s3-2.1 PR-1]

### DIFF
--- a/crates/hippius-drain-agent/src/main.rs
+++ b/crates/hippius-drain-agent/src/main.rs
@@ -31,7 +31,13 @@ async fn main() -> Result<(), StartupError> {
     // Honor the configured claim lease so a crashed/partitioned agent's claim is
     // re-claimable after the TTL (the H1 crash-recovery path) instead of the
     // store's hardcoded default.
-    let store = Store::connect(&config.database_url).await?.with_claim_lease(config.claim_lease);
+    // Scope claims/records to this node: parts live on node-local SSD, so this agent
+    // may only drain parts it holds (otherwise it claims a peer's part and fails on
+    // the missing local source). See migration 0006 + Store::with_node_id.
+    let store = Store::connect(&config.database_url)
+        .await?
+        .with_claim_lease(config.claim_lease)
+        .with_node_id(config.node_id.as_str());
 
     // The enforcer starts at the floor (conservative) with a one-second burst of
     // the node's capability; the allocation-pull worker raises it to the leader's

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -138,7 +138,10 @@ async fn run_drain(token: CancellationToken, period: Duration, deps: DrainDeps) 
         // here — recording it again would double-count.
         match drain_until_empty(&deps.ceph, &deps.ssd, &deps.store, deps.enforcer.as_ref(), Some(&deps.snapshot), &token).await {
             Ok(drained) => tracing::debug!(drained, "drain cycle complete"),
-            Err(err) => tracing::warn!(error = %err, "drain cycle failed; SSD copy retained, will retry"),
+            // Debug-format the error so the `PartDrainError` variant + `DrainStep` + the
+            // underlying io errno surface; `%err` (Display) only prints the opaque
+            // "draining a part failed" and hides which step/errno actually failed.
+            Err(err) => tracing::warn!(error = ?err, "drain cycle failed; SSD copy retained, will retry"),
         }
 
         tokio::select! {

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -66,20 +66,19 @@ impl Drop for PermitGuard<'_> {
 }
 
 /// The SSD byte size the bandwidth gate charges for this part: the sum of its chunk
-/// files. An unresolvable id or a failed stat (e.g. a vanished file) charges nothing,
-/// so the drain then surfaces the real error and records a failure rather than the
-/// gate silently admitting phantom work.
-async fn part_size(ssd: &LocalSsd, part: &PartKey) -> u64 {
-    let Ok(indices) = ssd.list_chunks(part).await else {
-        return 0;
-    };
+/// files. `None` if listing or stat-ing any chunk fails — the caller then denies
+/// admission and retries rather than charging 0 and draining unmetered (audit F7).
+/// Charging 0 on a stat race would defeat the rate gate exactly under SSD I/O
+/// pressure, when it matters most.
+async fn part_size(ssd: &LocalSsd, part: &PartKey) -> Option<u64> {
+    let indices = ssd.list_chunks(part).await.ok()?;
     let mut total = 0_u64;
     for index in indices {
-        if let Ok(path) = ssd.chunk_source(part, index) {
-            total = total.saturating_add(tokio::fs::metadata(&path).await.map_or(0, |meta| meta.len()));
-        }
+        let path = ssd.chunk_source(part, index).ok()?;
+        let meta = tokio::fs::metadata(&path).await.ok()?;
+        total = total.saturating_add(meta.len());
     }
-    total
+    Some(total)
 }
 
 /// Claims one pending part and drains it SSD → pool, gated by `enforcer`.
@@ -105,7 +104,15 @@ pub async fn drain_next(
     };
 
     if let Some(enforcer) = enforcer {
-        let bytes = part_size(ssd, claim.part()).await;
+        let Some(bytes) = part_size(ssd, claim.part()).await else {
+            // A stat/list failure must not admit the part at zero cost (audit F7): hand
+            // the claim back and retry next wake. With node-scoped claims (migration
+            // 0006) a missing local part dir no longer happens, so this is a genuine
+            // transient I/O error worth backing off on.
+            store.release_part(claim.part()).await?;
+            tracing::debug!("part size unavailable; part returned to pending");
+            return Ok(None);
+        };
         // The guard's scope ends before the drain await — a `MutexGuard` must never
         // cross an `.await` (axiom rust_quality_74). Poisoning recovers via
         // `into_inner`: the `Enforcer` is a small `Copy` value whose sync methods

--- a/crates/hippius-drain-core/migrations/0006_replication_status_node.sql
+++ b/crates/hippius-drain-core/migrations/0006_replication_status_node.sql
@@ -1,0 +1,20 @@
+-- Node-scope the part replication queue.
+--
+-- A part's chunks live on the node-local SSD ingest dir, so a part may only be
+-- drained by the node that holds it. cephor_replication_status was global (keyed by
+-- (object_id, version, part_number), no node), and claim_part selected the oldest
+-- pending row regardless of node. With >1 ingest node a drain-agent therefore
+-- routinely claimed a part whose data sits on a *peer* node, found the local part dir
+-- missing, and failed at the meta copy (ENOENT) -- churning forever, draining nothing.
+--
+-- Add node_id so the per-node reconciler stamps the owning node (record_landed_part
+-- UPSERT) and claim_part scopes to it. Legacy rows are NULL until the node that still
+-- holds the part locally re-records and adopts them.
+ALTER TABLE cephor_replication_status ADD COLUMN node_id TEXT;
+
+-- The claim selector is now (node_id = $node AND status = 'pending') ordered by
+-- landed_at; replace the global pending index with a node-scoped one that matches.
+DROP INDEX IF EXISTS cephor_replication_status_pending;
+CREATE INDEX cephor_replication_status_pending
+    ON cephor_replication_status (node_id, landed_at)
+    WHERE status = 'pending';

--- a/crates/hippius-drain-core/migrations/0006_replication_status_node.sql
+++ b/crates/hippius-drain-core/migrations/0006_replication_status_node.sql
@@ -8,9 +8,18 @@
 -- missing, and failed at the meta copy (ENOENT) -- churning forever, draining nothing.
 --
 -- Add node_id so the per-node reconciler stamps the owning node (record_landed_part
--- UPSERT) and claim_part scopes to it. Legacy rows are NULL until the node that still
--- holds the part locally re-records and adopts them.
+-- UPSERT) and claim_part scopes to it.
 ALTER TABLE cephor_replication_status ADD COLUMN node_id TEXT;
+
+-- Existing non-terminal rows predate node ownership (node_id NULL) and are unclaimable
+-- under the node-scoped claim. They are NOT self-healing: the reconciler only records a
+-- part it sees as absent (status None), never one already 'pending'/'draining', so a
+-- NULL-node row would orphan forever. The node-local SSD is the source of truth, so
+-- clear the in-flight queue here and let each node's reconciler rebuild it node-aware
+-- (scan SSD -> status None -> record_landed stamps node_id). Terminal rows
+-- ('replicated'/'failed') are kept. This runs once; in steady state record_landed_part
+-- always stamps a node, so no node_id IS NULL rows are created.
+DELETE FROM cephor_replication_status WHERE node_id IS NULL AND status IN ('pending', 'draining');
 
 -- The claim selector is now (node_id = $node AND status = 'pending') ordered by
 -- landed_at; replace the global pending index with a node-scoped one that matches.

--- a/crates/hippius-drain-core/src/enforce.rs
+++ b/crates/hippius-drain-core/src/enforce.rs
@@ -153,6 +153,14 @@ impl TokenBucket {
         self.rate
     }
 
+    /// The burst ceiling (the max tokens the bucket holds — one second of rate). The
+    /// drain admission clamps an oversize part's charge to this so it can always make
+    /// progress (audit F1).
+    #[must_use]
+    pub fn burst(&self) -> u64 {
+        self.burst.get()
+    }
+
     fn refill(&mut self, now: Instant) {
         let elapsed = now.saturating_duration_since(self.last);
         // Exact integer refill: tokens = (rate * elapsed_nanos + carried remainder)
@@ -304,11 +312,18 @@ impl Enforcer {
         if !self.breaker.allows(now) {
             return DrainDecision::Denied(DenyReason::BreakerOpen);
         }
-        if !self.bucket.try_take(bytes, now) {
+        // Clamp the bandwidth charge to the burst ceiling. A part larger than one second
+        // of rate could otherwise never be admitted — `tokens` caps at `burst`, so
+        // `tokens >= bytes` is unsatisfiable and the part loops `Denied(RateLimited)`
+        // forever, never draining (audit F1). An oversize part is admitted once the
+        // bucket is full and pays at most one burst; charge and refund use the same
+        // clamped value so a later concurrency denial still costs no budget.
+        let charge = bytes.min(self.bucket.burst());
+        if !self.bucket.try_take(charge, now) {
             return DrainDecision::Denied(DenyReason::RateLimited);
         }
         if !self.concurrency.try_acquire() {
-            self.bucket.refund(bytes);
+            self.bucket.refund(charge);
             return DrainDecision::Denied(DenyReason::AtConcurrencyLimit);
         }
         DrainDecision::Allowed
@@ -587,6 +602,24 @@ mod tests {
         // after releasing the permit, a 900-byte drain still fits the original 1000 burst.
         e.record_outcome(true, now);
         assert_eq!(e.try_drain(900, now), DrainDecision::Allowed);
+    }
+
+    #[test]
+    fn enforcer_admits_a_part_larger_than_the_burst_ceiling() {
+        // Regression for F1: a part bigger than one second of rate (burst) must still
+        // drain. Before the charge-clamp it looped Denied(RateLimited) forever because
+        // `tokens` caps at `burst`, so `tokens >= bytes` was unsatisfiable.
+        let now = t0();
+        let mut e = enforcer(now); // burst = 1_000
+        assert_eq!(
+            e.try_drain(5_000, now),
+            DrainDecision::Allowed,
+            "a 5_000-byte part must be admitted from a full 1_000 burst, not stalled",
+        );
+        // It paid at most one burst: the bucket is now empty, so the next drain is rate
+        // limited (and the oversize part did NOT overdraw into a negative balance).
+        e.record_outcome(true, now);
+        assert_eq!(e.try_drain(1, now), DrainDecision::Denied(DenyReason::RateLimited));
     }
 
     #[test]

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -213,6 +213,11 @@ pub struct Store {
     /// How long a `draining` claim is honored before [`Store::claim_chunk`]
     /// treats it as abandoned and re-claims it (the H1 crash-recovery TTL).
     claim_lease: Duration,
+    /// The agent's node id. Parts live on node-local SSD, so a part may only be
+    /// drained by the node that holds it: `record_landed_part` stamps this and
+    /// `claim_part` scopes to it. `None` for the allocator, which records/claims
+    /// no parts.
+    node_id: Option<String>,
 }
 
 impl Store {
@@ -226,6 +231,7 @@ impl Store {
         Ok(Self {
             pool,
             claim_lease: DEFAULT_CLAIM_LEASE,
+            node_id: None,
         })
     }
 
@@ -235,6 +241,7 @@ impl Store {
         Self {
             pool,
             claim_lease: DEFAULT_CLAIM_LEASE,
+            node_id: None,
         }
     }
 
@@ -243,6 +250,15 @@ impl Store {
     #[must_use]
     pub fn with_claim_lease(mut self, lease: Duration) -> Self {
         self.claim_lease = lease;
+        self
+    }
+
+    /// Sets the agent's node id (the daemon wires this from `CEPHOR_NODE_ID`).
+    /// Required for `record_landed_part`/`claim_part` to scope parts to this node;
+    /// the allocator leaves it unset.
+    #[must_use]
+    pub fn with_node_id(mut self, node: &str) -> Self {
+        self.node_id = Some(node.to_owned());
         self
     }
 
@@ -516,13 +532,20 @@ impl Store {
     ///
     /// [`StoreError::Database`].
     pub async fn record_landed_part(&self, part: &PartKey) -> Result<()> {
+        // Stamp the recording node so `claim_part` only drains parts whose data is on
+        // this node's SSD. The UPSERT self-heals legacy rows: a row first written
+        // without a node (or by an older agent) is adopted by whichever node still
+        // holds the part locally and re-records it; a row already owned is left alone.
         sqlx::query(
-            "INSERT INTO cephor_replication_status (object_id, version, part_number, status) \
-             VALUES ($1, $2, $3, 'pending') ON CONFLICT (object_id, version, part_number) DO NOTHING",
+            "INSERT INTO cephor_replication_status (object_id, version, part_number, status, node_id) \
+             VALUES ($1, $2, $3, 'pending', $4) \
+             ON CONFLICT (object_id, version, part_number) \
+             DO UPDATE SET node_id = EXCLUDED.node_id WHERE cephor_replication_status.node_id IS NULL",
         )
         .bind(part.object().as_str())
         .bind(i64::from(part.version().get()))
         .bind(i64::from(part.part().get()))
+        .bind(self.node_id.as_deref())
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -546,13 +569,15 @@ impl Store {
             "UPDATE cephor_replication_status SET status = 'draining', updated_at = now(), claimed_at = now() \
              WHERE (object_id, version, part_number) IN ( \
                 SELECT object_id, version, part_number FROM cephor_replication_status \
-                WHERE status = 'pending' \
-                   OR (status = 'draining' AND claimed_at < now() - $1 * interval '1 second') \
+                WHERE node_id = $2 \
+                  AND ( status = 'pending' \
+                        OR (status = 'draining' AND claimed_at < now() - $1 * interval '1 second') ) \
                 ORDER BY landed_at \
                 FOR UPDATE SKIP LOCKED LIMIT 1 \
              ) RETURNING object_id, version, part_number",
         )
         .bind(self.claim_lease.as_secs_f64())
+        .bind(self.node_id.as_deref())
         .fetch_optional(&self.pool)
         .await?;
         row.map(PartRow::into_claimed).transpose()
@@ -731,6 +756,66 @@ mod tests {
         let fresh = store.load_fleet(Duration::ZERO).await.unwrap();
         assert!(fresh.is_empty(), "row stamped before the query instant is stale at window 0");
         assert_eq!(store.load_fleet(Duration::from_hours(1)).await.unwrap().len(), 1);
+    }
+
+    #[sqlx::test]
+    async fn claim_part_is_scoped_to_the_recording_node(pool: PgPool) {
+        // G1 regression: parts live on node-local SSD, so an agent must only claim parts
+        // it recorded (holds locally). Before node-scoping, the global claim let an agent
+        // grab a peer's part and fail at the missing-local meta copy, churning forever.
+        use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
+        let part_a = PartKey::new(
+            ObjectId::from_str("466916c0-d61b-4518-b81b-9576b574270a").unwrap(),
+            Version::new(1),
+            PartNumber::new(1),
+        );
+        let part_b = PartKey::new(
+            ObjectId::from_str("00000000-0000-4000-8000-000000000000").unwrap(),
+            Version::new(1),
+            PartNumber::new(1),
+        );
+        let node_a = Store::from_pool(pool.clone()).with_node_id("node-a");
+        let node_b = Store::from_pool(pool.clone()).with_node_id("node-b");
+
+        node_a.record_landed_part(&part_a).await.unwrap();
+        node_b.record_landed_part(&part_b).await.unwrap();
+
+        let claim = node_a.claim_part().await.unwrap().expect("node-a claims its own part");
+        assert_eq!(claim.part(), &part_a);
+        assert!(
+            node_a.claim_part().await.unwrap().is_none(),
+            "node-a must not claim node-b's part (its only other pending row)",
+        );
+        let claim_b = node_b.claim_part().await.unwrap().expect("node-b claims its own part");
+        assert_eq!(claim_b.part(), &part_b);
+    }
+
+    #[sqlx::test]
+    async fn record_landed_part_adopts_a_legacy_nodeless_row(pool: PgPool) {
+        // The UPSERT self-heals rows written before node_id existed (NULL node): the node
+        // that still holds the part locally re-records it and stamps its node_id, so the
+        // claim then sees it.
+        use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
+        let part = PartKey::new(
+            ObjectId::from_str("466916c0-d61b-4518-b81b-9576b574270a").unwrap(),
+            Version::new(2),
+            PartNumber::new(3),
+        );
+        sqlx::query("INSERT INTO cephor_replication_status (object_id, version, part_number, status) VALUES ($1, 2, 3, 'pending')")
+            .bind(part.object().as_str())
+            .execute(&pool)
+            .await
+            .unwrap();
+        let node_a = Store::from_pool(pool.clone()).with_node_id("node-a");
+        assert!(
+            node_a.claim_part().await.unwrap().is_none(),
+            "a NULL-node row is unclaimable until adopted"
+        );
+        node_a.record_landed_part(&part).await.unwrap();
+        assert!(
+            node_a.claim_part().await.unwrap().is_some(),
+            "after re-recording, node-a owns and claims it"
+        );
     }
 
     #[sqlx::test]

--- a/s3-2.1-todo.md
+++ b/s3-2.1-todo.md
@@ -1,0 +1,224 @@
+# s3-2.1 — release plan & living TODO
+
+> **Living doc — the source of truth across sessions.** Update the PR dashboard + session log as work lands.
+> Branch base: **`release/s3-2.1`** off **`staging`** (the drain code lives only on staging; `origin/main` has 0
+> of the `crates/hippius-drain-*` files). Each workstream = its own surgical PR off `release/s3-2.1`.
+
+## 1. Why
+s3-2.0 introduced the tiered cache: node-local SSD ingest → CephFS via the new Rust **`hippius-drain`** stack
+(`drain-allocator` singleton + `drain-agent` DaemonSet), with the api fleet running all-local on staging. Two
+inputs drive s3-2.1:
+- **The architecture-review audit** of `hippius-drain` (findings **F1–F22**; safe-to-run in staging, no data-loss
+  bug, but 3 P1s + many P2s/nits).
+- **Our own validation on staging (2026-06-18):** the drain is **dead-stalled** (every `cephor_replication_status`
+  row `pending`, agents looping `"draining a part failed"`, 0 replicated), and the **enqueue-timing race** is real
+  (api enqueues the Arion upload at PUT time → uploader blocks 30s polling ceph holding its inflight slot →
+  head-of-line stall → DLQ churn; reconcile ~60s > 30s wait).
+
+**Goal:** a clean, releasable s3-2.1 that makes the drain architecture *correct and production-bound*: green the
+drain, fix the enqueue-timing race (drain-gated upload), enforce CI/lint/supply-chain + safety guardrails, and
+validate end-to-end with a benchmark.
+
+## 2. Branch / PR strategy
+- Umbrella branch: `release/s3-2.1` (off `staging`). Per-PR feature branches off it; PRs target `release/s3-2.1`;
+  the umbrella merges to `staging` → (eventually) `main` when the release is cut.
+- **Surgical PRs** — one concern each, independently reviewable + revertable. Rust and Python split where possible.
+- Never commit/push without explicit ask. Rust CI gates (PR-3) should land early so later Rust PRs are enforced.
+
+## 3. PR dashboard
+| PR | Title | Lang | Sev | Status | Depends on |
+|----|-------|------|-----|--------|------------|
+| PR-1 | Drain node-scoped claim (G1) + rate-control (F1/F7) + observability | Rust | **P1 blocker** | ✅ code done — CI build + staging deploy to verify | — |
+| PR-2 | Drain store/allocator fencing correctness | Rust | P2 | ☐ todo | — |
+| PR-3 | Rust CI gates + lints + supply-chain + deploy-wait fix | Rust/CI | **P1 process** | ☐ todo | — |
+| PR-4 | Drain security posture (symlink-safe, non-root allocator) | Rust/k8s | P2 | ☐ todo | — |
+| PR-5 | Drain supervisor/exit semantics | Rust | P2 | ☐ todo | — |
+| PR-6 | Node-isolation enforcement + manifest hygiene | k8s/docs | **P1 doc/safety** | ☐ todo | — |
+| PR-7 | Enqueue-timing fix: drain-gated upload (the headline) | Python + 1-line Rust | **P1 functional** | ☐ todo | PR-1 |
+| PR-8 | Reconciler hardening | Rust | nits | ☐ todo | — |
+| PR-9 | GC safety gate (keep `gc-cephfs` off until write-fence) | Rust | P2 deferred | ☐ todo | — |
+| PR-10 | Validation: replication-lag experiment + 1GB MPU benchmark + report | ops | — | ☐ todo | PR-1, PR-7 |
+
+Recommended order: **PR-1 → PR-3 → PR-6 → PR-7**, with PR-2/4/5/8/9 parallelizable; **PR-10 last**.
+
+---
+
+## 4. Workstreams
+
+### PR-1 — Drain node-scoped claim (G1) + rate-control (F1/F7) + observability  [Rust, P1 BLOCKER]
+**G1 (NEW, confirmed root cause of the live stall) — global claim queue vs node-local SSD.**
+`cephor_replication_status` has **no `node_id`** (migration 0005); `record_landed_part` (store.rs:518) records none
+and `claim_part` (store.rs:544) is global (`WHERE status='pending' … SKIP LOCKED LIMIT 1`). But each `drain-agent`
+only mounts its **own** node's SSD (node-local hostPath). So an agent claims parts whose data is on the *other*
+node → `list_chunk_indices` returns `Ok(empty)` for the missing-local dir (localfs.rs, by design) → `drain_part`
+skips to `persist_meta` → `create_dir_all`s the empty pool dir then `copy`s a non-existent local meta → **ENOENT →
+`Io(Persist)` → the generic `"draining a part failed"` WARN.** Net: agents waste cycles on foreign parts, ~nothing
+drains. **Fix:** add `node_id` to `cephor_replication_status` (migration 0006); reconciler stamps its
+`CEPHOR_NODE_ID` via `record_landed` UPSERT (`ON CONFLICT … DO UPDATE SET node_id=EXCLUDED.node_id WHERE node_id IS
+NULL`, self-healing existing NULL rows); `claim_part(node_id)` filters `AND node_id=$node_id` (incl. the
+stale-`draining` reclaim); update the `pending` partial index → `(node_id, landed_at)`. Tests: an agent must not
+claim a foreign-node part; a part is claimed only by the node that recorded it.
+**Plus the rate-control + observability items:**
+- **F1** (`crates/hippius-drain-agent/src/worker.rs:107`, `crates/hippius-drain-core/src/enforce.rs:172` `try_take`,
+  `agent/src/main.rs:39` burst=max_drain_rate): a part with bytes > burst can never be admitted → loops
+  Denied→release→re-claim forever. Fix: clamp charge to burst (`try_take(min(bytes,burst))`) + reconcile remainder,
+  or one-shot overdraft when a single part > burst; or validate `burst >= max_part_size`. **Regression test:** part
+  with `bytes > burst` must drain, not loop.
+- **F7** (`agent/src/worker.rs:72` `part_size`): stat/list failure charges 0 → admits unmetered. Fix: on stat error
+  **deny** admission (charge `burst`/over-budget) and retry next wake; or meter actual bytes post-transfer.
+- **Live stall:** set `RUST_LOG=debug` on one agent, capture the concrete error behind `"draining a part failed"`;
+  inspect `cephor_replication_status` failed rows; check staging-PG latency. Fix root cause (likely raise the
+  allocator static ceiling — per-node budget was ~528 KB — and/or relieve PG contention).
+- **F14 (nit, decide here):** `DRAIN_CONCURRENCY=4` is unused (serial drains). Decide serial vs batched-claim.
+- **Acceptance:** staging `cephor_replication_status` moves pending→replicated; 100 MB+ object drains; no
+  `"draining a part failed"` loop; uploader stops DLQ-churning on drained objects.
+
+### PR-2 — Drain store/allocator fencing correctness  [Rust, P2]
+**Findings:** F4, F6, F18.
+- **F4** (`core/src/store.rs:621` `mark_replicated`, `:546` `claim_part`): add a monotonic `claim_seq` (or per-claim
+  UUID), return in `ClaimedPart`, add `AND claim_seq=$N` to the `mark_replicated` guard (mirror `fencing_epoch`).
+  Or, if keeping determinism-only safety, rewrite the `PartClaimLost` doc + migration comment to say so.
+- **F6** (`core/src/store.rs:350` `write_allocations`): skip the trailing zeroing UPDATE when the plan is empty (a
+  deposed leader with an empty plan currently zeroes a live leader's budgets); or fold zeroing into the fenced txn.
+- **F18** (`core/src/store.rs:644`): `mark_failed` should null `claimed_at` (consistency with `release_part`).
+- **Tests:** lease-expiry double-commit; deposed-leader empty-plan must not zero current leader's rows.
+- **Coordinate with PR-7:** the drain `pg_notify` lands in `mark_replicated` — sequence PR-2 before/with PR-7.
+
+### PR-3 — Rust CI gates + lints + supply-chain + deploy-wait fix  [Rust/CI, P1 process]
+**Findings:** F2, F8, F9, F13, F22.
+- **F2:** add a Rust CI job (pinned toolchain `1.95.0`) gating the staging deploy: `cargo fmt --all -- --check`,
+  `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo deny check`, pure-logic tests; gate
+  the `#[sqlx::test]` Postgres tiers behind a testcontainers/Docker service.
+- **F8** (`.github/workflows/staging-deploy.yaml` drain-agent rollout `|| echo`): gate on `numberReady >= 1` (or grep
+  for the specific pod-capacity condition) instead of swallowing every non-zero exit.
+- **F9** (`Cargo.toml [lints]`): add `arithmetic_side_effects` + `indexing_slicing` (warn/deny); convert verified
+  sites to `checked_*`/`saturating_*`/`get()` with `#[expect]` justifications.
+- **F13** (`deny.toml`): set `vulnerability="deny"`, `unmaintained="warn"`.
+- **F22:** collapse duplicate dep majors (sha2 0.10+0.11, rand/rand_core, getrandom, hashbrown) — adopt sqlx's
+  sha2 0.10; flagged once `multiple-versions="warn"`.
+- **Acceptance:** CI goes red on a clippy/test/advisory regression.
+
+### PR-4 — Drain security posture  [Rust/k8s, P2]
+**Findings:** F5, F12.
+- **F5** (`agent/src/localfs.rs:176/200/201/204`): open chunk files with `O_NOFOLLOW`
+  (`OpenOptionsExt::custom_flags(libc::O_NOFOLLOW)`) for hash + copy; reject symlinked dir components; or document
+  the SSD-tree trust boundary as a relied-upon invariant.
+- **F12** (`Dockerfile.drain:49-56` + manifests): allocator `runAsNonRoot: true` (+ `runAsUser`); drop unneeded caps
+  on both; revisit agent root once api uid aligns.
+
+### PR-5 — Drain supervisor/exit semantics  [Rust, P2 — confirm intent]
+**Findings:** F10, F21.
+- **F10** (`agent/src/supervisor.rs:188-212`): "restart loop" framing but any worker exit cancels the supervisor.
+  Decide: escalate-to-shutdown (then rename/clarify) vs per-worker restart + bounded backoff + crash-loop breaker.
+- **F21** (`agent/src/main.rs:63`): exit non-zero when `!report.clean` so k8s restarts a pod whose worker died.
+
+### PR-6 — Node-isolation enforcement + manifest hygiene  [k8s/docs, P1 doc/safety — OUR AREA]
+**Findings:** F3, F20.
+- **F3:** placement currently relies *only* on the `s3-staging-local-ingest=true` label (we dropped the
+  `nodeAffinity` allow-list when going label-only, but the README still claims allow-list + psql taints). Fix
+  (preferred): add a `nodeAffinity` hostname allow-list (node1/2/3) to **both** `api-local-deployments-staging.yaml`
+  and `drain-agent-daemonset.yaml` so a mislabel alone can't place ingest on a psql/cache node — belt-and-suspenders
+  with the label. Reconcile the README either way.
+- **F20:** remove stale `cache-replicator` references in `api-local-deployments-staging.yaml`,
+  `drain-agent-daemonset.yaml`, `ingest-node-labels-staging.yaml` comments.
+- **Acceptance:** manifests enforce the README's safety story.
+
+### PR-7 — Enqueue-timing fix: drain-gated upload  [Python + 1-line Rust, P1 functional — HEADLINE]
+**Problem (validated):** api enqueues `arion_upload_requests` at PUT/MPU-complete before the part is on ceph;
+`arion-uploader` (`MAX_INFLIGHT=4`/pod) then blocks up to 30s in `get_meta_with_wait` holding its slot → head-of-line
+stall → DLQ. **Verified enablers:** the upload workers are DB-driven by part identity (only `address` is
+non-derivable); multi-backend fan-out already exists (`enqueue_upload_to_backends`, `hippius_s3/queue.py`);
+per-backend persistence already tracked in `chunk_backend`; drained-to-ceph already tracked in
+`cephor_replication_status.status='replicated'`.
+- **Fix (event-driven, minimal Rust):**
+  1. Migration: add `address` (main account) to `object_versions` (`hippius_s3/sql/migrations/`), api writes it in
+     `object_writer.py`.
+  2. Rust (1 line, with PR-2): `pg_notify('cephor_replicated','<object_id>:<version>:<part>')` in `mark_replicated`.
+  3. New `hippius_s3/workers/upload_promoter.py` + `workers/run_upload_promoter_in_loop.py`: `LISTEN cephor_replicated`,
+     build the full `UploadChainRequest` from DB by object_id, call existing `enqueue_upload_to_backends()`.
+  4. Flag-gate the api PUT/MPU enqueue (`put_object_endpoint.py`, `multipart.py`) to flip api-enqueue ↔ promoter.
+  5. `k8s/staging/upload-promoter-deployment.yaml` + kustomization entry.
+- **Interim mitigation (ship first, can be its own micro-PR):** uploader requeue-with-delay instead of a 30s blocking
+  poll — quick `cephor_replication_status`/ceph-meta check; if absent, push to a delayed retry set + release the
+  inflight slot. Removes head-of-line blocking immediately.
+- **Acceptance:** uploads fire only post-ceph; uploader DLQ ~0; no inflight saturation; per-part pipelining on MPU.
+
+### PR-8 — Reconciler hardening  [Rust, nits]
+**Findings:** F15 (paginate `scan_parts`/status round-trips), F16 (TOCTOU `recovered` over-count), F17 (post-replication
+S4 appends not re-drained — **design decision** for owners), F19 (backlog metric assumes dedicated ingest volume).
+
+### PR-9 — GC safety gate  [Rust, P2 deferred]
+**Finding:** F11. Keep `gc-cephfs` feature **off** (default `[]`) until the api↔GC write-fence lands; bind a
+terminal-state predicate into `GcClaim` construction before enabling. Mostly guard + doc this release.
+
+### PR-10 — Validation: replication-lag experiment + 1GB MPU benchmark + report  [ops]
+After PR-1 + PR-7 are green on staging:
+1. Replication-lag experiment (`aws` cli + `.aws.cli.env`, endpoint `s3-staging.hippius.com`, isolated
+   `AWS_CONFIG_FILE`): per object record t0 (PUT 200) → t1 (`replicated`) = lag; watch uploader DLQ/retry + inflight.
+2. 1GB MPU up/down ×3 → avg MB/s + lag per run.
+3. HTML report → create `veggies` bucket, public-read, upload to `veggies/s3/benchmark.html`. md5 round-trip check.
+
+---
+
+## 5. Findings coverage matrix (audit F1–F22 + our items)
+| Item | PR | | Item | PR |
+|---|---|---|---|---|
+| F1 oversize-part stall | PR-1 | | F12 root allocator | PR-4 |
+| F2 no Rust CI | PR-3 | | F13 deny.toml advisories | PR-3 |
+| F3 node-isolation doc/safety | PR-6 | | F14 DRAIN_CONCURRENCY unused | PR-1 |
+| F4 claim fencing token | PR-2 | | F15 reconciler unbounded scan | PR-8 |
+| F5 symlink follow | PR-4 | | F16 recovered metric TOCTOU | PR-8 |
+| F6 empty-plan not fenced | PR-2 | | F17 S4 append re-drain | PR-8 |
+| F7 stat-failure under-meter | PR-1 | | F18 mark_failed claimed_at | PR-2 |
+| F8 rollout-wait masks failures | PR-3 | | F19 backlog shared-volume | PR-8 |
+| F9 lint deny-set gaps | PR-3 | | F20 stale cache-replicator refs | PR-6 |
+| F10 supervisor restart | PR-5 | | F21 always exit 0 | PR-5 |
+| F11 GcClaim terminality | PR-9 | | F22 dup dep majors | PR-3 |
+| **live drain stall** | PR-1 | | **enqueue-timing race** | PR-7 |
+| **1GB benchmark + report** | PR-10 | | | |
+
+## 6. Open decisions
+- **D1 (PR-1):** F1 fix — clamp-to-burst vs one-shot overdraft vs validate `burst>=max_part`? (Lean: clamp + reconcile.)
+- **D2 (PR-2/PR-7):** F4 — implement `claim_seq` fencing token, or accept determinism-only + rewrite the docs?
+- **D3 (PR-5):** supervisor — escalate-to-shutdown (clarify docs) vs per-worker restart+backoff?
+- **D4 (PR-7):** per-part promotion (faster, more messages) vs per-object (one message, matches today's shape)?
+- **D5 (release):** when to merge `release/s3-2.1` → `main` (main currently has none of the drain code).
+
+## 7. Session log
+- **2026-06-18:** Created `release/s3-2.1` off `staging`. Authored this plan from the architecture-review audit
+  (F1–F22) + our staging validation (drain dead-stalled: all `cephor_replication_status` rows `pending`, agents
+  looping `"draining a part failed"`, 0 replicated; node1 drain-agent `Pending`; allocator lease upserts 2–5s;
+  per-node budget ~528 KB) + the verified enqueue-timing race. Next: start **PR-1** (root-cause the live stall +
+  F1/F7).
+- **2026-06-18 (PR-1 root-cause):** Two distinct problems confirmed: (1) **F1** — 256 MB parts (64×4 MiB) exceed the
+  100 MB burst → silently rate-denied (no WARN), never drain. (2) **A separate `drain_part` Io failure on SMALL
+  (1-chunk, 4 MiB) parts** — they ARE admitted, then fail with an empty pool dir; every individual syscall
+  (copy/file-fsync/dir-fsync/fchmod) reproduces fine in the agent against the live CephFS mount, so the errno is
+  hidden by the generic `error=%err` (Display-only) WARN at `runtime.rs:141`. → strace-ing the live agent to get the
+  syscall+errno. **Observability gap is itself a fix:** PR-1 must change the WARN to log the `PartDrainError` source
+  chain + `DrainStep`.
+- **2026-06-18 (PR-1 ROOT CAUSE found):** The live stall is **G1 — global claim queue vs node-local SSD** (see PR-1).
+  Confirmed by code: `cephor_replication_status` has no `node_id`, `claim_part` is global, agents only see their own
+  node's hostPath SSD → they claim foreign parts → `drain_part` fails at `persist_meta` (ENOENT on the missing local
+  source) → the generic WARN. F1 (256 MB > 100 MB burst) is a *second*, compounding bug (head-of-line block). PR-1
+  now leads with the `node_id` schema fix. Next: implement migration 0006 + node-scoped claim + F1 clamp + F7 +
+  error-logging on `release/s3-2.1`.
+
+- **2026-06-18/19 (PR-1 IMPLEMENTED on `release/s3-2.1`):** 6 files + migration. **G1:** migration
+  `0006_replication_status_node.sql` adds `node_id`; `Store` gains a `node_id` (builder `with_node_id`, wired in
+  agent `main.rs`); `record_landed_part` UPSERT stamps it (self-heals legacy NULL rows); `claim_part` filters
+  `AND node_id=$node`; pending index → `(node_id, landed_at)`. **F1:** `Enforcer::try_drain` clamps the charge to
+  the burst (`bucket.burst()` getter) so an oversize part is admitted once + pays ≤1 burst (symmetric refund).
+  **F7:** `part_size` → `Option<u64>`, deny+retry on stat error instead of charging 0. **Observability:**
+  `runtime.rs` WARN now `error=?err` (Debug → variant+`DrainStep`+errno). Verified locally: `cargo check`/`clippy`/
+  `fmt` clean; F1 regression + 20 enforce tests pass. Added `#[sqlx::test]`s (CI-only, need PG): node-scoped claim +
+  legacy-row adoption. **Next:** CI build the `drain` image + deploy to staging → watch `cephor_replication_status`
+  move pending→replicated. Then PR-6 (node1 + nodeAffinity) and PR-7 (enqueue-gating).
+
+## 8. Known staging infra issues (not s3-2.1 code, but blocking validation)
+- **Staging Postgres is slow / contended.** Staging runs the **ceph-backed `postgres` CNPG cluster** (prod uses the
+  NVMe one). Observed: drain `claim/heartbeat/release` queries take **1–4.5 s** and allocator `cephor_leader_lease`
+  upserts **2–5 s** (sqlx `slow_threshold=1s` WARNs). Effects: every drain cycle is slow, the leader lease churns,
+  and any replication-lag/benchmark numbers (PR-10) will be skewed by DB latency rather than real drain throughput.
+  Likely the ceph-backed PG is under-resourced (IOPS) on staging. **Action:** before PR-10 benchmarking, either move
+  staging onto faster PG storage or carve out a quieter window; track separately from the s3-2.1 code work.


### PR DESCRIPTION
## Summary
PR-1 of the **s3-2.1** drain-hardening release. Fixes the **staging drain stall** (0 parts replicated; agents looping `"draining a part failed"`) plus the audit's oversize-part bug. Drain-only Rust + one migration — no API/Python changes.

## Root cause
**G1 — a global claim queue over node-local storage.** `cephor_replication_status` had no `node_id` and `claim_part` picked the oldest pending row globally, but each `drain-agent` only mounts its **own** node's SSD. So an agent routinely claimed a part whose data lives on a *peer* node, found the local part dir missing, and failed at the meta copy (ENOENT) — churning forever, draining nothing. The generic `error=%err` WARN hid the real failure.

**F1 (compounding)** — a part larger than the one-second burst (~100 MB) could never pass the rate gate, so large objects head-of-line-blocked the queue.

## Changes (largest → smallest)
- **G1 node-scoped claim** — `migration 0006` adds `node_id`; `Store` gains `node_id` (`with_node_id`, wired in the agent); `record_landed_part` UPSERT stamps it; `claim_part` filters `AND node_id = $node`; pending index → `(node_id, landed_at)`. The migration also **clears the legacy non-terminal queue** so each node's reconciler rebuilds it node-aware from the SSD (existing `pending` rows have NULL `node_id` and would otherwise orphan — see Review).
- **F1 rate-control** — `Enforcer::try_drain` clamps the bandwidth charge to the burst (oversize part admitted once, pays ≤ one burst, symmetric refund). Regression test added.
- **F7 metering** — `part_size` → `Option`; a stat error denies + retries instead of charging 0 unmetered.
- **Observability** — the drain WARN now Debug-formats the error (surfaces `PartDrainError` variant + `DrainStep` + errno).
- Adds `s3-2.1-todo.md` — the living release plan (audit F1–F22 mapped to PRs).

## Review (self-review, addressed)
- **P1 (fixed, `2b87ab5`)** — existing/backlog `pending` rows would never get a `node_id` (the reconciler only records `status=None` parts), so the current staging backlog would stay stuck. Migration 0006 now resets the non-terminal nodeless queue → rebuilt node-aware from the SSD.
- **P3 (by design)** — a `draining` part on a dead node is only drainable by that node (its data is node-local); cross-node recovery would fail anyway.
- **P3 (deferred)** — `DRAIN_CONCURRENCY` unused (serial drains); tracked in `s3-2.1-todo.md`.

## Verification
- `cargo fmt --check` / `clippy` (pedantic + unwrap/panic deny) clean; F1 regression + the full `enforce` suite pass locally.
- Added `#[sqlx::test]`s (node-scoped claim + legacy-row adoption) that run under CI Postgres. Migration 0006 is exercised by every `#[sqlx::test]`.

## Still needed to validate on staging
The allocator applies `migration 0006` on startup; once deployed, each node's reconciler rebuilds the queue node-aware, claims go node-scoped, and oversize parts admit. **Watch `cephor_replication_status` move `pending → replicated`.** Staging Postgres is currently slow (1–4.5 s queries), which throttles drain throughput regardless.

## Conclusion
Unblocks the drain — the core of the tiered-cache architecture. Follow-ups in `s3-2.1-todo.md`: node-isolation `nodeAffinity` (PR-6), drain-gated upload enqueue (PR-7), Rust CI gates (PR-3), remaining audit findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
