### PR TITLE
fix(scripts): drain the soft-delete unpin backlog + unpin by default

### DIFF
--- a/hippius_s3/scripts/backfill_soft_delete_unpins.py
+++ b/hippius_s3/scripts/backfill_soft_delete_unpins.py
@@ -1,0 +1,212 @@
+"""Backfill unpins for the soft-delete backlog so hard-delete can finally drain it.
+
+Why this exists: millions of objects have `deleted_at` set but their `chunk_backend`
+rows are still `deleted=false` — their unpins were lost (never processed / purged,
+see the redis-queues unpin-overrun incident, and destructive scripts that hard-deleted
+without enqueuing unpins). The janitor hard-delete query (now fast + index-driven)
+therefore deletes nothing, because nothing is "ready". This script re-drives the unpins:
+
+  - Live backends with an unpin worker: re-enqueue an unpin via `enqueue_unpin_request`,
+    which routes to the configured `delete_backends` (HIPPIUS_DELETE_BACKENDS). The
+    unpin workers delete the chunks from their backend AND mark `chunk_backend.deleted=true`,
+    so the object becomes ready for hard-delete.
+  - Deprecated backends with no worker (default: `ipfs`) — those chunks are gone, so we
+    reconcile the rows in-DB (mark deleted). Set with --deprecated-backends.
+
+Then the next janitor Phase-4 cycle hard-deletes the now-ready metadata (cascade clears
+object_versions/parts/part_chunks/chunk_backend → DB bloat shrinks).
+
+SAFETY: only touches objects with `deleted_at` set (genuinely deleted — verified no live
+same-key object exists). Re-enqueues are idempotent (a worker deleting an already-gone
+chunk is a no-op).
+
+THROTTLE: the load-bearing guard against re-flooding the unpin queues — before each batch
+we wait until the combined depth of --throttle-queues is under --queue-cap, so we never
+enqueue faster than the workers drain. Pass every unpin queue you want paced against here.
+
+Resumable: keyset-paginates by (deleted_at, object_id); pass the last printed cursor via
+--start-after-ts/--start-after-id to resume. --loop re-scans from the start after each full
+pass (continuous sweeper mode) to catch newly soft-deleted objects.
+
+  python -m hippius_s3.scripts.backfill_soft_delete_unpins --dry-run
+  python -m hippius_s3.scripts.backfill_soft_delete_unpins --batch 1000 --queue-cap 50000 \
+      --throttle-queues arion_unpin_requests
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime
+import logging
+
+import asyncpg
+import redis.asyncio as async_redis
+
+from hippius_s3.config import get_config
+from hippius_s3.queue import UnpinChainRequest
+from hippius_s3.queue import enqueue_unpin_request
+from hippius_s3.queue import initialize_queue_client
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("backfill_unpins")
+
+# Select a batch of soft-deleted-past-grace objects after a keyset cursor, flagging
+# whether each still has live unpinnable chunks (needs an unpin enqueue) and/or live
+# deprecated-backend chunks (needs in-DB reconcile). $4 = deprecated backends array.
+# Index-driven via idx_objects_deleted.
+_SELECT = """
+WITH c AS MATERIALIZED (
+    SELECT object_id, current_object_version, deleted_at, bucket_id
+    FROM objects
+    WHERE deleted_at IS NOT NULL
+      AND deleted_at < now() - INTERVAL '1 hour'
+      AND (deleted_at, object_id) > ($2::timestamptz, $3::uuid)
+    ORDER BY deleted_at, object_id
+    LIMIT $1
+)
+SELECT c.object_id, c.current_object_version AS object_version, c.deleted_at, b.main_account_id,
+    EXISTS (
+        SELECT 1 FROM parts p JOIN part_chunks pc ON pc.part_id = p.part_id
+        JOIN chunk_backend cb ON cb.chunk_id = pc.id
+        WHERE p.object_id = c.object_id AND NOT cb.deleted AND cb.backend <> ALL($4::text[])
+    ) AS needs_unpin,
+    EXISTS (
+        SELECT 1 FROM parts p JOIN part_chunks pc ON pc.part_id = p.part_id
+        JOIN chunk_backend cb ON cb.chunk_id = pc.id
+        WHERE p.object_id = c.object_id AND NOT cb.deleted AND cb.backend = ANY($4::text[])
+    ) AS has_deprecated
+FROM c JOIN buckets b ON b.bucket_id = c.bucket_id
+ORDER BY c.deleted_at, c.object_id
+"""
+
+# Reconcile deprecated-backend rows for one object (chunks gone; no backend call).
+_RECONCILE_DEPRECATED = """
+UPDATE chunk_backend cb
+SET deleted = true, deleted_at = now()
+FROM part_chunks pc
+JOIN parts p ON p.part_id = pc.part_id
+WHERE cb.chunk_id = pc.id
+  AND cb.backend = ANY($2::text[])
+  AND NOT cb.deleted
+  AND p.object_id = $1
+"""
+
+_EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+_ZERO_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+async def _wait_for_queue_room(redis_q: async_redis.Redis, queues: list[str], cap: int) -> None:
+    """Block until the combined depth of `queues` is under cap (throttle)."""
+    while True:
+        depth = sum([int(await redis_q.llen(q)) for q in queues])  # ty: ignore[invalid-await]
+        if depth < cap:
+            return
+        logger.info(f"unpin queue depth {depth} >= cap {cap}; waiting for workers to drain...")
+        await asyncio.sleep(10)
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    config = get_config()
+    deprecated = [b.strip() for b in args.deprecated_backends.split(",") if b.strip()]
+    throttle_queues = [q.strip() for q in args.throttle_queues.split(",") if q.strip()]
+    db = await asyncpg.connect(config.database_url)
+    redis_q = async_redis.from_url(config.redis_queues_url)
+    initialize_queue_client(redis_q)
+
+    start_ts = datetime.datetime.fromisoformat(args.start_after_ts) if args.start_after_ts else _EPOCH
+    start_id = args.start_after_id or _ZERO_UUID
+    cursor_ts, cursor_id = start_ts, start_id
+
+    enqueued = reconciled = scanned = 0
+    try:
+        while True:
+            if not args.dry_run and throttle_queues:
+                await _wait_for_queue_room(redis_q, throttle_queues, args.queue_cap)
+
+            rows = await db.fetch(_SELECT, args.batch, cursor_ts, cursor_id, deprecated)
+            if not rows:
+                if args.loop and not args.dry_run:
+                    logger.info(f"reached end; sweeper sleeping {args.loop_sleep}s then re-scanning")
+                    cursor_ts, cursor_id = start_ts, start_id
+                    await asyncio.sleep(args.loop_sleep)
+                    continue
+                logger.info("no more soft-deleted objects past the cursor; done")
+                break
+
+            for r in rows:
+                scanned += 1
+                oid = r["object_id"]
+                if r["needs_unpin"]:
+                    if not r["main_account_id"]:
+                        logger.warning(f"skip {oid}: bucket has no main_account_id")
+                    elif args.dry_run:
+                        enqueued += 1
+                    else:
+                        await enqueue_unpin_request(
+                            payload=UnpinChainRequest(
+                                address=r["main_account_id"],
+                                object_id=str(oid),
+                                object_version=int(r["object_version"]),
+                            )
+                        )
+                        enqueued += 1
+                if r["has_deprecated"]:
+                    if not args.dry_run:
+                        await db.execute(_RECONCILE_DEPRECATED, oid, deprecated)
+                    reconciled += 1
+
+            last = rows[-1]
+            cursor_ts, cursor_id = last["deleted_at"], last["object_id"]
+            logger.info(
+                f"batch done: scanned={scanned} enqueued={enqueued} deprecated_reconciled={reconciled} "
+                f"cursor=({cursor_ts.isoformat()}, {cursor_id})"
+            )
+
+            if args.max_objects and scanned >= args.max_objects:
+                logger.info(f"reached --max-objects {args.max_objects}; stopping")
+                break
+            if args.sleep:
+                await asyncio.sleep(args.sleep)
+
+        logger.info(
+            f"DONE{' (dry-run)' if args.dry_run else ''}: scanned={scanned} unpins_enqueued={enqueued} "
+            f"deprecated_reconciled={reconciled}. Resume after a stop with: "
+            f"--start-after-ts '{cursor_ts.isoformat()}' --start-after-id {cursor_id}"
+        )
+        return 0
+    finally:
+        await db.close()
+        await redis_q.aclose()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Backfill unpins for the soft-delete backlog so hard-delete can drain it")
+    ap.add_argument("--batch", type=int, default=1000, help="Objects selected per batch")
+    ap.add_argument(
+        "--queue-cap", type=int, default=50000, help="Pause enqueueing while combined throttle-queue depth >= this"
+    )
+    ap.add_argument(
+        "--throttle-queues",
+        default="arion_unpin_requests",
+        help="Comma-separated unpin queues to pace against (pass every unpin queue you want throttled)",
+    )
+    ap.add_argument(
+        "--deprecated-backends",
+        default="ipfs",
+        help="Comma-separated backends with no unpin worker; their rows are reconciled in-DB (no backend call)",
+    )
+    ap.add_argument("--max-objects", type=int, default=0, help="Stop after scanning this many objects (0 = all)")
+    ap.add_argument("--sleep", type=float, default=0.0, help="Seconds to sleep between batches")
+    ap.add_argument("--loop", action="store_true", help="Sweeper mode: re-scan from the start after each full pass")
+    ap.add_argument("--loop-sleep", type=float, default=300.0, help="Seconds to sleep between sweeps in --loop mode")
+    ap.add_argument("--start-after-ts", default="", help="Resume: deleted_at cursor (ISO-8601)")
+    ap.add_argument("--start-after-id", default="", help="Resume: object_id cursor (UUID)")
+    ap.add_argument("--dry-run", action="store_true", help="Count what would be enqueued/reconciled; change nothing")
+    args = ap.parse_args()
+    raise SystemExit(asyncio.run(main_async(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/hippius_s3/scripts/delete_legacy_object_versions.py
+++ b/hippius_s3/scripts/delete_legacy_object_versions.py
@@ -7,8 +7,12 @@ from contextlib import suppress
 from dataclasses import dataclass
 
 import asyncpg
+import redis.asyncio as async_redis
 
 from hippius_s3.config import get_config
+from hippius_s3.queue import UnpinChainRequest
+from hippius_s3.queue import enqueue_unpin_request
+from hippius_s3.queue import initialize_queue_client
 
 
 @dataclass(frozen=True)
@@ -19,11 +23,17 @@ class DeleteCandidate:
     object_key: str
     storage_version: int
     is_current: bool
+    main_account_id: str
 
 
 async def main_async(args: argparse.Namespace) -> int:
     cfg = get_config()
     db = await asyncpg.connect(cfg.database_url)
+    unpin = not args.no_unpin
+    redis_q = None
+    if unpin and not args.dry_run:
+        redis_q = async_redis.from_url(cfg.redis_queues_url)
+        initialize_queue_client(redis_q)
     try:
         max_sv = int(args.max_storage_version)
         include_current = bool(args.include_current)
@@ -82,6 +92,7 @@ async def main_async(args: argparse.Namespace) -> int:
               ov.object_version,
               ov.storage_version,
               (ov.object_version = o.current_object_version) AS is_current,
+              b.main_account_id,
               f.has_v4
             FROM object_versions ov
             JOIN objects o ON o.object_id = ov.object_id
@@ -108,6 +119,7 @@ async def main_async(args: argparse.Namespace) -> int:
                 object_key=str(r["object_key"]),
                 storage_version=int(r["storage_version"]),
                 is_current=bool(r["is_current"]),
+                main_account_id=str(r["main_account_id"]),
             )
             for r in rows
         ]
@@ -153,28 +165,43 @@ async def main_async(args: argparse.Namespace) -> int:
         # 1) If requested, delete legacy-only objects entirely (cascades to versions/parts).
         # This is the only reliable way to delete an object whose current version is legacy.
         if include_objects_without_v4:
-            r0 = await db.execute(
+            # Enqueue unpins BEFORE the delete — the cascade removes chunk_backend, after which
+            # the unpin workers couldn't find anything to delete from the backends.
+            legacy_only = await db.fetch(
                 """
