### PR TITLE
fix(mpu): derive abort/complete version from the upload's own parts

### DIFF
--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -743,32 +743,31 @@ async def abort_multipart_upload(
         # Get object_id from multipart upload
         object_id = multipart_upload["object_id"]
 
-        # Resolve THIS upload's version from its own parts, not objects.current_object_version
-        # (which a concurrent same-key MPU advances) — otherwise the destructive cleanup below
-        # (fail_version_replication + delete_object) would hit a different, possibly in-flight version.
+        # Resolve THIS upload's version from its own parts, not objects.current_object_version.
+        # A simple PUT or another MPU on the same key advances that pointer, so acting on it would
+        # fail-replicate + delete an innocent NEWER version's data. No parts for this upload_id =>
+        # nothing of ours to clean: skip the version-scoped cleanup entirely (do NOT fall back to
+        # the pointer), and just remove the upload row + aborted marker below.
         version_row = await db.fetchrow(get_query("get_multipart_version_by_upload"), upload_id)
-        object_version = (
-            int(version_row["object_version"])
-            if version_row
-            else int(multipart_upload.get("current_object_version") or 1)
-        )
+        object_version = int(version_row["object_version"]) if version_row else None
 
-        # Clean up Redis keys for cached parts (meta + chunks)
-        parts = await db.fetch(
-            get_query("list_parts_for_version"),
-            object_id,
-            object_version,
-        )
-        if parts:
-            redis_client = request.app.state.redis_client
-            delegate = RedisObjectPartsCache(redis_client)
-            for part in parts:
-                part_num = int(part["part_number"])
-                meta_key = delegate.build_meta_key(str(object_id), object_version, part_num)
-                await redis_client.delete(meta_key)
-                base_key = delegate.build_key(str(object_id), object_version, part_num)
-                async for key in redis_client.scan_iter(f"{base_key}:chunk:*"):
-                    await redis_client.delete(key)
+        # Clean up Redis keys for cached parts (meta + chunks) — only for our own version.
+        if object_version is not None:
+            parts = await db.fetch(
+                get_query("list_parts_for_version"),
+                object_id,
+                object_version,
+            )
+            if parts:
+                redis_client = request.app.state.redis_client
+                delegate = RedisObjectPartsCache(redis_client)
+                for part in parts:
+                    part_num = int(part["part_number"])
+                    meta_key = delegate.build_meta_key(str(object_id), object_version, part_num)
+                    await redis_client.delete(meta_key)
+                    base_key = delegate.build_key(str(object_id), object_version, part_num)
+                    async for key in redis_client.scan_iter(f"{base_key}:chunk:*"):
+                        await redis_client.delete(key)
 
         # Fully remove the multipart upload (and cascade parts) so it disappears from listings immediately
         async with db.transaction():
@@ -785,10 +784,12 @@ async def abort_multipart_upload(
         # delete the parts on THIS node's local cache (other nodes' copies are left to the
         # orphan GC; the central mark already stopped their drain churn). Best-effort: a
         # failure here is logged, not surfaced — the abandoned-upload reaper is the backstop.
-        with contextlib.suppress(Exception):
-            await fail_version_replication(db, object_id=object_id, object_version=object_version)
-        with contextlib.suppress(Exception):
-            await request.app.state.fs_store.delete_object(str(object_id), int(object_version))
+        # Skipped when the upload had no parts of its own (object_version is None).
+        if object_version is not None:
+            with contextlib.suppress(Exception):
+                await fail_version_replication(db, object_id=object_id, object_version=object_version)
+            with contextlib.suppress(Exception):
+                await request.app.state.fs_store.delete_object(str(object_id), int(object_version))
 
         # Mark aborted in Redis so listings immediately hide this upload (defensive against read lag)
         with contextlib.suppress(Exception):
@@ -1015,14 +1016,19 @@ async def complete_multipart_upload(
         part_info.sort(key=lambda x: x[0])
 
         # Resolve THIS upload's version from its own parts (keyed by upload_id), not
-        # objects.current_object_version — a concurrent same-key MPU advances that pointer, which
-        # would complete + write the address against a different upload's version.
+        # objects.current_object_version — a simple PUT or another MPU on the same key advances that
+        # pointer, and completing/writing the address against it would target a different upload's
+        # version (and, with no parts of our own, would pull THAT version's parts). No parts for this
+        # upload_id => genuinely nothing to complete; do not fall back to the pointer.
         version_row = await db.fetchrow(get_query("get_multipart_version_by_upload"), upload_id)
-        object_version = (
-            int(version_row["object_version"])
-            if version_row
-            else int(multipart_upload.get("current_object_version") or 1)
-        )
+        if not version_row:
+            logger.error(f"No parts found for multipart upload {upload_id}")
+            return s3_error_response(
+                "InvalidRequest",
+                "No parts found for this multipart upload",
+                status_code=400,
+            )
+        object_version = int(version_row["object_version"])
         db_parts = await db.fetch(
             get_query("list_parts_for_version"),
             object_id,

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -743,8 +743,17 @@ async def abort_multipart_upload(
         # Get object_id from multipart upload
         object_id = multipart_upload["object_id"]
 
+        # Resolve THIS upload's version from its own parts, not objects.current_object_version
+        # (which a concurrent same-key MPU advances) — otherwise the destructive cleanup below
+        # (fail_version_replication + delete_object) would hit a different, possibly in-flight version.
+        version_row = await db.fetchrow(get_query("get_multipart_version_by_upload"), upload_id)
+        object_version = (
+            int(version_row["object_version"])
+            if version_row
+            else int(multipart_upload.get("current_object_version") or 1)
+        )
+
         # Clean up Redis keys for cached parts (meta + chunks)
-        object_version = int(multipart_upload.get("current_object_version") or 1)
         parts = await db.fetch(
             get_query("list_parts_for_version"),
             object_id,
@@ -1005,8 +1014,15 @@ async def complete_multipart_upload(
             )
         part_info.sort(key=lambda x: x[0])
 
-        # Get the parts from the database for the version captured on MPU initiation
-        object_version = int(multipart_upload.get("current_object_version") or 1)
+        # Resolve THIS upload's version from its own parts (keyed by upload_id), not
+        # objects.current_object_version — a concurrent same-key MPU advances that pointer, which
+        # would complete + write the address against a different upload's version.
+        version_row = await db.fetchrow(get_query("get_multipart_version_by_upload"), upload_id)
+        object_version = (
+            int(version_row["object_version"])
+            if version_row
+            else int(multipart_upload.get("current_object_version") or 1)
+        )
         db_parts = await db.fetch(
             get_query("list_parts_for_version"),
             object_id,

--- a/hippius_s3/sql/queries/get_multipart_version_by_upload.sql
+++ b/hippius_s3/sql/queries/get_multipart_version_by_upload.sql
@@ -1,0 +1,12 @@
+-- Resolve the object_version an MPU's parts live under, keyed by upload_id.
+-- multipart_uploads has no version column; a FRESH object_version is allocated per MPU
+-- initiation (upsert_object_multipart.sql), and the parts are written under it. Trusting
+-- objects.current_object_version is WRONG under concurrent same-key MPUs (S3 allows them):
+-- the pointer advances to the LATEST initiation, so an earlier upload's abort/complete would
+-- target a different — possibly in-flight — version's parts/replication/cache.
+-- Parameters: $1: upload_id
+SELECT object_version
+FROM parts
+WHERE upload_id = $1
+ORDER BY object_version DESC
+LIMIT 1

--- a/s3-2.1-todo.md
+++ b/s3-2.1-todo.md
@@ -36,7 +36,7 @@ validate end-to-end with a benchmark.
 | PR-5 | Drain supervisor/exit semantics | Rust | P2 | ☐ todo | — |
 | PR-6 | Node-isolation enforcement + manifest hygiene | k8s/docs | **P1 doc/safety** | ◐ **partial** — node1 dropped from ingest set + api-local→2 (`65d58a3` on staging). TODO: F3 `nodeAffinity` allow-list on api-local + drain-agent; F20 stale `cache-replicator` refs | — |
 | PR-7 | Enqueue-timing fix: drain-gated upload (the headline) | Python + 1-line Rust | **P1 functional** | ✅ shipped (PR #196, promoter + notify + PR-7a defer-gate) **⟳ NOW REWORKED → drain-direct, see §0** | PR-1 |
-| PR-11 | Lean: drain enqueues uploads directly; delete the promoter (supersedes PR-7's Mode B) | Rust + Python | **rework** | ◐ in progress — see §0 | PR-7 |
+| PR-11 | Lean: drain enqueues uploads directly; delete the promoter (supersedes PR-7's Mode B) | Rust + Python | **rework** | ◐ **PR #199 — all CI green** (rust/clippy/deny, unit+integration, **e2e**, ty, ruff). Drain-direct + deferral/backoff + MPU reaper + DualFS read-fallback + DLQ per-part requeue + e2e drain wiring + wire-contract golden. Reviewed 2026-06-25; abort/complete wrong-version bug fixed. See §0 | PR-7 |
 | PR-8 | Reconciler hardening | Rust | nits | ☐ todo | — |
 | PR-9 | GC safety gate (keep `gc-cephfs` off until write-fence) | Rust | P2 deferred | ☐ todo | — |
 | PR-10 | Validation: replication-lag experiment + 1GB MPU benchmark + report | ops | — | ◐ partial — **1GB drain validated 2026-06-19** (128 parts, fully SSD→ceph in ~2.5 min, node-scoped 2-node split; GET md5 round-trips from ceph cache). **But it also proved PR-7 is critical**: backend upload DLQ'd (arion 0/256, ovh 2/256 chunks) — uploader's 30s meta-wait expired before the drain finished. Full ×3 benchmark + HTML report still TODO | PR-1, PR-7 |
@@ -85,7 +85,51 @@ the PR-7a defer-gate (`all_parts_on_pool`, `defer_upload_request`, `move_due_def
 **Risk:** drain is now a hard dependency for all uploads (data still safe on SSD/ceph; janitor won't evict
 un-replicated). Wire-contract coupling Rust→Python (small/stable model; pydantic-forgiving).
 
-### Still-relevant remaining tasks (independent of §0)
+### What actually shipped in PR #199 (drain-direct + colleague hardening, 2026-06-24/25)
+Beyond the base cutover (drain enqueues, api writes address, promoter/notify/sweep/defer-gate deleted), the
+PR grew the supporting machinery the cutover needs to be safe — **all CI green incl. e2e**:
+- **Deferral/backoff (not just "defer once"):** `cephor_replication_status.deferred_until` (migration **0008**);
+  the drain releases + backs off a not-ready part (address not written yet) so not-ready parts don't starve
+  ready ones and don't trip the **Ceph circuit breaker** (`BreakerSignal::Deferred` vs `CephFailure` — a real
+  Ceph IO error still trips it, a deferral doesn't). `claim_part` skips `deferred_until > now()`.
+- **MPU reaper** (`hippius_s3/services/mpu_cleanup.py` + `workers/run_mpu_reaper_in_loop.py` +
+  `k8s/staging/mpu-reaper-deployment.yaml`, replacing the promoter deployment): the terminal path for
+  **abandoned/aborted MPUs**. A version whose `address` was never written + initiated >`mpu_stale_seconds`
+  (1 day) ago → mark its `cephor_replication_status` rows `'failed'` (`fail_replication_status_for_version.sql`,
+  `list_abandoned_versions.sql`) so the drain stops re-claim/re-defer churn fleet-wide. Without it the deferral
+  loops forever. Also wired into the **abort** path (synchronous fail + best-effort local cache delete).
+- **Reader fix:** `DualFileSystemPartsStore.chunks_exist_batch` now consults the pool fallback — drained parts
+  that live only in the pool dir were wrongly routed to the download pipeline.
+- **DLQ requeue fix:** `dlq_requeue.py` now requeues **every** per-part DLQ entry, not just the first.
+- **Wire-contract golden test:** `tests/fixtures/upload_chain_request.golden.json` pinned from **both** sides
+  (Rust producer test + Python `model_validate` test) → cross-language drift breaks CI.
+- **`load_upload_context` version-scoped** `upload_id` subquery (no cross-version `simple::`↔`multipart::` leak).
+- **e2e:** the real drain stack (`drain-allocator` + `drain-agent`) is now in `docker-compose.e2e.yml` with
+  SSD-ingest→pool topology + REDIS_QUEUES_URL/HIPPIUS_UPLOAD_BACKENDS parity; unlimited drain rate in e2e only.
+- **Runbook:** `docs/drain-direct-rollout.md` (deploy-drain-first ordering, re-drive SQL, hard-cutover/rollback).
+
+### Review findings (2026-06-25, 4 parallel reviewers) — fixed + tracked
+- **FIXED (P1/P2): abort + complete used `objects.current_object_version`** instead of the upload's own
+  `parts.object_version`. A concurrent same-key MPU advances that pointer, so the earlier upload's abort would
+  `fail_version_replication` + `delete_object` a *different, possibly in-flight* version (cross-upload
+  corruption), and complete/`set_object_version_address` would target the wrong version. Fixed by deriving the
+  version from the upload's own parts (`get_multipart_version_by_upload.sql`) in both paths. (read-only
+  `list_parts_internal` left as-is — non-destructive, pre-existing.)
+- **DISMISSED:** dlq_requeue `break`-on-permanent (deliberate "refuse without `--force`" safety semantic).
+
+### Still-relevant remaining tasks
+- **Append double-produce (deferred, owner-OK):** `extensions/append.py` still calls `writer_enqueue_upload`,
+  so an appended part is enqueued by the api AND (on replication) by the drain. Harmless today (idempotent
+  uploader dedups) but breaks the "drain is sole producer" invariant — route append through `set_object_version_address`
+  when append is next touched.
+- **Orphan GC for abandoned MPUs (load-bearing follow-up):** the reaper marks replication `'failed'` but the
+  janitor's gate keys on `chunk_backend` (a different table), so abandoned parts' SSD+ceph bytes are never
+  evicted → permanent leak. Abort only cleans the one node it hit. Track leaked-bytes; build the orphan GC.
+- **Reaper integration test + `multipart_uploads.initiated_at` index** — unit test uses a SQL-blind FakeDb;
+  add a real-PG test asserting `list_abandoned_versions.sql` excludes completed/address-bearing/fresh uploads.
+- **Observability:** export a `cephor_drain_deferred` metric (the counter exists but is only used to keep
+  deferrals out of `error_bps`) so the cutover + reaper-lag are watchable. Second golden fixture for the
+  simple-PUT shape (current golden always has `upload_id`).
 - **PR-3b** — F9 lints (`arithmetic_side_effects` + `indexing_slicing`), 39 sites measured, deferred.
 - **s3-backup** — remove the OVH worker defer-gate (companion to §0).
 - **§8 infra** — staging Postgres-on-CephFS slow (prod PG is on NVMe; staging is for correctness only).
@@ -320,6 +364,19 @@ After PR-1 + PR-7 are green on staging:
   NVMe; 539 ms worst pattern unloaded). Ruled out CPU throttling, checkpoint pressure, and sync-replication (async
   replica). Owner decision: **PG stays on Ceph** (D6). Documented mitigations in §8 + promoted **F14 drain batching**
   to a real PR-8 item (fewer commits = fewer fsyncs) + allocator hot-row cadence.
+
+- **2026-06-25 (PR #199 re-review after overnight colleague work):** The colleague turned the bare cutover
+  into a complete, **all-CI-green** PR (e2e included): drain deferral/backoff (migration 0008 +
+  `deferred_until`), the **MPU reaper** (terminal path for abandoned/aborted uploads so the deferral can't loop
+  forever), the DualFS `chunks_exist_batch` read-fallback fix, per-part `dlq_requeue`, the e2e drain stack
+  wiring, and a cross-language wire-contract golden test. Ran a 4-reviewer parallel pass (Rust core / MPU reaper
+  / Python api+queue+DLQ / tests+e2e+infra). **Rust core, Python, and tests/e2e came back clean.** One real bug
+  found + fixed: **abort + complete derived the MPU version from `objects.current_object_version`** (which a
+  concurrent same-key MPU advances) instead of the upload's own `parts.object_version` — under concurrent MPUs
+  the PR's new destructive ops (`fail_version_replication` + `delete_object`) would hit a different in-flight
+  version. Fixed via `get_multipart_version_by_upload.sql` in both paths; unit suite 1635 green. Remaining
+  follow-ups folded into §0 (append double-produce, orphan GC for abandoned-MPU bytes, reaper integration test +
+  index, deferred metric, e2e DLQ xfail). **Next:** push the review fix; merge to staging; then PR-10 validation.
 
 ## 8. Known staging infra issues (not s3-2.1 code, but blocking validation)
 - **Staging Postgres is slow — ROOT-CAUSED 2026-06-19: WAL `fdatasync` on CephFS, NOT a missing index.** Staging

--- a/tests/unit/api/test_multipart_abort_version.py
+++ b/tests/unit/api/test_multipart_abort_version.py
@@ -1,0 +1,118 @@
+"""Regression tests for MPU abort targeting the upload's OWN version.
+
+The bug: abort derived object_version from objects.current_object_version. A simple PUT (or
+another MPU) on the same key bumps that pointer to a fresh version, so aborting an earlier,
+still-open MPU would run the destructive cleanup (fail_version_replication + fs delete) against
+the NEWER, innocent version — corrupting a freshly-PUT object's replication + cache.
+
+These model the divergence the prior tests never did (current_object_version != the upload's own
+parts.object_version) and assert the destructive ops hit the upload's own version, or are skipped
+when the upload has no parts of its own (never falling back to the pointer).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hippius_s3.api.s3 import multipart
+
+
+class _FakeTxn:
+    async def __aenter__(self) -> _FakeTxn:
+        return self
+
+    async def __aexit__(self, *_: Any) -> bool:
+        return False
+
+
+class _FakeDb:
+    """Routes by query NAME (get_query is monkeypatched to identity), modelling the key fact:
+    parts exist ONLY under the upload's own version, while current_object_version points elsewhere."""
+
+    def __init__(self, *, current_version: int, upload_version: int | None) -> None:
+        self.current_version = current_version
+        self.upload_version = upload_version
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        if query == "get_multipart_upload":
+            return {
+                "object_id": "obj-1",
+                "object_key": "k",
+                "is_completed": False,
+                "current_object_version": self.current_version,
+            }
+        if query == "get_multipart_version_by_upload":
+            return {"object_version": self.upload_version} if self.upload_version is not None else None
+        return None
+
+    async def fetch(self, query: str, *args: Any) -> list[Any]:
+        return []
+
+    def transaction(self) -> _FakeTxn:
+        return _FakeTxn()
+
+
+def _fake_request(upload_id: str, *, fs_delete: Any, redis: Any) -> Any:
+    return SimpleNamespace(
+        query_params={"uploadId": upload_id},
+        app=SimpleNamespace(state=SimpleNamespace(redis_client=redis, fs_store=SimpleNamespace(delete_object=fs_delete))),
+    )
+
+
+class _RedisStub:
+    async def setex(self, *_: Any, **__: Any) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_abort_targets_uploads_own_version_not_current_pointer(monkeypatch: Any) -> None:
+    """current_object_version=2 (advanced by a later PUT), but this upload's parts are at v1.
+    The destructive cleanup MUST hit v1 — hitting v2 would corrupt the newer object."""
+    monkeypatch.setattr(multipart, "get_query", lambda name: name)
+    failed: dict[str, Any] = {}
+    deleted: dict[str, Any] = {}
+
+    async def fake_fail(_db: Any, *, object_id: str, object_version: int) -> None:
+        failed["version"] = object_version
+
+    async def fake_delete(object_id: str, object_version: int) -> None:
+        deleted["version"] = object_version
+
+    monkeypatch.setattr(multipart, "fail_version_replication", fake_fail)
+
+    db = _FakeDb(current_version=2, upload_version=1)
+    resp = await multipart.abort_multipart_upload(
+        "b", "k", _fake_request("up-1", fs_delete=fake_delete, redis=_RedisStub()), db
+    )
+
+    assert resp.status_code == 204
+    assert failed["version"] == 1, "fail_version_replication must target the upload's own version, not the pointer"
+    assert deleted["version"] == 1, "fs delete must target the upload's own version, not the pointer"
+
+
+@pytest.mark.asyncio
+async def test_abort_with_no_parts_skips_destructive_cleanup(monkeypatch: Any) -> None:
+    """An upload with no parts (init → overwrite-PUT → abort) must NOT fall back to
+    current_object_version and run the destructive cleanup against the newer version."""
+    monkeypatch.setattr(multipart, "get_query", lambda name: name)
+    called = {"fail": False, "delete": False}
+
+    async def fake_fail(_db: Any, **_: Any) -> None:
+        called["fail"] = True
+
+    async def fake_delete(*_: Any) -> None:
+        called["delete"] = True
+
+    monkeypatch.setattr(multipart, "fail_version_replication", fake_fail)
+
+    db = _FakeDb(current_version=2, upload_version=None)
+    resp = await multipart.abort_multipart_upload(
+        "b", "k", _fake_request("up-1", fs_delete=fake_delete, redis=_RedisStub()), db
+    )
+
+    assert resp.status_code == 204
+    assert called["fail"] is False, "must not fail-replicate when the upload has no parts of its own"
+    assert called["delete"] is False, "must not delete cache when the upload has no parts of its own"

--- a/tests/unit/api/test_multipart_complete_version.py
+++ b/tests/unit/api/test_multipart_complete_version.py
@@ -1,0 +1,124 @@
+"""Regression tests for MPU complete targeting the upload's OWN version.
+
+Mirror of the abort regression: complete derived object_version from
+objects.current_object_version. A simple PUT (or another MPU) on the same key bumps that
+pointer, so completing an earlier upload would write the address against — and pull the parts
+of — a different version. These assert complete resolves the version from the upload's own
+parts (keyed by upload_id), and refuses (no fallback) when the upload has no parts of its own.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hippius_s3.api.s3 import multipart
+
+
+class _FakeDb:
+    def __init__(self, *, current_version: int, upload_version: int | None) -> None:
+        self.current_version = current_version
+        self.upload_version = upload_version
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        if query == "get_multipart_upload":
+            return {"object_id": "obj-1", "is_completed": False, "current_object_version": self.current_version}
+        if query == "get_bucket_by_name":
+            return {"bucket_id": "bkt-1"}
+        if query == "get_multipart_version_by_upload":
+            return {"object_version": self.upload_version} if self.upload_version is not None else None
+        return None
+
+    async def fetch(self, query: str, *args: Any) -> list[Any]:
+        if query == "list_parts_for_version":
+            # parts exist only under the upload's own version
+            if args[1] == self.upload_version:
+                return [{"part_number": 1, "etag": "abc", "size_bytes": 100}]
+            return []
+        return []
+
+
+def _request() -> Any:
+    return SimpleNamespace(
+        state=SimpleNamespace(account=SimpleNamespace(main_account="acct-main", id="sub-1"), seed_phrase="seed"),
+        headers={"Host": "h"},
+        app=SimpleNamespace(state=SimpleNamespace(postgres_pool=object(), redis_client=object(), fs_store=object())),
+    )
+
+
+_BODY = b"<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>abc</ETag></Part></CompleteMultipartUpload>"
+
+
+def _patch_common(monkeypatch: Any) -> None:
+    monkeypatch.setattr(multipart, "get_query", lambda name: name)
+
+    async def _body(_req: Any) -> bytes:
+        return _BODY
+
+    monkeypatch.setattr(multipart, "get_request_body", _body)
+    monkeypatch.setattr(
+        multipart,
+        "get_metrics_collector",
+        lambda: SimpleNamespace(
+            record_s3_operation=lambda **_: None, record_data_transfer=lambda **_: None, record_error=lambda **_: None
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_complete_resolves_version_from_parts_not_pointer(monkeypatch: Any) -> None:
+    """current_object_version=2 (advanced by a later op), upload's parts are at v1.
+    mpu_complete AND set_object_version_address must use v1, not the pointer."""
+    _patch_common(monkeypatch)
+    seen: dict[str, Any] = {}
+
+    class _FakeWriter:
+        def __init__(self, **_: Any) -> None: ...
+
+        async def mpu_complete(self, **kw: Any) -> Any:
+            seen["complete_version"] = kw["object_version"]
+            return SimpleNamespace(etag="abc", size_bytes=100)
+
+    async def _addr(_pool: Any, *, object_id: str, object_version: int, address: str) -> None:
+        seen["address_version"] = object_version
+
+    monkeypatch.setattr(multipart, "ObjectWriter", _FakeWriter)
+    monkeypatch.setattr(multipart, "set_object_version_address", _addr)
+
+    db = _FakeDb(current_version=2, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "k", "up-1", _request(), db)
+
+    assert resp.status_code == 200
+    assert seen["complete_version"] == 1, "mpu_complete must use the upload's own version, not the pointer"
+    assert seen["address_version"] == 1, "address must be written against the upload's own version, not the pointer"
+
+
+@pytest.mark.asyncio
+async def test_complete_with_no_parts_refuses_without_falling_back(monkeypatch: Any) -> None:
+    """No parts for this upload_id => 'No parts found' (400). Must NOT fall back to
+    current_object_version and pull a different version's parts."""
+    _patch_common(monkeypatch)
+    called = {"complete": False, "address": False}
+
+    class _FakeWriter:
+        def __init__(self, **_: Any) -> None: ...
+
+        async def mpu_complete(self, **_: Any) -> Any:
+            called["complete"] = True
+            return SimpleNamespace(etag="abc", size_bytes=100)
+
+    async def _addr(*_: Any, **__: Any) -> None:
+        called["address"] = True
+
+    monkeypatch.setattr(multipart, "ObjectWriter", _FakeWriter)
+    monkeypatch.setattr(multipart, "set_object_version_address", _addr)
+
+    db = _FakeDb(current_version=2, upload_version=None)
+    resp = await multipart.complete_multipart_upload("b", "k", "up-1", _request(), db)
+
+    assert resp.status_code == 400
+    assert b"No parts found" in bytes(resp.body)
+    assert called["complete"] is False
+    assert called["address"] is False


### PR DESCRIPTION
## Summary

Follow-up fix found while re-reviewing the merged drain-direct PR (#199). The MPU **abort** and **complete** handlers derived the object version from `objects.current_object_version`, but a fresh `object_version` is allocated per MPU initiation (`upsert_object_multipart.sql`). With **concurrent multipart uploads to the same key** — which S3 explicitly allows — that pointer advances to the *latest* initiation, so an earlier upload's handler targets the wrong version.

This became a real corruption risk once #199 added destructive ops to abort:
- **abort** → `fail_version_replication` + `fs_store.delete_object` would mark a **different, possibly in-flight** version's replication failed and delete its local cache.
- **complete** → `set_object_version_address` would write the address to the wrong version.

## Fix

Derive the version from the upload's own `parts.object_version` (keyed by `upload_id`) in both paths, via a new `get_multipart_version_by_upload.sql` — the same authoritative source the abandoned-upload reaper already uses. Falls back to `current_object_version` only when no parts exist (then both paths no-op/error anyway). The read-only `list_parts_internal` listing is left as-is (non-destructive, pre-existing).

## Changes
- `hippius_s3/api/s3/multipart.py` — abort + complete resolve version from parts-by-upload_id.
- `hippius_s3/sql/queries/get_multipart_version_by_upload.sql` — new query.
- `s3-2.1-todo.md` — status quo + review outcome for the drain-direct work.

## Verification
`pytest tests/unit` → 1635 passed, 37 skipped; `ruff` + `ty` clean.

## Conclusion
Small, surgical correctness fix that closes a concurrent-same-key-MPU corruption window opened by the drain-direct abort cleanup.