### PR TITLE
s3-2.1: node-isolation (PR-6) + drain-gated uploads (PR-7a/7) + drain fencing (PR-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "hippius-drain-agent"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "hippius-drain-core",
  "nix",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.150"
 proptest = "=1.11.0"
 tokio = { version = "=1.52.3", features = ["rt-multi-thread", "macros", "time", "fs", "io-util", "signal"] }
+# Concurrent stream combinator (FuturesUnordered) for the drain worker's bounded
+# concurrency — already in the tree via sqlx/tokio, so this pins, not adds, a version.
+futures = "=0.3.32"
 # CancellationToken (hierarchical child tokens) for the agent task supervisor;
 # it lives in the always-on `sync` module, so no extra feature is needed.
 tokio-util = "=0.7.18"

--- a/crates/hippius-drain-agent/Cargo.toml
+++ b/crates/hippius-drain-agent/Cargo.toml
@@ -11,6 +11,7 @@ description = "cephor per-node drain daemon (runs as a DaemonSet on each ingest 
 [dependencies]
 hippius-drain-core = { workspace = true, features = ["pg"] }
 tokio = { workspace = true }
+futures = { workspace = true }
 tokio-util = { workspace = true }
 sha2 = { workspace = true }
 nix = { workspace = true }

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -704,7 +704,7 @@ mod part_tests {
         let ceph = LocalFs::new(pool_dir.path());
         let store = MemPartStore::default();
         store.set(&part, ReplicationState::Pending);
-        let claim = ClaimedPart::new(part.clone());
+        let claim = ClaimedPart::new(part.clone(), 0);
 
         let outcome = drain_part(&ceph, &ssd, &store, &claim).await.unwrap();
 

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -136,7 +136,17 @@ async fn run_drain(token: CancellationToken, period: Duration, deps: DrainDeps) 
         // recorded and retried on the next poll; the backlog is never lost. Per-part
         // outcome counting lives in `drain_next`, so the burst result is only logged
         // here — recording it again would double-count.
-        match drain_until_empty(&deps.ceph, &deps.ssd, &deps.store, deps.enforcer.as_ref(), Some(&deps.snapshot), &token).await {
+        match drain_until_empty(
+            &deps.ceph,
+            &deps.ssd,
+            &deps.store,
+            deps.enforcer.as_ref(),
+            Some(&deps.snapshot),
+            &token,
+            DRAIN_CONCURRENCY as usize,
+        )
+        .await
+        {
             Ok(drained) => tracing::debug!(drained, "drain cycle complete"),
             // Debug-format the error so the `PartDrainError` variant + `DrainStep` + the
             // underlying io errno surface; `%err` (Display) only prints the opaque

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -7,6 +7,8 @@
 //! [`crate::runtime`]); here each call is a single, independently-testable step.
 
 use crate::localfs::{LocalFs, LocalSsd};
+use futures::stream::FuturesUnordered;
+use futures::stream::StreamExt;
 use hippius_drain_core::{DrainDecision, DrainOutcome, Enforcer, PartDrainError, PartKey, PartSource, SnapshotCell, Store, StoreError, drain_part};
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Instant;
@@ -182,22 +184,32 @@ pub async fn drain_next(
     result.map(Some).map_err(DrainCycleError::from)
 }
 
-/// Drains pending parts until the backlog is empty, the enforcer throttles, or
-/// `token` is cancelled, returning how many were drained.
+/// Drains pending parts — up to `concurrency` at once — until the backlog is empty,
+/// the enforcer throttles, or `token` is cancelled, returning how many were drained.
 ///
-/// Repeats [`drain_next`] until it reports nothing more to do (an empty backlog or a
-/// throttle), so one wake handles a burst rather than a single part. A drain failure
-/// stops the run and propagates (every failed part's SSD copy is intact, so the next
-/// call resumes the backlog).
+/// Runs up to `concurrency` [`drain_next`] calls concurrently rather than one at a
+/// time. `claim_part` uses `FOR UPDATE SKIP LOCKED`, so concurrent claims take distinct
+/// parts; running them together overlaps the per-part commit `fsync`s, which on the
+/// ceph-backed Postgres are the dominant cost (each commit is a slow WAL flush), so a
+/// serial loop left the configured concurrency (the `Enforcer`'s `ConcurrencyLimiter`)
+/// unused and the backlog draining one slow commit at a time. The admission
+/// `Enforcer` still bounds the real rate/concurrency; this just stops the *driver*
+/// from being the bottleneck.
 ///
-/// Cancellation is observed at each part boundary: on shutdown a large backlog winds
-/// down within the supervisor's grace instead of running to completion and being
-/// force-aborted mid-drain — a forced abort would strand the in-flight part in
-/// `draining` until the claim lease expires (axiom `rust_quality_129_async_graceful_shutdown`).
+/// A `drain_next` returning `None` (empty backlog or a throttle/denial) stops claiming
+/// new work, but in-flight drains are awaited to completion — never abandoned
+/// mid-flight, since dropping one at its await would strand its part in `draining`
+/// until the claim lease expires. A drain *failure* likewise stops new claims and is
+/// surfaced (the first one) only after the in-flight set drains; each failed
+/// `drain_next` has already released its own part.
+///
+/// Cancellation is observed before claiming each new part: on shutdown the burst stops
+/// taking work immediately and only the already-started drains finish, so the worker
+/// exits well within the supervisor's grace (axiom `rust_quality_129_async_graceful_shutdown`).
 ///
 /// # Errors
 ///
-/// The first [`DrainCycleError`] a cycle hits.
+/// The first [`DrainCycleError`] a cycle hits (after the in-flight set has drained).
 pub async fn drain_until_empty(
     ceph: &LocalFs,
     ssd: &LocalSsd,
@@ -205,19 +217,51 @@ pub async fn drain_until_empty(
     enforcer: Option<&Arc<Mutex<Enforcer>>>,
     snapshot: Option<&SnapshotCell>,
     token: &CancellationToken,
+    concurrency: usize,
 ) -> Result<u64, DrainCycleError> {
-    let mut drained = 0;
-    // Check cancellation at the top of each cycle (the part boundary): a started drain
-    // always runs to its own completion — verify-before-unlink makes that the safe
-    // point — but the burst stops claiming new work the moment shutdown is signalled,
-    // so the worker exits well within the grace window.
-    while !token.is_cancelled() {
-        if drain_next(ceph, ssd, store, enforcer, snapshot).await?.is_none() {
+    let concurrency = concurrency.max(1);
+    let mut drained = 0u64;
+    let mut first_err: Option<DrainCycleError> = None;
+    // Cleared by an empty backlog, a throttle, a failure, or cancellation — once we
+    // stop refilling we only wind down the in-flight set.
+    let mut refill = true;
+    let mut inflight = FuturesUnordered::new();
+
+    // Prime the in-flight set (stopping early on cancellation).
+    for _ in 0..concurrency {
+        if token.is_cancelled() {
+            refill = false;
             break;
         }
-        drained += 1;
+        inflight.push(drain_next(ceph, ssd, store, enforcer, snapshot));
     }
-    Ok(drained)
+
+    // Pushing into a FuturesUnordered while iterating it is supported; the `.next()`
+    // borrow ends before the body runs, so the refill push is safe.
+    while let Some(outcome) = inflight.next().await {
+        match outcome {
+            Ok(Some(_)) => {
+                drained += 1;
+                if refill && !token.is_cancelled() {
+                    inflight.push(drain_next(ceph, ssd, store, enforcer, snapshot));
+                } else {
+                    refill = false;
+                }
+            }
+            Ok(None) => refill = false,
+            Err(err) => {
+                if first_err.is_none() {
+                    first_err = Some(err);
+                }
+                refill = false;
+            }
+        }
+    }
+
+    match first_err {
+        Some(err) => Err(err),
+        None => Ok(drained),
+    }
 }
 
 #[cfg(test)]
@@ -485,8 +529,11 @@ mod tests {
         store.record_landed_part(&part_at(5, 2)).await.unwrap();
 
         // The burst drains the good part then fails on the bad one. The #10 fix:
-        // the part drained before the failure is NOT discarded.
-        drain_until_empty(&ceph, &ssd, &store, None, Some(&snapshot), &token).await.unwrap_err();
+        // the part drained before the failure is NOT discarded. concurrency=1 keeps the
+        // strict landed_at order this test asserts on.
+        drain_until_empty(&ceph, &ssd, &store, None, Some(&snapshot), &token, 1)
+            .await
+            .unwrap_err();
         let counts = snapshot.load();
         assert_eq!(counts.drained, 1, "the part drained before the failure is kept");
         assert_eq!(counts.failed, 1, "the failed part is counted once");
@@ -508,10 +555,30 @@ mod tests {
         }
 
         let token = CancellationToken::new();
-        let drained = drain_until_empty(&ceph, &ssd, &store, None, None, &token).await.unwrap();
+        let drained = drain_until_empty(&ceph, &ssd, &store, None, None, &token, 4).await.unwrap();
         assert_eq!(drained, 3, "every pending part was drained in one run");
         // The backlog is now empty.
-        assert_eq!(drain_until_empty(&ceph, &ssd, &store, None, None, &token).await.unwrap(), 0);
+        assert_eq!(drain_until_empty(&ceph, &ssd, &store, None, None, &token, 4).await.unwrap(), 0);
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn drain_until_empty_refills_beyond_the_initial_concurrency_wave(pool: PgPool) {
+        // F14: a backlog larger than the concurrency must still drain fully — the
+        // in-flight set is refilled as each drain completes, not capped at one wave.
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = Store::from_pool(pool);
+
+        for number in 1..=8_u32 {
+            seed_part(ssd_dir.path(), &store, &part_at(5, number), &[b"backlog part"]).await;
+        }
+
+        let token = CancellationToken::new();
+        let drained = drain_until_empty(&ceph, &ssd, &store, None, None, &token, 3).await.unwrap();
+        assert_eq!(drained, 8, "all 8 parts drained with concurrency 3 (refill works)");
+        assert_eq!(drain_until_empty(&ceph, &ssd, &store, None, None, &token, 3).await.unwrap(), 0);
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
@@ -532,7 +599,7 @@ mod tests {
         // honors the supervisor's grace instead of being force-aborted mid-backlog.
         let token = CancellationToken::new();
         token.cancel();
-        let drained = drain_until_empty(&ceph, &ssd, &store, None, None, &token).await.unwrap();
+        let drained = drain_until_empty(&ceph, &ssd, &store, None, None, &token, 4).await.unwrap();
         assert_eq!(drained, 0, "a cancelled drain stops before touching the backlog");
     }
 }

--- a/crates/hippius-drain-allocator/src/config.rs
+++ b/crates/hippius-drain-allocator/src/config.rs
@@ -15,7 +15,13 @@ use thiserror::Error;
 /// long so a brief stall does not lose leadership, short enough to fail over.
 const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(30);
 /// Allocation tick period when `CEPHOR_ALLOCATOR_TICK_SECS` is unset.
-const DEFAULT_TICK: Duration = Duration::from_secs(2);
+///
+/// Each tick renews the leader lease and rewrites allocations — two hot-row writes,
+/// each a slow WAL fsync on the ceph-backed Postgres (where they were measured at
+/// 2–5 s). 5 s (was 2 s) cuts that write churn ~2.5× while still giving the 30 s lease
+/// six renewals of headroom; rate allocation does not need sub-5 s updates. Tune via
+/// `CEPHOR_ALLOCATOR_TICK_SECS` per deployment.
+const DEFAULT_TICK: Duration = Duration::from_secs(5);
 /// Heartbeats older than this are ignored when loading the fleet
 /// (`CEPHOR_FLEET_STALE_SECS`). Several agent heartbeat periods (~10s) wide.
 const DEFAULT_FLEET_STALE: Duration = Duration::from_secs(30);

--- a/crates/hippius-drain-core/migrations/0007_claim_seq.sql
+++ b/crates/hippius-drain-core/migrations/0007_claim_seq.sql
@@ -1,0 +1,15 @@
+-- F4: a per-claim fencing token for cephor_replication_status.
+--
+-- claim_part stamps a fresh, globally-monotonic value (nextval) on each claim and
+-- returns it in ClaimedPart; mark_replicated commits only if the row STILL carries
+-- the same token. Without it, a `draining` claim re-won after lease expiry (the
+-- crash-recovery path) leaves the row `status='draining'` under the new claimer — so
+-- the stale original claimer's commit would match the bare `status='draining'` guard,
+-- mark the part replicated, and unlink the SSD copy out from under the live drain.
+-- The token makes that stale commit match zero rows -> StoreError::PartClaimLost.
+--
+-- Nullable with no backfill: any pre-deploy `draining` row carries NULL and is simply
+-- re-claimed (fresh token) by an agent after the lease, since agents restart on deploy
+-- and hold no in-flight claims across it.
+CREATE SEQUENCE IF NOT EXISTS cephor_claim_seq;
+ALTER TABLE cephor_replication_status ADD COLUMN IF NOT EXISTS claim_seq BIGINT;

--- a/crates/hippius-drain-core/src/partdrain.rs
+++ b/crates/hippius-drain-core/src/partdrain.rs
@@ -65,19 +65,31 @@ pub enum DrainOutcome {
 #[derive(Debug)]
 pub struct ClaimedPart {
     part: PartKey,
+    claim_seq: i64,
 }
 
 impl ClaimedPart {
-    /// Binds a claim to its part.
+    /// Binds a claim to its part and the fencing token the store stamped on it.
+    ///
+    /// `claim_seq` is an opaque, per-claim monotonic token the store returns from
+    /// `claim_part`; the commit (`mark_replicated`) is guarded by it so a claim
+    /// re-won after lease expiry fences the stale original claimer. Off-store callers
+    /// (unit tests of the drain pipeline that never touch Postgres) pass any value.
     #[must_use]
-    pub fn new(part: PartKey) -> Self {
-        Self { part }
+    pub fn new(part: PartKey, claim_seq: i64) -> Self {
+        Self { part, claim_seq }
     }
 
     /// The claimed part.
     #[must_use]
     pub fn part(&self) -> &PartKey {
         &self.part
+    }
+
+    /// The store fencing token stamped when this part was claimed.
+    #[must_use]
+    pub fn claim_seq(&self) -> i64 {
+        self.claim_seq
     }
 }
 
@@ -534,7 +546,8 @@ mod tests {
     }
 
     fn claim(part: &PartKey) -> ClaimedPart {
-        ClaimedPart::new(part.clone())
+        // The in-memory store below ignores the fencing token, so any value works here.
+        ClaimedPart::new(part.clone(), 0)
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-core/src/reconcile.rs
+++ b/crates/hippius-drain-core/src/reconcile.rs
@@ -25,7 +25,11 @@ pub struct ReconcileReport {
     pub scanned: u64,
     /// Had no row and were recorded as pending (a recovered missing trigger).
     pub recovered: u64,
-    /// Already pending — a worker will claim them.
+    /// Were a legacy NULL-node `pending` row this node adopted (stamped its `node_id`)
+    /// so node-scoped `claim_part` can drain them (G2). Distinct from `recovered`
+    /// (which had no row at all) and `already_pending` (already node-owned).
+    pub adopted: u64,
+    /// Already pending and node-owned — a worker will claim them.
     pub already_pending: u64,
     /// Already draining: a live claim in flight, or a stale orphan that
     /// `claim_part` re-claims once its claim outlives the lease (the H1 path).
@@ -40,7 +44,7 @@ pub struct ReconcileReport {
 }
 
 impl ReconcileReport {
-    /// The sum of the five per-status categories.
+    /// The sum of the per-status categories.
     ///
     /// Every scanned part falls into exactly one category, so this must equal
     /// [`scanned`](Self::scanned) — the report's invariant, which [`reconcile_parts`]
@@ -49,6 +53,7 @@ impl ReconcileReport {
     #[must_use]
     pub fn categorized(&self) -> u64 {
         self.recovered
+            .saturating_add(self.adopted)
             .saturating_add(self.already_pending)
             .saturating_add(self.in_flight)
             .saturating_add(self.replicated_orphan)
@@ -98,6 +103,21 @@ pub trait PartScan: Send + Sync {
     fn scan_parts(&self) -> impl Future<Output = std::io::Result<Vec<DiscoveredPart>>> + Send;
 }
 
+/// A part's stored status as the reconciler sees it: its replication state plus
+/// whether the row is an adoptable legacy row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PartStatus {
+    /// The part's replication state.
+    pub state: ReplicationState,
+    /// True when the row is `pending` with no owning `node_id` — a legacy row
+    /// predating node-scoping. Such a row is invisible to the node-scoped
+    /// [`claim_part`](crate::Store::claim_part) and so never drains; the node that
+    /// still holds the part on SSD (the one scanning it now) must adopt it (stamp its
+    /// `node_id`) to make it claimable (G2). Adopting only these — never the common
+    /// node-owned `pending` row — avoids a per-cycle write on the slow store.
+    pub adoptable: bool,
+}
+
 /// The store seam the part reconciler needs: read a part's status, and record a
 /// freshly-landed part as pending. The part analogue of [`LandingLog`], implemented
 /// by [`crate::Store`] (under `pg`).
@@ -105,11 +125,12 @@ pub trait PartLandingLog: Send + Sync {
     /// Store-specific failure, boxed into [`ReconcileError::Log`].
     type Error: std::error::Error + Send + Sync + 'static;
 
-    /// The part's replication state, or `None` when the store has no row.
-    fn status(&self, part: &PartKey) -> impl Future<Output = Result<Option<ReplicationState>, Self::Error>> + Send;
+    /// The part's status (state + adoptability), or `None` when the store has no row.
+    fn status(&self, part: &PartKey) -> impl Future<Output = Result<Option<PartStatus>, Self::Error>> + Send;
 
     /// Record a part as landed (`pending`). Idempotent: a part that already has a row
-    /// is left untouched, so a re-scan or a trigger race cannot duplicate it.
+    /// is left untouched UNLESS it is a NULL-node row, which it adopts to this node —
+    /// so the reconciler can both recover a dropped trigger and adopt a legacy row.
     fn record_landed(&self, part: &PartKey) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
@@ -139,10 +160,20 @@ where
                 log.record_landed(&discovered.part).await.map_err(ReconcileError::log)?;
                 report.recovered += 1;
             }
-            Some(ReplicationState::Pending) => report.already_pending += 1,
-            Some(ReplicationState::Draining) => report.in_flight += 1,
-            Some(ReplicationState::Replicated) => report.replicated_orphan += 1,
-            Some(ReplicationState::Failed) => report.failed += 1,
+            // A legacy NULL-node `pending` row: adopt it to this node (which holds the
+            // part on SSD — we just scanned it) via the idempotent record_landed UPSERT,
+            // so node-scoped claim_part can finally drain it (G2). Checked before the
+            // state match so an adoptable row is never miscounted as already_pending.
+            Some(status) if status.adoptable => {
+                log.record_landed(&discovered.part).await.map_err(ReconcileError::log)?;
+                report.adopted += 1;
+            }
+            Some(status) => match status.state {
+                ReplicationState::Pending => report.already_pending += 1,
+                ReplicationState::Draining => report.in_flight += 1,
+                ReplicationState::Replicated => report.replicated_orphan += 1,
+                ReplicationState::Failed => report.failed += 1,
+            },
         }
     }
     debug_assert_eq!(report.scanned, report.categorized(), "every scanned part lands in exactly one category");
@@ -152,7 +183,7 @@ where
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod part_tests {
-    use super::{DiscoveredPart, PartLandingLog, PartScan, ReconcileError, ReconcileReport, reconcile_parts};
+    use super::{DiscoveredPart, PartLandingLog, PartScan, PartStatus, ReconcileError, ReconcileReport, reconcile_parts};
     use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
     use crate::state::ReplicationState;
     use core::future::Future;
@@ -195,7 +226,7 @@ mod part_tests {
     /// plus a record of every recorded part.
     #[derive(Default)]
     struct FakePartLog {
-        statuses: Mutex<HashMap<String, ReplicationState>>,
+        statuses: Mutex<HashMap<String, PartStatus>>,
         recorded: Mutex<Vec<String>>,
         fail_status: bool,
     }
@@ -208,8 +239,27 @@ mod part_tests {
         fn with(statuses: &[(&PartKey, ReplicationState)]) -> Self {
             let log = FakePartLog::default();
             for (part, state) in statuses {
-                log.statuses.lock().unwrap().insert(part_key_string(part), *state);
+                log.statuses.lock().unwrap().insert(
+                    part_key_string(part),
+                    PartStatus {
+                        state: *state,
+                        adoptable: false,
+                    },
+                );
             }
+            log
+        }
+
+        /// A log holding one legacy NULL-node `pending` row (G2): `pending` + adoptable.
+        fn with_adoptable(part: &PartKey) -> Self {
+            let log = FakePartLog::default();
+            log.statuses.lock().unwrap().insert(
+                part_key_string(part),
+                PartStatus {
+                    state: ReplicationState::Pending,
+                    adoptable: true,
+                },
+            );
             log
         }
 
@@ -221,7 +271,7 @@ mod part_tests {
     impl PartLandingLog for FakePartLog {
         type Error = io::Error;
 
-        fn status(&self, part: &PartKey) -> impl Future<Output = Result<Option<ReplicationState>, io::Error>> + Send {
+        fn status(&self, part: &PartKey) -> impl Future<Output = Result<Option<PartStatus>, io::Error>> + Send {
             let outcome = if self.fail_status {
                 Err(io::Error::other("status failed"))
             } else {
@@ -309,6 +359,7 @@ mod part_tests {
             ReconcileReport {
                 scanned: 5,
                 recovered: 1,
+                adopted: 0,
                 already_pending: 1,
                 in_flight: 1,
                 replicated_orphan: 1,
@@ -317,6 +368,29 @@ mod part_tests {
         );
         assert_eq!(report.scanned, report.categorized(), "every scanned part lands in exactly one category");
         assert_eq!(log.recorded_parts(), vec![part_key_string(&part_at(UUID_A, 1, 1))]);
+    }
+
+    #[tokio::test]
+    async fn a_legacy_nodeless_pending_part_is_adopted() {
+        // G2: a `pending` row with no owning node (a row predating node-scoping) is
+        // invisible to the node-scoped claim_part. The reconciler on the node that
+        // holds the part re-records it (adopting it to this node) rather than leaving
+        // it stuck — and does NOT count it as an ordinary already_pending row.
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakePartScan {
+            parts: vec![discovered(UUID_A, 5, 1)],
+            fail: false,
+        };
+        let log = FakePartLog::with_adoptable(&part);
+        let report = reconcile_parts(&scan, &log).await.unwrap();
+        assert_eq!(report.adopted, 1, "the legacy nodeless pending row was adopted");
+        assert_eq!(report.already_pending, 0, "an adoptable row is not an ordinary already_pending");
+        assert_eq!(report.scanned, report.categorized());
+        assert_eq!(
+            log.recorded_parts(),
+            vec![part_key_string(&part)],
+            "adoption re-records the part (the idempotent UPSERT stamps this node)",
+        );
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -688,18 +688,30 @@ impl PartReplicationStore for Store {
         // false Ok. The claim_seq is what distinguishes "I still hold it" from "someone
         // re-won it and it's draining again under them" (F4).
         let part = claim.part();
-        let affected = sqlx::query(
-            "UPDATE cephor_replication_status SET status = 'replicated', updated_at = now() \
-             WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'draining' AND claim_seq = $4",
+        // One statement commits the part Replicated AND emits the `cephor_replicated`
+        // notification atomically (PR-7): the pg_notify runs only for the row the
+        // fenced UPDATE matched, so a lost claim emits nothing, and the payload is bound
+        // to the same commit. The notification (`object_id:version:part`) wakes the
+        // upload-promoter to enqueue the backend upload now that the data is on ceph;
+        // the promoter ALSO sweeps replicated-but-unpromoted parts as a backstop, so a
+        // missed LISTEN (no listener at commit) costs latency, not correctness.
+        let committed = sqlx::query(
+            "WITH updated AS ( \
+                UPDATE cephor_replication_status SET status = 'replicated', updated_at = now() \
+                WHERE object_id = $1 AND version = $2 AND part_number = $3 \
+                  AND status = 'draining' AND claim_seq = $4 \
+                RETURNING object_id, version, part_number \
+             ) \
+             SELECT pg_notify('cephor_replicated', object_id || ':' || version || ':' || part_number) \
+             FROM updated",
         )
         .bind(part.object().as_str())
         .bind(i64::from(part.version().get()))
         .bind(i64::from(part.part().get()))
         .bind(claim.claim_seq())
-        .execute(&self.pool)
-        .await?
-        .rows_affected();
-        if affected == 0 {
+        .fetch_optional(&self.pool)
+        .await?;
+        if committed.is_none() {
             return Err(StoreError::PartClaimLost {
                 part: part.relative_dir().to_string_lossy().into_owned().into(),
             });
@@ -1270,6 +1282,30 @@ mod part_tests {
         let claimed = store.claim_part().await.unwrap().unwrap();
         store.mark_replicated(&claimed, &PartVerified::for_test()).await.unwrap();
         assert_eq!(store.status(&p).await.unwrap(), Some(ReplicationState::Replicated));
+    }
+
+    #[sqlx::test]
+    async fn mark_replicated_emits_a_cephor_replicated_notification(pool: PgPool) {
+        // PR-7: committing a part Replicated emits `cephor_replicated` = object:version:part
+        // so the upload-promoter can enqueue the backend upload now the data is on ceph.
+        use sqlx::postgres::PgListener;
+
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+        let claimed = store.claim_part().await.unwrap().unwrap();
+
+        // LISTEN before the commit, or the fire-and-forget notification is missed.
+        let mut listener = PgListener::connect_with(&pool).await.unwrap();
+        listener.listen("cephor_replicated").await.unwrap();
+
+        store.mark_replicated(&claimed, &PartVerified::for_test()).await.unwrap();
+
+        let notification = tokio::time::timeout(std::time::Duration::from_secs(5), listener.recv())
+            .await
+            .expect("a cephor_replicated notification within 5s")
+            .unwrap();
+        assert_eq!(notification.payload(), format!("{UUID_A}:5:1"));
     }
 
     #[sqlx::test]

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -14,6 +14,7 @@ use crate::gc::GcClaim;
 use crate::ids::{FileId, NodeId};
 use crate::partdrain::{ClaimedPart, PartReplicationStore, PartVerified};
 use crate::reconcile::PartLandingLog;
+use crate::reconcile::PartStatus;
 use crate::state::ReplicationState;
 use crate::units::{ByteRate, Bytes, DiskPressure};
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -181,12 +182,31 @@ impl PartRow {
         Ok(PartKey::new(object, Version::new(version), PartNumber::new(part)))
     }
 
-    fn into_claimed(self) -> Result<ClaimedPart> {
-        Ok(ClaimedPart::new(self.into_part()?))
-    }
-
     fn into_pending(self) -> Result<PendingPart> {
         Ok(PendingPart { part: self.into_part()? })
+    }
+}
+
+/// A claimed part read back from the `claim_part` UPDATE … RETURNING — the part
+/// identity plus the [`claim_seq`](ClaimedPart::claim_seq) fencing token the claim
+/// stamped, so the commit can prove it still holds the claim it was granted.
+#[derive(sqlx::FromRow)]
+struct ClaimedPartRow {
+    object_id: String,
+    version: i64,
+    part_number: i64,
+    claim_seq: i64,
+}
+
+impl ClaimedPartRow {
+    fn into_claimed(self) -> Result<ClaimedPart> {
+        let part = PartRow {
+            object_id: self.object_id,
+            version: self.version,
+            part_number: self.part_number,
+        }
+        .into_part()?;
+        Ok(ClaimedPart::new(part, self.claim_seq))
     }
 }
 
@@ -331,6 +351,15 @@ impl Store {
     ///
     /// [`StoreError::OutOfRange`] if a budget exceeds i64; [`StoreError::Database`] on failure.
     pub async fn write_allocations(&self, epoch: u64, allocations: &[Allocation]) -> Result<()> {
+        // F6: an empty plan carries no fleet information, so it must be a no-op. The
+        // node-absence zeroing below uses `node_id <> ALL($present)`, which with an
+        // empty `present` matches EVERY row — so an empty plan would zero the whole
+        // live fleet's budgets on a transient empty view. Stale budgets are already
+        // handled on read (load_allocation treats un-refreshed rows as absent), so
+        // there is nothing an empty plan needs to do here.
+        if allocations.is_empty() {
+            return Ok(());
+        }
         let epoch_i = to_i64(epoch)?;
         let mut tx = self.pool.begin().await?;
         let mut present: Vec<&str> = Vec::with_capacity(allocations.len());
@@ -568,8 +597,12 @@ impl Store {
     ///
     /// [`StoreError::Database`]; [`StoreError::Invalid`] if a stored part is malformed.
     pub async fn claim_part(&self) -> Result<Option<ClaimedPart>> {
-        let row = sqlx::query_as::<_, PartRow>(
-            "UPDATE cephor_replication_status SET status = 'draining', updated_at = now(), claimed_at = now() \
+        // Stamp a fresh fencing token (nextval) on the claim and return it: the commit
+        // (mark_replicated) is guarded by it, so a claim re-won here after lease expiry
+        // gets a NEW token and the prior claimant's stale commit fences out (F4).
+        let row = sqlx::query_as::<_, ClaimedPartRow>(
+            "UPDATE cephor_replication_status \
+             SET status = 'draining', updated_at = now(), claimed_at = now(), claim_seq = nextval('cephor_claim_seq') \
              WHERE (object_id, version, part_number) IN ( \
                 SELECT object_id, version, part_number FROM cephor_replication_status \
                 WHERE node_id = $2 \
@@ -577,13 +610,13 @@ impl Store {
                         OR (status = 'draining' AND claimed_at < now() - $1 * interval '1 second') ) \
                 ORDER BY landed_at \
                 FOR UPDATE SKIP LOCKED LIMIT 1 \
-             ) RETURNING object_id, version, part_number",
+             ) RETURNING object_id, version, part_number, claim_seq",
         )
         .bind(self.claim_lease.as_secs_f64())
         .bind(self.node_id.as_deref())
         .fetch_optional(&self.pool)
         .await?;
-        row.map(PartRow::into_claimed).transpose()
+        row.map(ClaimedPartRow::into_claimed).transpose()
     }
 
     /// Returns a claimed (`draining`) part to `pending` so it is re-claimed on a
@@ -647,17 +680,22 @@ impl PartReplicationStore for Store {
     }
 
     async fn mark_replicated(&self, claim: &ClaimedPart, _proof: &PartVerified) -> Result<()> {
-        // Guard on `draining`: only a part this agent claimed may be committed. Zero
-        // rows means the claim was lost (reset/re-claimed), so the caller must not
-        // unlink the SSD copy — surface PartClaimLost instead of a false Ok.
+        // Guard on `draining` AND the claim's fencing token: only the agent that still
+        // holds THIS claim may commit. Zero rows means the claim was lost — either the
+        // row left `draining`, or it was re-claimed (a new claim_seq) after the lease,
+        // e.g. this agent stalled past the lease and another re-won the part. Either
+        // way the caller must NOT unlink the SSD copy — surface PartClaimLost, not a
+        // false Ok. The claim_seq is what distinguishes "I still hold it" from "someone
+        // re-won it and it's draining again under them" (F4).
         let part = claim.part();
         let affected = sqlx::query(
             "UPDATE cephor_replication_status SET status = 'replicated', updated_at = now() \
-             WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'draining'",
+             WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'draining' AND claim_seq = $4",
         )
         .bind(part.object().as_str())
         .bind(i64::from(part.version().get()))
         .bind(i64::from(part.part().get()))
+        .bind(claim.claim_seq())
         .execute(&self.pool)
         .await?
         .rows_affected();
@@ -671,10 +709,12 @@ impl PartReplicationStore for Store {
 
     async fn mark_failed(&self, claim: &ClaimedPart, _reason: &str) -> Result<()> {
         // Terminal sink: a corrupt part is marked Failed regardless of its prior
-        // state, and an already-absent row is a harmless no-op (idempotent).
+        // state, and an already-absent row is a harmless no-op (idempotent). Clear
+        // claimed_at for consistency with release_part — a failed part holds no live
+        // claim, so its claim timestamp must not linger (F18).
         let part = claim.part();
         sqlx::query(
-            "UPDATE cephor_replication_status SET status = 'failed', updated_at = now() \
+            "UPDATE cephor_replication_status SET status = 'failed', updated_at = now(), claimed_at = NULL \
              WHERE object_id = $1 AND version = $2 AND part_number = $3",
         )
         .bind(part.object().as_str())
@@ -686,15 +726,35 @@ impl PartReplicationStore for Store {
     }
 }
 
-/// The part reconciler's view of the store: read a part's status and record a
-/// freshly-landed one. Delegates to the [`PartReplicationStore::status`] and the
-/// inherent [`Store::record_landed_part`], so the reconciler shares one definition
-/// of each operation with the drain path.
+/// The part reconciler's view of the store: read a part's status (+ adoptability)
+/// and record/adopt a freshly-landed one (via the inherent
+/// [`Store::record_landed_part`]), so the reconciler shares one definition of the
+/// landed write with the drain path.
 impl PartLandingLog for Store {
     type Error = StoreError;
 
-    async fn status(&self, part: &PartKey) -> Result<Option<ReplicationState>> {
-        <Self as PartReplicationStore>::status(self, part).await
+    async fn status(&self, part: &PartKey) -> Result<Option<PartStatus>> {
+        // One read returns both the state and adoptability — a `pending` row with no
+        // owning node is a legacy row the scanning node should adopt (G2). Reading
+        // node_id here (rather than writing every cycle) is what keeps the reconciler
+        // from a per-cycle write against the slow store for already-owned rows.
+        let row = sqlx::query_as::<_, (String, bool)>(
+            "SELECT status, (status = 'pending' AND node_id IS NULL) \
+             FROM cephor_replication_status \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(part.object().as_str())
+        .bind(i64::from(part.version().get()))
+        .bind(i64::from(part.part().get()))
+        .fetch_optional(&self.pool)
+        .await?;
+        match row {
+            None => Ok(None),
+            Some((status, adoptable)) => Ok(Some(PartStatus {
+                state: state_from_db(&status)?,
+                adoptable,
+            })),
+        }
     }
 
     async fn record_landed(&self, part: &PartKey) -> Result<()> {
@@ -902,6 +962,32 @@ mod tests {
             store.load_allocation(&b, fresh).await.unwrap(),
             None,
             "the departed node's zeroed, sentinel-dated row reads as absent",
+        );
+    }
+
+    #[sqlx::test]
+    async fn write_allocations_with_an_empty_plan_is_a_noop(pool: PgPool) {
+        // F6: an empty plan carries no fleet info and must NOT run the node-absence
+        // zeroing (which, with no nodes present, matches every row and would wipe the
+        // live fleet's budgets). An existing budget survives an empty tick untouched.
+        let store = Store::from_pool(pool);
+        let node = NodeId::from_str("node-a").unwrap();
+        let fresh = Duration::from_hours(1);
+        store
+            .write_allocations(
+                1,
+                &[Allocation {
+                    node: node.clone(),
+                    budget: ByteRate::new(50_000_000),
+                }],
+            )
+            .await
+            .unwrap();
+        store.write_allocations(2, &[]).await.unwrap();
+        assert_eq!(
+            store.load_allocation(&node, fresh).await.unwrap().map(|s| s.budget),
+            Some(ByteRate::new(50_000_000)),
+            "an empty plan leaves existing budgets intact",
         );
     }
 
@@ -1192,8 +1278,9 @@ mod part_tests {
         let p = part(UUID_A, 5, 1);
         store.record_landed_part(&p).await.unwrap(); // status = pending, never claimed
         // A ClaimedPart constructed without claiming must NOT be able to commit: the
-        // row is still 'pending', so the 'draining' guard matches no row.
-        let unclaimed = ClaimedPart::new(p.clone());
+        // row is still 'pending', so the 'draining' guard matches no row (the token
+        // value is irrelevant here — the status guard already rejects it).
+        let unclaimed = ClaimedPart::new(p.clone(), 0);
         let err = store.mark_replicated(&unclaimed, &PartVerified::for_test()).await.unwrap_err();
         let expected = p.relative_dir().to_string_lossy().into_owned();
         assert!(
@@ -1216,6 +1303,65 @@ mod part_tests {
         store.mark_failed(&claimed, "chunk copy byte mismatch").await.unwrap();
         assert_eq!(store.status(&p).await.unwrap(), Some(ReplicationState::Failed));
         store.mark_failed(&claimed, "again").await.unwrap(); // idempotent no-op
+    }
+
+    #[sqlx::test]
+    async fn mark_failed_clears_claimed_at(pool: PgPool) {
+        // F18: a failed part holds no live claim, so its claimed_at must be nulled
+        // (mirroring release_part) — otherwise a lingering timestamp misrepresents it
+        // as freshly claimed.
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+        let claimed = store.claim_part().await.unwrap().unwrap(); // stamps claimed_at
+        store.mark_failed(&claimed, "byte mismatch").await.unwrap();
+        let claimed_at_is_null: bool = sqlx::query_scalar(
+            "SELECT claimed_at IS NULL FROM cephor_replication_status \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(p.object().as_str())
+        .bind(i64::from(p.version().get()))
+        .bind(i64::from(p.part().get()))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(claimed_at_is_null, "mark_failed clears claimed_at");
+    }
+
+    #[sqlx::test]
+    async fn a_reclaim_after_lease_expiry_fences_the_stale_committer(pool: PgPool) {
+        // F4: the crash-recovery race. Agent 1 claims a part; its claim ages past the
+        // lease; another claim re-wins it (here the same store, after backdating
+        // claimed_at) and gets a FRESH fencing token. Agent 1 then finishes and tries
+        // to commit — the row is `draining` again (under the new claim), so the bare
+        // status guard would wrongly accept it and unlink the SSD copy. The claim_seq
+        // guard rejects the stale commit (PartClaimLost) while the live claim commits.
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+        let first = store.claim_part().await.unwrap().expect("the pending part is claimable");
+
+        sqlx::query("UPDATE cephor_replication_status SET claimed_at = now() - interval '1 hour' WHERE object_id = $1")
+            .bind(p.object().as_str())
+            .execute(&pool)
+            .await
+            .unwrap();
+        let second = store.claim_part().await.unwrap().expect("the stale claim is re-won past the lease");
+        assert_ne!(first.claim_seq(), second.claim_seq(), "the re-claim gets a fresh fencing token");
+
+        let err = store.mark_replicated(&first, &PartVerified::for_test()).await.unwrap_err();
+        let expected = p.relative_dir().to_string_lossy().into_owned();
+        assert!(
+            matches!(err, StoreError::PartClaimLost { ref part } if part.as_ref() == expected),
+            "the stale claimant is fenced out, got: {err:?}",
+        );
+        assert_eq!(
+            store.status(&p).await.unwrap(),
+            Some(ReplicationState::Draining),
+            "the fenced commit leaves the live claim's draining row untouched",
+        );
+        store.mark_replicated(&second, &PartVerified::for_test()).await.unwrap();
+        assert_eq!(store.status(&p).await.unwrap(), Some(ReplicationState::Replicated));
     }
 
     #[sqlx::test]
@@ -1271,6 +1417,49 @@ mod part_tests {
         assert_eq!(report.recovered, 1, "the dropped-trigger part was recovered to pending");
 
         let claimed = store.claim_part().await.unwrap().expect("the recovered part is claimable");
+        assert_eq!(claimed.part(), &p);
+    }
+
+    #[sqlx::test]
+    async fn reconcile_adopts_a_legacy_nodeless_pending_part(pool: PgPool) {
+        // G2: a `pending` row with no owning node (written before node-scoping) is
+        // invisible to the node-scoped claim_part, so it never drains. The reconciler
+        // on the node that still holds the part on SSD adopts it (stamps its node_id)
+        // via the idempotent record_landed UPSERT, making it claimable again.
+        use crate::reconcile::{DiscoveredPart, PartScan, reconcile_parts};
+        use core::future::Future;
+
+        struct OnePart(DiscoveredPart);
+        impl PartScan for OnePart {
+            fn scan_parts(&self) -> impl Future<Output = std::io::Result<Vec<DiscoveredPart>>> + Send {
+                let parts = vec![self.0.clone()];
+                async move { Ok(parts) }
+            }
+        }
+
+        let p = part(UUID_A, 5, 1);
+        sqlx::query(
+            "INSERT INTO cephor_replication_status (object_id, version, part_number, status, node_id) \
+             VALUES ($1, $2, $3, 'pending', NULL)",
+        )
+        .bind(p.object().as_str())
+        .bind(i64::from(p.version().get()))
+        .bind(i64::from(p.part().get()))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let node_b = Store::from_pool(pool.clone()).with_node_id("node-b");
+        assert!(
+            node_b.claim_part().await.unwrap().is_none(),
+            "a NULL-node row is unclaimable by any node before adoption",
+        );
+
+        let scanner = OnePart(DiscoveredPart { part: p.clone() });
+        let report = reconcile_parts(&scanner, &node_b).await.unwrap();
+        assert_eq!(report.adopted, 1, "the legacy nodeless row was adopted by the scanning node");
+
+        let claimed = node_b.claim_part().await.unwrap().expect("the adopted part is now claimable by node-b");
         assert_eq!(claimed.part(), &p);
     }
 }

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -34,6 +34,7 @@ from hippius_s3.queue import UploadChainRequest
 from hippius_s3.queue import enqueue_upload_request
 from hippius_s3.storage_version import require_supported_storage_version
 from hippius_s3.utils import get_query
+from hippius_s3.writer.db import set_object_version_address
 from hippius_s3.writer.object_writer import ObjectWriter
 from hippius_s3.xml_helpers import add_subelement
 from hippius_s3.xml_helpers import create_element
@@ -1035,30 +1036,42 @@ async def complete_multipart_upload(
         )
 
         # After commit, enqueue background publish
-        parts = await db.fetch(
-            get_query("list_parts_for_version"),
-            object_id,
-            object_version,
-        )
-        ray_id = getattr(request.state, "ray_id", None)
-        await enqueue_upload_request(
-            UploadChainRequest(
-                address=request.state.account.id,
-                bucket_name=bucket_name,
-                object_key=object_key,
+        if config.drain_gated_upload_enabled:
+            # Drain-gated path (s3-2.1 PR-7): persist the address instead of enqueuing —
+            # the upload-promoter enqueues each part's backend upload once the drain
+            # replicates it to ceph. Uses main_account (the upload identity, as the put
+            # path + mpu_complete do), not the subaccount id.
+            await set_object_version_address(
+                request.app.state.postgres_pool,
                 object_id=str(object_id),
                 object_version=int(object_version),
-                chunks=[
-                    Chunk(
-                        id=part["part_number"],
-                    )
-                    for part in parts
-                ],
-                upload_id=upload_id,
-                ray_id=ray_id,
-                upload_backends=get_config().upload_backends,
-            ),
-        )
+                address=request.state.account.main_account,
+            )
+        else:
+            parts = await db.fetch(
+                get_query("list_parts_for_version"),
+                object_id,
+                object_version,
+            )
+            ray_id = getattr(request.state, "ray_id", None)
+            await enqueue_upload_request(
+                UploadChainRequest(
+                    address=request.state.account.id,
+                    bucket_name=bucket_name,
+                    object_key=object_key,
+                    object_id=str(object_id),
+                    object_version=int(object_version),
+                    chunks=[
+                        Chunk(
+                            id=part["part_number"],
+                        )
+                        for part in parts
+                    ],
+                    upload_id=upload_id,
+                    ray_id=ray_id,
+                    upload_backends=get_config().upload_backends,
+                ),
+            )
 
         # Create XML response
         xml_bytes = f"""<?xml version="1.0" encoding="UTF-8"?>

--- a/hippius_s3/api/s3/objects/put_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/put_object_endpoint.py
@@ -20,6 +20,7 @@ from hippius_s3.config import get_config
 from hippius_s3.db_pool import acquire_with_timeout
 from hippius_s3.monitoring import get_metrics_collector
 from hippius_s3.utils import get_query
+from hippius_s3.writer.db import set_object_version_address
 from hippius_s3.writer.object_writer import ObjectWriter
 from hippius_s3.writer.queue import enqueue_upload as writer_enqueue_upload
 
@@ -200,16 +201,27 @@ async def handle_put_object(
             "put_object.enqueue_upload",
             attributes={"upload_id": str(put_res.upload_id), "has_upload_id": True},
         ):
-            await writer_enqueue_upload(
-                address=request.state.account.main_account,
-                bucket_name=bucket_name,
-                object_key=object_key,
-                object_id=str(put_res.object_id),
-                object_version=int(put_res.object_version),
-                upload_id=str(put_res.upload_id),
-                chunk_ids=[1],
-                ray_id=getattr(request.state, "ray_id", "no-ray-id"),
-            )
+            if config.drain_gated_upload_enabled:
+                # Drain-gated path (s3-2.1 PR-7): do NOT enqueue the backend upload here —
+                # the part isn't on ceph yet. Persist the address so the upload-promoter
+                # can rebuild the request and enqueue once the drain replicates the part.
+                await set_object_version_address(
+                    request.app.state.postgres_pool,
+                    object_id=str(put_res.object_id),
+                    object_version=int(put_res.object_version),
+                    address=request.state.account.main_account,
+                )
+            else:
+                await writer_enqueue_upload(
+                    address=request.state.account.main_account,
+                    bucket_name=bucket_name,
+                    object_key=object_key,
+                    object_id=str(put_res.object_id),
+                    object_version=int(put_res.object_version),
+                    upload_id=str(put_res.upload_id),
+                    chunk_ids=[1],
+                    ray_id=getattr(request.state, "ray_id", "no-ray-id"),
+                )
 
         # Mark upload completed only AFTER a successful enqueue. If enqueue fails above, this is
         # skipped so the row stays is_completed=FALSE and remains eligible for the DELETE cascade

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -172,6 +172,18 @@ class Config:
     # poll. After the window = genuine fault → raise (classifier routes
     # to DLQ as permanent).
     fs_meta_wait_seconds: float = env("HIPPIUS_FS_META_WAIT_SECONDS:30", convert=float)
+    # Drain-gating (s3-2.1 PR-7a interim). The api enqueues the backend upload at
+    # PUT/MPU-complete, before the drain has copied the parts to the shared ceph pool.
+    # An upload dequeued that early is "too early", not failed: the loop re-schedules
+    # it after this delay WITHOUT consuming the retry budget (see defer_upload_request),
+    # so it neither blocks an inflight slot polling for meta nor DLQs prematurely. The
+    # drain-gated promoter (PR-7) makes this unnecessary; until then it stops the
+    # head-of-line block + DLQ churn for large objects whose drain outlasts the wait.
+    uploader_not_ready_delay_seconds: float = env("HIPPIUS_UPLOADER_NOT_READY_DELAY_SECONDS:5", convert=float)
+    # Wall-clock ceiling (measured from first_enqueued_at) on the not-ready deferral.
+    # Past this, a part still absent from ceph is treated as a genuine fault and routed
+    # to the DLQ. Generous enough to cover normal drain lag for large MPU objects.
+    uploader_not_ready_max_wait_seconds: float = env("HIPPIUS_UPLOADER_NOT_READY_MAX_WAIT_SECONDS:1800", convert=float)
 
     # Unpinner configuration
     # How many unpin requests one unpinner pod processes concurrently (outer bounded-dispatch,

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -78,6 +78,18 @@ class Config:
     enable_bypass_credit_check: bool = env("HIPPIUS_BYPASS_CREDIT_CHECK:false", convert=lambda x: x.lower() == "true")
     read_only_mode: bool = env("HIPPIUS_READ_ONLY_MODE:false", convert=lambda x: x.lower() == "true")
 
+    # s3-2.1 PR-7: drain-gated upload. When true, the api persists object_versions.address
+    # and does NOT enqueue the backend upload at PUT/MPU-complete; the upload-promoter
+    # enqueues it once the part replicates to ceph (LISTEN cephor_replicated + a periodic
+    # sweep backstop). When false (default), the api enqueues at PUT time as today.
+    drain_gated_upload_enabled: bool = env(
+        "HIPPIUS_DRAIN_GATED_UPLOAD_ENABLED:false", convert=lambda x: x.lower() == "true"
+    )
+    # How often the upload-promoter sweeps for replicated-but-unpromoted parts (the
+    # backstop for a missed NOTIFY), and the max parts promoted per sweep.
+    promoter_sweep_interval_seconds: float = env("HIPPIUS_PROMOTER_SWEEP_INTERVAL_SECONDS:30", convert=float)
+    promoter_sweep_batch: int = env("HIPPIUS_PROMOTER_SWEEP_BATCH:512", convert=int)
+
     # S3 Validation Limits
     min_bucket_name_length: int = env("MIN_BUCKET_NAME_LENGTH", convert=int)
     max_bucket_name_length: int = env("MAX_BUCKET_NAME_LENGTH", convert=int)

--- a/hippius_s3/queue.py
+++ b/hippius_s3/queue.py
@@ -205,6 +205,32 @@ async def enqueue_retry_request(
     )
 
 
+async def defer_upload_request(
+    payload: UploadChainRequest,
+    *,
+    backend_name: str,
+    delay_seconds: float,
+) -> None:
+    """Re-schedule an upload that isn't yet replicated to ceph.
+
+    Unlike ``enqueue_retry_request`` this does NOT increment ``attempts`` — a part that
+    has not drained to the shared pool yet is "too early", not a failure, so it must not
+    burn the retry budget (which would DLQ a large object before its drain finishes).
+    Reuses the same retry ZSET, so the existing ``move_due_upload_retries`` mover picks
+    it up. ``first_enqueued_at`` is preserved so the caller's wall-clock ceiling still
+    bounds how long an upload may stay un-replicated before it is treated as a fault.
+    """
+    client = get_queue_client()
+    if payload.request_id is None:
+        payload.request_id = uuid.uuid4().hex
+    if payload.first_enqueued_at is None:
+        payload.first_enqueued_at = time.time()
+    next_ts = time.time() + max(0.0, float(delay_seconds))
+    member = payload.model_dump_json()
+    zset_key = _upload_retry_zset(backend_name)
+    await client.zadd(zset_key, {member: next_ts})
+
+
 async def move_due_upload_retries(
     *,
     backend_name: str,

--- a/hippius_s3/sql/migrations/20260622122700_object_versions_address.sql
+++ b/hippius_s3/sql/migrations/20260622122700_object_versions_address.sql
@@ -1,0 +1,10 @@
+-- s3-2.1 PR-7: the main-account address (SS58) for the drain-gated upload promoter.
+--
+-- The arion-uploader / ovh-backup workers re-derive everything they need about an
+-- object from the DB by object_id EXCEPT the main-account address (the Arion/S3
+-- upload identity). Today the api carries it in the enqueued UploadChainRequest. The
+-- drain-gated promoter (PR-7d) builds that request itself once a part replicates, so
+-- it needs the address persisted. The api writes it on the promoter path only
+-- (PR-7e), so the column is NULL for legacy/non-gated rows — harmless, the promoter
+-- only runs when the feature is enabled.
+ALTER TABLE object_versions ADD COLUMN IF NOT EXISTS address TEXT;

--- a/hippius_s3/sql/migrations/20260622122700_object_versions_address.sql
+++ b/hippius_s3/sql/migrations/20260622122700_object_versions_address.sql
@@ -1,3 +1,5 @@
+-- migrate:up
+
 -- s3-2.1 PR-7: the main-account address (SS58) for the drain-gated upload promoter.
 --
 -- The arion-uploader / ovh-backup workers re-derive everything they need about an
@@ -8,3 +10,7 @@
 -- (PR-7e), so the column is NULL for legacy/non-gated rows — harmless, the promoter
 -- only runs when the feature is enabled.
 ALTER TABLE object_versions ADD COLUMN IF NOT EXISTS address TEXT;
+
+-- migrate:down
+
+ALTER TABLE object_versions DROP COLUMN IF EXISTS address;

--- a/hippius_s3/sql/queries/promoter_build_request.sql
+++ b/hippius_s3/sql/queries/promoter_build_request.sql
@@ -1,0 +1,9 @@
+-- Build the non-derivable fields the upload-promoter needs to reconstruct an
+-- UploadChainRequest for an object version (s3-2.1 PR-7). The upload workers re-derive
+-- parts/chunks by object_id; only bucket_name, object_key and the main-account address
+-- need looking up (address persisted by the api on the promoter path).
+SELECT b.bucket_name, o.object_key, ov.address
+FROM objects o
+JOIN object_versions ov ON ov.object_id = o.object_id AND ov.object_version = $2
+JOIN buckets b ON b.bucket_id = o.bucket_id
+WHERE o.object_id = $1;

--- a/hippius_s3/sql/queries/promoter_sweep_unpromoted.sql
+++ b/hippius_s3/sql/queries/promoter_sweep_unpromoted.sql
@@ -1,0 +1,15 @@
+-- Backstop for a missed `cephor_replicated` NOTIFY (s3-2.1 PR-7): replicated parts
+-- with at least one chunk that has NO chunk_backend row on any backend — i.e. the
+-- backend upload never ran. Bounded and self-clearing: once a part is promoted and
+-- uploaded, every chunk gains a chunk_backend row and the part drops out of this set.
+-- A part already (partially) on a backend is left to that backend worker's own retry.
+SELECT DISTINCT crs.object_id, crs.version, crs.part_number
+FROM cephor_replication_status crs
+JOIN parts p
+  ON p.object_id = crs.object_id::uuid
+ AND p.object_version = crs.version
+ AND p.part_number = crs.part_number
+JOIN part_chunks pc ON pc.part_id = p.part_id
+LEFT JOIN chunk_backend cb ON cb.chunk_id = pc.id
+WHERE crs.status = 'replicated' AND cb.chunk_id IS NULL
+LIMIT $1;

--- a/hippius_s3/sql/queries/set_object_version_address.sql
+++ b/hippius_s3/sql/queries/set_object_version_address.sql
@@ -1,0 +1,6 @@
+-- Persist the main-account address on an object version for the drain-gated upload
+-- promoter (s3-2.1 PR-7). Written by the api on the promoter path in place of the
+-- PUT-time enqueue, so the promoter can build the UploadChainRequest by object_id.
+UPDATE object_versions
+SET address = $3
+WHERE object_id = $1 AND object_version = $2;

--- a/hippius_s3/workers/upload_promoter.py
+++ b/hippius_s3/workers/upload_promoter.py
@@ -1,0 +1,185 @@
+import asyncio
+import logging
+import uuid
+from typing import Any
+from typing import Optional
+
+from hippius_s3.queue import Chunk
+from hippius_s3.queue import UploadChainRequest
+from hippius_s3.queue import enqueue_upload_to_backends
+from hippius_s3.utils import get_query
+
+
+logger = logging.getLogger(__name__)
+
+
+async def promote_part(
+    db_pool: Any,
+    config: Any,
+    *,
+    object_id: str,
+    object_version: int,
+    part_number: int,
+) -> bool:
+    """Enqueue the backend upload for a single part that has replicated to ceph.
+
+    The drain-gated counterpart to the api's PUT-time enqueue: once a part is on the
+    shared pool, the workers can read it, so we build the (now fully derivable)
+    UploadChainRequest by object_id and fan it out to the configured backends. Per-part
+    so MPU parts pipeline to the backends as each one lands. Returns False (and logs)
+    when the version row or its address is missing — the sweep will retry.
+    """
+    oid = uuid.UUID(object_id)
+    async with db_pool.acquire() as conn:
+        row = await conn.fetchrow(get_query("promoter_build_request"), oid, int(object_version))
+        # upload_id is only set for MPU objects; the uploader also re-derives it, but
+        # passing it avoids a redundant lookup there.
+        upload_id = await conn.fetchval(
+            "SELECT upload_id FROM multipart_uploads WHERE object_id = $1 ORDER BY initiated_at DESC LIMIT 1",
+            oid,
+        )
+
+    if row is None or row["address"] is None:
+        logger.warning(
+            "promoter: cannot build request (missing version row or address) object_id=%s v=%s part=%s",
+            object_id,
+            object_version,
+            part_number,
+        )
+        return False
+
+    payload = UploadChainRequest(
+        address=row["address"],
+        bucket_name=row["bucket_name"],
+        object_key=row["object_key"],
+        object_id=object_id,
+        object_version=int(object_version),
+        chunks=[Chunk(id=int(part_number))],
+        upload_id=str(upload_id) if upload_id is not None else None,
+        upload_backends=config.upload_backends,
+    )
+    await enqueue_upload_to_backends(payload)
+    logger.info(
+        "Promoted part to backend upload object_id=%s v=%s part=%s backends=%s",
+        object_id,
+        object_version,
+        part_number,
+        config.upload_backends,
+    )
+    return True
+
+
+def _parse_notification(payload: str) -> Optional[tuple[str, int, int]]:
+    """Parse a `cephor_replicated` payload `<object_id>:<version>:<part>`.
+
+    object_id is a UUID (no colons), so a plain split is unambiguous. Returns None on a
+    malformed payload (logged by the caller) rather than killing the listen loop.
+    """
+    parts = payload.split(":")
+    if len(parts) != 3:
+        return None
+    object_id, version, part_number = parts
+    if not version.isdigit() or not part_number.isdigit():
+        return None
+    return object_id, int(version), int(part_number)
+
+
+async def run_upload_promoter_loop() -> None:
+    import asyncpg
+    from redis.asyncio import Redis
+
+    from hippius_s3.config import get_config
+    from hippius_s3.queue import initialize_queue_client
+
+    config = get_config()
+
+    # The drain emits cephor_replicated unconditionally, but the api only stops its
+    # PUT-time enqueue when the flag is on. So if we promoted while the flag is off, the
+    # api's enqueue AND ours would both fire — a double upload. Idle until enabled (the
+    # pod stays up; flipping the flag restarts it). With the flag off, notifications go
+    # to no listener and are harmlessly dropped.
+    if not config.drain_gated_upload_enabled:
+        logger.info("drain-gated upload disabled; upload-promoter idling (set HIPPIUS_DRAIN_GATED_UPLOAD_ENABLED=true)")
+        # Park forever (until the pod is restarted by a flag change) without spinning.
+        await asyncio.Event().wait()
+        return
+
+    db_pool = await asyncpg.create_pool(config.database_url, min_size=2, max_size=10)
+    redis_queues_client = Redis.from_url(config.redis_queues_url)
+    initialize_queue_client(redis_queues_client)
+
+    # Work items are `(object_id, version, part)` tuples fed by BOTH the LISTEN
+    # callback (low-latency) and the periodic sweep (backstop). A bounded queue applies
+    # backpressure if promotion can't keep up with a replication burst.
+    work_q: asyncio.Queue[tuple[str, int, int]] = asyncio.Queue(maxsize=10000)
+
+    # Dedicated connection for LISTEN — pooled connections get recycled, which would
+    # silently drop the subscription.
+    listen_conn = await asyncpg.connect(config.database_url)
+
+    def _on_notify(_conn: Any, _pid: int, _channel: str, payload: str) -> None:
+        parsed = _parse_notification(payload)
+        if parsed is None:
+            logger.warning("promoter: ignoring malformed cephor_replicated payload %r", payload)
+            return
+        try:
+            work_q.put_nowait(parsed)
+        except asyncio.QueueFull:
+            # Dropped here is harmless: the sweep re-finds any un-promoted part.
+            logger.warning("promoter: work queue full, dropping notify (sweep will recover) %r", payload)
+
+    await listen_conn.add_listener("cephor_replicated", _on_notify)
+
+    async def _sweeper() -> None:
+        while True:
+            await asyncio.sleep(config.promoter_sweep_interval_seconds)
+            try:
+                async with db_pool.acquire() as conn:
+                    rows = await conn.fetch(get_query("promoter_sweep_unpromoted"), int(config.promoter_sweep_batch))
+                for r in rows:
+                    work_q.put_nowait((str(r["object_id"]), int(r["version"]), int(r["part_number"])))
+                if rows:
+                    logger.info("promoter sweep enqueued %d replicated-but-unpromoted parts", len(rows))
+            except asyncio.QueueFull:
+                logger.warning("promoter: work queue full during sweep; will retry next interval")
+            except Exception as e:
+                logger.error("promoter sweep failed: %s", e)
+
+    sweeper_task = asyncio.create_task(_sweeper())
+    logger.info(
+        "Starting upload-promoter (sweep_interval=%ss batch=%s backends=%s)",
+        config.promoter_sweep_interval_seconds,
+        config.promoter_sweep_batch,
+        config.upload_backends,
+    )
+
+    try:
+        while True:
+            object_id, object_version, part_number = await work_q.get()
+            try:
+                await promote_part(
+                    db_pool,
+                    config,
+                    object_id=object_id,
+                    object_version=object_version,
+                    part_number=part_number,
+                )
+            except Exception as e:
+                # A failed promote is not fatal — the sweep re-finds the part (it still
+                # has no chunk_backend rows) and retries. Surface it and keep draining.
+                logger.error(
+                    "promoter: promote_part failed object_id=%s v=%s part=%s: %s",
+                    object_id,
+                    object_version,
+                    part_number,
+                    e,
+                )
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        logger.info("upload-promoter stopping…")
+    finally:
+        sweeper_task.cancel()
+        await asyncio.gather(sweeper_task, return_exceptions=True)
+        await listen_conn.remove_listener("cephor_replicated", _on_notify)
+        await listen_conn.close()
+        await redis_queues_client.aclose()
+        await db_pool.close()

--- a/hippius_s3/workers/uploader.py
+++ b/hippius_s3/workers/uploader.py
@@ -117,6 +117,20 @@ class Uploader:
             return acquire()
         return Uploader._ConnCtx(self.db)
 
+    async def all_parts_on_pool(self, payload: UploadChainRequest) -> bool:
+        """True once every part of this request has a meta.json on the shared pool.
+
+        The drain writes meta last, so meta presence == "the part is on ceph". The loop
+        uses this to defer an upload dequeued before the drain finished copying, instead
+        of blocking an inflight slot in get_meta_with_wait or DLQ-ing prematurely.
+        Short-circuits on the first missing part.
+        """
+        object_version = int(payload.object_version or 1)
+        for chunk in payload.chunks:
+            if await self.fs_store.get_meta(payload.object_id, object_version, int(chunk.id)) is None:
+                return False
+        return True
+
     async def process_upload(self, payload: UploadChainRequest) -> List[str]:
         with tracer.start_as_current_span(
             "uploader.process_upload",

--- a/hippius_s3/writer/db.py
+++ b/hippius_s3/writer/db.py
@@ -9,6 +9,27 @@ from typing import Any
 from hippius_s3.utils import get_query
 
 
+async def set_object_version_address(
+    db: Any,
+    *,
+    object_id: str,
+    object_version: int,
+    address: str,
+) -> None:
+    """Persist the main-account address on an object version (s3-2.1 PR-7).
+
+    Written by the api on the drain-gated promoter path in place of the PUT-time
+    enqueue, so the upload-promoter can rebuild the UploadChainRequest by object_id
+    once the part replicates to ceph.
+    """
+    await db.execute(
+        get_query("set_object_version_address"),
+        object_id,
+        int(object_version),
+        address,
+    )
+
+
 async def upsert_object_basic(
     db: Any,
     *,

--- a/k8s/staging/README-local-ingest-trial.md
+++ b/k8s/staging/README-local-ingest-trial.md
@@ -1,10 +1,10 @@
 # Staging trial: node-local-SSD ingest tier (s3-2.0 prototype)
 
 Prototype the [s3-2.0](../../s3-2.0.html) upload flow on staging: run the **entire staging `api`
-fleet on node-local SSD** (3 pods spread across general workers), served through the **normal `api`
+fleet on node-local SSD** (2 pods, one per ingest node), served through the **normal `api`
 Service / gateway front door**, while all workers stay on CephFS exactly as today.
-**Infra wiring only — the replicator daemon is a separate follow-up; uploads complete e2e only once
-it is installed.**
+**The `hippius-drain` stack (per-node `drain-agent` DaemonSet + `drain-allocator`) is now installed
+and draining local→ceph** — uploads complete e2e (see the drain-gating caveat under "Uploads" below).
 
 ## What this adds / changes (all under `k8s/staging/`)
 
@@ -14,7 +14,8 @@ it is installed.**
 | `resource-limits.yaml` (modified) | Base (ceph) `api` deployment scaled to **0** — no ceph api pods. |
 | `kustomization.yaml` (inline patch) | `api` Service selector switched `app: api` → `app: api-local`, so the gateway routes to the local pods. |
 | `ingest-node-labels-staging.yaml` | **The ONE list** of staging ingest nodes — applying it labels them `s3-staging-local-ingest=true`. |
-| `replicator-daemonset-staging.yaml` | **Placeholder** for the replicator (NOT in kustomization; daemon not built yet). |
+| `drain-agent-daemonset.yaml` | The per-node `hippius-drain` agent — drains each node's local SSD → CephFS pool. Selects the ingest label + a hostname allow-list. |
+| `drain-allocator-deployment.yaml` | The singleton (leader-elected) drain budget allocator. |
 
 Untouched / still on ceph: `gateway`, `arion-uploader/downloader/unpinner`, `janitor`, the
 `s3-backup` stack (`backup`/`hydrator`/`cleanup`), the shared configmap, `object-cache-pvc`.
@@ -35,16 +36,22 @@ deploys cleanly via CI.**
 > the node — the kubelet fails the mount otherwise, and that prep can't run in a CI deploy. hostPath
 > uses the node root disk and isn't size-enforced — keep trial data bounded (no janitor on this tier yet).
 
-## Scheduling: one node-label list, api + replicator in lockstep
+## Scheduling: one node-label list + a hostname allow-list, api + drain-agent in lockstep
 
 Ingest nodes are declared **once** in `ingest-node-labels-staging.yaml` (partial `Node` objects that
 carry `s3-staging-local-ingest=true`). Deploying applies that label; **both** the `api-local`
-Deployment and the `cache-replicator` DaemonSet select on it (`nodeSelector`), so they always target
+Deployment and the `drain-agent` DaemonSet select on it (`nodeSelector`), so they always target
 the identical node set — no duplicated hostname list to drift. The DaemonSet (one pod per labeled
 node) therefore covers every node an api pod can land on. Current staging set: **node2, node3** (node1 is
 excluded — it runs at its pod cap, so the agent can't schedule there and would block the DaemonSet roll)
 (node4/5 are near pod-cap and left for prod). `api-local` also uses preferred pod anti-affinity to
 spread its 2 replicas across the labeled nodes.
+
+**Belt-and-suspenders:** both the `api-local` Deployment and the `drain-agent` DaemonSet ALSO carry a
+**required `nodeAffinity` hostname allow-list** (`kubernetes.io/hostname In [node2, node3]`) on top of
+the label. So a node that gets the ingest label by mistake still won't host ingest unless its hostname
+is on the allow-list — a single misconfiguration can't leak ingest onto a psql/cache node. The label
+and the two allow-lists must be kept in sync (all three live under `k8s/staging/`).
 
 **Shared cluster, disjoint sets:** prod will label *different* nodes with `s3-local-ingest=true`. Two
 distinct labels on distinct nodes + the per-env path denominator = staging and prod ingest never mix.
@@ -62,32 +69,40 @@ The gateway forwards to `http://api:8000` (the `api` Service) and blocks on an i
 and switches the `api` Service selector to `app: api-local`, so the gateway's backend is the 3 local
 pods — normal front door, no separate target. Prod is unaffected (its overlay omits these patches).
 
-## ⚠️ Uploads need the replicator (by design, for now)
+## Uploads: the drain copies local→ceph (now live)
 
-Every api pod writes chunks to its **node-local** disk; the workers read **ceph**. With no ceph api
-pods, **every** PUT stages locally and — until the replicator copies local→ceph — that object:
-- is **invisible to `arion-uploader` / `backup`** → never uploaded to Arion/OVH → stays `pending`;
-- **404s / hangs** on a GET that lands on a different-node api pod.
+Every api pod writes chunks to its **node-local** disk; the workers read **ceph**. The `drain-agent`
+copies each complete part local→ceph (meta-last) and the read path serves from the ceph cache, so a
+cross-node GET returns the object once its parts are drained. Replication lag is bounded by the drain
+throughput (measured ~2.5 min for a 1GB / 128-part object on staging, fsync-bound by ceph-backed PG).
 
-This is the agreed state: stand up the stack now, install + test the replicator when it's ready. Keep
-trial traffic bounded until then.
+> **Known caveat (tracked in `s3-2.1-todo.md`, PR-7):** the api still enqueues the Arion/OVH backend
+> upload at PUT/MPU-complete, *before* the drain has copied to ceph. For large objects the uploader's
+> 30s meta-wait can expire before the drain finishes → the backend upload DLQs (`object_version=failed`)
+> even though the object is on ceph and downloadable. The drain-gated upload (PR-7) fixes this; until it
+> ships, keep large-object trial traffic bounded.
 
 ## Deploy & verify
 
 ```bash
 kubectl kustomize k8s/staging | less          # review first
 kubectl apply -k k8s/staging                  # or via the staging-deploy pipeline
-kubectl -n hippius-s3-staging rollout status deploy/api-local --timeout=5m   # 3/3 Ready
-kubectl -n hippius-s3-staging get pods -l app=api-local -o wide              # 3 pods, spread
+kubectl -n hippius-s3-staging rollout status deploy/api-local --timeout=5m   # 2/2 Ready
+kubectl -n hippius-s3-staging get pods -l app=api-local -o wide              # 2 pods, one per ingest node
 kubectl -n hippius-s3-staging get deploy api                                 # base api 0/0
-kubectl -n hippius-s3-staging get endpoints api                              # 3 endpoint IPs (local pods)
+kubectl -n hippius-s3-staging get endpoints api                              # 2 endpoint IPs (local pods)
+kubectl -n hippius-s3-staging get ds drain-agent                            # 2/2 ready (node2, node3)
 
-# watch a local pod's ingest dir fill on PUT; same object_id is ABSENT on ceph until the replicator runs
+# watch a local pod's ingest dir fill on PUT; the object appears on ceph once the drain-agent copies it
 kubectl -n hippius-s3-staging exec deploy/api-local -c api -- sh -c 'ls -R /var/lib/hippius/local_object_cache | head'
+# watch replication progress (pending→replicated) in the cephor table:
+kubectl -n hippius-s3-staging exec postgres-1 -c postgres -- psql -U postgres -d hippius -tAc \
+  "SELECT status, node_id, count(*) FROM cephor_replication_status GROUP BY 1,2 ORDER BY 1;"
 ```
 
-After the replicator lands: confirm it copies local→ceph (meta-last) + rings `notify:`, the uploader
-completes to Arion (`uploaded`→`published`), and a cross-node GET returns the object. Measure lag.
+The `drain-agent` copies local→ceph (meta-last) + rings `notify:`; a cross-node GET returns the object
+once its parts are `replicated`. (Backend upload to Arion/OVH is still PUT-time enqueued — see the PR-7
+caveat above.)
 
 ## Teardown
 
@@ -96,7 +111,7 @@ completes to Arion (`uploaded`→`published`), and a cross-node GET returns the 
 # patch (restores selector to app: api); in resource-limits.yaml: set base api replicas back to 2.
 kubectl apply -k k8s/staging
 # optionally clear the node dirs: rm -rf /var/lib/hippius/local_ingest_staging/* on each node via a privileged pod
-# and clear the labels: kubectl label node k8s-v3-node1 k8s-v3-node2 k8s-v3-node3 s3-staging-local-ingest-
+# and clear the labels: kubectl label node k8s-v3-node2 k8s-v3-node3 s3-staging-local-ingest-
 ```
 
 ## Notes / risks

--- a/k8s/staging/api-local-deployments-staging.yaml
+++ b/k8s/staging/api-local-deployments-staging.yaml
@@ -17,9 +17,11 @@
 # never collide).
 #
 # Scheduling: pinned to nodes labeled `s3-staging-local-ingest=true` (the ONE list
-# lives in ingest-node-labels-staging.yaml). The cache-replicator DaemonSet selects
+# lives in ingest-node-labels-staging.yaml). The drain-agent DaemonSet selects
 # the SAME label, so they stay in lockstep. Preferred pod anti-affinity spreads the
-# 2 replicas across the labeled nodes.
+# 2 replicas across the labeled nodes. A required nodeAffinity hostname allow-list
+# (node2/node3) is belt-and-suspenders WITH the label: a stray/mislabeled node alone
+# can't place ingest on a psql/cache node — the hostname must ALSO be on the list.
 #
 # Routing: the existing `api` Service (the gateway's GATEWAY_BACKEND_URL=
 # http://api:8000 upstream) is patched to select `app: api-local`
@@ -47,6 +49,18 @@ spec:
       nodeSelector:
         s3-staging-local-ingest: "true"
       affinity:
+        # Belt-and-suspenders with the nodeSelector label: even a mislabeled node
+        # can't host ingest unless its hostname is ALSO on this allow-list. Keep in
+        # sync with ingest-node-labels-staging.yaml (the label list).
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - k8s-v3-node2
+                      - k8s-v3-node3
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -1,5 +1,5 @@
-# The hippius-drain agent: the per-node drain daemon (replaces the cache-replicator
-# placeholder). One pod per ingest node, draining that node's local-SSD ingest dir to
+# The hippius-drain agent: the per-node drain daemon.
+# One pod per ingest node, draining that node's local-SSD ingest dir to
 # the shared CephFS pool, path-preservingly per the api part layout
 # (<object_id>/v<version>/part_<n>/). The reconciler is the sole trigger — it scans the
 # SSD for complete parts (a meta.json marker) with no replication row and records them,
@@ -38,6 +38,19 @@ spec:
       # Same label as api-local — keeps them in lockstep (see header).
       nodeSelector:
         s3-staging-local-ingest: "true"
+      affinity:
+        # Belt-and-suspenders with the nodeSelector label, identical to api-local's
+        # allow-list: a drain-agent only runs where an api-local pod can land. Keep in
+        # sync with ingest-node-labels-staging.yaml + api-local-deployments-staging.yaml.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - k8s-v3-node2
+                      - k8s-v3-node3
       # > the agent's shutdown grace (CEPHOR_GRACE_SECS default 30s): a burst winds
       # down before the kubelet force-kills, so no in-flight part is stranded draining.
       terminationGracePeriodSeconds: 40

--- a/k8s/staging/ingest-node-labels-staging.yaml
+++ b/k8s/staging/ingest-node-labels-staging.yaml
@@ -2,8 +2,10 @@
 #
 # This is the ONE list. `kubectl apply -k k8s/staging` (the deploy) applies the
 # `s3-staging-local-ingest=true` label to these nodes; the api-local Deployment and
-# the cache-replicator DaemonSet both select on that label, so they stay in lockstep
-# automatically. To change the set, edit the Node stanzas here.
+# the drain-agent DaemonSet both select on that label, so they stay in lockstep
+# automatically. Both ALSO carry a required nodeAffinity hostname allow-list (node2,
+# node3) — keep that allow-list in sync with the stanzas below. To change the set,
+# edit the Node stanzas here AND both allow-lists.
 #
 # SHARED CLUSTER: staging and prod run on the same physical nodes, so their ingest
 # sets MUST be disjoint — prod uses a different label (s3-local-ingest) on DIFFERENT

--- a/k8s/staging/kustomization.yaml
+++ b/k8s/staging/kustomization.yaml
@@ -17,6 +17,9 @@ resources:
   # and the per-ingest-node drain agent DaemonSet. Both use the `drain` image.
   - drain-allocator-deployment.yaml
   - drain-agent-daemonset.yaml
+  # Drain-gated upload promoter (s3-2.1 PR-7). Deploys OFF (idle) until
+  # HIPPIUS_DRAIN_GATED_UPLOAD_ENABLED is flipped on it + api-local.
+  - upload-promoter-deployment.yaml
 
 patches:
   - path: namespace-patch.yaml

--- a/k8s/staging/upload-promoter-deployment.yaml
+++ b/k8s/staging/upload-promoter-deployment.yaml
@@ -1,0 +1,95 @@
+# The upload-promoter: the drain-gated counterpart to the api's PUT-time enqueue
+# (s3-2.1 PR-7). It LISTENs on the `cephor_replicated` NOTIFY the drain emits when a
+# part lands on the shared ceph pool, and enqueues that part's backend upload — so the
+# uploader/backup workers only ever dequeue data that is already readable on ceph
+# (closing the enqueue-timing race that DLQ'd uploads of slow-draining objects). A
+# periodic sweep re-promotes any replicated-but-unpromoted part as a backstop for a
+# missed NOTIFY.
+#
+# Gated by HIPPIUS_DRAIN_GATED_UPLOAD_ENABLED. While "false" (default) the promoter
+# idles and the api enqueues at PUT time as today — so this deploys safely OFF. To cut
+# over: set the flag "true" on BOTH this deployment AND the api-local pods (so the api
+# stops enqueuing exactly as the promoter starts), then redeploy. DB + redis-queues
+# only — it reads object metadata and enqueues; it never touches chunk bytes, so no
+# object-cache / KMS / Arion wiring.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: upload-promoter
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: upload-promoter
+  template:
+    metadata:
+      labels:
+        app: upload-promoter
+        worker-type: promoter
+    spec:
+      initContainers:
+        - name: wait-for-services
+          image: busybox:1.35
+          command:
+            - sh
+            - -c
+            - until nc -z postgres-rw 5432 && nc -z redis-queues 6379; do echo waiting for services; sleep 5; done
+      containers:
+        - name: upload-promoter
+          image: ghcr.io/thenervelab/hippius-s3/workers:latest
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: hippius-s3-defaults
+            - configMapRef:
+                name: hippius-s3-environment
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment=$(ENVIRONMENT),service.namespace=$(K8S_NAMESPACE),service.instance.id=$(POD_NAME)"
+            - name: WORKER_SCRIPT
+              value: "workers/run_upload_promoter_in_loop.py"
+            # Flip to "true" here AND on api-local to cut over to drain-gated uploads.
+            - name: HIPPIUS_DRAIN_GATED_UPLOAD_ENABLED
+              value: "false"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: DATABASE_URL
+            - name: REDIS_QUEUES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: REDIS_QUEUES_URL
+            - name: HIPPIUS_UPLOAD_BACKENDS
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_UPLOAD_BACKENDS
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "test -d /proc/1 && grep -q python /proc/1/cmdline"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi

--- a/s3-2.1-todo.md
+++ b/s3-2.1-todo.md
@@ -199,7 +199,9 @@ After PR-1 + PR-7 are green on staging:
 
 ## 6. Open decisions
 - **D1 (PR-1):** F1 fix — clamp-to-burst vs one-shot overdraft vs validate `burst>=max_part`? (Lean: clamp + reconcile.)
-- **D2 (PR-2/PR-7):** F4 — implement `claim_seq` fencing token, or accept determinism-only + rewrite the docs?
+- **D2 (DECIDED 2026-06-22):** F4 — implement a **`claim_seq` fencing token** (monotonic per-claim seq returned in
+  `ClaimedPart`, `mark_replicated` guarded with `AND claim_seq=$N`). Real protection vs a lease-expiry double-commit,
+  not just the determinism argument. Lands on **PR #196** (same PR as PR-6/PR-7a, per owner).
 - **D3 (PR-5):** supervisor — escalate-to-shutdown (clarify docs) vs per-worker restart+backoff?
 - **D4 (DECIDED 2026-06-22):** PR-7 promotion is **per-part** `pg_notify` (pipelines MPU parts to backends as each
   lands — the win observed on the 1GB test). Promoter builds/dedupes the per-object `UploadChainRequest`. Also

--- a/tests/unit/test_queue_retry.py
+++ b/tests/unit/test_queue_retry.py
@@ -9,6 +9,7 @@ from fakeredis.aioredis import FakeRedis
 from hippius_s3.queue import Chunk
 from hippius_s3.queue import UnpinChainRequest
 from hippius_s3.queue import UploadChainRequest
+from hippius_s3.queue import defer_upload_request
 from hippius_s3.queue import enqueue_retry_request
 from hippius_s3.queue import enqueue_unpin_retry_request
 from hippius_s3.queue import initialize_queue_client
@@ -56,6 +57,42 @@ async def test_enqueue_retry_request_sets_attempts_and_schedules() -> None:
     assert data["attempts"] == 2  # incremented
     assert data["last_error"] == "test error"
     assert data["request_id"] == "req-456"
+
+
+@pytest.mark.asyncio
+async def test_defer_upload_request_does_not_increment_attempts() -> None:
+    """defer_upload_request (the PR-7a not-ready path) must NOT burn the retry budget:
+    a part that hasn't drained to ceph yet is "too early", not a failure. It schedules
+    on the SAME retry ZSET (so the existing mover picks it up) and preserves
+    first_enqueued_at (the wall-clock DLQ ceiling)."""
+    redis = FakeRedis()
+    initialize_queue_client(redis)
+    enqueued_at = time.time() - 12.0
+    payload = UploadChainRequest(
+        address="user1",
+        bucket_name="test-bucket",
+        object_key="test-key",
+        object_id="obj-not-ready",
+        object_version=1,
+        chunks=[Chunk(id=1)],
+        upload_id=None,
+        attempts=3,
+        first_enqueued_at=enqueued_at,
+        request_id="req-789",
+    )
+
+    t0 = time.time()
+    await defer_upload_request(payload, backend_name="arion", delay_seconds=5.0)
+
+    members = await redis.zrange("arion_upload_retries", 0, -1, withscores=True)
+    assert len(members) == 1
+    stored_payload, score = members[0]
+    assert score >= t0 + 4.5  # scheduled with the delay
+
+    data = json.loads(stored_payload)
+    assert data["attempts"] == 3, "defer must NOT increment attempts"
+    assert data["first_enqueued_at"] == enqueued_at, "wall-clock origin preserved"
+    assert data["request_id"] == "req-789"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_upload_promoter.py
+++ b/tests/unit/test_upload_promoter.py
@@ -1,0 +1,91 @@
+"""Unit tests for the drain-gated upload-promoter (s3-2.1 PR-7d).
+
+The promoter turns a `cephor_replicated` signal (a part landed on ceph) into a
+per-part backend UploadChainRequest, rebuilt by object_id now that the data is
+readable. These cover the request-building + the notification parsing; the LISTEN /
+sweep wiring is exercised on staging.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from hippius_s3.workers import upload_promoter as up
+
+
+OBJ = "11111111-1111-1111-1111-111111111111"
+
+
+def _db_pool(*, row, upload_id):
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=row)
+    conn.fetchval = AsyncMock(return_value=upload_id)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(return_value=conn), __aexit__=AsyncMock()))
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_promote_part_builds_single_part_request_and_fans_out() -> None:
+    pool = _db_pool(
+        row={"bucket_name": "buck", "object_key": "key/obj", "address": "5MainAcct"},
+        upload_id="upl-123",
+    )
+    config = SimpleNamespace(upload_backends=["arion", "ovh"])
+
+    with patch.object(up, "enqueue_upload_to_backends", new=AsyncMock()) as enqueue:
+        ok = await up.promote_part(pool, config, object_id=OBJ, object_version=2, part_number=7)
+
+    assert ok is True
+    enqueue.assert_awaited_once()
+    req = enqueue.await_args.args[0]
+    assert req.object_id == OBJ
+    assert req.object_version == 2
+    assert req.address == "5MainAcct"
+    assert req.bucket_name == "buck"
+    assert req.object_key == "key/obj"
+    assert req.upload_id == "upl-123"
+    assert req.upload_backends == ["arion", "ovh"]
+    assert [c.id for c in req.chunks] == [7], "promotes exactly the one replicated part"
+
+
+@pytest.mark.asyncio
+async def test_promote_part_skips_when_address_missing() -> None:
+    # A version row with no address (e.g. written before the promoter path was on) can't
+    # be promoted — skip and let the sweep retry, don't enqueue a broken request.
+    pool = _db_pool(row={"bucket_name": "b", "object_key": "k", "address": None}, upload_id=None)
+    config = SimpleNamespace(upload_backends=["arion"])
+
+    with patch.object(up, "enqueue_upload_to_backends", new=AsyncMock()) as enqueue:
+        ok = await up.promote_part(pool, config, object_id=OBJ, object_version=1, part_number=1)
+
+    assert ok is False
+    enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_promote_part_simple_object_has_no_upload_id() -> None:
+    pool = _db_pool(
+        row={"bucket_name": "b", "object_key": "k", "address": "5Acct"},
+        upload_id=None,
+    )
+    config = SimpleNamespace(upload_backends=["arion"])
+
+    with patch.object(up, "enqueue_upload_to_backends", new=AsyncMock()) as enqueue:
+        await up.promote_part(pool, config, object_id=OBJ, object_version=1, part_number=1)
+
+    assert enqueue.await_args.args[0].upload_id is None
+
+
+def test_parse_notification_valid() -> None:
+    assert up._parse_notification(f"{OBJ}:3:12") == (OBJ, 3, 12)
+
+
+@pytest.mark.parametrize("bad", ["", "not-a-payload", f"{OBJ}:3", f"{OBJ}:x:1", f"{OBJ}:1:y"])
+def test_parse_notification_rejects_malformed(bad: str) -> None:
+    assert up._parse_notification(bad) is None

--- a/tests/unit/test_uploader_loop.py
+++ b/tests/unit/test_uploader_loop.py
@@ -12,6 +12,7 @@ the downloader loop. These tests verify:
 from __future__ import annotations
 
 import asyncio
+import time
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -29,6 +30,8 @@ def _make_config(*, max_inflight: int) -> MagicMock:
     cfg.uploader_max_attempts = 5
     cfg.uploader_backoff_base_ms = 1
     cfg.uploader_backoff_max_ms = 10
+    cfg.uploader_not_ready_delay_seconds = 5.0
+    cfg.uploader_not_ready_max_wait_seconds = 1800.0
     cfg.redis_url = "redis://localhost:6379"
     cfg.redis_queues_url = "redis://localhost:6382"
     cfg.database_url = "postgresql://localhost/test"
@@ -43,6 +46,7 @@ def _req(name: str) -> MagicMock:
     r.chunks = []
     r.attempts = 0
     r.address = "5Addr"
+    r.first_enqueued_at = time.time()
     return r
 
 
@@ -68,6 +72,9 @@ class _Harness:
     def _make_uploader(self, *args, **kwargs):
         u = MagicMock()
         u.db = MagicMock()
+        # Default: parts already on ceph, so the drain-gate is a no-op and the loop
+        # behaves as before. The not-ready path is covered by the _handle_upload tests.
+        u.all_parts_on_pool = AsyncMock(return_value=True)
 
         async def _process(req):
             self.process_calls.append(req)
@@ -190,6 +197,7 @@ async def test_handle_upload_requeues_transient_failure():
     from unittest.mock import patch
 
     uploader = MagicMock()
+    uploader.all_parts_on_pool = AsyncMock(return_value=True)
     uploader.process_upload = AsyncMock(side_effect=ValueError("arion blip"))
     uploader._push_to_dlq = AsyncMock()
     req = _req("obj-transient")
@@ -214,6 +222,7 @@ async def test_handle_upload_dlqs_permanent_failure_and_marks_failed():
     from unittest.mock import patch
 
     uploader = MagicMock()
+    uploader.all_parts_on_pool = AsyncMock(return_value=True)
     uploader.process_upload = AsyncMock(side_effect=ValueError("malformed object"))
     uploader._push_to_dlq = AsyncMock()
     conn = AsyncMock()
@@ -234,3 +243,59 @@ async def test_handle_upload_dlqs_permanent_failure_and_marks_failed():
     enqueue.assert_not_called()
     assert conn.execute.await_count == 1
     assert "status = 'failed'" in conn.execute.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_handle_upload_defers_when_not_yet_on_ceph():
+    """An upload dequeued before the drain copied its parts to ceph is re-scheduled
+    (defer_upload_request) WITHOUT touching the retry/DLQ paths or process_upload."""
+    uploader = MagicMock()
+    uploader.all_parts_on_pool = AsyncMock(return_value=False)
+    uploader.process_upload = AsyncMock()
+    uploader._push_to_dlq = AsyncMock()
+    req = _req("obj-not-ready")
+    req.first_enqueued_at = time.time()  # just enqueued → well within the wall-clock cap
+
+    with (
+        patch.object(up, "config", _make_config(max_inflight=4)),
+        patch.object(up, "defer_upload_request", new=AsyncMock()) as defer,
+        patch.object(up, "enqueue_retry_request", new=AsyncMock()) as enqueue,
+        patch.object(up, "get_logger_with_ray_id", return_value=MagicMock()),
+    ):
+        await up._handle_upload(uploader, MagicMock(), req)
+
+    defer.assert_awaited_once()
+    assert defer.await_args.kwargs["backend_name"] == "arion"
+    uploader.process_upload.assert_not_called()
+    enqueue.assert_not_called()
+    uploader._push_to_dlq.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_upload_stops_deferring_past_max_wait():
+    """A part still absent from ceph past the wall-clock ceiling stops deferring and
+    falls through to process_upload (which routes the genuine fault to the DLQ)."""
+    uploader = MagicMock()
+    uploader.all_parts_on_pool = AsyncMock(return_value=False)
+    uploader.process_upload = AsyncMock(side_effect=RuntimeError("Missing meta"))
+    uploader._push_to_dlq = AsyncMock()
+    conn = AsyncMock()
+    db_pool = MagicMock()
+    db_pool.acquire = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(return_value=conn), __aexit__=AsyncMock()))
+    req = _req("obj-stuck")
+    req.first_enqueued_at = time.time() - 4000.0  # older than the 1800s ceiling
+
+    with (
+        patch.object(up, "config", _make_config(max_inflight=4)),
+        patch.object(up, "defer_upload_request", new=AsyncMock()) as defer,
+        patch.object(up, "classify_error", return_value="permanent"),
+        patch.object(up, "extract_http_status_code", return_value=""),
+        patch.object(up, "enqueue_retry_request", new=AsyncMock()),
+        patch.object(up, "get_metrics_collector", return_value=MagicMock()),
+        patch.object(up, "get_logger_with_ray_id", return_value=MagicMock()),
+    ):
+        await up._handle_upload(uploader, db_pool, req)
+
+    defer.assert_not_called()
+    uploader.process_upload.assert_awaited_once()
+    uploader._push_to_dlq.assert_awaited_once()

--- a/workers/run_arion_uploader_in_loop.py
+++ b/workers/run_arion_uploader_in_loop.py
@@ -20,6 +20,7 @@ from hippius_s3.config import get_config
 from hippius_s3.logging_config import setup_loki_logging
 from hippius_s3.monitoring import get_metrics_collector
 from hippius_s3.monitoring import initialize_metrics_collector
+from hippius_s3.queue import defer_upload_request
 from hippius_s3.queue import dequeue_upload_request
 from hippius_s3.queue import enqueue_retry_request
 from hippius_s3.queue import move_due_upload_retries
@@ -51,6 +52,30 @@ async def _handle_upload(uploader, db_pool, upload_request) -> None:
     ray_id = upload_request.ray_id or "no-ray-id"
     ray_id_context.set(ray_id)
     worker_logger = get_logger_with_ray_id(__name__, ray_id)
+
+    # Drain-gating (s3-2.1 PR-7a interim): the api enqueues this upload at PUT/MPU-complete,
+    # before the drain has copied the parts to the shared ceph pool — and the workers read
+    # ceph. An upload dequeued that early can't be served, so rather than block an inflight
+    # slot polling for meta (then DLQ as "permanent"), re-schedule it after a short delay
+    # WITHOUT burning the retry budget. A generous wall-clock ceiling still routes a
+    # genuinely-stuck part to the DLQ via the normal process_upload path below.
+    if not await uploader.all_parts_on_pool(upload_request):
+        waited = time.time() - (upload_request.first_enqueued_at or time.time())
+        if waited < config.uploader_not_ready_max_wait_seconds:
+            await defer_upload_request(
+                upload_request, backend_name="arion", delay_seconds=config.uploader_not_ready_delay_seconds
+            )
+            worker_logger.info(
+                f"Deferring upload; parts not yet on ceph object_id={upload_request.object_id} "
+                f"waited={waited:.0f}s delay={config.uploader_not_ready_delay_seconds}s"
+            )
+            return
+        worker_logger.warning(
+            f"Upload parts still absent from ceph after {waited:.0f}s "
+            f"(> {config.uploader_not_ready_max_wait_seconds}s); routing to DLQ "
+            f"object_id={upload_request.object_id}"
+        )
+
     worker_logger.info(
         f"Processing Arion upload request object_id={upload_request.object_id} "
         f"chunks={len(upload_request.chunks)} attempts={upload_request.attempts or 0}"

--- a/workers/run_upload_promoter_in_loop.py
+++ b/workers/run_upload_promoter_in_loop.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from hippius_s3.config import get_config
+from hippius_s3.logging_config import setup_loki_logging
+from hippius_s3.sentry import init_sentry
+from hippius_s3.workers.upload_promoter import run_upload_promoter_loop
+
+
+config = get_config()
+setup_loki_logging(config, "upload-promoter")
+logger = logging.getLogger(__name__)
+init_sentry("upload-promoter", is_worker=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(run_upload_promoter_loop())


### PR DESCRIPTION
The s3-2.1 hardening batch against `staging`. Greens the drain architecture and closes the enqueue-timing race end-to-end.

## PR-7 — drain-gated upload (the functional headline)
The api enqueues the backend upload at PUT/MPU-complete, before the drain has copied parts to ceph; the workers then block polling for data that isn't there yet and DLQ slow-draining objects. PR-7 makes the upload fire after replication.
- **PR-7c (Rust):** `mark_replicated` commits the part Replicated AND emits `pg_notify('cephor_replicated','<object>:<version>:<part>')` in one atomic statement (only for the row the fenced UPDATE matched).
- **PR-7b:** new nullable `object_versions.address` column + `set_object_version_address` (the only field the workers can't re-derive by object_id).
- **PR-7d:** new **upload-promoter** worker — `LISTEN cephor_replicated` → rebuild the per-part `UploadChainRequest` by object_id → `enqueue_upload_to_backends`. Per-part promotion pipelines MPU parts to backends as each lands. A periodic **sweep** (replicated parts with a chunk lacking any `chunk_backend` row) is the backstop for a missed NOTIFY.
- **PR-7e:** the api put + mpu-complete paths persist `address` instead of enqueuing when `HIPPIUS_DRAIN_GATED_UPLOAD_ENABLED` is on.
- **PR-7f:** `k8s/staging/upload-promoter-deployment.yaml` + kustomization.
- **PR-7a (interim, already here):** drain-gate the arion uploader (defer not block+DLQ).

## PR-2 — drain store/allocator fencing correctness (Rust)
- **F4** claim fencing token (`claim_seq`, migration `0007`): `mark_replicated` only commits if the claim still holds, so a lease-expiry re-claim fences the stale committer.
- **F6** `write_allocations` empty-plan guard (a transient empty plan no longer wipes the fleet's budgets).
- **F18** `mark_failed` nulls `claimed_at`.
- **G2** reconciler adopts legacy NULL-node `pending` rows (only those — no per-cycle write on owned rows).

## PR-6 — node-isolation + manifest hygiene
- **F3** required `nodeAffinity` hostname allow-list on api-local + drain-agent (belt-and-suspenders with the label).
- **F20** drop stale `cache-replicator` refs; reconcile the README.

## Validation
- Rust: `fmt` / `clippy -D warnings` / full `cargo test --workspace` against local PG — agent 61, allocator 23, core 157 + 6 integration (incl. fencing + notify-delivery tests).
- Python: full unit suite **1638 passed**; `ruff` + `ty check hippius_s3 gateway` clean.
- k8s: `kubectl kustomize k8s/staging` renders.

## Migrations
- Rust drain DB: `0007_claim_seq` (nullable column + sequence).
- App DB: `..._object_versions_address` (nullable column). Both additive, no backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)