-                DELETE FROM objects o
-                USING buckets b
-                WHERE b.bucket_id = o.bucket_id
-                  AND ($2::text IS NULL OR b.bucket_name = $2)
+                SELECT o.object_id, o.current_object_version, b.main_account_id
+                FROM objects o
+                JOIN buckets b ON b.bucket_id = o.bucket_id
+                WHERE ($2::text IS NULL OR b.bucket_name = $2)
                   AND EXISTS (
                     SELECT 1 FROM object_versions ov
-                    WHERE ov.object_id = o.object_id
-                      AND ov.storage_version <= $1
+                    WHERE ov.object_id = o.object_id AND ov.storage_version <= $1
                   )
                   AND NOT EXISTS (
                     SELECT 1 FROM object_versions ov
-                    WHERE ov.object_id = o.object_id
-                      AND ov.storage_version >= 4
+                    WHERE ov.object_id = o.object_id AND ov.storage_version >= 4
                   )
                 """,
                 max_sv,
                 bucket,
             )
-            with suppress(Exception):
-                deleted_objects += int(str(r0).split()[-1])
+            if unpin:
+                for lr in legacy_only:
+                    with suppress(Exception):
+                        await enqueue_unpin_request(
+                            payload=UnpinChainRequest(
+                                address=str(lr["main_account_id"]),
+                                object_id=str(lr["object_id"]),
+                                object_version=int(lr["current_object_version"]),
+                            )
+                        )
+            if legacy_only:
+                r0 = await db.execute(
+                    "DELETE FROM objects WHERE object_id = ANY($1::uuid[])",
+                    [lr["object_id"] for lr in legacy_only],
+                )
+                with suppress(Exception):
+                    deleted_objects += int(str(r0).split()[-1])
 
         # Deleting object_versions will cascade-delete parts and part_chunks due to FKs:
         # - parts_object_version_fk ON DELETE CASCADE
@@ -187,6 +214,16 @@ async def main_async(args: argparse.Namespace) -> int:
                 # Defensive: avoid surprising failures unless user explicitly asked.
                 continue
 
+            if unpin:
+                # Enqueue before the cascade removes chunk_backend (see note above).
+                with suppress(Exception):
+                    await enqueue_unpin_request(
+                        payload=UnpinChainRequest(
+                            address=c.main_account_id,
+                            object_id=c.object_id,
+                            object_version=int(c.object_version),
+                        )
+                    )
             await db.execute(
                 """
                 DELETE FROM object_versions
