### PR TITLE
feat(drain): SSD-ingest reclaim worker (ssd_reclaim)

### DIFF
--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -44,6 +44,20 @@ const DEFAULT_DEFER_BACKOFF: Duration = Duration::from_secs(5);
 /// it the allocator is treated as silent on this node and the rate decays toward
 /// the floor (a few allocator ticks — the allocator tick is ~2s).
 const DEFAULT_ALLOCATION_STALE: Duration = Duration::from_secs(10);
+/// Reclaim scan period when `CEPHOR_RECLAIM_POLL_SECS` is unset: the SSD-ingest GC
+/// runs less often than the drain — eviction is a backstop, not a hot path.
+const DEFAULT_RECLAIM_POLL: Duration = Duration::from_mins(5);
+/// Reclaim grace when `CEPHOR_RECLAIM_GRACE_SECS` is unset: how long a terminal part
+/// is kept on SSD before eviction under normal pressure (a generous diagnosis /
+/// drain-race window; also the orphan-temp sweep's max age).
+const DEFAULT_RECLAIM_GRACE: Duration = Duration::from_hours(1);
+/// Reclaim grace under disk pressure when `CEPHOR_RECLAIM_PRESSURE_GRACE_SECS` is
+/// unset: evict terminal parts sooner to relieve a filling SSD.
+const DEFAULT_RECLAIM_PRESSURE_GRACE: Duration = Duration::from_mins(1);
+/// SSD fullness (basis points) at/above which reclaim uses the pressure grace, when
+/// `CEPHOR_RECLAIM_PRESSURE_BPS` is unset — 90%, just under the `fs_cache_pressure`
+/// 503 cliff, so eviction accelerates before the api starts rejecting PUTs.
+const DEFAULT_RECLAIM_PRESSURE_BPS: u16 = 9000;
 
 /// The daemon's startup configuration.
 #[derive(Debug, Clone)]
@@ -87,6 +101,15 @@ pub struct Config {
     /// Backends to enqueue each part's upload to (`{backend}_upload_requests`), from
     /// `HIPPIUS_UPLOAD_BACKENDS` (comma-list). Defaults to `["arion"]`.
     pub upload_backends: Vec<String>,
+    /// How often the SSD-reclaim worker scans for terminal aged parts to evict.
+    pub reclaim_poll: Duration,
+    /// How long a terminal (replicated/failed) part is kept on SSD before eviction
+    /// under normal pressure.
+    pub reclaim_grace: Duration,
+    /// The shorter grace used when the SSD is under pressure.
+    pub reclaim_pressure_grace: Duration,
+    /// SSD fullness (basis points) at/above which reclaim uses the pressure grace.
+    pub reclaim_pressure_bps: u16,
 }
 
 /// A failure parsing the daemon configuration from the environment.
@@ -143,6 +166,10 @@ impl Config {
         RuntimeConfig {
             drain_poll: self.drain_poll,
             reconcile_poll: self.reconcile_poll,
+            reclaim_poll: self.reclaim_poll,
+            reclaim_grace: self.reclaim_grace,
+            reclaim_pressure_grace: self.reclaim_pressure_grace,
+            reclaim_pressure_bps: self.reclaim_pressure_bps,
             grace: self.grace,
         }
     }
@@ -179,6 +206,10 @@ impl Config {
             allocation_stale: duration_secs(&get, "CEPHOR_ALLOCATION_STALE_SECS", DEFAULT_ALLOCATION_STALE)?,
             redis_queues_url: required(&get, "REDIS_QUEUES_URL")?,
             upload_backends: parse_backends(&get, "HIPPIUS_UPLOAD_BACKENDS"),
+            reclaim_poll: duration_secs(&get, "CEPHOR_RECLAIM_POLL_SECS", DEFAULT_RECLAIM_POLL)?,
+            reclaim_grace: duration_secs(&get, "CEPHOR_RECLAIM_GRACE_SECS", DEFAULT_RECLAIM_GRACE)?,
+            reclaim_pressure_grace: duration_secs(&get, "CEPHOR_RECLAIM_PRESSURE_GRACE_SECS", DEFAULT_RECLAIM_PRESSURE_GRACE)?,
+            reclaim_pressure_bps: bps_or(&get, "CEPHOR_RECLAIM_PRESSURE_BPS", DEFAULT_RECLAIM_PRESSURE_BPS)?,
         })
     }
 }
@@ -222,6 +253,15 @@ fn positive_u64_or(get: &impl Fn(&str) -> Option<String>, var: &'static str, def
     }
 }
 
+/// Resolves an optional basis-points (`0..=10000`) variable. Builds on [`u64_or`]
+/// (so a present-but-unparsable value still errors), then clamps a value above 10000
+/// down to 10000 — a "never enter pressure mode" config that is pointless but safe,
+/// not a startup failure.
+fn bps_or(get: &impl Fn(&str) -> Option<String>, var: &'static str, default: u16) -> Result<u16, ConfigError> {
+    let raw = u64_or(get, var, u64::from(default))?;
+    Ok(u16::try_from(raw.min(10_000)).unwrap_or(default))
+}
+
 /// Resolves a required filesystem path, rejecting unset, empty, or whitespace-only
 /// values as [`Missing`](ConfigError::Missing). A blank path is the dangerous case
 /// `required` alone misses: it is non-empty, so it would pass into a `PathBuf` and
@@ -252,7 +292,8 @@ fn duration_secs(get: &impl Fn(&str) -> Option<String>, var: &'static str, defau
 mod tests {
     use super::{
         Config, ConfigError, DEFAULT_ALLOCATION_POLL, DEFAULT_ALLOCATION_STALE, DEFAULT_CLAIM_LEASE, DEFAULT_DECAY_HALF_LIFE, DEFAULT_DRAIN_POLL,
-        DEFAULT_FLOOR_RATE_BPS, DEFAULT_HEARTBEAT_POLL, DEFAULT_MAX_DRAIN_RATE_BPS,
+        DEFAULT_FLOOR_RATE_BPS, DEFAULT_HEARTBEAT_POLL, DEFAULT_MAX_DRAIN_RATE_BPS, DEFAULT_RECLAIM_GRACE, DEFAULT_RECLAIM_POLL,
+        DEFAULT_RECLAIM_PRESSURE_BPS, DEFAULT_RECLAIM_PRESSURE_GRACE,
     };
     use core::str::FromStr;
     use hippius_drain_core::{ByteRate, NodeId};
@@ -358,6 +399,39 @@ mod tests {
         pairs.push(("CEPHOR_ALLOCATION_STALE_SECS", "30"));
         let config = Config::from_lookup(lookup(&pairs)).unwrap();
         assert_eq!(config.allocation_stale, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn defaults_the_reclaim_knobs() {
+        let config = Config::from_lookup(lookup(&required_only())).unwrap();
+        assert_eq!(config.reclaim_poll, DEFAULT_RECLAIM_POLL);
+        assert_eq!(config.reclaim_grace, DEFAULT_RECLAIM_GRACE);
+        assert_eq!(config.reclaim_pressure_grace, DEFAULT_RECLAIM_PRESSURE_GRACE);
+        assert_eq!(config.reclaim_pressure_bps, DEFAULT_RECLAIM_PRESSURE_BPS);
+    }
+
+    #[test]
+    fn numeric_reclaim_knobs_override_the_defaults() {
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_RECLAIM_POLL_SECS", "120"));
+        pairs.push(("CEPHOR_RECLAIM_GRACE_SECS", "600"));
+        pairs.push(("CEPHOR_RECLAIM_PRESSURE_GRACE_SECS", "30"));
+        pairs.push(("CEPHOR_RECLAIM_PRESSURE_BPS", "8500"));
+        let config = Config::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(config.reclaim_poll, Duration::from_mins(2));
+        assert_eq!(config.reclaim_grace, Duration::from_mins(10));
+        assert_eq!(config.reclaim_pressure_grace, Duration::from_secs(30));
+        assert_eq!(config.reclaim_pressure_bps, 8500);
+    }
+
+    #[test]
+    fn an_out_of_range_reclaim_pressure_bps_is_clamped_not_rejected() {
+        // Above 10000 just means "never enter pressure mode" — a pointless but safe
+        // config, clamped rather than failing startup.
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_RECLAIM_PRESSURE_BPS", "99999"));
+        let config = Config::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(config.reclaim_pressure_bps, 10_000);
     }
 
     #[test]

--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -47,17 +47,10 @@ const DEFAULT_ALLOCATION_STALE: Duration = Duration::from_secs(10);
 /// Reclaim scan period when `CEPHOR_RECLAIM_POLL_SECS` is unset: the SSD-ingest GC
 /// runs less often than the drain — eviction is a backstop, not a hot path.
 const DEFAULT_RECLAIM_POLL: Duration = Duration::from_mins(5);
-/// Reclaim grace when `CEPHOR_RECLAIM_GRACE_SECS` is unset: how long a terminal part
-/// is kept on SSD before eviction under normal pressure (a generous diagnosis /
-/// drain-race window; also the orphan-temp sweep's max age).
+/// Reclaim grace when `CEPHOR_RECLAIM_GRACE_SECS` is unset: how long a `failed`
+/// (abandoned-upload) part — and an orphan write-temp — is kept on SSD before
+/// eviction (a diagnosis / abort-settle window).
 const DEFAULT_RECLAIM_GRACE: Duration = Duration::from_hours(1);
-/// Reclaim grace under disk pressure when `CEPHOR_RECLAIM_PRESSURE_GRACE_SECS` is
-/// unset: evict terminal parts sooner to relieve a filling SSD.
-const DEFAULT_RECLAIM_PRESSURE_GRACE: Duration = Duration::from_mins(1);
-/// SSD fullness (basis points) at/above which reclaim uses the pressure grace, when
-/// `CEPHOR_RECLAIM_PRESSURE_BPS` is unset — 90%, just under the `fs_cache_pressure`
-/// 503 cliff, so eviction accelerates before the api starts rejecting PUTs.
-const DEFAULT_RECLAIM_PRESSURE_BPS: u16 = 9000;
 
 /// The daemon's startup configuration.
 #[derive(Debug, Clone)]
@@ -101,15 +94,11 @@ pub struct Config {
     /// Backends to enqueue each part's upload to (`{backend}_upload_requests`), from
     /// `HIPPIUS_UPLOAD_BACKENDS` (comma-list). Defaults to `["arion"]`.
     pub upload_backends: Vec<String>,
-    /// How often the SSD-reclaim worker scans for terminal aged parts to evict.
+    /// How often the SSD-reclaim worker scans for `failed` (abandoned-upload) parts.
     pub reclaim_poll: Duration,
-    /// How long a terminal (replicated/failed) part is kept on SSD before eviction
-    /// under normal pressure.
+    /// How long a `failed` part (and an orphan write-temp) is kept on SSD before
+    /// eviction (a diagnosis / abort-settle window).
     pub reclaim_grace: Duration,
-    /// The shorter grace used when the SSD is under pressure.
-    pub reclaim_pressure_grace: Duration,
-    /// SSD fullness (basis points) at/above which reclaim uses the pressure grace.
-    pub reclaim_pressure_bps: u16,
 }
 
 /// A failure parsing the daemon configuration from the environment.
@@ -168,8 +157,6 @@ impl Config {
             reconcile_poll: self.reconcile_poll,
             reclaim_poll: self.reclaim_poll,
             reclaim_grace: self.reclaim_grace,
-            reclaim_pressure_grace: self.reclaim_pressure_grace,
-            reclaim_pressure_bps: self.reclaim_pressure_bps,
             grace: self.grace,
         }
     }
@@ -208,8 +195,6 @@ impl Config {
             upload_backends: parse_backends(&get, "HIPPIUS_UPLOAD_BACKENDS"),
             reclaim_poll: duration_secs(&get, "CEPHOR_RECLAIM_POLL_SECS", DEFAULT_RECLAIM_POLL)?,
             reclaim_grace: duration_secs(&get, "CEPHOR_RECLAIM_GRACE_SECS", DEFAULT_RECLAIM_GRACE)?,
-            reclaim_pressure_grace: duration_secs(&get, "CEPHOR_RECLAIM_PRESSURE_GRACE_SECS", DEFAULT_RECLAIM_PRESSURE_GRACE)?,
-            reclaim_pressure_bps: bps_or(&get, "CEPHOR_RECLAIM_PRESSURE_BPS", DEFAULT_RECLAIM_PRESSURE_BPS)?,
         })
     }
 }
@@ -253,15 +238,6 @@ fn positive_u64_or(get: &impl Fn(&str) -> Option<String>, var: &'static str, def
     }
 }
 
-/// Resolves an optional basis-points (`0..=10000`) variable. Builds on [`u64_or`]
-/// (so a present-but-unparsable value still errors), then clamps a value above 10000
-/// down to 10000 — a "never enter pressure mode" config that is pointless but safe,
-/// not a startup failure.
-fn bps_or(get: &impl Fn(&str) -> Option<String>, var: &'static str, default: u16) -> Result<u16, ConfigError> {
-    let raw = u64_or(get, var, u64::from(default))?;
-    Ok(u16::try_from(raw.min(10_000)).unwrap_or(default))
-}
-
 /// Resolves a required filesystem path, rejecting unset, empty, or whitespace-only
 /// values as [`Missing`](ConfigError::Missing). A blank path is the dangerous case
 /// `required` alone misses: it is non-empty, so it would pass into a `PathBuf` and
