### PR TITLE
docs(s3-2.1): ssd_reclaim audit + harden a flaky allocation-decay test

### DIFF
--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -620,9 +620,11 @@ mod tests {
         let signal = shutdown.clone();
         let handle = tokio::spawn(async move { runtime.run(signal.cancelled_owned()).await });
 
-        // The worker first pulls the budget into the enforcer.
+        // The worker first pulls the budget into the enforcer. Generous window (~5s):
+        // the allocation-pull worker shares a single-threaded runtime with the other
+        // workers and can be starved under a full parallel sqlx-test run.
         let mut loaded = false;
-        for _ in 0..200 {
+        for _ in 0..500 {
             if enforcer.lock().unwrap().rate() == budget {
                 loaded = true;
                 break;
@@ -646,8 +648,10 @@ mod tests {
         clock.advance(Duration::from_secs(10));
         let near_floor = floor.get().saturating_mul(2);
 
+        // Generous window (~5s) for the same reason: the rate is applied on the next
+        // allocation-pull tick, which can lag under a starved parallel test run.
         let mut decayed = false;
-        for _ in 0..200 {
+        for _ in 0..500 {
             if enforcer.lock().unwrap().rate().get() <= near_floor {
                 decayed = true;
                 break;

--- a/s3-2.1-todo.md
+++ b/s3-2.1-todo.md
@@ -465,6 +465,12 @@ roadmap + the SSD-worker design live in the plan file `on-hippius-s3-prod-we-are
   `ssd_reclaim.rs` (mirrors `reconcile.rs`) + **batched** `Store::part_states` (one `IN (UNNEST(…))` query, not the
   reconciler's per-part SELECT) + `runtime.rs` worker + `config.rs` `CEPHOR_RECLAIM_POLL_SECS`/`_GRACE_SECS` +
   `snapshot.rs` `reclaimed` counter + daemonset env.
+  - **Reviewed (3 passes) + test-coverage audited 2026-06-30:** 22 reclaim-specific tests — the safety invariant
+    (`pending`/`draining`/`replicated`/no-row never reclaimed, any age), the `age == grace` boundary, batched-query
+    `#[sqlx::test]`, the orphan-temp sweep incl. the no-meta crash-dir + non-dir-junk cases, and a `reclaim_once`
+    `#[sqlx::test]` proving it runs both reclaim + sweep. Out of unit scope (staging-validated): the full
+    reaper→reclaim e2e and reclaim/drain concurrency. CI green (rust/clippy/deny/e2e/ty); cross-language
+    terminal-sink invariant verified.
   - **Residual / follow-up:** replicated crash-orphans (drain dies in the commit→unlink window) have no owner; if
     `skipped_replicated` ever trends non-zero, add a drain-side re-drive. The `reclaimed`/`skipped_replicated`
     counters are in-process only (no agent metrics endpoint yet — M9); surfaced via `tracing` for now.


### PR DESCRIPTION
Two small changes:

1. **docs** — updates the Goal 1 entry in `s3-2.1-todo.md` to record the completed review (3 passes) + test-coverage audit for the SSD-ingest reclaim worker (#201, now merged): 22 reclaim-specific tests covering the safety invariant, the grace boundary, the batched query, the orphan-temp sweep (incl. no-meta crash dirs + non-dir junk), and `reclaim_once` running both reclaim + sweep.

2. **test flake fix** — `the_allocation_worker_decays_on_an_injected_clock` (pre-existing, unrelated to the docs change) flaked this PR's Rust CI: it polled a 2s window for the allocation-pull worker to apply the decayed rate, but under a full parallel sqlx-test run the single-threaded runtime starves that worker. Widened both poll loops to ~5s (same hardening already applied to the reclaim integration test). Verified the test passes repeatedly locally; clippy/fmt clean.