@@ -226,6 +263,8 @@ async def main_async(args: argparse.Namespace) -> int:
         return 0
     finally:
         await db.close()
+        if redis_q is not None:
+            await redis_q.aclose()
 
 
 def main() -> None:
@@ -255,6 +294,11 @@ def main() -> None:
     )
     ap.add_argument("--dry-run", action="store_true", help="Print counts/examples; do not delete")
     ap.add_argument("--yes", action="store_true", help="Required to actually delete")
+    ap.add_argument(
+        "--no-unpin",
+        action="store_true",
+        help="Skip enqueuing unpins before delete (DANGEROUS: leaks backend chunks, no soft-delete record left)",
+    )
     args = ap.parse_args()
     rc = asyncio.run(main_async(args))
     raise SystemExit(rc)

--- a/hippius_s3/scripts/nuke_user.py
+++ b/hippius_s3/scripts/nuke_user.py
@@ -306,7 +306,12 @@ async def main_async(args: argparse.Namespace) -> int:
 
         log.info(f"Successfully deleted user: {args.address}")
 
-        if args.unpin:
+        if args.no_unpin:
+            log.warning(
+                "--no-unpin: skipping unpins. Backend chunks are NOT reclaimed and the rows stay "
+                "un-unpinned, leaving a soft-delete backlog the janitor can never hard-delete."
+            )
+        else:
             log.info(f"Starting unpin operations for {len(cids)} CIDs...")
             unpin_results = await unpin_cids(cids, config, args.address)
             log.info(
@@ -336,7 +341,9 @@ def main() -> None:
     ap.add_argument("--address", help="User address (main_account_id) to delete")
     ap.add_argument("--dry-run", action="store_true", help="Preview deletions without executing")
     ap.add_argument(
-        "--unpin", action="store_true", help="Unpin CIDs from IPFS and enqueue unpin requests (ignored in dry-run)"
+        "--no-unpin",
+        action="store_true",
+        help="Skip unpins (DANGEROUS: leaks backend chunks + leaves an un-drainable backlog; ignored in dry-run)",
     )
     ap.add_argument(
         "--from-json",

--- a/hippius_s3/scripts/nuke_user.py
+++ b/hippius_s3/scripts/nuke_user.py
@@ -248,7 +248,7 @@ async def main_async(args: argparse.Namespace) -> int:
 
     db = await asyncpg.connect(config.database_url)
 
-    if args.unpin and not args.dry_run:
+    if not args.no_unpin and not args.dry_run:
         redis_queues_client = async_redis.from_url(config.redis_queues_url)
         from hippius_s3.queue import initialize_queue_client
 
@@ -352,8 +352,8 @@ def main() -> None:
     args = ap.parse_args()
 
     if args.from_json:
-        if args.address or args.dry_run or args.unpin:
-            ap.error("--from-json must be used alone (without --address, --dry-run, or --unpin)")
+        if args.address or args.dry_run or args.no_unpin:
+            ap.error("--from-json must be used alone (without --address, --dry-run, or --no-unpin)")
     elif not args.address:
         ap.error("--address is required when not using --from-json")
 

--- a/hippius_s3/scripts/purge_buckets.py
+++ b/hippius_s3/scripts/purge_buckets.py
@@ -343,7 +343,12 @@ async def main_async(args: argparse.Namespace) -> int:
 
         log.info(f"Successfully deleted buckets: {deleted_bucket_names_sorted}")
 
-        if args.unpin:
+        if args.no_unpin:
+            log.warning(
+                "--no-unpin: skipping unpins. The backend chunks are NOT reclaimed and the rows "
+                "stay un-unpinned, leaving a soft-delete backlog the janitor can never hard-delete."
+            )
+        else:
             redis_queues_client = async_redis.from_url(config.redis_queues_url)
             from hippius_s3.queue import initialize_queue_client
 
@@ -372,7 +377,11 @@ def main() -> None:
     ap.add_argument(
         "--dry-run", action="store_true", help="Preview and write CID list JSON, without deleting/unpinning"
     )
-    ap.add_argument("--unpin", action="store_true", help="Enqueue unpin requests after DB deletion")
+    ap.add_argument(
+        "--no-unpin",
+        action="store_true",
+        help="Skip enqueuing unpins (DANGEROUS: leaks backend chunks + leaves an un-drainable backlog)",
+    )
     ap.add_argument("--output-json", help="Where to write the CID list JSON (default: purge_buckets_<...>.json)")
     ap.add_argument("--yes", action="store_true", help="Required to actually delete")
     args = ap.parse_args()


### PR DESCRIPTION
## Summary

After the janitor hard-delete fix (#205) the backlog still wouldn't drain: millions of objects have `deleted_at` set but their `chunk_backend` rows are still `deleted=false` — their unpins were lost, so hard-delete never sees them as "ready". This adds a controlled backfill to re-drive those unpins, and closes the gap so the backlog can't rebuild.

## Changes

- **New `backfill_soft_delete_unpins.py`** — keyset-paginated, index-driven sweeper over the dead-but-blocked backlog (`deleted_at` past a 1h grace). Re-enqueues unpins via the existing config-driven `enqueue_unpin_request`, and reconciles rows for deprecated/worker-less backends in-DB. Throttled against configurable queue depth (`--throttle-queues`, `--queue-cap`) so it never re-floods the unpin queues; resumable (`--start-after-*`) and a continuous `--loop` sweeper mode.
- **Make unpin the default in the destructive scripts** — `purge_buckets.py`, `nuke_user.py`, and `delete_legacy_object_versions.py` now enqueue unpins by default (opt out with `--no-unpin`), enqueuing **before** the cascade removes `chunk_backend`. This stops new deletes from re-creating the backlog.
- **Fix `nuke_user.py` flag rename** — two stale `args.unpin` references updated to `--no-unpin` (the script crashed on every run otherwise).

## Notes

- Backend routing is entirely config-driven (`HIPPIUS_DELETE_BACKENDS`); the workers no-op for any backend an object isn't on, so re-enqueues are idempotent and safe to re-run.
- Targets only genuinely-deleted objects (verified no live same-key object); no dedup, so a dead object's chunks can never belong to a live one.

## Conclusion

Drains the existing soft-delete backlog safely and rate-limited, and removes the recurrence so the janitor can keep DB bloat in check going forward.