@@ -293,7 +269,6 @@ mod tests {
     use super::{
         Config, ConfigError, DEFAULT_ALLOCATION_POLL, DEFAULT_ALLOCATION_STALE, DEFAULT_CLAIM_LEASE, DEFAULT_DECAY_HALF_LIFE, DEFAULT_DRAIN_POLL,
         DEFAULT_FLOOR_RATE_BPS, DEFAULT_HEARTBEAT_POLL, DEFAULT_MAX_DRAIN_RATE_BPS, DEFAULT_RECLAIM_GRACE, DEFAULT_RECLAIM_POLL,
-        DEFAULT_RECLAIM_PRESSURE_BPS, DEFAULT_RECLAIM_PRESSURE_GRACE,
     };
     use core::str::FromStr;
     use hippius_drain_core::{ByteRate, NodeId};
@@ -406,8 +381,6 @@ mod tests {
         let config = Config::from_lookup(lookup(&required_only())).unwrap();
         assert_eq!(config.reclaim_poll, DEFAULT_RECLAIM_POLL);
         assert_eq!(config.reclaim_grace, DEFAULT_RECLAIM_GRACE);
-        assert_eq!(config.reclaim_pressure_grace, DEFAULT_RECLAIM_PRESSURE_GRACE);
-        assert_eq!(config.reclaim_pressure_bps, DEFAULT_RECLAIM_PRESSURE_BPS);
     }
 
     #[test]
@@ -415,23 +388,9 @@ mod tests {
         let mut pairs = required_only();
         pairs.push(("CEPHOR_RECLAIM_POLL_SECS", "120"));
         pairs.push(("CEPHOR_RECLAIM_GRACE_SECS", "600"));
-        pairs.push(("CEPHOR_RECLAIM_PRESSURE_GRACE_SECS", "30"));
-        pairs.push(("CEPHOR_RECLAIM_PRESSURE_BPS", "8500"));
         let config = Config::from_lookup(lookup(&pairs)).unwrap();
         assert_eq!(config.reclaim_poll, Duration::from_mins(2));
         assert_eq!(config.reclaim_grace, Duration::from_mins(10));
-        assert_eq!(config.reclaim_pressure_grace, Duration::from_secs(30));
-        assert_eq!(config.reclaim_pressure_bps, 8500);
-    }
-
-    #[test]
-    fn an_out_of_range_reclaim_pressure_bps_is_clamped_not_rejected() {
-        // Above 10000 just means "never enter pressure mode" — a pointless but safe
-        // config, clamped rather than failing startup.
-        let mut pairs = required_only();
-        pairs.push(("CEPHOR_RECLAIM_PRESSURE_BPS", "99999"));
-        let config = Config::from_lookup(lookup(&pairs)).unwrap();
-        assert_eq!(config.reclaim_pressure_bps, 10_000);
     }
 
     #[test]

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -889,4 +889,49 @@ mod part_tests {
         let ssd = LocalSsd::new("/no/such/cephor/cache/dir");
         assert_eq!(ssd.sweep_orphan_tmp(Duration::ZERO).await.unwrap(), 0);
     }
+
+    #[tokio::test]
+    async fn sweep_orphan_tmp_reaches_a_temp_in_an_incomplete_no_meta_part_dir() {
+        // The real orphan case: a PUT crashed mid-write, leaving a temp in a part dir with
+        // NO meta.json (and no completed chunk). scan_parts skips such dirs, so only the
+        // sweep can reclaim it — it must walk no-meta dirs, not just complete ones.
+        let dir = TempDir::new().unwrap();
+        let part = part_key(7, 3);
+        let part_dir = dir.path().join(part.relative_dir());
+        std::fs::create_dir_all(&part_dir).unwrap();
+        let orphan = part_dir.join("chunk_0.bin.tmp.cafebabecafebabe");
+        std::fs::write(&orphan, b"half-written").unwrap();
+
+        let ssd = LocalSsd::new(dir.path());
+        assert_eq!(
+            ssd.sweep_orphan_tmp(Duration::ZERO).await.unwrap(),
+            1,
+            "the temp in a no-meta dir is swept"
+        );
+        assert!(!orphan.exists());
+    }
+
+    #[tokio::test]
+    async fn sweep_orphan_tmp_tolerates_non_dir_entries_at_every_level() {
+        // The walk must skip non-directory junk at the object/version/part levels rather
+        // than abort, and still find the real temp.
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        let part = part_key(1, 1); // root/<uuid>/v1/part_1
+        let part_dir = root.join(part.relative_dir());
+        std::fs::create_dir_all(&part_dir).unwrap();
+        // Stray files where dirs would be, at each level.
+        std::fs::write(root.join("stray-at-root"), b"x").unwrap();
+        std::fs::write(root.join(part.object().as_str()).join("stray-at-object"), b"x").unwrap();
+        std::fs::write(part_dir.parent().unwrap().join("stray-at-version"), b"x").unwrap();
+        // A real aged temp in the proper part dir -> still swept.
+        std::fs::write(part_dir.join("meta.json.tmp.feedfacefeedface"), b"partial").unwrap();
+
+        let ssd = LocalSsd::new(root);
+        assert_eq!(
+            ssd.sweep_orphan_tmp(Duration::ZERO).await.unwrap(),
+            1,
+            "non-dir junk is skipped and the real temp is swept",
+        );
+    }
 }

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -12,12 +12,14 @@
 //! `<object_id>` folder).
 
 use hippius_drain_core::{
-    CephFs, ChunkIndex, DiscoveredPart, FileId, META_FILE_NAME, PartKey, PartPool, PartScan, PartSource, SsdCache, chunk_file_name, parse_part_dir,
+    CephFs, ChunkIndex, DiscoveredPart, FileId, META_FILE_NAME, PartKey, PartPool, PartRemover, PartScan, PartSource, SsdCache, chunk_file_name,
+    parse_part_dir,
 };
 use sha2::{Digest, Sha256};
 use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 use tokio::fs;
 use tokio::io::AsyncReadExt;
 
@@ -148,6 +150,51 @@ impl LocalSsd {
     pub fn root(&self) -> &Path {
         self.root.as_path()
     }
+
+    /// Removes orphaned write-temp files left on the SSD by a crashed mid-write PUT
+    /// (the api's `<name>.tmp.<uuid>`) or a cancelled persist (the agent's
+    /// `.tmp-<name>`), once older than `max_age`.
+    ///
+    /// Walks the `<object>/v<version>/part_<n>/` layout and only ever unlinks a temp
+    /// FILE — never a real `chunk_*.bin`/`meta.json`, never a directory — so it cannot
+    /// touch a complete or in-flight part; the age gate keeps a temp an active writer
+    /// is still using. Returns how many temps it removed; a missing root is an empty
+    /// cache, not an error. The companion to whole-part reclaim (`reclaim_ssd`), which
+    /// already clears temps inside a reclaimed part dir.
+    ///
+    /// # Errors
+    ///
+    /// [`io::Error`] if walking the cache or unlinking a temp fails for a reason other
+    /// than a concurrently-removed entry (which is tolerated).
+    pub async fn sweep_orphan_tmp(&self, max_age: Duration) -> io::Result<u64> {
+        let mut removed = 0;
+        let Some(mut objects) = open_dir(&self.root).await? else {
+            return Ok(0);
+        };
+        while let Some(object) = objects.next_entry().await? {
+            if !object.file_type().await?.is_dir() {
+                continue;
+            }
+            let Some(mut versions) = open_dir(&object.path()).await? else {
+                continue;
+            };
+            while let Some(version) = versions.next_entry().await? {
+                if !version.file_type().await?.is_dir() {
+                    continue;
+                }
+                let Some(mut parts) = open_dir(&version.path()).await? else {
+                    continue;
+                };
+                while let Some(part) = parts.next_entry().await? {
+                    if !part.file_type().await?.is_dir() {
+                        continue;
+                    }
+                    removed += sweep_part_tmp(&part.path(), max_age).await?;
+                }
+            }
+        }
+        Ok(removed)
+    }
 }
 
 impl SsdCache for LocalSsd {
@@ -215,6 +262,61 @@ async fn remove_part_dir(root: &Path, part: &PartKey) -> io::Result<()> {
         Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(err),
     }
+}
+
+/// Opens `dir` for reading, mapping a vanished dir (a concurrent reclaim removed it)
+/// to `None` rather than an error, so a sweep walking a live tree never aborts.
+async fn open_dir(dir: &Path) -> io::Result<Option<fs::ReadDir>> {
+    match fs::read_dir(dir).await {
+        Ok(read) => Ok(Some(read)),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+/// Whether a directory-entry name is a write temp — the agent's `.tmp-<name>` or the
+/// api's `<name>.tmp.<uuid>`. A real `chunk_<i>.bin`/`meta.json` matches neither.
+fn is_temp_name(name: &str) -> bool {
+    name.starts_with(".tmp-") || name.contains(".tmp.")
+}
+
+/// How long ago `meta` was last modified, or [`Duration::ZERO`] if its mtime is
+/// unavailable or in the future (clock skew) — the fail-safe direction (reads young,
+/// so the temp is kept rather than removed).
+fn file_age(meta: &std::fs::Metadata) -> Duration {
+    meta.modified()
+        .ok()
+        .and_then(|mtime| SystemTime::now().duration_since(mtime).ok())
+        .unwrap_or(Duration::ZERO)
+}
+
+/// Unlinks aged orphan write-temps directly inside one part dir. Only temp FILES older
+/// than `max_age` are removed; real chunk/meta files, fresh temps, and any subdirectory
+/// are left untouched. A temp another writer renamed away mid-sweep is already gone.
+async fn sweep_part_tmp(part_path: &Path, max_age: Duration) -> io::Result<u64> {
+    let mut removed = 0;
+    let Some(mut entries) = open_dir(part_path).await? else {
+        return Ok(0);
+    };
+    while let Some(entry) = entries.next_entry().await? {
+        let raw = entry.file_name();
+        let Some(name) = raw.to_str() else {
+            continue;
+        };
+        if !is_temp_name(name) {
+            continue;
+        }
+        let meta = entry.metadata().await?;
+        if !meta.is_file() || file_age(&meta) < max_age {
+            continue;
+        }
+        match fs::remove_file(entry.path()).await {
+            Ok(()) => removed += 1,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(removed)
 }
 
 /// Parse a `chunk_<index>.bin` file name into its [`ChunkIndex`], or `None` for any
@@ -380,6 +482,15 @@ impl PartScan for LocalSsd {
     }
 }
 
+impl PartRemover for LocalSsd {
+    async fn unlink_part(&self, part: &PartKey) -> io::Result<()> {
+        // The reclaim worker's removal seam — the same idempotent whole-part unlink the
+        // drain's success path (`PartSource::remove_part`) uses, so a reclaim racing
+        // that unlink is harmless.
+        remove_part_dir(&self.root, part).await
+    }
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
@@ -480,13 +591,14 @@ mod part_tests {
     use core::future::Future;
     use core::str::FromStr;
     use hippius_drain_core::{
-        ChunkIndex, ClaimedPart, DrainOutcome, ObjectId, PartKey, PartNumber, PartPool, PartReplicationStore, PartScan, PartSource, PartVerified,
-        ReplicationState, UploadEnqueuer, Version, drain_part,
+        ChunkIndex, ClaimedPart, DrainOutcome, ObjectId, PartKey, PartNumber, PartPool, PartRemover, PartReplicationStore, PartScan, PartSource,
+        PartVerified, ReplicationState, UploadEnqueuer, Version, drain_part,
     };
     use sha2::{Digest, Sha256};
     use std::collections::HashMap;
     use std::io;
     use std::sync::Mutex;
+    use std::time::Duration;
     use tempfile::TempDir;
 
     /// A no-op upload enqueuer for the localfs drain test.
@@ -729,5 +841,52 @@ mod part_tests {
         assert!(pool_part.join("meta.json").exists(), "meta marker copied last");
         assert!(!ssd_part.exists(), "SSD part unlinked only after a verified, committed copy exists");
         assert_eq!(store.status_of(&part), Some(ReplicationState::Replicated));
+    }
+
+    #[tokio::test]
+    async fn part_remover_unlinks_the_part_dir_idempotently() {
+        let dir = TempDir::new().unwrap();
+        let part = part_key(5, 1);
+        seed_ssd_part(dir.path(), &part, &[(0, b"x")]);
+        let ssd = LocalSsd::new(dir.path());
+
+        ssd.unlink_part(&part).await.unwrap();
+        assert!(!dir.path().join(part.relative_dir()).exists(), "the reclaimed part dir is gone");
+        // A second reclaim of an already-absent part is Ok (mirrors the drain's unlink).
+        ssd.unlink_part(&part).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn sweep_orphan_tmp_removes_aged_temps_and_keeps_real_and_fresh_files() {
+        let dir = TempDir::new().unwrap();
+        let part = part_key(5, 1);
+        let part_dir = dir.path().join(part.relative_dir());
+        std::fs::create_dir_all(&part_dir).unwrap();
+        // Real files alongside both temp flavors: the api's `<name>.tmp.<uuid>` and the
+        // agent's `.tmp-<name>`.
+        std::fs::write(part_dir.join("chunk_0.bin"), b"real").unwrap();
+        std::fs::write(part_dir.join("meta.json"), b"{}").unwrap();
+        let api_tmp = part_dir.join("chunk_0.bin.tmp.deadbeefdeadbeef");
+        let agent_tmp = part_dir.join(".tmp-chunk_0.bin");
+        std::fs::write(&api_tmp, b"partial").unwrap();
+        std::fs::write(&agent_tmp, b"partial").unwrap();
+
+        let ssd = LocalSsd::new(dir.path());
+
+        // A long window keeps the just-written temps (younger than max_age).
+        assert_eq!(ssd.sweep_orphan_tmp(Duration::from_hours(1)).await.unwrap(), 0);
+        assert!(api_tmp.exists() && agent_tmp.exists(), "fresh temps within the window are kept");
+
+        // A zero window ages every temp, so both flavors are removed; real files stay.
+        assert_eq!(ssd.sweep_orphan_tmp(Duration::ZERO).await.unwrap(), 2, "both temp flavors removed");
+        assert!(!api_tmp.exists() && !agent_tmp.exists(), "aged temps unlinked");
+        assert!(part_dir.join("chunk_0.bin").exists(), "the real chunk is untouched");
+        assert!(part_dir.join("meta.json").exists(), "the meta marker is untouched");
+    }
+
+    #[tokio::test]
+    async fn sweep_orphan_tmp_of_a_missing_root_is_zero() {
+        let ssd = LocalSsd::new("/no/such/cephor/cache/dir");
+        assert_eq!(ssd.sweep_orphan_tmp(Duration::ZERO).await.unwrap(), 0);
     }
 }

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -223,6 +223,20 @@ struct ReclaimParams {
     pressure_bps: u16,
 }
 
+impl ReclaimParams {
+    /// The grace to apply at `pressure_bps` SSD fullness: the shorter `pressure_grace`
+    /// at or above the threshold (evict sooner to relieve a filling disk), the normal
+    /// `grace` below it. A pure decision, extracted so the mode selection is unit-tested
+    /// without needing to drive real disk fullness.
+    fn grace_for(self, pressure_bps: u16) -> Duration {
+        if pressure_bps >= self.pressure_bps {
+            self.pressure_grace
+        } else {
+            self.grace
+        }
+    }
+}
+
 /// One reclaim pass: probe SSD pressure (off the async runtime — statvfs blocks) to
 /// pick the grace, then evict terminal aged parts and sweep orphan write-temps.
 ///
@@ -232,8 +246,7 @@ struct ReclaimParams {
 async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, params: ReclaimParams) {
     let root = ssd.root().to_path_buf();
     let grace = match tokio::task::spawn_blocking(move || disk_usage(&root)).await {
-        Ok(Ok(usage)) if usage.pressure.bps() >= params.pressure_bps => params.pressure_grace,
-        Ok(Ok(_)) => params.grace,
+        Ok(Ok(usage)) => params.grace_for(usage.pressure.bps()),
         Ok(Err(err)) => {
             tracing::warn!(error = %err, "reclaim disk probe failed; using the normal grace");
             params.grace
@@ -476,13 +489,13 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::{AgentRuntime, HeartbeatConfig, RateControl, RuntimeConfig, default_enforcer};
+    use super::{AgentRuntime, HeartbeatConfig, RateControl, ReclaimParams, RuntimeConfig, default_enforcer};
     use crate::localfs::{LocalFs, LocalSsd};
     use crate::supervisor::ShutdownTrigger;
     use core::str::FromStr;
     use hippius_drain_core::{
-        Allocation, ByteRate, Bytes, Clock, NodeId, ObjectId, PartKey, PartNumber, PartReplicationStore, ReplicationState, Store, TestClock,
-        UploadEnqueuer, Version,
+        Allocation, ByteRate, Bytes, Clock, NodeId, ObjectId, PartKey, PartNumber, PartReplicationStore, ReplicationState, SnapshotCell, Store,
+        TestClock, UploadEnqueuer, Version,
     };
 
     /// A no-op upload enqueuer for the runtime tests (drain-direct's Redis fan-out is
@@ -504,6 +517,21 @@ mod tests {
 
     fn part_at(version: u32, number: u32) -> PartKey {
         PartKey::new(ObjectId::from_str(UUID).unwrap(), Version::new(version), PartNumber::new(number))
+    }
+
+    #[test]
+    fn reclaim_grace_switches_to_the_pressure_grace_at_the_threshold() {
+        let params = ReclaimParams {
+            grace: Duration::from_hours(1),
+            pressure_grace: Duration::from_mins(1),
+            pressure_bps: 9000,
+        };
+        // Below the threshold -> the normal (longer) grace.
+        assert_eq!(params.grace_for(0), Duration::from_hours(1));
+        assert_eq!(params.grace_for(8999), Duration::from_hours(1));
+        // At or above the threshold -> the shorter pressure grace (evict sooner).
+        assert_eq!(params.grace_for(9000), Duration::from_mins(1));
+        assert_eq!(params.grace_for(10_000), Duration::from_mins(1));
     }
 
     /// Lays a complete SSD part (chunk files + meta.json) and records it pending.
@@ -859,13 +887,15 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
-    async fn the_reclaim_worker_evicts_a_terminal_aged_part_and_keeps_a_live_one(pool: PgPool) {
-        // The SSD-ingest GC: a `replicated` part still on SSD (a crash-orphaned copy) is
-        // unlinked once aged, while a `pending` part the drain still owns is never touched
-        // — the absolute safety invariant, exercised end-to-end against real Postgres.
+    async fn reclaim_once_evicts_a_terminal_aged_part_and_keeps_a_live_one(pool: PgPool) {
+        // The SSD-ingest GC, exercised against real Postgres + a real LocalSsd + disk
+        // probe: a `replicated` part still on SSD (a crash-orphaned copy) is unlinked once
+        // aged, while a `pending` part the drain still owns is never touched (the absolute
+        // safety invariant). Driving reclaim_once directly keeps it deterministic — the
+        // periodic spawn machinery is the same run_periodic the sibling worker tests cover.
         let ssd_dir = tempfile::tempdir().unwrap();
-        let pool_dir = tempfile::tempdir().unwrap();
-        let store = Arc::new(Store::from_pool(pool.clone()));
+        let store = Store::from_pool(pool.clone());
+        let snapshot = SnapshotCell::new();
 
         // A replicated part still on SSD, forced 2h old -> reclaimable.
         let replicated = part_at(5, 1);
@@ -887,55 +917,31 @@ mod tests {
         seed_ssd_dir(ssd_dir.path(), &pending);
         store.record_landed_part(&pending).await.unwrap();
 
-        let runtime = AgentRuntime::new(
-            Arc::new(LocalFs::new(pool_dir.path())),
-            Arc::new(LocalSsd::new(ssd_dir.path())),
-            Arc::clone(&store),
-            Arc::new(NoopEnqueuer),
-            RuntimeConfig {
-                // Park drain + reconcile so ONLY the reclaim worker acts on the SSD (a
-                // live drain would replicate + unlink the pending part, masking the test).
-                drain_poll: Duration::from_mins(1),
-                reconcile_poll: Duration::from_mins(1),
-                reclaim_poll: Duration::from_millis(20),
-                // Both graces tiny so the 2h-old part is reclaimed whatever the host
-                // disk's pressure band — the test is deterministic regardless of mode.
-                reclaim_grace: Duration::from_secs(1),
-                reclaim_pressure_grace: Duration::from_secs(1),
-                reclaim_pressure_bps: 9000,
-                grace: Duration::from_secs(5),
-            },
+        let ssd = LocalSsd::new(ssd_dir.path());
+        // Tiny graces so the 2h-old part is reclaimed whatever the host disk's pressure
+        // band reads — the assertion is deterministic regardless of which grace is picked.
+        let params = ReclaimParams {
+            grace: Duration::from_secs(1),
+            pressure_grace: Duration::from_secs(1),
+            pressure_bps: 9000,
+        };
+
+        super::reclaim_once(&ssd, &store, &snapshot, params).await;
+
+        assert!(
+            !ssd_dir.path().join(replicated.relative_dir()).exists(),
+            "the terminal aged part was evicted from the SSD",
         );
-
-        let snapshot = runtime.snapshot();
-        let shutdown = CancellationToken::new();
-        let signal = shutdown.clone();
-        let handle = tokio::spawn(async move { runtime.run(signal.cancelled_owned()).await });
-
-        let replicated_dir = ssd_dir.path().join(replicated.relative_dir());
-        let pending_dir = ssd_dir.path().join(pending.relative_dir());
-        // Generous window (~5s): the reclaim tick spawn_blocks a statvfs probe, which can
-        // queue behind sibling sqlx tests' blocking work under a full parallel run.
-        let mut evicted = false;
-        for _ in 0..500 {
-            if !replicated_dir.exists() {
-                evicted = true;
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-        assert!(evicted, "the reclaim worker evicted the terminal aged part from the SSD");
-        assert!(pending_dir.exists(), "a live (pending) part is never reclaimed");
-        assert!(snapshot.load().reclaimed >= 1, "the reclaim was counted");
+        assert!(
+            ssd_dir.path().join(pending.relative_dir()).exists(),
+            "a live (pending) part is never reclaimed"
+        );
+        assert_eq!(snapshot.load().reclaimed, 1, "the reclaim was counted");
         // Reclaim only unlinks the SSD copy; the DB row is left intact.
         assert_eq!(
             <Store as PartReplicationStore>::status(&store, &replicated).await.unwrap(),
             Some(ReplicationState::Replicated),
             "reclaim does not touch the replication row",
         );
-
-        shutdown.cancel();
-        let report = handle.await.unwrap();
-        assert!(report.clean, "every worker wound down within grace");
     }
 }

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -857,6 +857,29 @@ mod tests {
         );
     }
 
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn reclaim_once_also_runs_the_orphan_temp_sweep(pool: PgPool) {
+        // reclaim_once must do BOTH the failed-part reclaim AND the orphan-temp sweep.
+        // An orphan temp in an incomplete (no-meta) part dir is invisible to the part
+        // scan, so if it gets removed it can only be the sweep — proving the wiring.
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let store = Store::from_pool(pool);
+        let snapshot = SnapshotCell::new();
+
+        let part = part_at(9, 1);
+        let part_dir = ssd_dir.path().join(part.relative_dir());
+        std::fs::create_dir_all(&part_dir).unwrap();
+        let orphan = part_dir.join("chunk_0.bin.tmp.0badf00d0badf00d");
+        std::fs::write(&orphan, b"half-written").unwrap();
+
+        let ssd = LocalSsd::new(ssd_dir.path());
+        // Zero grace so the just-written temp is past the (no-)window.
+        super::reclaim_once(&ssd, &store, &snapshot, Duration::ZERO).await;
+
+        assert!(!orphan.exists(), "reclaim_once swept the orphan temp");
+        assert_eq!(snapshot.load().reclaimed, 0, "no failed part -> nothing reclaimed, only the temp swept");
+    }
+
     /// Forces a part's row to `status` with `updated_at` backdated 2h, so the reclaim
     /// age reads deterministically older than any test grace.
     async fn force_terminal_2h(pool: &PgPool, part: &PartKey, status: &str) {

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -5,8 +5,10 @@
 //! [`Supervisor`](crate::supervisor): a drain worker that empties the pending
 //! part backlog on each poll, a reconciler worker that backfills parts whose
 //! landed row is missing (the reconciler is the sole trigger — there is no api
-//! NOTIFY in the part model), and an opt-in heartbeat worker that reports this
-//! node's disk pressure to the allocator. With rate control on, the drain worker
+//! NOTIFY in the part model), an `ssd_reclaim` worker that GCs `failed`
+//! (broken/abandoned-upload) parts + orphan write-temps off the local SSD, and an
+//! opt-in heartbeat worker that reports this node's disk pressure to the allocator.
+//! With rate control on, the drain worker
 //! gates through a shared
 //! [`Enforcer`] and an allocation-pull worker keeps that enforcer synced to the
 //! leader's write-budget. Each worker is a [`run_periodic`] loop that observes
@@ -220,6 +222,14 @@ async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, gr
                 // Aggregate, not per-part: an abandoned MPU reclaims many parts at once,
                 // so a per-part line would spam.
                 tracing::info!(reclaimed = report.reclaimed, "reclaimed broken/abandoned-upload SSD parts");
+            }
+            // The one signal that the (deliberately un-handled) replicated crash-orphan
+            // leak is actually occurring — otherwise invisible. Warn so it surfaces.
+            if report.skipped_replicated > 0 {
+                tracing::warn!(
+                    skipped_replicated = report.skipped_replicated,
+                    "replicated parts still on SSD — drain crash-orphans nothing currently reclaims"
+                );
             }
         }
         Err(err) => tracing::warn!(error = ?err, "ssd reclaim cycle failed; will retry next poll"),

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -20,7 +20,7 @@ use crate::supervisor::{RunReport, Supervisor, WorkerName};
 use crate::worker::drain_until_empty;
 use hippius_drain_core::{
     BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, Enforcer, NodeId, NodeObservation, SnapshotCell, Store, SystemClock,
-    TokenBucket, UploadEnqueuer, decay_rate, reconcile_parts,
+    TokenBucket, UploadEnqueuer, decay_rate, reclaim_ssd, reconcile_parts,
 };
 use std::future::Future;
 use std::sync::{Arc, Mutex, PoisonError};
@@ -58,6 +58,18 @@ pub struct RuntimeConfig {
     pub drain_poll: Duration,
     /// How often the reconciler scans the SSD cache for parts missing a landed row.
     pub reconcile_poll: Duration,
+    /// How often the reclaim worker scans the SSD for terminal aged parts to evict.
+    pub reclaim_poll: Duration,
+    /// How long a terminal (replicated/failed) part is kept before the reclaim worker
+    /// unlinks it under normal pressure (its diagnosis / drain-race window). Also the
+    /// orphan-temp sweep's max age.
+    pub reclaim_grace: Duration,
+    /// The shorter grace the reclaim worker uses when the SSD is under pressure, to
+    /// relieve a filling disk sooner. Never relaxes the terminal-state gate.
+    pub reclaim_pressure_grace: Duration,
+    /// SSD fullness (basis points, `0..=10000`) at or above which the reclaim worker
+    /// switches from `reclaim_grace` to `reclaim_pressure_grace`.
+    pub reclaim_pressure_bps: u16,
     /// How long workers get to finish an in-flight tick after cancellation
     /// before the supervisor force-aborts them.
     pub grace: Duration,
@@ -199,6 +211,64 @@ async fn heartbeat_once(ssd: &LocalSsd, store: &Store, node: &NodeId, max_drain_
     };
     if let Err(err) = store.upsert_node_state(node, &observation).await {
         tracing::warn!(error = %err, "heartbeat upsert failed");
+    }
+}
+
+/// The reclaim worker's grace policy: the normal grace, the shorter grace used when
+/// the SSD is under pressure, and the pressure threshold (basis points) that selects it.
+#[derive(Debug, Clone, Copy)]
+struct ReclaimParams {
+    grace: Duration,
+    pressure_grace: Duration,
+    pressure_bps: u16,
+}
+
+/// One reclaim pass: probe SSD pressure (off the async runtime — statvfs blocks) to
+/// pick the grace, then evict terminal aged parts and sweep orphan write-temps.
+///
+/// A probe failure falls back to the relaxed normal grace — never escalating
+/// aggression on a bad reading. Reclaim and sweep errors are logged and skipped; the
+/// next tick retries, and no part is ever removed without a successful status read.
+async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, params: ReclaimParams) {
+    let root = ssd.root().to_path_buf();
+    let grace = match tokio::task::spawn_blocking(move || disk_usage(&root)).await {
+        Ok(Ok(usage)) if usage.pressure.bps() >= params.pressure_bps => params.pressure_grace,
+        Ok(Ok(_)) => params.grace,
+        Ok(Err(err)) => {
+            tracing::warn!(error = %err, "reclaim disk probe failed; using the normal grace");
+            params.grace
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "reclaim disk probe task panicked; using the normal grace");
+            params.grace
+        }
+    };
+
+    match reclaim_ssd(ssd, ssd, store, grace).await {
+        Ok(report) => {
+            snapshot.record_reclaimed(report.total_reclaimed());
+            if report.total_reclaimed() > 0 {
+                // Aggregate, not per-part: an abandoned MPU reclaims many parts at once,
+                // so a per-part line would spam — the counts give the diagnosis signal.
+                tracing::info!(
+                    replicated = report.reclaimed_replicated,
+                    failed = report.reclaimed_failed,
+                    grace_secs = grace.as_secs(),
+                    "reclaimed terminal SSD parts"
+                );
+            }
+        }
+        Err(err) => tracing::warn!(error = ?err, "ssd reclaim cycle failed; will retry next poll"),
+    }
+
+    // Always use the NORMAL grace for temps, never the pressure-shortened one: a temp
+    // is tiny (sweeping it frees no meaningful space, so there is nothing to gain by
+    // being aggressive under pressure) and a recent temp may belong to a slow in-flight
+    // PUT — unlinking it would break that upload's atomic rename.
+    match ssd.sweep_orphan_tmp(params.grace).await {
+        Ok(0) => {}
+        Ok(removed) => tracing::info!(removed, "swept orphan SSD write-temps"),
+        Err(err) => tracing::warn!(error = %err, "orphan-temp sweep failed; will retry next poll"),
     }
 }
 
@@ -357,6 +427,25 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
             })
         });
 
+        // SSD reclaim worker: evict terminal (replicated/failed) parts the drain is
+        // done with, plus orphan write-temps, once aged — the SSD-ingest tier's GC, so
+        // a stuck drain's backlog does not fill the disk and 503 every PUT on the node.
+        let (ssd, store, snapshot) = (Arc::clone(&self.ssd), Arc::clone(&self.store), Arc::clone(&self.snapshot));
+        let reclaim_poll = self.config.reclaim_poll;
+        let params = ReclaimParams {
+            grace: self.config.reclaim_grace,
+            pressure_grace: self.config.reclaim_pressure_grace,
+            pressure_bps: self.config.reclaim_pressure_bps,
+        };
+        supervisor.spawn(WorkerName::new("ssd_reclaim"), move |token| {
+            run_periodic(token, reclaim_poll, move || {
+                let (ssd, store, snapshot) = (Arc::clone(&ssd), Arc::clone(&store), Arc::clone(&snapshot));
+                async move {
+                    reclaim_once(&ssd, &store, &snapshot, params).await;
+                }
+            })
+        });
+
         // Heartbeat worker (opt-in): report this node's disk pressure + capability
         // so the allocator can weight it. Without it the node is never in the fleet.
         if let Some(heartbeat) = self.heartbeat {
@@ -419,11 +508,17 @@ mod tests {
 
     /// Lays a complete SSD part (chunk files + meta.json) and records it pending.
     async fn seed_part(ssd_root: &Path, store: &Store, part: &PartKey) {
+        seed_ssd_dir(ssd_root, part);
+        store.record_landed_part(part).await.unwrap();
+    }
+
+    /// Lays a complete SSD part dir (chunk + meta) WITHOUT a DB row — for the reclaim
+    /// test, which sets the row's status/age itself.
+    fn seed_ssd_dir(ssd_root: &Path, part: &PartKey) {
         let dir = ssd_root.join(part.relative_dir());
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("chunk_0.bin"), b"runtime backlog part").unwrap();
         std::fs::write(dir.join("meta.json"), br#"{"chunk_size":20,"num_chunks":1,"size_bytes":20}"#).unwrap();
-        store.record_landed_part(part).await.unwrap();
     }
 
     async fn all_replicated(store: &Store, parts: &[PartKey]) -> bool {
@@ -475,6 +570,10 @@ mod tests {
             RuntimeConfig {
                 drain_poll: Duration::from_mins(1),
                 reconcile_poll: Duration::from_mins(1),
+                reclaim_poll: Duration::from_mins(1),
+                reclaim_grace: Duration::from_hours(1),
+                reclaim_pressure_grace: Duration::from_mins(1),
+                reclaim_pressure_bps: 9000,
                 grace: Duration::from_secs(5),
             },
         )
@@ -536,6 +635,10 @@ mod tests {
             RuntimeConfig {
                 drain_poll: Duration::from_mins(1),
                 reconcile_poll: Duration::from_mins(1),
+                reclaim_poll: Duration::from_mins(1),
+                reclaim_grace: Duration::from_hours(1),
+                reclaim_pressure_grace: Duration::from_mins(1),
+                reclaim_pressure_bps: 9000,
                 grace: Duration::from_secs(5),
             },
         )
@@ -617,6 +720,10 @@ mod tests {
                 // Park drain/reconcile; this test exercises only the heartbeat.
                 drain_poll: Duration::from_mins(1),
                 reconcile_poll: Duration::from_mins(1),
+                reclaim_poll: Duration::from_mins(1),
+                reclaim_grace: Duration::from_hours(1),
+                reclaim_pressure_grace: Duration::from_mins(1),
+                reclaim_pressure_bps: 9000,
                 grace: Duration::from_secs(5),
             },
         )
@@ -675,6 +782,10 @@ mod tests {
             RuntimeConfig {
                 drain_poll: Duration::from_millis(20),
                 reconcile_poll: Duration::from_millis(20),
+                reclaim_poll: Duration::from_mins(1),
+                reclaim_grace: Duration::from_hours(1),
+                reclaim_pressure_grace: Duration::from_mins(1),
+                reclaim_pressure_bps: 9000,
                 grace: Duration::from_secs(5),
             },
         );
@@ -717,6 +828,10 @@ mod tests {
             RuntimeConfig {
                 drain_poll: Duration::from_millis(20),
                 reconcile_poll: Duration::from_millis(50),
+                reclaim_poll: Duration::from_mins(1),
+                reclaim_grace: Duration::from_hours(1),
+                reclaim_pressure_grace: Duration::from_mins(1),
+                reclaim_pressure_bps: 9000,
                 grace: Duration::from_secs(5),
             },
         );
@@ -741,5 +856,86 @@ mod tests {
         let snap = snapshot.load();
         assert_eq!(snap.drained, 3, "every drained part was counted once");
         assert_eq!(snap.failed, 0, "the happy path records no failures");
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn the_reclaim_worker_evicts_a_terminal_aged_part_and_keeps_a_live_one(pool: PgPool) {
+        // The SSD-ingest GC: a `replicated` part still on SSD (a crash-orphaned copy) is
+        // unlinked once aged, while a `pending` part the drain still owns is never touched
+        // — the absolute safety invariant, exercised end-to-end against real Postgres.
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(Store::from_pool(pool.clone()));
+
+        // A replicated part still on SSD, forced 2h old -> reclaimable.
+        let replicated = part_at(5, 1);
+        seed_ssd_dir(ssd_dir.path(), &replicated);
+        store.record_landed_part(&replicated).await.unwrap();
+        sqlx::query(
+            "UPDATE cephor_replication_status SET status = 'replicated', updated_at = now() - interval '2 hours' \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(replicated.object().as_str())
+        .bind(i64::from(replicated.version().get()))
+        .bind(i64::from(replicated.part().get()))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // A pending part the drain still owns -> must survive regardless of age.
+        let pending = part_at(5, 2);
+        seed_ssd_dir(ssd_dir.path(), &pending);
+        store.record_landed_part(&pending).await.unwrap();
+
+        let runtime = AgentRuntime::new(
+            Arc::new(LocalFs::new(pool_dir.path())),
+            Arc::new(LocalSsd::new(ssd_dir.path())),
+            Arc::clone(&store),
+            Arc::new(NoopEnqueuer),
+            RuntimeConfig {
+                // Park drain + reconcile so ONLY the reclaim worker acts on the SSD (a
+                // live drain would replicate + unlink the pending part, masking the test).
+                drain_poll: Duration::from_mins(1),
+                reconcile_poll: Duration::from_mins(1),
+                reclaim_poll: Duration::from_millis(20),
+                // Both graces tiny so the 2h-old part is reclaimed whatever the host
+                // disk's pressure band — the test is deterministic regardless of mode.
+                reclaim_grace: Duration::from_secs(1),
+                reclaim_pressure_grace: Duration::from_secs(1),
+                reclaim_pressure_bps: 9000,
+                grace: Duration::from_secs(5),
+            },
+        );
+
+        let snapshot = runtime.snapshot();
+        let shutdown = CancellationToken::new();
+        let signal = shutdown.clone();
+        let handle = tokio::spawn(async move { runtime.run(signal.cancelled_owned()).await });
+
+        let replicated_dir = ssd_dir.path().join(replicated.relative_dir());
+        let pending_dir = ssd_dir.path().join(pending.relative_dir());
+        // Generous window (~5s): the reclaim tick spawn_blocks a statvfs probe, which can
+        // queue behind sibling sqlx tests' blocking work under a full parallel run.
+        let mut evicted = false;
+        for _ in 0..500 {
+            if !replicated_dir.exists() {
+                evicted = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(evicted, "the reclaim worker evicted the terminal aged part from the SSD");
+        assert!(pending_dir.exists(), "a live (pending) part is never reclaimed");
+        assert!(snapshot.load().reclaimed >= 1, "the reclaim was counted");
+        // Reclaim only unlinks the SSD copy; the DB row is left intact.
+        assert_eq!(
+            <Store as PartReplicationStore>::status(&store, &replicated).await.unwrap(),
+            Some(ReplicationState::Replicated),
+            "reclaim does not touch the replication row",
+        );
+
+        shutdown.cancel();
+        let report = handle.await.unwrap();
+        assert!(report.clean, "every worker wound down within grace");
     }
 }

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -58,18 +58,11 @@ pub struct RuntimeConfig {
     pub drain_poll: Duration,
     /// How often the reconciler scans the SSD cache for parts missing a landed row.
     pub reconcile_poll: Duration,
-    /// How often the reclaim worker scans the SSD for terminal aged parts to evict.
+    /// How often the reclaim worker scans the SSD for `failed` (abandoned-upload) parts.
     pub reclaim_poll: Duration,
-    /// How long a terminal (replicated/failed) part is kept before the reclaim worker
-    /// unlinks it under normal pressure (its diagnosis / drain-race window). Also the
-    /// orphan-temp sweep's max age.
+    /// How long a `failed` part (and an orphan write-temp) is kept before the reclaim
+    /// worker unlinks it — a diagnosis / abort-settle window.
     pub reclaim_grace: Duration,
-    /// The shorter grace the reclaim worker uses when the SSD is under pressure, to
-    /// relieve a filling disk sooner. Never relaxes the terminal-state gate.
-    pub reclaim_pressure_grace: Duration,
-    /// SSD fullness (basis points, `0..=10000`) at or above which the reclaim worker
-    /// switches from `reclaim_grace` to `reclaim_pressure_grace`.
-    pub reclaim_pressure_bps: u16,
     /// How long workers get to finish an in-flight tick after cancellation
     /// before the supervisor force-aborts them.
     pub grace: Duration,
@@ -214,71 +207,25 @@ async fn heartbeat_once(ssd: &LocalSsd, store: &Store, node: &NodeId, max_drain_
     }
 }
 
-/// The reclaim worker's grace policy: the normal grace, the shorter grace used when
-/// the SSD is under pressure, and the pressure threshold (basis points) that selects it.
-#[derive(Debug, Clone, Copy)]
-struct ReclaimParams {
-    grace: Duration,
-    pressure_grace: Duration,
-    pressure_bps: u16,
-}
-
-impl ReclaimParams {
-    /// The grace to apply at `pressure_bps` SSD fullness: the shorter `pressure_grace`
-    /// at or above the threshold (evict sooner to relieve a filling disk), the normal
-    /// `grace` below it. A pure decision, extracted so the mode selection is unit-tested
-    /// without needing to drive real disk fullness.
-    fn grace_for(self, pressure_bps: u16) -> Duration {
-        if pressure_bps >= self.pressure_bps {
-            self.pressure_grace
-        } else {
-            self.grace
-        }
-    }
-}
-
-/// One reclaim pass: probe SSD pressure (off the async runtime — statvfs blocks) to
-/// pick the grace, then evict terminal aged parts and sweep orphan write-temps.
+/// One reclaim pass: evict `failed` (broken/abandoned-upload) SSD parts older than
+/// `grace`, then sweep orphan write-temps older than `grace`.
 ///
-/// A probe failure falls back to the relaxed normal grace — never escalating
-/// aggression on a bad reading. Reclaim and sweep errors are logged and skipped; the
-/// next tick retries, and no part is ever removed without a successful status read.
-async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, params: ReclaimParams) {
-    let root = ssd.root().to_path_buf();
-    let grace = match tokio::task::spawn_blocking(move || disk_usage(&root)).await {
-        Ok(Ok(usage)) => params.grace_for(usage.pressure.bps()),
-        Ok(Err(err)) => {
-            tracing::warn!(error = %err, "reclaim disk probe failed; using the normal grace");
-            params.grace
-        }
-        Err(err) => {
-            tracing::warn!(error = %err, "reclaim disk probe task panicked; using the normal grace");
-            params.grace
-        }
-    };
-
+/// Reclaim and sweep errors are logged and skipped; the next tick retries, and no part
+/// is ever removed without a successful status read (fail-safe).
+async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, grace: Duration) {
     match reclaim_ssd(ssd, ssd, store, grace).await {
         Ok(report) => {
-            snapshot.record_reclaimed(report.total_reclaimed());
-            if report.total_reclaimed() > 0 {
+            snapshot.record_reclaimed(report.reclaimed);
+            if report.reclaimed > 0 {
                 // Aggregate, not per-part: an abandoned MPU reclaims many parts at once,
-                // so a per-part line would spam — the counts give the diagnosis signal.
-                tracing::info!(
-                    replicated = report.reclaimed_replicated,
-                    failed = report.reclaimed_failed,
-                    grace_secs = grace.as_secs(),
-                    "reclaimed terminal SSD parts"
-                );
+                // so a per-part line would spam.
+                tracing::info!(reclaimed = report.reclaimed, "reclaimed broken/abandoned-upload SSD parts");
             }
         }
         Err(err) => tracing::warn!(error = ?err, "ssd reclaim cycle failed; will retry next poll"),
     }
 
-    // Always use the NORMAL grace for temps, never the pressure-shortened one: a temp
-    // is tiny (sweeping it frees no meaningful space, so there is nothing to gain by
-    // being aggressive under pressure) and a recent temp may belong to a slow in-flight
-    // PUT — unlinking it would break that upload's atomic rename.
-    match ssd.sweep_orphan_tmp(params.grace).await {
+    match ssd.sweep_orphan_tmp(grace).await {
         Ok(0) => {}
         Ok(removed) => tracing::info!(removed, "swept orphan SSD write-temps"),
         Err(err) => tracing::warn!(error = %err, "orphan-temp sweep failed; will retry next poll"),
@@ -440,21 +387,17 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
             })
         });
 
-        // SSD reclaim worker: evict terminal (replicated/failed) parts the drain is
-        // done with, plus orphan write-temps, once aged — the SSD-ingest tier's GC, so
-        // a stuck drain's backlog does not fill the disk and 503 every PUT on the node.
+        // SSD reclaim worker: clean up broken/abandoned uploads (`failed` parts) the
+        // drain skips forever, plus orphan write-temps — the SSD-ingest tier's GC so
+        // abandoned-upload junk does not accumulate on the node-local disk.
         let (ssd, store, snapshot) = (Arc::clone(&self.ssd), Arc::clone(&self.store), Arc::clone(&self.snapshot));
         let reclaim_poll = self.config.reclaim_poll;
-        let params = ReclaimParams {
-            grace: self.config.reclaim_grace,
-            pressure_grace: self.config.reclaim_pressure_grace,
-            pressure_bps: self.config.reclaim_pressure_bps,
-        };
+        let reclaim_grace = self.config.reclaim_grace;
         supervisor.spawn(WorkerName::new("ssd_reclaim"), move |token| {
             run_periodic(token, reclaim_poll, move || {
                 let (ssd, store, snapshot) = (Arc::clone(&ssd), Arc::clone(&store), Arc::clone(&snapshot));
                 async move {
-                    reclaim_once(&ssd, &store, &snapshot, params).await;
+                    reclaim_once(&ssd, &store, &snapshot, reclaim_grace).await;
                 }
             })
         });
@@ -489,7 +432,7 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::{AgentRuntime, HeartbeatConfig, RateControl, ReclaimParams, RuntimeConfig, default_enforcer};
+    use super::{AgentRuntime, HeartbeatConfig, RateControl, RuntimeConfig, default_enforcer};
     use crate::localfs::{LocalFs, LocalSsd};
     use crate::supervisor::ShutdownTrigger;
     use core::str::FromStr;
@@ -517,21 +460,6 @@ mod tests {
 
     fn part_at(version: u32, number: u32) -> PartKey {
         PartKey::new(ObjectId::from_str(UUID).unwrap(), Version::new(version), PartNumber::new(number))
-    }
-
-    #[test]
-    fn reclaim_grace_switches_to_the_pressure_grace_at_the_threshold() {
-        let params = ReclaimParams {
-            grace: Duration::from_hours(1),
-            pressure_grace: Duration::from_mins(1),
-            pressure_bps: 9000,
-        };
-        // Below the threshold -> the normal (longer) grace.
-        assert_eq!(params.grace_for(0), Duration::from_hours(1));
-        assert_eq!(params.grace_for(8999), Duration::from_hours(1));
-        // At or above the threshold -> the shorter pressure grace (evict sooner).
-        assert_eq!(params.grace_for(9000), Duration::from_mins(1));
-        assert_eq!(params.grace_for(10_000), Duration::from_mins(1));
     }
 
     /// Lays a complete SSD part (chunk files + meta.json) and records it pending.
@@ -600,8 +528,6 @@ mod tests {
                 reconcile_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
-                reclaim_pressure_grace: Duration::from_mins(1),
-                reclaim_pressure_bps: 9000,
                 grace: Duration::from_secs(5),
             },
         )
@@ -665,8 +591,6 @@ mod tests {
                 reconcile_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
-                reclaim_pressure_grace: Duration::from_mins(1),
-                reclaim_pressure_bps: 9000,
                 grace: Duration::from_secs(5),
             },
         )
@@ -750,8 +674,6 @@ mod tests {
                 reconcile_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
-                reclaim_pressure_grace: Duration::from_mins(1),
-                reclaim_pressure_bps: 9000,
                 grace: Duration::from_secs(5),
             },
         )
@@ -812,8 +734,6 @@ mod tests {
                 reconcile_poll: Duration::from_millis(20),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
-                reclaim_pressure_grace: Duration::from_mins(1),
-                reclaim_pressure_bps: 9000,
                 grace: Duration::from_secs(5),
             },
         );
@@ -858,8 +778,6 @@ mod tests {
                 reconcile_poll: Duration::from_millis(50),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
-                reclaim_pressure_grace: Duration::from_mins(1),
-                reclaim_pressure_bps: 9000,
                 grace: Duration::from_secs(5),
             },
         );
@@ -887,61 +805,61 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
-    async fn reclaim_once_evicts_a_terminal_aged_part_and_keeps_a_live_one(pool: PgPool) {
-        // The SSD-ingest GC, exercised against real Postgres + a real LocalSsd + disk
-        // probe: a `replicated` part still on SSD (a crash-orphaned copy) is unlinked once
-        // aged, while a `pending` part the drain still owns is never touched (the absolute
-        // safety invariant). Driving reclaim_once directly keeps it deterministic — the
-        // periodic spawn machinery is the same run_periodic the sibling worker tests cover.
+    async fn reclaim_once_evicts_a_failed_aged_part_and_keeps_a_replicated_one(pool: PgPool) {
+        // The SSD-ingest GC, against real Postgres + a real LocalSsd: a `failed` part (a
+        // broken/abandoned upload) is unlinked once aged, while a `replicated` part (the
+        // drain's own to clean) and the DB rows are left untouched. Driving reclaim_once
+        // directly keeps it deterministic — the periodic spawn machinery is the same
+        // run_periodic the sibling worker tests cover.
         let ssd_dir = tempfile::tempdir().unwrap();
         let store = Store::from_pool(pool.clone());
         let snapshot = SnapshotCell::new();
 
-        // A replicated part still on SSD, forced 2h old -> reclaimable.
-        let replicated = part_at(5, 1);
+        // A failed part (abandoned upload), forced 2h old -> reclaimable.
+        let failed = part_at(5, 1);
+        seed_ssd_dir(ssd_dir.path(), &failed);
+        store.record_landed_part(&failed).await.unwrap();
+        force_terminal_2h(&pool, &failed, "failed").await;
+
+        // A replicated part -> the drain's own to clean up; the reclaimer leaves it.
+        let replicated = part_at(5, 2);
         seed_ssd_dir(ssd_dir.path(), &replicated);
         store.record_landed_part(&replicated).await.unwrap();
-        sqlx::query(
-            "UPDATE cephor_replication_status SET status = 'replicated', updated_at = now() - interval '2 hours' \
-             WHERE object_id = $1 AND version = $2 AND part_number = $3",
-        )
-        .bind(replicated.object().as_str())
-        .bind(i64::from(replicated.version().get()))
-        .bind(i64::from(replicated.part().get()))
-        .execute(&pool)
-        .await
-        .unwrap();
-
-        // A pending part the drain still owns -> must survive regardless of age.
-        let pending = part_at(5, 2);
-        seed_ssd_dir(ssd_dir.path(), &pending);
-        store.record_landed_part(&pending).await.unwrap();
+        force_terminal_2h(&pool, &replicated, "replicated").await;
 
         let ssd = LocalSsd::new(ssd_dir.path());
-        // Tiny graces so the 2h-old part is reclaimed whatever the host disk's pressure
-        // band reads — the assertion is deterministic regardless of which grace is picked.
-        let params = ReclaimParams {
-            grace: Duration::from_secs(1),
-            pressure_grace: Duration::from_secs(1),
-            pressure_bps: 9000,
-        };
-
-        super::reclaim_once(&ssd, &store, &snapshot, params).await;
+        super::reclaim_once(&ssd, &store, &snapshot, Duration::from_secs(1)).await;
 
         assert!(
-            !ssd_dir.path().join(replicated.relative_dir()).exists(),
-            "the terminal aged part was evicted from the SSD",
+            !ssd_dir.path().join(failed.relative_dir()).exists(),
+            "the aged failed (abandoned-upload) part was evicted from the SSD",
         );
         assert!(
-            ssd_dir.path().join(pending.relative_dir()).exists(),
-            "a live (pending) part is never reclaimed"
+            ssd_dir.path().join(replicated.relative_dir()).exists(),
+            "a replicated part is left for the drain, never reclaimed here",
         );
-        assert_eq!(snapshot.load().reclaimed, 1, "the reclaim was counted");
+        assert_eq!(snapshot.load().reclaimed, 1, "exactly the failed part was counted");
         // Reclaim only unlinks the SSD copy; the DB row is left intact.
         assert_eq!(
-            <Store as PartReplicationStore>::status(&store, &replicated).await.unwrap(),
-            Some(ReplicationState::Replicated),
+            <Store as PartReplicationStore>::status(&store, &failed).await.unwrap(),
+            Some(ReplicationState::Failed),
             "reclaim does not touch the replication row",
         );
+    }
+
+    /// Forces a part's row to `status` with `updated_at` backdated 2h, so the reclaim
+    /// age reads deterministically older than any test grace.
+    async fn force_terminal_2h(pool: &PgPool, part: &PartKey, status: &str) {
+        sqlx::query(
+            "UPDATE cephor_replication_status SET status = $4, updated_at = now() - interval '2 hours' \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(part.object().as_str())
+        .bind(i64::from(part.version().get()))
+        .bind(i64::from(part.part().get()))
+        .bind(status)
+        .execute(pool)
+        .await
+        .unwrap();
     }
 }

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -16,6 +16,7 @@ mod mgr;
 mod partdrain;
 mod reconcile;
 mod snapshot;
+mod ssd_reclaim;
 mod state;
 #[cfg(feature = "pg")]
 mod store;
@@ -38,6 +39,7 @@ pub use partdrain::{
 };
 pub use reconcile::{DiscoveredPart, PartLandingLog, PartScan, ReconcileError, ReconcileReport, reconcile_parts};
 pub use snapshot::{AgentSnapshot, SnapshotCell};
+pub use ssd_reclaim::{PartRemover, PartStatusAge, ReclaimError, ReclaimLog, ReclaimReport, reclaim_ssd};
 pub use state::{CephCeiling, PressureZone, ReplicationState};
 pub use units::{ByteRate, Bytes, DiskPressure};
 

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -89,6 +89,9 @@ pub struct AgentSnapshot {
     pub deferred: u64,
     /// Chunks the reconciler recovered after a dropped `chunk_landed` trigger.
     pub reconciler_recovered: u64,
+    /// Terminal (replicated/failed) SSD parts the reclaim worker unlinked — the
+    /// SSD-ingest tier's eviction throughput, distinct from the drain's `CephFS` work.
+    pub reclaimed: u64,
 }
 
 impl AgentSnapshot {
@@ -122,6 +125,7 @@ pub struct SnapshotCell {
     failed: AtomicU64,
     deferred: AtomicU64,
     reconciler_recovered: AtomicU64,
+    reclaimed: AtomicU64,
     /// Recent drain latencies, behind a `Mutex` because a percentile needs the
     /// whole window (no single atomic suffices). Off the wait-free `load` path.
     latency: Mutex<LatencyWindow>,
@@ -155,6 +159,11 @@ impl SnapshotCell {
         self.reconciler_recovered.fetch_add(n, Ordering::Relaxed);
     }
 
+    /// Adds `n` to the SSD-reclaim total (terminal parts the reclaim worker unlinked).
+    pub fn record_reclaimed(&self, n: u64) {
+        self.reclaimed.fetch_add(n, Ordering::Relaxed);
+    }
+
     /// Records a completed drain's latency for the windowed p99 estimate.
     ///
     /// The lock is held only for an O(1) ring push and is never carried across an
@@ -179,6 +188,7 @@ impl SnapshotCell {
             failed: self.failed.load(Ordering::Relaxed),
             deferred: self.deferred.load(Ordering::Relaxed),
             reconciler_recovered: self.reconciler_recovered.load(Ordering::Relaxed),
+            reclaimed: self.reclaimed.load(Ordering::Relaxed),
         }
     }
 }
@@ -217,6 +227,7 @@ mod tests {
         cell.record_drained(2);
         cell.record_failed(1);
         cell.record_reconciled(4);
+        cell.record_reclaimed(6);
         assert_eq!(
             cell.load(),
             AgentSnapshot {
@@ -224,6 +235,7 @@ mod tests {
                 failed: 1,
                 deferred: 0,
                 reconciler_recovered: 4,
+                reclaimed: 6,
             },
         );
     }
@@ -257,6 +269,7 @@ mod tests {
             failed: u64::MAX,
             deferred: 0,
             reconciler_recovered: 0,
+            reclaimed: 0,
         };
         assert_eq!(snapshot.error_bps(), 10_000);
     }
@@ -268,6 +281,7 @@ mod tests {
             failed: 3,
             deferred: 0,
             reconciler_recovered: 0,
+            reclaimed: 0,
         };
         // 3 failed attempts of 10 total attempts = 30%, i.e. 3000 basis points.
         assert_eq!(snapshot.error_bps(), 3000);

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -89,7 +89,7 @@ pub struct AgentSnapshot {
     pub deferred: u64,
     /// Chunks the reconciler recovered after a dropped `chunk_landed` trigger.
     pub reconciler_recovered: u64,
-    /// Terminal (replicated/failed) SSD parts the reclaim worker unlinked — the
+    /// `failed` (broken/abandoned-upload) SSD parts the reclaim worker unlinked — the
     /// SSD-ingest tier's eviction throughput, distinct from the drain's `CephFS` work.
     pub reclaimed: u64,
 }

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -404,6 +404,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_failed_part_exactly_at_the_grace_boundary_is_reclaimed() {
+        // The gate is `age < grace -> keep`, so age == grace falls through to reclaim.
+        // Pins the boundary so a future `<` vs `<=` slip is caught.
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of(std::slice::from_ref(&part));
+        let remover = FakeRemover::default();
+        let log = FakeLog::with(&[(&part, ReplicationState::Failed, GRACE)]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        assert_eq!(report.reclaimed, 1, "age == grace reclaims");
+        assert_eq!(report.skipped_young, 0);
+    }
+
+    #[tokio::test]
     async fn the_status_read_is_batched_into_one_call() {
         let parts: Vec<PartKey> = (1..=5).map(|n| part_at(UUID_A, 5, n)).collect();
         let scan = FakeScan::of(&parts);

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -1,24 +1,24 @@
-//! The SSD-ingest reclaim backstop: delete node-local SSD parts the drain is done
-//! with, once they have aged past a grace.
+//! The SSD-ingest reclaim backstop: clean up **broken / abandoned uploads** left on
+//! the node-local SSD.
 //!
-//! The drain's success path already unlinks a part right after `mark_replicated`,
-//! so in steady state the SSD self-clears. This worker reclaims the leftovers that
-//! path misses, both terminal in the replication log:
-//! - a [`Replicated`](ReplicationState::Replicated) part orphaned by a crash between
-//!   the commit and the unlink (the at-least-once gap), and
-//! - a [`Failed`](ReplicationState::Failed) part — an aborted/abandoned upload that
-//!   `claim_part` skips forever, so the drain never unlinks it.
+//! Scope is deliberately narrow — only [`Failed`](ReplicationState::Failed) parts: an
+//! aborted or abandoned upload (an MPU abort, an abandoned MPU the reaper marked
+//! terminal, or a failed single-part PUT). `claim_part` skips a `failed` row forever,
+//! so the drain never unlinks it and its SSD bytes leak with nothing else to reclaim
+//! them. This worker is that missing owner.
 //!
-//! It NEVER touches a `pending`/`draining` part (owned by the drain pipeline) or a
-//! part with no row (pre-reconcile / mid-upload). The gate is absolute and mirrors
-//! the CephFS-pool janitor's replication gate: `replicated`/`failed` are terminal
-//! sinks (nothing returns a row to `pending` except `release_part`/`defer_part`,
-//! each guarded on `status='draining'`), so a terminal read cannot race back to a
-//! live part, and removal is idempotent, so racing the drain's own unlink is safe.
+//! It does NOT touch anything else, and in particular **not** `replicated` parts: the
+//! drain unlinks its own SSD copy the instant it commits a replication, and the SSD
+//! copy is never read (downloads stream from the `CephFS` pool, not the ingest SSD),
+//! so a successfully-replicated part is the drain's to clean up, not the reclaimer's.
+//! `pending`/`draining` parts are live (owned by the drain pipeline) and a part with
+//! no row may still be mid-upload — both are left strictly alone.
 //!
-//! A `failed` part is kept for the grace window too (a byte-mismatch copy is worth a
-//! brief diagnosis window), then reclaimed — the abandoned-upload leak is the same
-//! `failed` state and must not be kept forever.
+//! Safety: `failed` is a terminal sink (nothing returns a row to `pending` except
+//! `release_part`/`defer_part`, each guarded on `status='draining'`), so the read can
+//! never race back to a live part; removal is idempotent; a brief `grace` keeps a
+//! just-failed part (a diagnosis window, and headroom so an in-flight abort txn is not
+//! raced). Age uses the store's clock, so the grace has no agent-clock dependence.
 //!
 //! Like [`crate::reconcile_parts`] the orchestrator is I/O-free: it is generic over
 //! the [`PartScan`] discovery seam, a [`PartRemover`] removal seam, and a
@@ -81,35 +81,31 @@ pub trait ReclaimLog: Send + Sync {
 pub struct ReclaimReport {
     /// Parts seen on SSD.
     pub scanned: u64,
-    /// `replicated` parts (durable on `CephFS`) reclaimed — crash-orphaned SSD copies.
-    pub reclaimed_replicated: u64,
     /// `failed` parts (aborted/abandoned uploads) reclaimed.
-    pub reclaimed_failed: u64,
+    pub reclaimed: u64,
     /// Left alone because still `pending`/`draining` — owned by the drain pipeline.
     pub skipped_live: u64,
+    /// Left alone because already `replicated`: the drain owns cleanup of its own
+    /// successful replications (it unlinks on commit). A replicated copy still on SSD
+    /// is a rare drain crash-orphan; counted only for visibility, never reclaimed here.
+    pub skipped_replicated: u64,
     /// Left alone because the store has no row yet — pre-reconcile or mid-upload.
     pub skipped_absent: u64,
-    /// Terminal but within the grace window (diagnosis / drain-race headroom).
+    /// `failed` but within the grace window (diagnosis / abort-race headroom).
     pub skipped_young: u64,
 }
 
 impl ReclaimReport {
-    /// Total parts reclaimed this pass (`replicated` + `failed`).
-    #[must_use]
-    pub fn total_reclaimed(&self) -> u64 {
-        self.reclaimed_replicated.saturating_add(self.reclaimed_failed)
-    }
-
     /// The sum of the per-disposition categories.
     ///
     /// Every scanned part falls into exactly one, so this must equal
     /// [`scanned`](Self::scanned) — the report's invariant, which [`reclaim_ssd`]
-    /// `debug_assert`s before returning.
+    /// `debug_asserts` before returning.
     #[must_use]
     pub fn categorized(&self) -> u64 {
-        self.reclaimed_replicated
-            .saturating_add(self.reclaimed_failed)
+        self.reclaimed
             .saturating_add(self.skipped_live)
+            .saturating_add(self.skipped_replicated)
             .saturating_add(self.skipped_absent)
             .saturating_add(self.skipped_young)
     }
@@ -138,21 +134,12 @@ impl ReclaimError {
     }
 }
 
-/// The two terminal states a reclaim may act on. Carrying the kind from the age gate
-/// to the tally keeps the per-state count exhaustive with no impossible match arm.
-#[derive(Debug, Clone, Copy)]
-enum Terminal {
-    Replicated,
-    Failed,
-}
-
-/// Reclaims terminal, aged parts from the SSD cache.
+/// Reclaims `failed` (broken/abandoned-upload) parts from the SSD cache, once aged.
 ///
-/// Scans every complete part on SSD, reads all their states in one batch, and for
-/// each one that is terminal (`replicated`/`failed`) AND older than `grace`, unlinks
-/// its directory. `pending`/`draining` parts and parts with no row are left untouched
-/// — the absolute safety gate (never delete a part the drain still owns or has not
-/// recorded). The caller resolves `grace` from the disk-pressure mode.
+/// Scans every complete part on SSD, reads all their states in one batch, and unlinks
+/// each one that is `failed` AND older than `grace`. Everything else is left untouched:
+/// `pending`/`draining` are live (drain-owned), `replicated` is the drain's own to
+/// clean up, and a part with no row may still be mid-upload — the absolute safety gate.
 ///
 /// # Errors
 ///
@@ -187,25 +174,22 @@ where
             continue;
         };
 
-        // pending/draining are owned by the drain pipeline; the age gate keeps a
-        // just-terminal part for the grace window. Everything else is reclaimable.
-        let terminal = match status.state {
-            ReplicationState::Pending | ReplicationState::Draining => {
-                report.skipped_live += 1;
-                continue;
+        match status.state {
+            // Live: owned by the drain pipeline.
+            ReplicationState::Pending | ReplicationState::Draining => report.skipped_live += 1,
+            // Replicated: the drain unlinks its own SSD copy on commit; a lingering one
+            // is a rare crash-orphan that is the drain's to clean up, not ours.
+            ReplicationState::Replicated => report.skipped_replicated += 1,
+            // Failed = a broken/abandoned upload (MPU abort, abandoned MPU, or a failed
+            // single-part PUT). The only thing we reclaim — once past the grace window.
+            ReplicationState::Failed => {
+                if status.age < grace {
+                    report.skipped_young += 1;
+                } else {
+                    remover.unlink_part(part).await.map_err(ReclaimError::Remove)?;
+                    report.reclaimed += 1;
+                }
             }
-            ReplicationState::Replicated => Terminal::Replicated,
-            ReplicationState::Failed => Terminal::Failed,
-        };
-        if status.age < grace {
-            report.skipped_young += 1;
-            continue;
-        }
-
-        remover.unlink_part(part).await.map_err(ReclaimError::Remove)?;
-        match terminal {
-            Terminal::Replicated => report.reclaimed_replicated += 1,
-            Terminal::Failed => report.reclaimed_failed += 1,
         }
     }
 
@@ -346,18 +330,6 @@ mod tests {
     const GRACE: Duration = Duration::from_mins(30);
 
     #[tokio::test]
-    async fn an_aged_replicated_part_is_reclaimed() {
-        let part = part_at(UUID_A, 5, 1);
-        let scan = FakeScan::of(std::slice::from_ref(&part));
-        let remover = FakeRemover::default();
-        let log = FakeLog::with(&[(&part, ReplicationState::Replicated, HOUR)]);
-
-        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
-        assert_eq!(report.reclaimed_replicated, 1);
-        assert_eq!(remover.removed(), vec![key(&part)], "the aged replicated part was unlinked");
-    }
-
-    #[tokio::test]
     async fn an_aged_failed_part_is_reclaimed() {
         let part = part_at(UUID_A, 5, 1);
         let scan = FakeScan::of(std::slice::from_ref(&part));
@@ -365,48 +337,63 @@ mod tests {
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, HOUR)]);
 
         let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
-        assert_eq!(report.reclaimed_failed, 1);
+        assert_eq!(report.reclaimed, 1);
         assert_eq!(remover.removed(), vec![key(&part)], "the aged failed (abandoned) part was unlinked");
     }
 
     #[tokio::test]
-    async fn pending_draining_and_no_row_parts_are_never_reclaimed() {
-        // The absolute safety invariant: a part the drain still owns (pending/draining)
-        // or has no row for must NEVER be unlinked, regardless of age.
+    async fn a_replicated_part_is_left_for_the_drain() {
+        // A replicated copy still on SSD is the drain's own to clean up (it unlinks on
+        // commit; this is a rare crash-orphan). The reclaimer never touches it.
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of(std::slice::from_ref(&part));
+        let remover = FakeRemover::default();
+        let log = FakeLog::with(&[(&part, ReplicationState::Replicated, HOUR)]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        assert_eq!(report.skipped_replicated, 1);
+        assert_eq!(report.reclaimed, 0);
+        assert!(remover.removed().is_empty(), "a replicated part is never reclaimed here");
+    }
+
+    #[tokio::test]
+    async fn pending_draining_replicated_and_no_row_parts_are_never_reclaimed() {
+        // The absolute safety invariant: a part the drain still owns (pending/draining),
+        // one it already replicated, or one with no row must NEVER be unlinked here,
+        // regardless of age.
         let pending = part_at(UUID_A, 1, 1);
         let draining = part_at(UUID_A, 1, 2);
+        let replicated = part_at(UUID_A, 1, 3);
         let absent = part_at(UUID_B, 7, 1);
-        let scan = FakeScan::of(&[pending.clone(), draining.clone(), absent.clone()]);
+        let scan = FakeScan::of(&[pending.clone(), draining.clone(), replicated.clone(), absent.clone()]);
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[
             (&pending, ReplicationState::Pending, HOUR),
             (&draining, ReplicationState::Draining, HOUR),
+            (&replicated, ReplicationState::Replicated, HOUR),
             // `absent` has no row in the log at all.
         ]);
 
         let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
-        assert_eq!(
-            report.reclaimed_replicated + report.reclaimed_failed,
-            0,
-            "nothing live or unrecorded is reclaimed"
-        );
+        assert_eq!(report.reclaimed, 0, "nothing but a failed part is ever reclaimed");
         assert_eq!(report.skipped_live, 2);
+        assert_eq!(report.skipped_replicated, 1);
         assert_eq!(report.skipped_absent, 1);
         assert!(remover.removed().is_empty(), "no part was unlinked");
     }
 
     #[tokio::test]
-    async fn a_young_terminal_part_is_kept_within_the_grace_window() {
+    async fn a_young_failed_part_is_kept_within_the_grace_window() {
         let part = part_at(UUID_A, 5, 1);
         let scan = FakeScan::of(std::slice::from_ref(&part));
         let remover = FakeRemover::default();
-        // Terminal but only just replicated — within grace (drain may be racing the
-        // unlink, or a failed copy is in its diagnosis window).
-        let log = FakeLog::with(&[(&part, ReplicationState::Replicated, Duration::from_mins(1))]);
+        // Failed but only just now — within grace (an abort txn may still be settling,
+        // and a corruption sample is worth a brief diagnosis window).
+        let log = FakeLog::with(&[(&part, ReplicationState::Failed, Duration::from_mins(1))]);
 
         let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
         assert_eq!(report.skipped_young, 1);
-        assert!(remover.removed().is_empty(), "a young terminal part is kept");
+        assert!(remover.removed().is_empty(), "a young failed part is kept");
     }
 
     #[tokio::test]
@@ -414,27 +401,27 @@ mod tests {
         let parts: Vec<PartKey> = (1..=5).map(|n| part_at(UUID_A, 5, n)).collect();
         let scan = FakeScan::of(&parts);
         let remover = FakeRemover::default();
-        let log = FakeLog::with(&parts.iter().map(|p| (p, ReplicationState::Replicated, HOUR)).collect::<Vec<_>>());
+        let log = FakeLog::with(&parts.iter().map(|p| (p, ReplicationState::Failed, HOUR)).collect::<Vec<_>>());
 
         let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
-        assert_eq!(report.reclaimed_replicated, 5);
+        assert_eq!(report.reclaimed, 5);
         assert_eq!(log.calls(), 1, "all five parts' statuses were read in one batched call");
     }
 
     #[tokio::test]
     async fn a_mixed_cache_tallies_each_disposition_and_sums_to_scanned() {
-        let repl = part_at(UUID_A, 1, 1); // aged replicated -> reclaimed
-        let fail = part_at(UUID_A, 1, 2); // aged failed -> reclaimed
+        let fail = part_at(UUID_A, 1, 1); // aged failed -> reclaimed
+        let repl = part_at(UUID_A, 1, 2); // replicated -> left for the drain
         let live = part_at(UUID_A, 1, 3); // draining -> live
-        let young = part_at(UUID_A, 1, 4); // young replicated -> kept
+        let young = part_at(UUID_A, 1, 4); // young failed -> kept
         let absent = part_at(UUID_B, 7, 1); // no row -> absent
-        let scan = FakeScan::of(&[repl.clone(), fail.clone(), live.clone(), young.clone(), absent.clone()]);
+        let scan = FakeScan::of(&[fail.clone(), repl.clone(), live.clone(), young.clone(), absent.clone()]);
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[
-            (&repl, ReplicationState::Replicated, HOUR),
             (&fail, ReplicationState::Failed, HOUR),
+            (&repl, ReplicationState::Replicated, HOUR),
             (&live, ReplicationState::Draining, HOUR),
-            (&young, ReplicationState::Replicated, Duration::from_secs(1)),
+            (&young, ReplicationState::Failed, Duration::from_secs(1)),
         ]);
 
         let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
@@ -442,9 +429,9 @@ mod tests {
             report,
             ReclaimReport {
                 scanned: 5,
-                reclaimed_replicated: 1,
-                reclaimed_failed: 1,
+                reclaimed: 1,
                 skipped_live: 1,
+                skipped_replicated: 1,
                 skipped_absent: 1,
                 skipped_young: 1,
             }
@@ -454,9 +441,7 @@ mod tests {
             report.categorized(),
             "every scanned part lands in exactly one disposition"
         );
-        assert_eq!(report.total_reclaimed(), 2);
-        // removed() is sorted ascending: repl is part_1, fail is part_2.
-        assert_eq!(remover.removed(), vec![key(&repl), key(&fail)], "exactly the two aged terminal parts");
+        assert_eq!(remover.removed(), vec![key(&fail)], "exactly the one aged failed part");
     }
 
     #[tokio::test]
@@ -491,7 +476,7 @@ mod tests {
             fail: true,
             ..FakeRemover::default()
         };
-        let log = FakeLog::with(&[(&part, ReplicationState::Replicated, HOUR)]);
+        let log = FakeLog::with(&[(&part, ReplicationState::Failed, HOUR)]);
         let err = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap_err();
         assert!(matches!(err, ReclaimError::Remove(_)), "got: {err:?}");
     }

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -7,10 +7,15 @@
 //! so the drain never unlinks it and its SSD bytes leak with nothing else to reclaim
 //! them. This worker is that missing owner.
 //!
-//! It does NOT touch anything else, and in particular **not** `replicated` parts: the
-//! drain unlinks its own SSD copy the instant it commits a replication, and the SSD
-//! copy is never read (downloads stream from the `CephFS` pool, not the ingest SSD),
-//! so a successfully-replicated part is the drain's to clean up, not the reclaimer's.
+//! It does NOT touch anything else, and in particular **not** `replicated` parts: on
+//! the happy path the drain unlinks its own SSD copy the instant it commits a
+//! replication, and the SSD copy is never read (downloads stream from the `CephFS`
+//! pool, not the ingest SSD), so a replicated part is normally the drain's to clean up.
+//! A replicated copy that lingers is only a rare **drain crash-orphan** (a crash
+//! between the `mark_replicated` commit and the unlink); `claim_part` never re-selects
+//! a `replicated` row, so nothing currently re-drives that unlink — it is a known
+//! residual leak, left out of scope here on purpose (counted `skipped_replicated` for
+//! visibility) to be handled by a drain-side re-drive if it ever proves to matter.
 //! `pending`/`draining` parts are live (owned by the drain pipeline) and a part with
 //! no row may still be mid-upload — both are left strictly alone.
 //!
@@ -85,9 +90,10 @@ pub struct ReclaimReport {
     pub reclaimed: u64,
     /// Left alone because still `pending`/`draining` — owned by the drain pipeline.
     pub skipped_live: u64,
-    /// Left alone because already `replicated`: the drain owns cleanup of its own
-    /// successful replications (it unlinks on commit). A replicated copy still on SSD
-    /// is a rare drain crash-orphan; counted only for visibility, never reclaimed here.
+    /// Left alone because already `replicated`. On the happy path the drain unlinks its
+    /// own copy on commit; a lingering one is a rare drain crash-orphan that NOTHING
+    /// currently re-drives (a known residual leak — see the module doc). Counted here so
+    /// a non-zero value surfaces that the orphan case is actually happening.
     pub skipped_replicated: u64,
     /// Left alone because the store has no row yet — pre-reconcile or mid-upload.
     pub skipped_absent: u64,
@@ -177,8 +183,9 @@ where
         match status.state {
             // Live: owned by the drain pipeline.
             ReplicationState::Pending | ReplicationState::Draining => report.skipped_live += 1,
-            // Replicated: the drain unlinks its own SSD copy on commit; a lingering one
-            // is a rare crash-orphan that is the drain's to clean up, not ours.
+            // Replicated: the drain unlinks its own SSD copy on commit. A lingering one
+            // is a rare crash-orphan nothing currently re-drives (known residual leak —
+            // see the module doc); left alone here, counted for visibility.
             ReplicationState::Replicated => report.skipped_replicated += 1,
             // Failed = a broken/abandoned upload (MPU abort, abandoned MPU, or a failed
             // single-part PUT). The only thing we reclaim — once past the grace window.

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -1,0 +1,508 @@
+//! The SSD-ingest reclaim backstop: delete node-local SSD parts the drain is done
+//! with, once they have aged past a grace.
+//!
+//! The drain's success path already unlinks a part right after `mark_replicated`,
+//! so in steady state the SSD self-clears. This worker reclaims the leftovers that
+//! path misses, both terminal in the replication log:
+//! - a [`Replicated`](ReplicationState::Replicated) part orphaned by a crash between
+//!   the commit and the unlink (the at-least-once gap), and
+//! - a [`Failed`](ReplicationState::Failed) part — an aborted/abandoned upload that
+//!   `claim_part` skips forever, so the drain never unlinks it.
+//!
+//! It NEVER touches a `pending`/`draining` part (owned by the drain pipeline) or a
+//! part with no row (pre-reconcile / mid-upload). The gate is absolute and mirrors
+//! the CephFS-pool janitor's replication gate: `replicated`/`failed` are terminal
+//! sinks (nothing returns a row to `pending` except `release_part`/`defer_part`,
+//! each guarded on `status='draining'`), so a terminal read cannot race back to a
+//! live part, and removal is idempotent, so racing the drain's own unlink is safe.
+//!
+//! A `failed` part is kept for the grace window too (a byte-mismatch copy is worth a
+//! brief diagnosis window), then reclaimed — the abandoned-upload leak is the same
+//! `failed` state and must not be kept forever.
+//!
+//! Like [`crate::reconcile_parts`] the orchestrator is I/O-free: it is generic over
+//! the [`PartScan`] discovery seam, a [`PartRemover`] removal seam, and a
+//! [`ReclaimLog`] batched-status seam, so it is tested with in-memory fakes while the
+//! real `tokio`/Postgres impls live at the edges (`LocalSsd`, this crate's `Store`).
+
+use crate::apipart::PartKey;
+use crate::reconcile::PartScan;
+use crate::state::ReplicationState;
+use core::future::Future;
+use std::collections::HashMap;
+use std::time::Duration;
+use thiserror::Error;
+
+/// The SSD removal seam: unlink a reclaimed part's whole directory.
+///
+/// Idempotent — an already-absent part is `Ok` — so a reclaim racing the drain's
+/// own success-path unlink (or a re-drive after a crash) is harmless. Implemented by
+/// `hippius-drain-agent`'s `LocalSsd`; faked in tests. The future is `Send` so the
+/// reclaim can be spawned on the multithreaded runtime.
+pub trait PartRemover: Send + Sync {
+    /// Unlinks the part's whole directory from the SSD cache. Named `unlink_part`
+    /// (not `remove_part`) so a concrete `LocalSsd` call stays unambiguous when this
+    /// seam and [`PartSource`](crate::PartSource) (the drain's success-path unlink)
+    /// are both in scope.
+    fn unlink_part(&self, part: &PartKey) -> impl Future<Output = std::io::Result<()>> + Send;
+}
+
+/// A scanned part's stored replication state and how long it has held it.
+///
+/// `age` is `now() - updated_at` measured by the store's clock (not the agent's), so
+/// the grace comparison has no clock-skew dependence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PartStatusAge {
+    /// The part's current replication state.
+    pub state: ReplicationState,
+    /// How long the part has held that state (`now() - updated_at`).
+    pub age: Duration,
+}
+
+/// The store seam the reclaim worker needs: read the replication state + age of a
+/// whole batch of scanned parts in ONE round-trip.
+///
+/// Distinct from [`PartLandingLog`](crate::PartLandingLog) (the reconciler's per-part
+/// `status`): the reclaim worker scans the entire SSD each cycle, so a per-part SELECT
+/// would be O(backlog) round-trips. Implemented by [`crate::Store`] (under `pg`) with a
+/// single `IN (UNNEST(...))` query; faked in tests.
+pub trait ReclaimLog: Send + Sync {
+    /// Store-specific failure, boxed into [`ReclaimError::Log`].
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// The replication state + age of every `parts` entry the store has a row for.
+    /// A part with no row is simply absent from the map (the caller skips it).
+    fn part_states(&self, parts: &[PartKey]) -> impl Future<Output = Result<HashMap<PartKey, PartStatusAge>, Self::Error>> + Send;
+}
+
+/// What one reclaim pass did, tallied by the part's disposition. `scanned` always
+/// equals the sum of the five outcome counts.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ReclaimReport {
+    /// Parts seen on SSD.
+    pub scanned: u64,
+    /// `replicated` parts (durable on `CephFS`) reclaimed — crash-orphaned SSD copies.
+    pub reclaimed_replicated: u64,
+    /// `failed` parts (aborted/abandoned uploads) reclaimed.
+    pub reclaimed_failed: u64,
+    /// Left alone because still `pending`/`draining` — owned by the drain pipeline.
+    pub skipped_live: u64,
+    /// Left alone because the store has no row yet — pre-reconcile or mid-upload.
+    pub skipped_absent: u64,
+    /// Terminal but within the grace window (diagnosis / drain-race headroom).
+    pub skipped_young: u64,
+}
+
+impl ReclaimReport {
+    /// Total parts reclaimed this pass (`replicated` + `failed`).
+    #[must_use]
+    pub fn total_reclaimed(&self) -> u64 {
+        self.reclaimed_replicated.saturating_add(self.reclaimed_failed)
+    }
+
+    /// The sum of the per-disposition categories.
+    ///
+    /// Every scanned part falls into exactly one, so this must equal
+    /// [`scanned`](Self::scanned) — the report's invariant, which [`reclaim_ssd`]
+    /// `debug_assert`s before returning.
+    #[must_use]
+    pub fn categorized(&self) -> u64 {
+        self.reclaimed_replicated
+            .saturating_add(self.reclaimed_failed)
+            .saturating_add(self.skipped_live)
+            .saturating_add(self.skipped_absent)
+            .saturating_add(self.skipped_young)
+    }
+}
+
+/// A reclaim failure.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ReclaimError {
+    /// Walking the SSD cache failed.
+    #[error("scanning the SSD cache failed")]
+    Scan(#[source] std::io::Error),
+    /// The batched status read failed. Boxed so the orchestrator stays decoupled
+    /// from any one store backend.
+    #[error("the reclaim log failed during a reclaim pass")]
+    Log(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// Unlinking a reclaimed part's directory failed.
+    #[error("removing a reclaimed part from the SSD cache failed")]
+    Remove(#[source] std::io::Error),
+}
+
+impl ReclaimError {
+    /// Boxes a [`ReclaimLog::Error`] into [`ReclaimError::Log`].
+    fn log<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
+        Self::Log(Box::new(err))
+    }
+}
+
+/// The two terminal states a reclaim may act on. Carrying the kind from the age gate
+/// to the tally keeps the per-state count exhaustive with no impossible match arm.
+#[derive(Debug, Clone, Copy)]
+enum Terminal {
+    Replicated,
+    Failed,
+}
+
+/// Reclaims terminal, aged parts from the SSD cache.
+///
+/// Scans every complete part on SSD, reads all their states in one batch, and for
+/// each one that is terminal (`replicated`/`failed`) AND older than `grace`, unlinks
+/// its directory. `pending`/`draining` parts and parts with no row are left untouched
+/// — the absolute safety gate (never delete a part the drain still owns or has not
+/// recorded). The caller resolves `grace` from the disk-pressure mode.
+///
+/// # Errors
+///
+/// - [`ReclaimError::Scan`] if walking the cache fails.
+/// - [`ReclaimError::Log`] if the batched status read fails (nothing is removed).
+/// - [`ReclaimError::Remove`] if unlinking a reclaimed part fails.
+pub async fn reclaim_ssd<S, R, L>(scanner: &S, remover: &R, log: &L, grace: Duration) -> Result<ReclaimReport, ReclaimError>
+where
+    S: PartScan,
+    R: PartRemover,
+    L: ReclaimLog,
+{
+    let parts = scanner.scan_parts().await.map_err(ReclaimError::Scan)?;
+    let mut report = ReclaimReport::default();
+    if parts.is_empty() {
+        return Ok(report);
+    }
+
+    // One batched status read for the whole scan — never a per-part SELECT (the
+    // reconciler's O(backlog) cost the reclaim worker must not repeat).
+    let keys: Vec<PartKey> = parts.iter().map(|discovered| discovered.part.clone()).collect();
+    let states = log.part_states(&keys).await.map_err(ReclaimError::log)?;
+
+    for discovered in parts {
+        report.scanned += 1;
+        let part = &discovered.part;
+
+        // No row yet: a part the reconciler has not recorded, or one the api is still
+        // writing. Never delete it — there is no terminal signal that it is done.
+        let Some(status) = states.get(part) else {
+            report.skipped_absent += 1;
+            continue;
+        };
+
+        // pending/draining are owned by the drain pipeline; the age gate keeps a
+        // just-terminal part for the grace window. Everything else is reclaimable.
+        let terminal = match status.state {
+            ReplicationState::Pending | ReplicationState::Draining => {
+                report.skipped_live += 1;
+                continue;
+            }
+            ReplicationState::Replicated => Terminal::Replicated,
+            ReplicationState::Failed => Terminal::Failed,
+        };
+        if status.age < grace {
+            report.skipped_young += 1;
+            continue;
+        }
+
+        remover.unlink_part(part).await.map_err(ReclaimError::Remove)?;
+        match terminal {
+            Terminal::Replicated => report.reclaimed_replicated += 1,
+            Terminal::Failed => report.reclaimed_failed += 1,
+        }
+    }
+
+    debug_assert_eq!(
+        report.scanned,
+        report.categorized(),
+        "every scanned part lands in exactly one disposition"
+    );
+    Ok(report)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::{PartRemover, PartStatusAge, ReclaimError, ReclaimLog, ReclaimReport, reclaim_ssd};
+    use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
+    use crate::reconcile::{DiscoveredPart, PartScan};
+    use crate::state::ReplicationState;
+    use core::future::Future;
+    use core::str::FromStr;
+    use std::collections::HashMap;
+    use std::io;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    const UUID_A: &str = "466916c0-d61b-4518-b81b-9576b574270a";
+    const UUID_B: &str = "00000000-0000-4000-8000-000000000000";
+
+    fn part_at(uuid: &str, version: u32, number: u32) -> PartKey {
+        PartKey::new(ObjectId::from_str(uuid).unwrap(), Version::new(version), PartNumber::new(number))
+    }
+
+    fn key(part: &PartKey) -> String {
+        part.relative_dir().to_string_lossy().into_owned()
+    }
+
+    /// A scanner yielding a fixed part list (or a fault).
+    struct FakeScan {
+        parts: Vec<DiscoveredPart>,
+        fail: bool,
+    }
+
+    impl FakeScan {
+        fn of(parts: &[PartKey]) -> Self {
+            Self {
+                parts: parts.iter().map(|p| DiscoveredPart { part: p.clone() }).collect(),
+                fail: false,
+            }
+        }
+    }
+
+    impl PartScan for FakeScan {
+        fn scan_parts(&self) -> impl Future<Output = io::Result<Vec<DiscoveredPart>>> + Send {
+            let result = if self.fail {
+                Err(io::Error::other("scan failed"))
+            } else {
+                Ok(self.parts.clone())
+            };
+            async move { result }
+        }
+    }
+
+    /// Records every part it is asked to remove; optionally faults.
+    #[derive(Default)]
+    struct FakeRemover {
+        removed: Mutex<Vec<String>>,
+        fail: bool,
+    }
+
+    impl FakeRemover {
+        fn removed(&self) -> Vec<String> {
+            let mut out = self.removed.lock().unwrap().clone();
+            out.sort();
+            out
+        }
+    }
+
+    impl PartRemover for FakeRemover {
+        fn unlink_part(&self, part: &PartKey) -> impl Future<Output = io::Result<()>> + Send {
+            let outcome = if self.fail {
+                Err(io::Error::other("remove failed"))
+            } else {
+                self.removed.lock().unwrap().push(key(part));
+                Ok(())
+            };
+            async move { outcome }
+        }
+    }
+
+    /// An in-memory batched status log: a state+age map plus a call counter (so a test
+    /// can assert the read is batched into exactly one call).
+    #[derive(Default)]
+    struct FakeLog {
+        states: HashMap<String, PartStatusAge>,
+        calls: Mutex<u32>,
+        fail: bool,
+    }
+
+    impl FakeLog {
+        fn with(entries: &[(&PartKey, ReplicationState, Duration)]) -> Self {
+            let mut states = HashMap::new();
+            for (part, state, age) in entries {
+                states.insert(key(part), PartStatusAge { state: *state, age: *age });
+            }
+            Self {
+                states,
+                calls: Mutex::new(0),
+                fail: false,
+            }
+        }
+
+        fn calls(&self) -> u32 {
+            *self.calls.lock().unwrap()
+        }
+    }
+
+    impl ReclaimLog for FakeLog {
+        type Error = io::Error;
+
+        fn part_states(&self, parts: &[PartKey]) -> impl Future<Output = Result<HashMap<PartKey, PartStatusAge>, io::Error>> + Send {
+            let outcome = if self.fail {
+                Err(io::Error::other("status failed"))
+            } else {
+                *self.calls.lock().unwrap() += 1;
+                let mut out = HashMap::new();
+                for part in parts {
+                    if let Some(status) = self.states.get(&key(part)) {
+                        out.insert(part.clone(), *status);
+                    }
+                }
+                Ok(out)
+            };
+            async move { outcome }
+        }
+    }
+
+    const HOUR: Duration = Duration::from_hours(1);
+    const GRACE: Duration = Duration::from_mins(30);
+
+    #[tokio::test]
+    async fn an_aged_replicated_part_is_reclaimed() {
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of(std::slice::from_ref(&part));
+        let remover = FakeRemover::default();
+        let log = FakeLog::with(&[(&part, ReplicationState::Replicated, HOUR)]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        assert_eq!(report.reclaimed_replicated, 1);
+        assert_eq!(remover.removed(), vec![key(&part)], "the aged replicated part was unlinked");
+    }
+
+    #[tokio::test]
+    async fn an_aged_failed_part_is_reclaimed() {
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of(std::slice::from_ref(&part));
+        let remover = FakeRemover::default();
+        let log = FakeLog::with(&[(&part, ReplicationState::Failed, HOUR)]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        assert_eq!(report.reclaimed_failed, 1);
+        assert_eq!(remover.removed(), vec![key(&part)], "the aged failed (abandoned) part was unlinked");
+    }
+
+    #[tokio::test]
+    async fn pending_draining_and_no_row_parts_are_never_reclaimed() {
+        // The absolute safety invariant: a part the drain still owns (pending/draining)
+        // or has no row for must NEVER be unlinked, regardless of age.
+        let pending = part_at(UUID_A, 1, 1);
+        let draining = part_at(UUID_A, 1, 2);
+        let absent = part_at(UUID_B, 7, 1);
+        let scan = FakeScan::of(&[pending.clone(), draining.clone(), absent.clone()]);
+        let remover = FakeRemover::default();
+        let log = FakeLog::with(&[
+            (&pending, ReplicationState::Pending, HOUR),
+            (&draining, ReplicationState::Draining, HOUR),
+            // `absent` has no row in the log at all.
+        ]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        assert_eq!(
+            report.reclaimed_replicated + report.reclaimed_failed,
+            0,
+            "nothing live or unrecorded is reclaimed"
+        );
+        assert_eq!(report.skipped_live, 2);
+        assert_eq!(report.skipped_absent, 1);
+        assert!(remover.removed().is_empty(), "no part was unlinked");
+    }
+
+    #[tokio::test]
+    async fn a_young_terminal_part_is_kept_within_the_grace_window() {
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of(std::slice::from_ref(&part));
+        let remover = FakeRemover::default();
+        // Terminal but only just replicated — within grace (drain may be racing the
+        // unlink, or a failed copy is in its diagnosis window).
+        let log = FakeLog::with(&[(&part, ReplicationState::Replicated, Duration::from_mins(1))]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        assert_eq!(report.skipped_young, 1);
+        assert!(remover.removed().is_empty(), "a young terminal part is kept");
+    }
+
+    #[tokio::test]
+    async fn the_status_read_is_batched_into_one_call() {
+        let parts: Vec<PartKey> = (1..=5).map(|n| part_at(UUID_A, 5, n)).collect();
+        let scan = FakeScan::of(&parts);
+        let remover = FakeRemover::default();
+        let log = FakeLog::with(&parts.iter().map(|p| (p, ReplicationState::Replicated, HOUR)).collect::<Vec<_>>());
+
+        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        assert_eq!(report.reclaimed_replicated, 5);
+        assert_eq!(log.calls(), 1, "all five parts' statuses were read in one batched call");
+    }
+
+    #[tokio::test]
+    async fn a_mixed_cache_tallies_each_disposition_and_sums_to_scanned() {
+        let repl = part_at(UUID_A, 1, 1); // aged replicated -> reclaimed
+        let fail = part_at(UUID_A, 1, 2); // aged failed -> reclaimed
+        let live = part_at(UUID_A, 1, 3); // draining -> live
+        let young = part_at(UUID_A, 1, 4); // young replicated -> kept
+        let absent = part_at(UUID_B, 7, 1); // no row -> absent
+        let scan = FakeScan::of(&[repl.clone(), fail.clone(), live.clone(), young.clone(), absent.clone()]);
+        let remover = FakeRemover::default();
+        let log = FakeLog::with(&[
+            (&repl, ReplicationState::Replicated, HOUR),
+            (&fail, ReplicationState::Failed, HOUR),
+            (&live, ReplicationState::Draining, HOUR),
+            (&young, ReplicationState::Replicated, Duration::from_secs(1)),
+        ]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        assert_eq!(
+            report,
+            ReclaimReport {
+                scanned: 5,
+                reclaimed_replicated: 1,
+                reclaimed_failed: 1,
+                skipped_live: 1,
+                skipped_absent: 1,
+                skipped_young: 1,
+            }
+        );
+        assert_eq!(
+            report.scanned,
+            report.categorized(),
+            "every scanned part lands in exactly one disposition"
+        );
+        assert_eq!(report.total_reclaimed(), 2);
+        // removed() is sorted ascending: repl is part_1, fail is part_2.
+        assert_eq!(remover.removed(), vec![key(&repl), key(&fail)], "exactly the two aged terminal parts");
+    }
+
+    #[tokio::test]
+    async fn a_scan_failure_is_surfaced_and_nothing_is_removed() {
+        let scan = FakeScan { parts: vec![], fail: true };
+        let remover = FakeRemover::default();
+        let log = FakeLog::default();
+        let err = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap_err();
+        assert!(matches!(err, ReclaimError::Scan(_)), "got: {err:?}");
+        assert!(remover.removed().is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_status_read_failure_is_surfaced_and_nothing_is_removed() {
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of(&[part]);
+        let remover = FakeRemover::default();
+        let log = FakeLog {
+            fail: true,
+            ..FakeLog::default()
+        };
+        let err = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap_err();
+        assert!(matches!(err, ReclaimError::Log(_)), "got: {err:?}");
+        assert!(remover.removed().is_empty(), "a failed status read removes nothing (fail-safe)");
+    }
+
+    #[tokio::test]
+    async fn a_remove_failure_is_surfaced() {
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of(std::slice::from_ref(&part));
+        let remover = FakeRemover {
+            fail: true,
+            ..FakeRemover::default()
+        };
+        let log = FakeLog::with(&[(&part, ReplicationState::Replicated, HOUR)]);
+        let err = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap_err();
+        assert!(matches!(err, ReclaimError::Remove(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn an_empty_cache_is_a_noop() {
+        let scan = FakeScan::of(&[]);
+        let remover = FakeRemover::default();
+        let log = FakeLog::default();
+        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        assert_eq!(report, ReclaimReport::default());
+        assert_eq!(log.calls(), 0, "an empty scan never queries the store");
+    }
+}

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -15,9 +15,11 @@ use crate::ids::{FileId, NodeId};
 use crate::partdrain::{ClaimedPart, PartReplicationStore, PartVerified};
 use crate::reconcile::PartLandingLog;
 use crate::reconcile::PartStatus;
+use crate::ssd_reclaim::{PartStatusAge, ReclaimLog};
 use crate::state::ReplicationState;
 use crate::units::{ByteRate, Bytes, DiskPressure};
 use sqlx::postgres::{PgPool, PgPoolOptions};
+use std::collections::HashMap;
 use std::time::Duration;
 use thiserror::Error;
 
@@ -95,6 +97,20 @@ fn state_from_db(raw: &str) -> Result<ReplicationState> {
         "failed" => Ok(ReplicationState::Failed),
         other => Err(StoreError::UnknownState { value: other.into() }),
     }
+}
+
+/// How many parts one [`ReclaimLog::part_states`] query covers. A whole-SSD scan is
+/// chunked into batches of this many tuples so a pathological backlog cannot build
+/// one giant `IN (...)` list; the worker still reads every part, just over a few
+/// queries instead of one unbounded one.
+const RECLAIM_STATUS_BATCH: usize = 500;
+
+/// Converts an `EXTRACT(EPOCH FROM (now() - updated_at))` age in seconds into a
+/// [`Duration`], clamping a negative (clock skew) or non-finite value to zero. A
+/// clamped-to-zero age reads as "just updated", so the reclaim age gate keeps the
+/// part — the fail-safe direction.
+fn age_from_secs(secs: f64) -> Duration {
+    Duration::try_from_secs_f64(secs.max(0.0)).unwrap_or(Duration::ZERO)
 }
 
 #[derive(sqlx::FromRow)]
@@ -890,6 +906,61 @@ impl PartLandingLog for Store {
     }
 }
 
+/// The reclaim worker's batched view of the store: read the replication state + age
+/// of many parts in ONE round-trip, so the per-cycle SSD scan never fans out into a
+/// per-part SELECT (the reconciler's O(backlog) cost the worker must not repeat).
+impl ReclaimLog for Store {
+    type Error = StoreError;
+
+    async fn part_states(&self, parts: &[PartKey]) -> Result<HashMap<PartKey, PartStatusAge>> {
+        let mut out = HashMap::with_capacity(parts.len());
+        // Chunk the IN-list so a pathological backlog never builds one giant query.
+        for batch in parts.chunks(RECLAIM_STATUS_BATCH) {
+            let mut object_ids: Vec<&str> = Vec::with_capacity(batch.len());
+            let mut versions: Vec<i64> = Vec::with_capacity(batch.len());
+            let mut part_numbers: Vec<i64> = Vec::with_capacity(batch.len());
+            for part in batch {
+                object_ids.push(part.object().as_str());
+                versions.push(i64::from(part.version().get()));
+                part_numbers.push(i64::from(part.part().get()));
+            }
+            // Match the batch by its PK tuple via UNNEST'd parallel arrays — one query,
+            // a PK lookup per element (no new index needed). A part with no row simply
+            // does not come back, so the caller treats it as absent.
+            let rows = sqlx::query_as::<_, (String, i64, i64, String, f64)>(
+                // EXTRACT(EPOCH ...) is `numeric` on PG 14+, which does not decode into
+                // f64 — cast to float8 so sqlx reads the age as a plain double.
+                "SELECT object_id, version, part_number, status, \
+                        EXTRACT(EPOCH FROM (now() - updated_at))::float8 \
+                 FROM cephor_replication_status \
+                 WHERE (object_id, version, part_number) IN \
+                       (SELECT * FROM UNNEST($1::text[], $2::bigint[], $3::bigint[]))",
+            )
+            .bind(&object_ids)
+            .bind(&versions)
+            .bind(&part_numbers)
+            .fetch_all(&self.pool)
+            .await?;
+            for (object_id, version, part_number, status, age_secs) in rows {
+                let part = PartRow {
+                    object_id,
+                    version,
+                    part_number,
+                }
+                .into_part()?;
+                out.insert(
+                    part,
+                    PartStatusAge {
+                        state: state_from_db(&status)?,
+                        age: age_from_secs(age_secs),
+                    },
+                );
+            }
+        }
+        Ok(out)
+    }
+}
+
 #[cfg(test)]
 #[cfg(feature = "pg")]
 #[expect(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
@@ -1285,15 +1356,72 @@ mod part_tests {
     use super::{Store, StoreError};
     use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
     use crate::partdrain::{ClaimedPart, PartReplicationStore, PartVerified};
+    use crate::ssd_reclaim::ReclaimLog;
     use crate::state::ReplicationState;
     use core::str::FromStr;
     use sqlx::postgres::PgPool;
+    use std::time::Duration;
 
     const UUID_A: &str = "466916c0-d61b-4518-b81b-9576b574270a";
     const UUID_B: &str = "00000000-0000-4000-8000-000000000000";
 
     fn part(uuid: &str, version: u32, number: u32) -> PartKey {
         PartKey::new(ObjectId::from_str(uuid).unwrap(), Version::new(version), PartNumber::new(number))
+    }
+
+    /// Forces a part's row to a terminal status with a backdated `updated_at`, so the
+    /// reclaim age reads deterministically older than any plausible grace.
+    async fn force_terminal(pool: &PgPool, part: &PartKey, status: &str) {
+        sqlx::query(
+            "UPDATE cephor_replication_status SET status = $4, updated_at = now() - interval '2 hours' \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(part.object().as_str())
+        .bind(i64::from(part.version().get()))
+        .bind(i64::from(part.part().get()))
+        .bind(status)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[sqlx::test]
+    async fn part_states_returns_state_and_age_for_known_parts_only(pool: PgPool) {
+        let store = Store::from_pool(pool.clone());
+        let pending = part(UUID_A, 5, 1);
+        let replicated = part(UUID_A, 5, 2);
+        let failed = part(UUID_A, 5, 3);
+        let absent = part(UUID_B, 7, 1);
+
+        store.record_landed_part(&pending).await.unwrap();
+        store.record_landed_part(&replicated).await.unwrap();
+        force_terminal(&pool, &replicated, "replicated").await;
+        store.record_landed_part(&failed).await.unwrap();
+        force_terminal(&pool, &failed, "failed").await;
+
+        let states = <Store as ReclaimLog>::part_states(&store, &[pending.clone(), replicated.clone(), failed.clone(), absent.clone()])
+            .await
+            .unwrap();
+
+        assert_eq!(states.len(), 3, "the part with no row is omitted (treated as absent)");
+        assert!(!states.contains_key(&absent), "an unknown part has no entry");
+
+        let pending_status = states.get(&pending).expect("pending part present");
+        assert_eq!(pending_status.state, ReplicationState::Pending);
+        assert!(pending_status.age < Duration::from_hours(1), "a freshly landed row reads young");
+
+        let replicated_status = states.get(&replicated).expect("replicated part present");
+        assert_eq!(replicated_status.state, ReplicationState::Replicated);
+        assert!(replicated_status.age >= Duration::from_hours(1), "the backdated row reads ~2h old");
+
+        assert_eq!(states.get(&failed).expect("failed part present").state, ReplicationState::Failed);
+    }
+
+    #[sqlx::test]
+    async fn part_states_of_an_empty_request_is_empty(pool: PgPool) {
+        let store = Store::from_pool(pool);
+        let states = <Store as ReclaimLog>::part_states(&store, &[]).await.unwrap();
+        assert!(states.is_empty(), "no parts requested -> no query, empty map");
     }
 
     #[sqlx::test]

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -98,6 +98,19 @@ spec:
                   key: REDIS_QUEUES_URL
             - name: HIPPIUS_UPLOAD_BACKENDS
               value: "arion"
+            # SSD-ingest reclaim worker: evict terminal (replicated/failed) parts the
+            # drain is done with, plus orphan write-temps, once aged — so a stuck drain's
+            # backlog cannot fill the SSD and 503 every PUT on the node. All four have
+            # safe code defaults (300s poll / 1h grace / 60s under pressure / 90% band);
+            # set here for visibility + per-node tuning.
+            - name: CEPHOR_RECLAIM_POLL_SECS
+              value: "300"
+            - name: CEPHOR_RECLAIM_GRACE_SECS
+              value: "3600"
+            - name: CEPHOR_RECLAIM_PRESSURE_GRACE_SECS
+              value: "60"
+            - name: CEPHOR_RECLAIM_PRESSURE_BPS
+              value: "9000"
             - name: RUST_LOG
               value: "info"
           volumeMounts:

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -98,19 +98,14 @@ spec:
                   key: REDIS_QUEUES_URL
             - name: HIPPIUS_UPLOAD_BACKENDS
               value: "arion"
-            # SSD-ingest reclaim worker: evict terminal (replicated/failed) parts the
-            # drain is done with, plus orphan write-temps, once aged — so a stuck drain's
-            # backlog cannot fill the SSD and 503 every PUT on the node. All four have
-            # safe code defaults (300s poll / 1h grace / 60s under pressure / 90% band);
-            # set here for visibility + per-node tuning.
+            # SSD-ingest reclaim worker: clean up broken/abandoned uploads (failed parts
+            # the drain skips forever) + orphan write-temps, once aged, so abandoned-upload
+            # junk does not accumulate on the node-local disk. Both have safe code defaults
+            # (300s poll / 1h grace); set here for visibility + per-node tuning.
             - name: CEPHOR_RECLAIM_POLL_SECS
               value: "300"
             - name: CEPHOR_RECLAIM_GRACE_SECS
               value: "3600"
-            - name: CEPHOR_RECLAIM_PRESSURE_GRACE_SECS
-              value: "60"
-            - name: CEPHOR_RECLAIM_PRESSURE_BPS
-              value: "9000"
             - name: RUST_LOG
               value: "info"
           volumeMounts:

--- a/s3-2.1-todo.md
+++ b/s3-2.1-todo.md
@@ -455,13 +455,19 @@ roadmap + the SSD-worker design live in the plan file `on-hippius-s3-prod-we-are
 | Tier4 ≥2-node pre-ack; Tier5 ATS; 0.3 MDS / 0.4 ceph near-full | **VALID (decision / future / ops)** | not code fixes |
 
 ### Prioritized roadmap
-- **Goal 1 — Local SSD ingest cleanup worker ⭐ (ACTIVE NEXT).** New in-process worker in the **Rust drain-agent**
-  (per-node already, owns the SSD + `remove_part` + `Store`). Reclaims SSD parts whose `cephor_replication_status`
-  is **terminal** (`replicated` = redundant after drain, or `failed` = aborted/abandoned) AND aged, plus orphan
-  `.tmp` (both the Rust `.tmp-` and api `*.tmp.<uuid>` prefixes); SSD-pressure mode relaxes only the age, never
-  the replication gate. New `ssd_reclaim.rs` (mirrors `reconcile.rs`) + **batched** `Store::terminal_states` (one
-  `IN (…)` query, not the reconciler's per-part SELECT) + `runtime.rs` worker + `config.rs` `CEPHOR_RECLAIM_*`
-  knobs + `snapshot.rs` counters + daemonset env. Full design in the plan file.
+- **Goal 1 — Local SSD ingest cleanup worker ⭐ (PR #201, in review).** New in-process worker in the **Rust
+  drain-agent** (per-node already, owns the SSD + `Store`). **Scoped to `failed` parts only** — broken/abandoned
+  uploads (MPU abort, abandoned-MPU reaped to `failed`, or a failed single-part PUT) `claim_part` skips forever,
+  plus orphan write-temps (`.tmp-` + `*.tmp.<uuid>`), once aged past one grace. **Does NOT touch `replicated`**
+  (the drain unlinks its own copy on commit; a rare crash-orphan is a known residual leak, counted
+  `skipped_replicated` + warn-logged) — and **no disk-pressure mode** (the SSD pressure source is the
+  pending/draining backlog the reclaimer must never touch, so racing junk cleanup buys nothing). New
+  `ssd_reclaim.rs` (mirrors `reconcile.rs`) + **batched** `Store::part_states` (one `IN (UNNEST(…))` query, not the
+  reconciler's per-part SELECT) + `runtime.rs` worker + `config.rs` `CEPHOR_RECLAIM_POLL_SECS`/`_GRACE_SECS` +
+  `snapshot.rs` `reclaimed` counter + daemonset env.
+  - **Residual / follow-up:** replicated crash-orphans (drain dies in the commit→unlink window) have no owner; if
+    `skipped_replicated` ever trends non-zero, add a drain-side re-drive. The `reclaimed`/`skipped_replicated`
+    counters are in-process only (no agent metrics endpoint yet — M9); surfaced via `tracing` for now.
 - **Goal 2 — Drain throughput cheap wins (now gate ALL uploads).** Batch fsync once per part + `fdatasync`;
   hash once during the copy stream (drop the CephFS readback — content-addressed naming self-verifies); make
   `DRAIN_CONCURRENCY` env-tunable.


### PR DESCRIPTION
## Summary

Adds a per-node worker to the Rust **drain-agent** that cleans up **broken / abandoned uploads** left on the node-local SSD ingest tier — the only cache tier with no cleanup today.

It targets exactly one thing: **`failed` parts** — an aborted MPU, an abandoned MPU the reaper marked terminal, or a failed single-part PUT. `claim_part` skips a `failed` row forever, so the drain never unlinks it and its SSD bytes leak with nothing else to reclaim them. This worker is that missing owner.

## What it deliberately does NOT touch

- **`replicated` parts** — the drain unlinks its own SSD copy the instant it commits a replication, and the ingest SSD is never read (downloads stream from the CephFS pool). So a successfully-replicated copy is the drain's to clean up, not the reclaimer's. A lingering one (a rare drain crash between commit and unlink) is counted `skipped_replicated` for visibility, never deleted here.
- **`pending`/`draining`** — live, owned by the drain pipeline.
- **No-row parts** — may still be mid-upload.

## Why no disk-pressure mode

An earlier revision had a pressure-aware "evict faster when the disk fills" mode. Dropped it: the thing that actually fills the SSD is the **pending/draining backlog**, which the reclaimer must never touch — so racing to clear abandoned-upload junk under pressure buys nothing. The real fix for a filling disk is the drain catching up (a separate roadmap item). One poll interval + one grace, that's it.

## How it works

Each cycle: scan the SSD for complete parts → read all their states in **one batched query** (`IN (UNNEST(...))`, chunked at 500) → unlink each `failed` part older than the grace → sweep orphan write-temps older than the grace. Aggregate counts logged.

## Safety invariant (absolute)

Delete a part **iff** its row is `failed` AND aged past the grace. `failed` is a terminal sink (nothing returns a row to `pending` except `release_part`/`defer_part`, both guarded on `status='draining'`), so the read can't race back to live; unlink is idempotent; age uses the DB clock; a brief grace gives an abort-settle / diagnosis window.

## Changes

- `hippius-drain-core/src/ssd_reclaim.rs` *(new)* — pure I/O-free orchestrator (`PartRemover` + `ReclaimLog` seams, faked in tests).
- `store.rs` — `ReclaimLog::part_states` batched query; `snapshot.rs` — `reclaimed` counter; `lib.rs` exports.
- `localfs.rs` — `LocalSsd` `PartRemover` (`unlink_part`) + `sweep_orphan_tmp`.
- `runtime.rs` — the worker + `reclaim_once`; `config.rs` — `CEPHOR_RECLAIM_POLL_SECS` / `CEPHOR_RECLAIM_GRACE_SECS`; k8s daemonset env.

## Tests

Orchestrator invariant (`failed`+aged → reclaimed; pending/draining/replicated/no-row → never; young-failed → kept; batched-into-one-call; mixed tally sums-to-scanned; scan/log/remove failures fail-safe), batched-query `#[sqlx::test]`, a deterministic `reclaim_once` `#[sqlx::test]` (failed evicted / replicated kept / row untouched), temp sweep, config. Full workspace suite green ×3; clippy `-D warnings` / fmt / cargo-deny clean. No migration, no new k8s object, no Python/api change.