### PR TITLE
feat(drain): throughput wins + coordination state to redis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,6 @@ version = "0.1.0"
 dependencies = [
  "hippius-drain-core",
  "reqwest",
- "sqlx",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -655,6 +654,7 @@ name = "hippius-drain-core"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "redis",
  "serde",
  "serde_json",
  "sqlx",
@@ -1268,6 +1268,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "ryu",
+ "sha1_smol",
  "tokio",
  "tokio-util",
  "url",
@@ -1436,6 +1437,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = "=0.3.32"
 # Async Redis client for the drain-direct upload enqueue (the drain LPUSHes the per-part
 # UploadChainRequest to the backend queues). connection-manager = auto-reconnecting
 # multiplexed handle for the long-lived daemon; tokio-comp for the tokio runtime.
-redis = { version = "=0.27.6", default-features = false, features = ["tokio-comp", "connection-manager"] }
+redis = { version = "=0.27.6", default-features = false, features = ["tokio-comp", "connection-manager", "script"] }
 # CancellationToken (hierarchical child tokens) for the agent task supervisor;
 # it lives in the always-on `sync` module, so no extra feature is needed.
 tokio-util = "=0.7.18"

--- a/crates/hippius-drain-agent/Cargo.toml
+++ b/crates/hippius-drain-agent/Cargo.toml
@@ -6,10 +6,10 @@ rust-version.workspace = true
 license.workspace = true
 description = "cephor per-node drain daemon (runs as a DaemonSet on each ingest SSD node)"
 
-# The daemon talks to Postgres (claim/commit, heartbeat, allocation), so it
-# enables hippius-drain-core's `pg` feature.
+# The daemon talks to Postgres for the durable drain state (`pg`) and to the
+# Redis-backed coordinator for heartbeats + allocation pulls (`coord`).
 [dependencies]
-hippius-drain-core = { workspace = true, features = ["pg"] }
+hippius-drain-core = { workspace = true, features = ["pg", "coord"] }
 tokio = { workspace = true }
 futures = { workspace = true }
 tokio-util = { workspace = true }
@@ -25,7 +25,7 @@ tracing-subscriber = { workspace = true }
 [dev-dependencies]
 # `test-util` brings in hippius-drain-core's TestClock for the clock-injection tests
 # (Cargo unifies this with the normal `pg` dependency above).
-hippius-drain-core = { workspace = true, features = ["pg", "test-util"] }
+hippius-drain-core = { workspace = true, features = ["pg", "coord", "test-util"] }
 tempfile = { workspace = true }
 proptest = { workspace = true }
 # For `#[sqlx::test]` against a real Postgres (migrations come from hippius-drain-core).

--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -30,6 +30,10 @@ const DEFAULT_FLOOR_RATE_BPS: u64 = 1_000_000;
 const DEFAULT_DECAY_HALF_LIFE: Duration = Duration::from_secs(30);
 /// Allocation re-pull period when `CEPHOR_ALLOCATION_POLL_SECS` is unset.
 const DEFAULT_ALLOCATION_POLL: Duration = Duration::from_secs(2);
+/// Maximum parts drained concurrently when `CEPHOR_DRAIN_CONCURRENCY` is unset.
+/// Tuning this lets the node hide fsync latency behind more in-flight parts (the
+/// AIMD allocator only tunes bytes/sec, never the concurrency).
+const DEFAULT_DRAIN_CONCURRENCY: u32 = 4;
 /// Claim lease TTL when `CEPHOR_CLAIM_LEASE_TTL_SECS` is unset: a `draining`
 /// claim older than this is treated as abandoned (the H1 crash-recovery TTL).
 /// Mirrors the store-side default; long enough not to reclaim a live slow drain,
@@ -40,10 +44,11 @@ const DEFAULT_CLAIM_LEASE: Duration = Duration::from_mins(5);
 /// parked before it is re-claimable, so the drain does not spin on not-ready parts every
 /// poll. Mirrors the store-side default.
 const DEFAULT_DEFER_BACKOFF: Duration = Duration::from_secs(5);
-/// Allocation staleness window when `CEPHOR_ALLOCATION_STALE_SECS` is unset: past
-/// it the allocator is treated as silent on this node and the rate decays toward
-/// the floor (a few allocator ticks — the allocator tick is ~2s).
-const DEFAULT_ALLOCATION_STALE: Duration = Duration::from_secs(10);
+/// Heartbeat key TTL when `CEPHOR_HEARTBEAT_TTL_SECS` is unset: how long this node's
+/// heartbeat stays live in the fleet before it must be refreshed. This IS the
+/// fleet-staleness window (the allocator drops a node whose key has expired), so it must
+/// be a few heartbeat periods (~10s) wide — long enough to survive a missed beat.
+const DEFAULT_HEARTBEAT_TTL: Duration = Duration::from_secs(30);
 /// Reclaim scan period when `CEPHOR_RECLAIM_POLL_SECS` is unset: the SSD-ingest GC
 /// runs less often than the drain — eviction is a backstop, not a hot path.
 const DEFAULT_RECLAIM_POLL: Duration = Duration::from_mins(5);
@@ -85,9 +90,9 @@ pub struct Config {
     /// How long a deferred (enqueue-not-ready) part is backed off before re-claim,
     /// wired into the store via `with_defer_backoff`.
     pub defer_backoff: Duration,
-    /// How long a stored allocation stays authoritative before the agent treats
-    /// the allocator as silent and decays toward the floor (M1 conservation).
-    pub allocation_stale: Duration,
+    /// TTL stamped on this node's heartbeat key — the fleet-staleness window the
+    /// allocator sees (a node whose key expires drops out of the fleet).
+    pub heartbeat_ttl: Duration,
     /// Redis URL for the upload queues — the drain pushes each replicated part's
     /// `UploadChainRequest` here (drain-direct; the drain is the sole upload producer).
     pub redis_queues_url: String,
@@ -99,6 +104,9 @@ pub struct Config {
     /// How long a `failed` part (and an orphan write-temp) is kept on SSD before
     /// eviction (a diagnosis / abort-settle window).
     pub reclaim_grace: Duration,
+    /// Maximum parts the drain worker processes concurrently — the in-flight gate
+    /// that lets the node overlap fsync latency across parts.
+    pub drain_concurrency: u32,
 }
 
 /// A failure parsing the daemon configuration from the environment.
@@ -135,6 +143,17 @@ pub enum ConfigError {
         /// The offending variable.
         var: &'static str,
     },
+    /// A count variable exceeded its representable maximum (e.g. a drain
+    /// concurrency past `u32::MAX`). A misconfiguration must fail fast.
+    #[error("environment variable `{var}` value {value} exceeds the maximum {limit}")]
+    OutOfRange {
+        /// The offending variable.
+        var: &'static str,
+        /// The value supplied.
+        value: u64,
+        /// The maximum it may take.
+        limit: u64,
+    },
 }
 
 impl Config {
@@ -158,6 +177,7 @@ impl Config {
             reclaim_poll: self.reclaim_poll,
             reclaim_grace: self.reclaim_grace,
             grace: self.grace,
+            drain_concurrency: self.drain_concurrency,
         }
     }
 
@@ -190,11 +210,12 @@ impl Config {
             allocation_poll: duration_secs(&get, "CEPHOR_ALLOCATION_POLL_SECS", DEFAULT_ALLOCATION_POLL)?,
             claim_lease: duration_secs(&get, "CEPHOR_CLAIM_LEASE_TTL_SECS", DEFAULT_CLAIM_LEASE)?,
             defer_backoff: duration_secs(&get, "CEPHOR_DEFER_BACKOFF_SECS", DEFAULT_DEFER_BACKOFF)?,
-            allocation_stale: duration_secs(&get, "CEPHOR_ALLOCATION_STALE_SECS", DEFAULT_ALLOCATION_STALE)?,
+            heartbeat_ttl: duration_secs(&get, "CEPHOR_HEARTBEAT_TTL_SECS", DEFAULT_HEARTBEAT_TTL)?,
             redis_queues_url: required(&get, "REDIS_QUEUES_URL")?,
             upload_backends: parse_backends(&get, "HIPPIUS_UPLOAD_BACKENDS"),
             reclaim_poll: duration_secs(&get, "CEPHOR_RECLAIM_POLL_SECS", DEFAULT_RECLAIM_POLL)?,
             reclaim_grace: duration_secs(&get, "CEPHOR_RECLAIM_GRACE_SECS", DEFAULT_RECLAIM_GRACE)?,
+            drain_concurrency: positive_u32_or(&get, "CEPHOR_DRAIN_CONCURRENCY", DEFAULT_DRAIN_CONCURRENCY)?,
         })
     }
 }
@@ -238,6 +259,22 @@ fn positive_u64_or(get: &impl Fn(&str) -> Option<String>, var: &'static str, def
     }
 }
 
+/// Resolves an optional positive count variable as a `u32`. Builds on [`u64_or`]
+/// but rejects an explicit zero (a zero drain concurrency would stall the worker)
+/// and a value past `u32::MAX`, mirroring [`positive_u64_or`]'s fail-fast contract.
+fn positive_u32_or(get: &impl Fn(&str) -> Option<String>, var: &'static str, default: u32) -> Result<u32, ConfigError> {
+    let value = u64_or(get, var, u64::from(default))?;
+    match u32::try_from(value) {
+        Ok(0) => Err(ConfigError::NonPositive { var }),
+        Ok(value) => Ok(value),
+        Err(_) => Err(ConfigError::OutOfRange {
+            var,
+            value,
+            limit: u64::from(u32::MAX),
+        }),
+    }
+}
+
 /// Resolves a required filesystem path, rejecting unset, empty, or whitespace-only
 /// values as [`Missing`](ConfigError::Missing). A blank path is the dangerous case
 /// `required` alone misses: it is non-empty, so it would pass into a `PathBuf` and
@@ -267,8 +304,9 @@ fn duration_secs(get: &impl Fn(&str) -> Option<String>, var: &'static str, defau
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::{
-        Config, ConfigError, DEFAULT_ALLOCATION_POLL, DEFAULT_ALLOCATION_STALE, DEFAULT_CLAIM_LEASE, DEFAULT_DECAY_HALF_LIFE, DEFAULT_DRAIN_POLL,
-        DEFAULT_FLOOR_RATE_BPS, DEFAULT_HEARTBEAT_POLL, DEFAULT_MAX_DRAIN_RATE_BPS, DEFAULT_RECLAIM_GRACE, DEFAULT_RECLAIM_POLL,
+        Config, ConfigError, DEFAULT_ALLOCATION_POLL, DEFAULT_CLAIM_LEASE, DEFAULT_DECAY_HALF_LIFE, DEFAULT_DRAIN_CONCURRENCY, DEFAULT_DRAIN_POLL,
+        DEFAULT_FLOOR_RATE_BPS, DEFAULT_HEARTBEAT_POLL, DEFAULT_HEARTBEAT_TTL, DEFAULT_MAX_DRAIN_RATE_BPS, DEFAULT_RECLAIM_GRACE,
+        DEFAULT_RECLAIM_POLL,
     };
     use core::str::FromStr;
     use hippius_drain_core::{ByteRate, NodeId};
@@ -363,17 +401,17 @@ mod tests {
     }
 
     #[test]
-    fn defaults_the_allocation_stale_window() {
+    fn defaults_the_heartbeat_ttl() {
         let config = Config::from_lookup(lookup(&required_only())).unwrap();
-        assert_eq!(config.allocation_stale, DEFAULT_ALLOCATION_STALE);
+        assert_eq!(config.heartbeat_ttl, DEFAULT_HEARTBEAT_TTL);
     }
 
     #[test]
-    fn a_numeric_allocation_stale_overrides_the_default() {
+    fn a_numeric_heartbeat_ttl_overrides_the_default() {
         let mut pairs = required_only();
-        pairs.push(("CEPHOR_ALLOCATION_STALE_SECS", "30"));
+        pairs.push(("CEPHOR_HEARTBEAT_TTL_SECS", "45"));
         let config = Config::from_lookup(lookup(&pairs)).unwrap();
-        assert_eq!(config.allocation_stale, Duration::from_secs(30));
+        assert_eq!(config.heartbeat_ttl, Duration::from_secs(45));
     }
 
     #[test]
@@ -513,6 +551,48 @@ mod tests {
         ];
         let err = Config::from_lookup(lookup(&pairs)).unwrap_err();
         assert!(matches!(err, ConfigError::Missing("REDIS_QUEUES_URL")));
+    }
+
+    #[test]
+    fn defaults_the_drain_concurrency() {
+        let config = Config::from_lookup(lookup(&required_only())).unwrap();
+        assert_eq!(config.drain_concurrency, DEFAULT_DRAIN_CONCURRENCY);
+    }
+
+    #[test]
+    fn a_numeric_drain_concurrency_overrides_the_default() {
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_DRAIN_CONCURRENCY", "12"));
+        let config = Config::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(config.drain_concurrency, 12);
+    }
+
+    #[test]
+    fn a_zero_drain_concurrency_is_rejected() {
+        // A zero concurrency would stall the drain worker entirely — fail fast.
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_DRAIN_CONCURRENCY", "0"));
+        let err = Config::from_lookup(lookup(&pairs)).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::NonPositive {
+                var: "CEPHOR_DRAIN_CONCURRENCY"
+            }
+        ));
+    }
+
+    #[test]
+    fn a_drain_concurrency_past_u32_is_out_of_range() {
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_DRAIN_CONCURRENCY", "4294967296"));
+        let err = Config::from_lookup(lookup(&pairs)).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::OutOfRange {
+                var: "CEPHOR_DRAIN_CONCURRENCY",
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -6,8 +6,9 @@
 //! implements [`PartSource`]/[`PartScan`] (list, locate, hash, scan, unlink a
 //! part) and [`LocalFs`] implements [`PartPool`] (persist chunk/meta, hash,
 //! remove). The crash-safety guarantee the drain depends on lives in
-//! [`persist_into`]: it copies, fsyncs, atomically renames within the part folder,
-//! and fsyncs the folder so a power loss never leaves a torn file. Both also
+//! [`copy_into`]: it streams+hashes the bytes, `fdatasync`s the temp, atomically
+//! renames within the part folder, and (once per part, via `finalize_part`) fsyncs
+//! the folder so a power loss never leaves a torn file. Both also
 //! implement the GC-only [`CephFs`]/[`SsdCache`] `remove_object` reclaim (by
 //! `<object_id>` folder).
 
@@ -22,6 +23,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 use tokio::fs;
 use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
 
 /// Streaming hash read buffer. Bounds memory so multi-gigabyte chunks are never
 /// read whole into memory just to hash them.
@@ -233,24 +235,51 @@ async fn hash_file(path: &Path) -> io::Result<String> {
     Ok(hex_lower(hasher.finalize().as_slice()))
 }
 
-/// Atomically place `source`'s bytes into `dir` as `name`: copy into a temp inside
-/// `dir`, fsync it, rename into place, then fsync `dir`. A crash leaves either no file
-/// or the complete one. The single-writer-per-part claim makes the `.tmp-<name>`
-/// temp collision-free (mirrors the chunk persist's within-folder atomic rename).
-async fn persist_into(dir: &Path, name: &str, source: &Path) -> io::Result<()> {
+/// Streams `source` into `dest`, computing the SHA-256 of the bytes in the same pass so the
+/// copy needs no second read to verify (the audit's hash-once win), and `fdatasync`s `dest`
+/// — [`File::sync_data`] skips the atime/mtime metadata flush a `sync_all` would force.
+/// Bounded by [`HASH_BUF_BYTES`] so a multi-gigabyte chunk is never read whole into memory.
+async fn stream_copy_hash(source: &Path, dest: &Path) -> io::Result<String> {
+    let mut reader = fs::File::open(source).await?;
+    let mut writer = fs::File::create(dest).await?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0_u8; HASH_BUF_BYTES];
+    loop {
+        let read = reader.read(&mut buf).await?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+        writer.write_all(&buf[..read]).await?;
+    }
+    writer.flush().await?;
+    writer.sync_data().await?;
+    Ok(hex_lower(hasher.finalize().as_slice()))
+}
+
+/// Atomically place `source`'s bytes into `dir` as `name`, returning the lowercase-hex
+/// SHA-256 of the bytes streamed during the copy: stream into a temp inside `dir`
+/// (`fdatasync`'d), rename into place, then — only when `sync_dir` is set — fsync `dir`.
+/// A crash leaves either no file or the complete one. The single-writer-per-part claim
+/// makes the `.tmp-<name>` temp collision-free (mirrors the within-folder atomic rename).
+///
+/// The directory fsync is deferred (`sync_dir = false` for chunks + meta) so the whole
+/// part costs ONE dir-fsync via [`sync_parent_dir`], not one per file — the caller drives
+/// it through `PartPool::finalize_part` after every rename lands.
+async fn copy_into(dir: &Path, name: &str, source: &Path, sync_dir: bool) -> io::Result<String> {
     let dest = dir.join(name);
     let tmp = dir.join(format!(".tmp-{name}"));
     fs::create_dir_all(dir).await?;
     // Arm temp cleanup before the copy: any failure or cancellation before the rename
     // must not leave a `.tmp-*` orphan in the pool (the drop-guard idiom, RfR ch.1).
     let guard = TmpGuard::arm(tmp.clone());
-    fs::copy(source, &tmp).await?;
-    let written = fs::File::open(&tmp).await?;
-    written.sync_all().await?;
-    drop(written);
+    let hash = stream_copy_hash(source, &tmp).await?;
     fs::rename(&tmp, &dest).await?;
     guard.dismiss();
-    sync_parent_dir(dir).await
+    if sync_dir {
+        sync_parent_dir(dir).await?;
+    }
+    Ok(hash)
 }
 
 /// Remove a part's whole directory; an already-absent dir is `Ok` (idempotent, so a
@@ -392,12 +421,20 @@ impl PartSource for LocalSsd {
 }
 
 impl PartPool for LocalFs {
-    async fn persist_chunk(&self, source: &Path, part: &PartKey, index: ChunkIndex) -> io::Result<()> {
-        persist_into(&part_dir(&self.root, part), &chunk_file_name(index), source).await
+    async fn persist_chunk(&self, source: &Path, part: &PartKey, index: ChunkIndex) -> io::Result<String> {
+        // sync_dir=false: the per-part dir fsync is batched into finalize_part below.
+        copy_into(&part_dir(&self.root, part), &chunk_file_name(index), source, false).await
     }
 
     async fn persist_meta(&self, source: &Path, part: &PartKey) -> io::Result<()> {
-        persist_into(&part_dir(&self.root, part), META_FILE_NAME, source).await
+        // sync_dir=false: meta's dir entry flushes with the chunks' in the single finalize.
+        copy_into(&part_dir(&self.root, part), META_FILE_NAME, source, false).await.map(|_| ())
+    }
+
+    async fn finalize_part(&self, part: &PartKey) -> io::Result<()> {
+        // One fsync of the part dir, after every chunk + meta rename has landed, so all
+        // those directory entries become durable together (Task 1: batch the fsync).
+        sync_parent_dir(&part_dir(&self.root, part)).await
     }
 
     async fn chunk_hash(&self, part: &PartKey, index: ChunkIndex) -> io::Result<String> {
@@ -744,15 +781,24 @@ mod part_tests {
         let ssd = LocalSsd::new(ssd_dir.path());
         let ceph = LocalFs::new(pool_dir.path());
         let source = ssd.chunk_source(&part, ChunkIndex::new(0)).unwrap();
-        ceph.persist_chunk(&source, &part, ChunkIndex::new(0)).await.unwrap();
+        let copy_hash = ceph.persist_chunk(&source, &part, ChunkIndex::new(0)).await.unwrap();
+        // The hash-once win: persist_chunk returns the SHA computed during the copy stream,
+        // so the drain needs no separate readback of the source to verify.
+        assert_eq!(copy_hash, sha256_hex(content), "persist_chunk returns the copy-time hash");
 
         let pooled = pool_dir.path().join(part.relative_dir()).join("chunk_0.bin");
         assert_eq!(std::fs::read(&pooled).unwrap(), content, "the pooled bytes match the source");
-        assert_eq!(ceph.chunk_hash(&part, ChunkIndex::new(0)).await.unwrap(), sha256_hex(content));
 
         let meta = ssd.meta_source(&part).unwrap();
         ceph.persist_meta(&meta, &part).await.unwrap();
+        // One dir-fsync for the whole part: after it, every chunk + meta is durably present.
+        ceph.finalize_part(&part).await.unwrap();
         assert!(pool_dir.path().join(part.relative_dir()).join("meta.json").exists(), "meta marker landed");
+        assert_eq!(
+            ceph.chunk_hash(&part, ChunkIndex::new(0)).await.unwrap(),
+            sha256_hex(content),
+            "the pooled chunk is durable + verifiable after finalize",
+        );
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-agent/src/main.rs
+++ b/crates/hippius-drain-agent/src/main.rs
@@ -10,9 +10,14 @@ use hippius_drain_agent::config::{Config, ConfigError};
 use hippius_drain_agent::enqueue::RedisEnqueuer;
 use hippius_drain_agent::localfs::{LocalFs, LocalSsd};
 use hippius_drain_agent::runtime::{AgentRuntime, RateControl, default_enforcer};
-use hippius_drain_core::{Bytes, Store, StoreError};
+use hippius_drain_core::{Bytes, Coordinator, Store, StoreError};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use thiserror::Error;
+
+/// The agent never writes allocation keys (the allocator owns that key's TTL), so the
+/// alloc TTL on its shared coordinator is never read — a placeholder for the constructor.
+const AGENT_ALLOC_TTL_UNUSED: Duration = Duration::from_secs(15);
 
 /// A failure bringing the daemon up. Each variant maps to a distinct operator
 /// fix: a bad environment versus an unreachable store or Redis.
@@ -47,21 +52,26 @@ async fn main() -> Result<(), StartupError> {
 
     // Drain-direct: the drain LPUSHes each replicated part's UploadChainRequest to the
     // upload-queue Redis (the api no longer enqueues at PUT). A multiplexed, auto-
-    // reconnecting manager shared across the concurrent drains.
+    // reconnecting manager shared across the concurrent drains AND the coordinator below
+    // (same redis-queues instance — one connection, cloned).
     let redis = redis::aio::ConnectionManager::new(redis::Client::open(config.redis_queues_url.as_str())?).await?;
-    let enqueuer = Arc::new(RedisEnqueuer::new(Arc::clone(&store), redis, config.upload_backends.clone()));
+    let enqueuer = Arc::new(RedisEnqueuer::new(Arc::clone(&store), redis.clone(), config.upload_backends.clone()));
+
+    // The Redis-backed coordinator: the heartbeat worker upserts this node's state under
+    // `heartbeat_ttl`, and the allocation-pull worker reads its budget. The agent never
+    // writes allocations, so its alloc TTL is unused (the allocator owns that key's TTL).
+    let coordinator = Arc::new(Coordinator::new(redis, config.heartbeat_ttl, AGENT_ALLOC_TTL_UNUSED));
 
     // The enforcer starts at the floor (conservative) with a one-second burst of
     // the node's capability; the allocation-pull worker raises it to the leader's
     // budget on its first tick.
-    let enforcer = default_enforcer(config.floor_rate, Bytes::new(config.max_drain_rate.get()));
+    let enforcer = default_enforcer(config.floor_rate, Bytes::new(config.max_drain_rate.get()), config.drain_concurrency);
     let rate_control = RateControl {
         enforcer: Arc::new(Mutex::new(enforcer)),
         node: config.node_id.clone(),
         floor: config.floor_rate,
         half_life: config.decay_half_life,
         poll: config.allocation_poll,
-        stale_after: config.allocation_stale,
     };
 
     let runtime = AgentRuntime::new(
@@ -71,6 +81,7 @@ async fn main() -> Result<(), StartupError> {
         enqueuer,
         config.runtime_config(),
     )
+    .with_coordinator(coordinator)
     .with_heartbeat(config.heartbeat_config())
     .with_rate_control(rate_control);
 

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -21,8 +21,8 @@ use crate::localfs::{LocalFs, LocalSsd};
 use crate::supervisor::{RunReport, Supervisor, WorkerName};
 use crate::worker::drain_until_empty;
 use hippius_drain_core::{
-    BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, Enforcer, NodeId, NodeObservation, SnapshotCell, Store, SystemClock,
-    TokenBucket, UploadEnqueuer, decay_rate, reclaim_ssd, reconcile_parts,
+    BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, Coordinator, Enforcer, NodeId, NodeObservation, SnapshotCell, Store,
+    SystemClock, TokenBucket, UploadEnqueuer, decay_rate, reclaim_ssd, reconcile_parts,
 };
 use std::future::Future;
 use std::sync::{Arc, Mutex, PoisonError};
@@ -33,23 +33,22 @@ use tokio_util::sync::CancellationToken;
 const BREAKER_FAILURES: u32 = 5;
 /// How long the breaker stays open before probing Ceph again.
 const BREAKER_COOLDOWN: Duration = Duration::from_secs(10);
-/// Maximum drains in flight at once (the concurrency gate).
-const DRAIN_CONCURRENCY: u32 = 4;
 
-/// Builds the agent's admission enforcer at `rate` with burst `burst`, using
-/// fixed breaker/concurrency policy. The breaker opens after [`BREAKER_FAILURES`]
-/// consecutive Ceph failures for [`BREAKER_COOLDOWN`]; up to [`DRAIN_CONCURRENCY`]
-/// drains run concurrently. The allocation-pull worker then keeps `rate` synced
-/// to the leader's budget.
+/// Builds the agent's admission enforcer at `rate` with burst `burst`, gating up to
+/// `concurrency` drains at once. The breaker opens after [`BREAKER_FAILURES`]
+/// consecutive Ceph failures for [`BREAKER_COOLDOWN`]; the allocation-pull worker
+/// then keeps `rate` synced to the leader's budget. `concurrency` comes from
+/// `CEPHOR_DRAIN_CONCURRENCY` so a node can hide fsync latency behind more in-flight
+/// parts (the AIMD allocator only tunes bytes/sec).
 #[must_use]
-pub fn default_enforcer(rate: ByteRate, burst: Bytes) -> Enforcer {
+pub fn default_enforcer(rate: ByteRate, burst: Bytes, concurrency: u32) -> Enforcer {
     Enforcer::new(
         CircuitBreaker::new(BreakerConfig {
             failure_threshold: BREAKER_FAILURES,
             cooldown: BREAKER_COOLDOWN,
         }),
         TokenBucket::new(rate, burst, Instant::now()),
-        ConcurrencyLimiter::new(DRAIN_CONCURRENCY),
+        ConcurrencyLimiter::new(concurrency),
     )
 }
 
@@ -68,6 +67,9 @@ pub struct RuntimeConfig {
     /// How long workers get to finish an in-flight tick after cancellation
     /// before the supervisor force-aborts them.
     pub grace: Duration,
+    /// Maximum parts the drain worker processes concurrently (the in-flight gate
+    /// that overlaps fsync latency across parts).
+    pub drain_concurrency: u32,
 }
 
 /// Runs `tick` immediately and then once per `period`, until `token` is
@@ -114,9 +116,6 @@ pub struct RateControl {
     pub half_life: Duration,
     /// How often to re-pull the allocation.
     pub poll: Duration,
-    /// How long a stored allocation stays authoritative; past it the allocator is
-    /// treated as silent on this node and the rate decays toward `floor`.
-    pub stale_after: Duration,
 }
 
 /// The drain worker's shared dependencies, bundled so the worker fn stays within
@@ -130,6 +129,8 @@ struct DrainDeps<E: UploadEnqueuer> {
     /// Publishes each part's backend upload request once it's durably on the pool
     /// (drain-direct; the drain is the sole upload producer).
     enqueuer: Arc<E>,
+    /// Maximum parts processed concurrently per drain cycle (`CEPHOR_DRAIN_CONCURRENCY`).
+    concurrency: u32,
 }
 
 /// Drains the part backlog on each `period` poll, until `token` is cancelled.
@@ -153,7 +154,7 @@ async fn run_drain<E: UploadEnqueuer>(token: CancellationToken, period: Duration
             deps.enforcer.as_ref(),
             Some(&deps.snapshot),
             &token,
-            DRAIN_CONCURRENCY as usize,
+            deps.concurrency as usize,
         )
         .await
         {
@@ -174,7 +175,7 @@ async fn run_drain<E: UploadEnqueuer>(token: CancellationToken, period: Duration
 /// Probes SSD disk pressure off the async runtime (statvfs blocks) and upserts
 /// this node's heartbeat. Probe or upsert failures are logged and skipped — the
 /// next tick retries; a missed heartbeat only ages the node out of the fleet.
-async fn heartbeat_once(ssd: &LocalSsd, store: &Store, node: &NodeId, max_drain_rate: ByteRate, snapshot: &SnapshotCell) {
+async fn heartbeat_once(ssd: &LocalSsd, coord: &Coordinator, node: &NodeId, max_drain_rate: ByteRate, snapshot: &SnapshotCell) {
     let root = ssd.root().to_path_buf();
     // statvfs is a blocking syscall — never run it on an executor thread (axiom
     // r4r_ch10_01); spawn_blocking moves it to the blocking pool.
@@ -204,7 +205,7 @@ async fn heartbeat_once(ssd: &LocalSsd, store: &Store, node: &NodeId, max_drain_
         observed_p99: snapshot.p99(),
         error_bps: snapshot.load().error_bps(),
     };
-    if let Err(err) = store.upsert_node_state(node, &observation).await {
+    if let Err(err) = coord.upsert_node_state(node, &observation).await {
         tracing::warn!(error = %err, "heartbeat upsert failed");
     }
 }
@@ -253,22 +254,23 @@ fn apply_rate(enforcer: &Arc<Mutex<Enforcer>>, rate: ByteRate) {
 /// `poll`, decaying toward `floor` when the allocator goes silent so a stale
 /// allocation cannot keep the node hammering Ceph. The async `load_allocation`
 /// runs *unlocked*; only the synchronous `set_rate` takes the lock.
-async fn run_alloc(token: CancellationToken, store: Arc<Store>, rate_control: RateControl, clock: Arc<dyn Clock>) {
+async fn run_alloc(token: CancellationToken, coord: Arc<Coordinator>, rate_control: RateControl, clock: Arc<dyn Clock>) {
     let RateControl {
         enforcer,
         node,
         floor,
         half_life,
         poll,
-        stale_after,
     } = rate_control;
     // Decay state: the last allocated rate and when it landed. A fresh
     // allocation resets both; silence decays `base` toward `floor` by age. The
     // age is measured against the injected `clock`, so decay timing is testable.
+    // The allocation key's Redis TTL is the staleness signal: once it expires,
+    // load_allocation returns None and the decay path engages.
     let mut base = floor;
     let mut allocated_at = clock.now();
     loop {
-        match store.load_allocation(&node, stale_after).await {
+        match coord.load_allocation(&node).await {
             Ok(Some(allocation)) => {
                 base = allocation.budget;
                 allocated_at = clock.now();
@@ -306,6 +308,10 @@ pub struct AgentRuntime<E: UploadEnqueuer> {
     /// (which gates through it) and the allocation-pull worker (which tunes it);
     /// `None` drains ungated.
     rate_control: Option<RateControl>,
+    /// The Redis-backed coordinator the heartbeat + allocation-pull workers use.
+    /// Required for those two workers to run; `None` (tests / drain-only e2e) skips
+    /// them even if heartbeat / rate control are configured.
+    coord: Option<Arc<Coordinator>>,
     /// The time source the allocation-pull worker reads for its decay timing.
     /// Defaults to [`SystemClock`]; tests inject a [`hippius_drain_core::TestClock`].
     clock: Arc<dyn Clock>,
@@ -325,6 +331,7 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
             snapshot: Arc::new(SnapshotCell::new()),
             heartbeat: None,
             rate_control: None,
+            coord: None,
             clock: Arc::new(SystemClock),
         }
     }
@@ -335,6 +342,15 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
     #[must_use]
     pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
         self.clock = clock;
+        self
+    }
+
+    /// Wires the Redis coordinator the heartbeat + allocation-pull workers need.
+    /// Without it those two workers do not run (the drain/reconcile/reclaim workers,
+    /// which use only the Postgres store, are unaffected).
+    #[must_use]
+    pub fn with_coordinator(mut self, coord: Arc<Coordinator>) -> Self {
+        self.coord = Some(coord);
         self
     }
 
@@ -378,6 +394,7 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
             // The drain worker and the allocation worker share one enforcer.
             enforcer: self.rate_control.as_ref().map(|rc| Arc::clone(&rc.enforcer)),
             enqueuer: Arc::clone(&self.enqueuer),
+            concurrency: self.config.drain_concurrency,
         };
         supervisor.spawn(WorkerName::new("drain"), move |token| run_drain(token, drain_poll, deps));
 
@@ -413,15 +430,16 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
         });
 
         // Heartbeat worker (opt-in): report this node's disk pressure + capability
-        // so the allocator can weight it. Without it the node is never in the fleet.
-        if let Some(heartbeat) = self.heartbeat {
-            let (ssd, store, snapshot) = (Arc::clone(&self.ssd), Arc::clone(&self.store), Arc::clone(&self.snapshot));
+        // so the allocator can weight it. Needs the coordinator; without it the node
+        // is never in the fleet.
+        if let (Some(heartbeat), Some(coord)) = (self.heartbeat, self.coord.as_ref()) {
+            let (ssd, coord, snapshot) = (Arc::clone(&self.ssd), Arc::clone(coord), Arc::clone(&self.snapshot));
             let HeartbeatConfig { node, max_drain_rate, poll } = heartbeat;
             supervisor.spawn(WorkerName::new("heartbeat"), move |token| {
                 run_periodic(token, poll, move || {
-                    let (ssd, store, node, snapshot) = (Arc::clone(&ssd), Arc::clone(&store), node.clone(), Arc::clone(&snapshot));
+                    let (ssd, coord, node, snapshot) = (Arc::clone(&ssd), Arc::clone(&coord), node.clone(), Arc::clone(&snapshot));
                     async move {
-                        heartbeat_once(&ssd, &store, &node, max_drain_rate, &snapshot).await;
+                        heartbeat_once(&ssd, &coord, &node, max_drain_rate, &snapshot).await;
                     }
                 })
             });
@@ -429,10 +447,11 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
 
         // Allocation-pull worker (opt-in): apply the leader's write-budget to the
         // shared enforcer, decaying toward the floor when the allocator is silent.
-        if let Some(rate_control) = self.rate_control {
-            let store = Arc::clone(&self.store);
+        // Needs the coordinator; without it the drain stays ungated at its floor.
+        if let (Some(rate_control), Some(coord)) = (self.rate_control, self.coord.as_ref()) {
+            let coord = Arc::clone(coord);
             let clock = Arc::clone(&self.clock);
-            supervisor.spawn(WorkerName::new("allocation"), move |token| run_alloc(token, store, rate_control, clock));
+            supervisor.spawn(WorkerName::new("allocation"), move |token| run_alloc(token, coord, rate_control, clock));
         }
 
         supervisor.run(shutdown).await
@@ -440,16 +459,31 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr, reason = "tests")]
 mod tests {
     use super::{AgentRuntime, HeartbeatConfig, RateControl, RuntimeConfig, default_enforcer};
     use crate::localfs::{LocalFs, LocalSsd};
     use crate::supervisor::ShutdownTrigger;
     use core::str::FromStr;
     use hippius_drain_core::{
-        Allocation, ByteRate, Bytes, Clock, NodeId, ObjectId, PartKey, PartNumber, PartReplicationStore, ReplicationState, SnapshotCell, Store,
-        TestClock, UploadEnqueuer, Version,
+        Allocation, ByteRate, Bytes, Clock, Coordinator, NodeId, ObjectId, PartKey, PartNumber, PartReplicationStore, ReplicationState, SnapshotCell,
+        Store, TestClock, UploadEnqueuer, Version,
     };
+
+    /// A coordinator on the test Redis under a per-test prefix, or `None` to skip the
+    /// redis-dependent runtime tests (Rust has no fakeredis; set
+    /// `CEPHOR_TEST_REDIS_URL=redis://localhost:6382/0`). `alloc_ttl` lets the decay test
+    /// expire a budget deterministically.
+    async fn test_coord(prefix: &str, node_ttl: Duration, alloc_ttl: Duration) -> Option<Coordinator> {
+        let url = std::env::var("CEPHOR_TEST_REDIS_URL").ok().filter(|value| !value.is_empty())?;
+        // Prefix with the process id so a re-run never collides with the prior run's
+        // still-TTL'd keys on a shared test Redis.
+        let coordinator = Coordinator::connect(&url, node_ttl, alloc_ttl)
+            .await
+            .expect("connect to the test redis")
+            .with_prefix(&format!("{}:{prefix}", std::process::id()));
+        Some(coordinator)
+    }
 
     /// A no-op upload enqueuer for the runtime tests (drain-direct's Redis fan-out is
     /// covered by the core partdrain tests + the agent enqueue module).
@@ -509,13 +543,18 @@ mod tests {
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
     async fn the_allocation_worker_applies_the_leaders_budget(pool: PgPool) {
+        let Some(coord) = test_coord("cephor-test:rt-applies:", Duration::from_secs(30), Duration::from_secs(30)).await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
+        let coord = Arc::new(coord);
         let ssd_dir = tempfile::tempdir().unwrap();
         let pool_dir = tempfile::tempdir().unwrap();
         let store = Arc::new(Store::from_pool(pool));
         let node = NodeId::from_str("node-alloc").unwrap();
 
         // The leader has already written this node a budget.
-        store
+        coord
             .write_allocations(
                 1,
                 &[Allocation {
@@ -527,7 +566,7 @@ mod tests {
             .unwrap();
 
         // The enforcer starts at zero, so any non-zero rate is the worker's doing.
-        let enforcer = Arc::new(Mutex::new(default_enforcer(ByteRate::new(0), Bytes::new(1 << 20))));
+        let enforcer = Arc::new(Mutex::new(default_enforcer(ByteRate::new(0), Bytes::new(1 << 20), 4)));
         let runtime = AgentRuntime::new(
             Arc::new(LocalFs::new(pool_dir.path())),
             Arc::new(LocalSsd::new(ssd_dir.path())),
@@ -539,15 +578,16 @@ mod tests {
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 grace: Duration::from_secs(5),
+                drain_concurrency: 4,
             },
         )
+        .with_coordinator(Arc::clone(&coord))
         .with_rate_control(RateControl {
             enforcer: Arc::clone(&enforcer),
             node,
             floor: ByteRate::new(1_000),
             half_life: Duration::from_secs(30),
             poll: Duration::from_millis(20),
-            stale_after: Duration::from_secs(10),
         });
 
         let shutdown = CancellationToken::new();
@@ -571,22 +611,28 @@ mod tests {
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
     async fn the_allocation_worker_decays_on_an_injected_clock(pool: PgPool) {
-        // #33: run_alloc reads the injected Clock for its decay timing. Load a
-        // budget (base jumps above the floor, allocated_at = clock.now()), then
-        // delete the row so the allocator reads "silent" and advance the TestClock
-        // past several half-lives. The enforcer rate must decay below the budget
-        // toward the floor — proving the *injected* clock drives decay, since no
-        // real time passes between the load and the assertion.
+        // #33: run_alloc reads the injected Clock for its decay timing. Load a budget
+        // (base jumps above the floor, allocated_at = clock.now()), then let the
+        // allocation key's short Redis TTL expire so the allocator reads "silent", and
+        // advance the TestClock past several half-lives. The enforcer rate must decay
+        // toward the floor — proving the *injected* clock drives decay, since no real
+        // time passes (on the test clock) between the load and the assertion.
+        let Some(coord) = test_coord("cephor-test:rt-decay:", Duration::from_secs(30), Duration::from_secs(1)).await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
+        let coord = Arc::new(coord);
         let ssd_dir = tempfile::tempdir().unwrap();
         let pool_dir = tempfile::tempdir().unwrap();
-        let store = Arc::new(Store::from_pool(pool.clone()));
+        let store = Arc::new(Store::from_pool(pool));
         let node = NodeId::from_str("node-decay").unwrap();
         let budget = ByteRate::new(800_000);
         let floor = ByteRate::new(1_000);
 
-        store.write_allocations(1, &[Allocation { node: node.clone(), budget }]).await.unwrap();
+        // alloc_ttl is 1s (above), so this budget key expires ~1s after the write.
+        coord.write_allocations(1, &[Allocation { node: node.clone(), budget }]).await.unwrap();
 
-        let enforcer = Arc::new(Mutex::new(default_enforcer(ByteRate::new(0), Bytes::new(1 << 20))));
+        let enforcer = Arc::new(Mutex::new(default_enforcer(ByteRate::new(0), Bytes::new(1 << 20), 4)));
         // Keep the concrete handle (for `advance`) and a trait-object clone (for the
         // runtime); the `let` binding is the unsizing coercion site.
         let clock = Arc::new(TestClock::new());
@@ -602,17 +648,16 @@ mod tests {
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 grace: Duration::from_secs(5),
+                drain_concurrency: 4,
             },
         )
+        .with_coordinator(Arc::clone(&coord))
         .with_rate_control(RateControl {
             enforcer: Arc::clone(&enforcer),
             node: node.clone(),
             floor,
             half_life: Duration::from_secs(1),
             poll: Duration::from_millis(10),
-            // SQL staleness off (1h): the DELETE below, not row aging, drives the
-            // load to None, so the test controls exactly when decay begins.
-            stale_after: Duration::from_hours(1),
         })
         .with_clock(clock_source);
 
@@ -622,7 +667,7 @@ mod tests {
 
         // The worker first pulls the budget into the enforcer. Generous window (~5s):
         // the allocation-pull worker shares a single-threaded runtime with the other
-        // workers and can be starved under a full parallel sqlx-test run.
+        // workers and can be starved under a full parallel test run.
         let mut loaded = false;
         for _ in 0..500 {
             if enforcer.lock().unwrap().rate() == budget {
@@ -633,18 +678,15 @@ mod tests {
         }
         assert!(loaded, "the worker loaded the budget before decay");
 
-        // The allocator goes silent (row removed), and the injected clock jumps
-        // well past the 1s half-life, so decay should drive the rate to the floor.
-        sqlx::query("DELETE FROM cephor_allocation WHERE node_id = $1")
-            .bind(node.as_str())
-            .execute(&pool)
-            .await
-            .unwrap();
-        // Ten half-lives on the injected clock -> the rate collapses to ~floor.
-        // This deep decay is reachable ONLY by the injected jump: the sub-second of
-        // real time the test spends polling, against the 1s half-life, could only
-        // shave the rate slightly. So a near-floor rate proves run_alloc read the
-        // injected clock, not the wall clock.
+        // Wait out the 1s alloc-key TTL so load_allocation reads None ("silent"). The
+        // injected clock has NOT advanced yet, so allocated_at freezes at the last load
+        // and elapsed stays 0 (no decay) until we jump the clock below.
+        tokio::time::sleep(Duration::from_millis(1_300)).await;
+
+        // Ten half-lives on the injected clock -> the rate collapses to ~floor. This
+        // deep decay is reachable ONLY by the injected jump (the test clock advances
+        // 10s while no real test-clock time passed), so a near-floor rate proves
+        // run_alloc reads the injected clock, not the wall clock.
         clock.advance(Duration::from_secs(10));
         let near_floor = floor.get().saturating_mul(2);
 
@@ -670,6 +712,11 @@ mod tests {
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
     async fn the_heartbeat_worker_upserts_this_node_into_the_fleet(pool: PgPool) {
+        let Some(coord) = test_coord("cephor-test:rt-hb:", Duration::from_secs(30), Duration::from_secs(30)).await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
+        let coord = Arc::new(coord);
         let ssd_dir = tempfile::tempdir().unwrap();
         let pool_dir = tempfile::tempdir().unwrap();
         let store = Arc::new(Store::from_pool(pool));
@@ -689,8 +736,10 @@ mod tests {
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 grace: Duration::from_secs(5),
+                drain_concurrency: 4,
             },
         )
+        .with_coordinator(Arc::clone(&coord))
         .with_heartbeat(HeartbeatConfig {
             node: node.clone(),
             max_drain_rate: rate,
@@ -705,7 +754,7 @@ mod tests {
         // (matched by its distinctive capability) appears.
         let mut seen = false;
         for _ in 0..100 {
-            let fleet = store.load_fleet(Duration::from_hours(1)).await.unwrap();
+            let fleet = coord.load_fleet().await.unwrap();
             if fleet
                 .iter()
                 .any(|(id, observation)| id == &node && observation.max_drain_rate == rate && observation.backlog.get() > 0)
@@ -749,6 +798,7 @@ mod tests {
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 grace: Duration::from_secs(5),
+                drain_concurrency: 4,
             },
         );
 
@@ -793,6 +843,7 @@ mod tests {
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 grace: Duration::from_secs(5),
+                drain_concurrency: 4,
             },
         );
 

--- a/crates/hippius-drain-allocator/Cargo.toml
+++ b/crates/hippius-drain-allocator/Cargo.toml
@@ -13,10 +13,10 @@ description = "cephor singleton allocator (leader-elected; allocates the global 
 default = ["http"]
 http = ["dep:reqwest"]
 
-# The allocator contends for the leader lease and reads/writes the central state,
-# so it enables hippius-drain-core's `pg` feature.
+# The allocator owns schema provisioning (`pg`) and contends for the leader lease /
+# reads the fleet / writes budgets via the Redis-backed coordinator (`coord`).
 [dependencies]
-hippius-drain-core = { workspace = true, features = ["pg"] }
+hippius-drain-core = { workspace = true, features = ["pg", "coord"] }
 tokio = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
@@ -25,8 +25,6 @@ tracing-subscriber = { workspace = true }
 reqwest = { workspace = true, optional = true }
 
 [dev-dependencies]
-# For `#[sqlx::test]` against a real Postgres (migrations come from hippius-drain-core).
-sqlx = { workspace = true }
 # CancellationToken drives the shutdown signal in the run-loop tests.
 tokio-util = { workspace = true }
 # Mock HTTP server for the probe's status/timeout/parse edge tests.

--- a/crates/hippius-drain-allocator/src/config.rs
+++ b/crates/hippius-drain-allocator/src/config.rs
@@ -22,9 +22,11 @@ const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(30);
 /// six renewals of headroom; rate allocation does not need sub-5 s updates. Tune via
 /// `CEPHOR_ALLOCATOR_TICK_SECS` per deployment.
 const DEFAULT_TICK: Duration = Duration::from_secs(5);
-/// Heartbeats older than this are ignored when loading the fleet
-/// (`CEPHOR_FLEET_STALE_SECS`). Several agent heartbeat periods (~10s) wide.
-const DEFAULT_FLEET_STALE: Duration = Duration::from_secs(30);
+/// TTL on each per-node allocation key when `CEPHOR_ALLOCATION_TTL_SECS` is unset.
+/// Past it the agent reads no budget and decays toward its floor, so it must be a few
+/// allocator ticks wide — long enough to survive a missed tick, short enough that a
+/// departed node's budget conserves promptly. Replaces the old PG node-absence zeroing.
+const DEFAULT_ALLOCATION_TTL: Duration = Duration::from_secs(15);
 /// Static Ceph write-ceiling (bytes/sec) when `CEPHOR_CEPH_CEILING_BPS` is unset.
 /// The operational default until the live Ceph-mgr probe lands; assumes Ceph is
 /// open at this rate, so the real cap is `max_total` and per-node demand.
@@ -66,8 +68,11 @@ pub struct AllocatorConfig {
     pub lease_ttl: Duration,
     /// How often to run an allocation tick.
     pub tick_interval: Duration,
-    /// Heartbeats older than this are ignored when reading the fleet.
-    pub fleet_stale: Duration,
+    /// Redis URL for the coordination state (leader lease / heartbeats / allocations) —
+    /// the redis-queues instance the agents also use.
+    pub redis_queues_url: String,
+    /// TTL stamped on each per-node allocation key the allocator writes.
+    pub alloc_ttl: Duration,
     /// The static Ceph write-ceiling (the open-rate the live probe hands out when
     /// Ceph is healthy, and the whole ceiling when no probe URL is configured).
     pub ceph_ceiling: ByteRate,
@@ -139,7 +144,6 @@ impl AllocatorConfig {
         TickConfig {
             instance_id: self.instance_id.clone(),
             lease_ttl: self.lease_ttl,
-            stale_after: self.fleet_stale,
             alloc: self.alloc,
         }
     }
@@ -178,7 +182,8 @@ impl AllocatorConfig {
             instance_id: required(&get, "CEPHOR_ALLOCATOR_INSTANCE_ID")?,
             lease_ttl: duration_secs(&get, "CEPHOR_LEADER_LEASE_TTL_SECS", DEFAULT_LEASE_TTL)?,
             tick_interval: duration_secs(&get, "CEPHOR_ALLOCATOR_TICK_SECS", DEFAULT_TICK)?,
-            fleet_stale: duration_secs(&get, "CEPHOR_FLEET_STALE_SECS", DEFAULT_FLEET_STALE)?,
+            redis_queues_url: required(&get, "REDIS_QUEUES_URL")?,
+            alloc_ttl: duration_secs(&get, "CEPHOR_ALLOCATION_TTL_SECS", DEFAULT_ALLOCATION_TTL)?,
             ceph_ceiling: ByteRate::new(positive_u64(&get, "CEPHOR_CEPH_CEILING_BPS", DEFAULT_CEPH_CEILING_BPS)?),
             // The first tick starts from the AIMD floor unless overridden, so a
             // fresh leader ramps up from a safe rate rather than a guess.
@@ -282,8 +287,8 @@ fn duration_millis(get: &impl Fn(&str) -> Option<String>, var: &'static str, def
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::{
-        AllocatorConfig, ConfigError, DEFAULT_CRITICAL_PRESSURE_BPS, DEFAULT_DECREASE_PERMILLE, DEFAULT_MAX_TOTAL_BPS, DEFAULT_MIN_TOTAL_BPS,
-        DEFAULT_TICK,
+        AllocatorConfig, ConfigError, DEFAULT_ALLOCATION_TTL, DEFAULT_CRITICAL_PRESSURE_BPS, DEFAULT_DECREASE_PERMILLE, DEFAULT_MAX_TOTAL_BPS,
+        DEFAULT_MIN_TOTAL_BPS, DEFAULT_TICK,
     };
     use hippius_drain_core::{ByteRate, CephCeiling, DiskPressure};
 
@@ -297,6 +302,7 @@ mod tests {
         vec![
             ("CEPHOR_DATABASE_URL", "postgres://localhost/cephor"),
             ("CEPHOR_ALLOCATOR_INSTANCE_ID", "alloc-1"),
+            ("REDIS_QUEUES_URL", "redis://localhost:6382/0"),
         ]
     }
 
@@ -333,6 +339,31 @@ mod tests {
         let pairs = vec![("CEPHOR_ALLOCATOR_INSTANCE_ID", "alloc-1")];
         let err = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap_err();
         assert!(matches!(err, ConfigError::Missing("CEPHOR_DATABASE_URL")));
+    }
+
+    #[test]
+    fn reads_the_redis_url_and_defaults_the_allocation_ttl() {
+        let config = AllocatorConfig::from_lookup(lookup(&required_only())).unwrap();
+        assert_eq!(config.redis_queues_url, "redis://localhost:6382/0");
+        assert_eq!(config.alloc_ttl, DEFAULT_ALLOCATION_TTL);
+    }
+
+    #[test]
+    fn a_numeric_allocation_ttl_overrides_the_default() {
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_ALLOCATION_TTL_SECS", "20"));
+        let config = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(config.alloc_ttl, std::time::Duration::from_secs(20));
+    }
+
+    #[test]
+    fn a_missing_redis_url_is_reported() {
+        let pairs = vec![
+            ("CEPHOR_DATABASE_URL", "postgres://localhost/cephor"),
+            ("CEPHOR_ALLOCATOR_INSTANCE_ID", "alloc-1"),
+        ];
+        let err = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap_err();
+        assert!(matches!(err, ConfigError::Missing("REDIS_QUEUES_URL")));
     }
 
     #[test]

--- a/crates/hippius-drain-allocator/src/main.rs
+++ b/crates/hippius-drain-allocator/src/main.rs
@@ -9,17 +9,26 @@
 
 use hippius_drain_allocator::config::{AllocatorConfig, ConfigError};
 use hippius_drain_allocator::run::run_allocator;
-use hippius_drain_core::{CephCeilingSource, Store, StoreError};
+use hippius_drain_core::{CephCeilingSource, CoordError, Coordinator, Store, StoreError};
+use std::time::Duration;
 use thiserror::Error;
 
+/// The agents own the heartbeat TTL (`CEPHOR_HEARTBEAT_TTL_SECS`), so the allocator's
+/// coordinator never writes node keys; this value is unused on its side, present only to
+/// satisfy the shared [`Coordinator`] constructor.
+const ALLOCATOR_NODE_TTL: Duration = Duration::from_secs(30);
+
 /// A failure bringing the allocator up. Each variant maps to a distinct operator
-/// fix: a bad environment, an unreachable store, or an unbuildable probe client.
+/// fix: a bad environment, an unreachable store / coordination redis, or an
+/// unbuildable probe client.
 #[derive(Debug, Error)]
 enum StartupError {
     #[error("invalid configuration")]
     Config(#[from] ConfigError),
     #[error("cannot connect to the state store")]
     Store(#[from] StoreError),
+    #[error("cannot connect to the coordination redis")]
+    Coord(#[from] CoordError),
     #[cfg(feature = "http")]
     #[error("cannot build the ceph mgr probe")]
     Probe(#[from] hippius_drain_allocator::probe::ProbeError),
@@ -39,19 +48,23 @@ async fn main() -> Result<(), StartupError> {
     // brief multi-replica overlap during rollout re-runs nothing.
     store.migrate().await?;
 
+    // Leadership, the fleet view, and the budgets live in Redis (TTL-keyed, epoch-fenced)
+    // — not Postgres — so the ~2s leader tick never touches the WAL.
+    let coordinator = Coordinator::connect(&config.redis_queues_url, ALLOCATOR_NODE_TTL, config.alloc_ttl).await?;
+
     tracing::info!(
         instance = %config.instance_id,
         tick_secs = config.tick_interval.as_secs(),
         "hippius-drain-allocator started"
     );
-    run_with_ceiling_source(&store, &config).await?;
+    run_with_ceiling_source(&coordinator, &config).await?;
     tracing::info!("hippius-drain-allocator stopped");
     Ok(())
 }
 
 /// Selects the ceiling source — the live mgr probe when a URL is configured (and the
 /// `http` feature is built), else the static ceiling — and runs the allocator on it.
-async fn run_with_ceiling_source(store: &Store, config: &AllocatorConfig) -> Result<(), StartupError> {
+async fn run_with_ceiling_source(coord: &Coordinator, config: &AllocatorConfig) -> Result<(), StartupError> {
     #[cfg(feature = "http")]
     if let Some(url) = config.ceph_mgr_metrics_url.clone() {
         // The decay floor is the AIMD floor: while the probe is blind, the fleet
@@ -64,19 +77,19 @@ async fn run_with_ceiling_source(store: &Store, config: &AllocatorConfig) -> Res
             config.ceph_probe_timeout,
         )?;
         tracing::info!(mgr_url = %url, "driving the budget from the live ceph-mgr ceiling probe");
-        drive(store, &probe, config).await;
+        drive(coord, &probe, config).await;
         return Ok(());
     }
     tracing::info!("no ceph mgr url configured; using the static ceiling");
-    drive(store, &config.ceiling(), config).await;
+    drive(coord, &config.ceiling(), config).await;
     Ok(())
 }
 
 /// Runs the allocator loop on `ceiling`, logging (not failing on) a shutdown
 /// relinquish error — the lease TTL recovers it, so the process still exits cleanly.
-async fn drive<C: CephCeilingSource>(store: &Store, ceiling: &C, config: &AllocatorConfig) {
+async fn drive<C: CephCeilingSource>(coord: &Coordinator, ceiling: &C, config: &AllocatorConfig) {
     if let Err(err) = run_allocator(
-        store,
+        coord,
         ceiling,
         &config.tick_config(),
         config.initial_total,

--- a/crates/hippius-drain-allocator/src/run.rs
+++ b/crates/hippius-drain-allocator/src/run.rs
@@ -1,6 +1,6 @@
 //! The allocator's tick loop: drive [`run_tick`] on a timer until shutdown.
 
-use hippius_drain_core::{BudgetController, ByteRate, CephCeilingSource, Store, StoreError, TickConfig, TickOutcome, run_tick};
+use hippius_drain_core::{BudgetController, ByteRate, CephCeilingSource, CoordError, Coordinator, TickConfig, TickOutcome, run_tick};
 use std::future::Future;
 use std::time::Duration;
 
@@ -13,29 +13,29 @@ use std::time::Duration;
 ///
 /// A fenced write — a higher-epoch leader took over between this instance's lease
 /// acquire and its write — is the designed leadership handoff, logged at info and
-/// ignored (the next tick observes `NotLeader`). Any other per-tick store error is
-/// logged and retried on the next tick, never propagated, so a transient database
-/// blip does not end the allocator; the lease TTL covers a truly dead one.
+/// ignored (the next tick observes `NotLeader`). Any other per-tick coordination error
+/// is logged and retried on the next tick, never propagated, so a transient Redis blip
+/// does not end the allocator; the lease TTL covers a truly dead one.
 ///
 /// On shutdown it relinquishes leadership so a successor leads on its next tick
 /// rather than waiting out the lease TTL.
 ///
 /// # Errors
 ///
-/// [`StoreError`] only from the final best-effort relinquish
-/// ([`Store::relinquish_leadership`]); per-tick errors never propagate.
+/// [`CoordError`] only from the final best-effort relinquish
+/// ([`Coordinator::relinquish_leadership`]); per-tick errors never propagate.
 pub async fn run_allocator<C: CephCeilingSource>(
-    store: &Store,
+    coord: &Coordinator,
     ceiling: &C,
     config: &TickConfig,
     initial: ByteRate,
     tick: Duration,
     shutdown: impl Future<Output = ()>,
-) -> Result<(), StoreError> {
+) -> Result<(), CoordError> {
     let mut controller = BudgetController::new(initial);
     tokio::pin!(shutdown);
     loop {
-        match run_tick(store, ceiling, config, controller).await {
+        match run_tick(coord, ceiling, config, controller).await {
             Ok(TickOutcome::Led(plan)) => {
                 tracing::debug!(
                     fleet_estimate = plan.controller.total().get(),
@@ -47,10 +47,10 @@ pub async fn run_allocator<C: CephCeilingSource>(
                 controller = plan.controller;
             }
             Ok(TickOutcome::NotLeader) => tracing::debug!("another instance holds leadership this tick"),
-            // The store fenced this instance's stale-epoch write: a higher-epoch
+            // The coordinator fenced this instance's stale-epoch write: a higher-epoch
             // leader exists, so this instance is deposed. Expected handoff, not an
             // alert. Keep the carried controller so a re-win resumes from a sane rate.
-            Err(StoreError::Fenced { epoch }) => tracing::info!(epoch, "allocation fenced; leadership has moved on"),
+            Err(CoordError::Fenced { epoch }) => tracing::info!(epoch, "allocation fenced; leadership has moved on"),
             Err(err) => tracing::warn!(error = %err, "allocation tick failed; retrying next tick"),
         }
         tokio::select! {
@@ -59,21 +59,33 @@ pub async fn run_allocator<C: CephCeilingSource>(
         }
     }
     // Best-effort handoff; the lease TTL is the backstop if it fails (the caller
-    // logs rather than failing shutdown — see Store::relinquish_leadership).
-    store.relinquish_leadership(&config.instance_id).await
+    // logs rather than failing shutdown — see Coordinator::relinquish_leadership).
+    coord.relinquish_leadership(&config.instance_id).await
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, reason = "tests")]
+#[expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr, reason = "tests")]
 mod tests {
     use super::run_allocator;
     use core::str::FromStr;
     use hippius_drain_core::{
-        AllocConfig, Allocation, ByteRate, Bytes, CephCeiling, DiskPressure, Lease, NodeId, NodeObservation, StaticCeiling, Store, TickConfig,
+        AllocConfig, Allocation, ByteRate, Bytes, CephCeiling, Coordinator, DiskPressure, NodeId, NodeObservation, StaticCeiling, TickConfig,
     };
-    use sqlx::postgres::PgPool;
     use std::time::Duration;
     use tokio_util::sync::CancellationToken;
+
+    /// A coordinator on the test Redis under a per-test prefix, or `None` to skip (Rust
+    /// has no fakeredis; set `CEPHOR_TEST_REDIS_URL=redis://localhost:6382/0`).
+    async fn coord(prefix: &str) -> Option<Coordinator> {
+        let url = std::env::var("CEPHOR_TEST_REDIS_URL").ok().filter(|value| !value.is_empty())?;
+        // Prefix with the process id so a re-run never collides with the prior run's
+        // still-TTL'd keys on a shared test Redis.
+        let coordinator = Coordinator::connect(&url, Duration::from_secs(30), Duration::from_secs(30))
+            .await
+            .expect("connect to the test redis")
+            .with_prefix(&format!("{}:{prefix}", std::process::id()));
+        Some(coordinator)
+    }
 
     fn alloc_config() -> AllocConfig {
         AllocConfig {
@@ -92,7 +104,6 @@ mod tests {
         TickConfig {
             instance_id: instance.to_owned(),
             lease_ttl: Duration::from_secs(30),
-            stale_after: Duration::from_hours(1),
             alloc: alloc_config(),
         }
     }
@@ -111,20 +122,23 @@ mod tests {
         StaticCeiling(CephCeiling::Open(ByteRate::new(1_000_000_000)))
     }
 
-    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
-    async fn run_allocator_leads_writes_a_budget_then_relinquishes(pool: PgPool) {
-        let store = Store::from_pool(pool);
+    #[tokio::test]
+    async fn run_allocator_leads_writes_a_budget_then_relinquishes() {
+        let Some(c) = coord("cephor-test:run-leads:").await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
         let node = NodeId::from_str("n1").unwrap();
-        store.upsert_node_state(&node, &observation()).await.unwrap();
+        c.upsert_node_state(&node, &observation()).await.unwrap();
 
         let config = tick_config("alloc-1");
         let ceiling = open_ceiling();
         let shutdown = CancellationToken::new();
 
         // Run the loop concurrently with a driver that waits for a budget to land,
-        // then signals shutdown — joined (not spawned) so `&store` is shared by ref.
+        // then signals shutdown — joined (not spawned) so `&c` is shared by ref.
         let runner = run_allocator(
-            &store,
+            &c,
             &ceiling,
             &config,
             ByteRate::new(190_000),
@@ -134,7 +148,7 @@ mod tests {
         let driver = async {
             let mut written = false;
             for _ in 0..200 {
-                if store.load_allocation(&node, Duration::from_hours(1)).await.unwrap().is_some() {
+                if c.load_allocation(&node).await.unwrap().is_some() {
                     written = true;
                     break;
                 }
@@ -147,33 +161,37 @@ mod tests {
         run_result.unwrap();
         assert!(written, "the leader wrote this node a budget");
 
-        // Leadership was relinquished on shutdown: the lease row is gone, so a fresh
-        // instance acquires it immediately at epoch 1 rather than waiting the TTL.
+        // Leadership was relinquished on shutdown: the lease key is gone, so a fresh
+        // instance acquires it immediately rather than waiting the TTL.
         // (Were it NOT relinquished, alloc-1's unexpired 30s lease would deny this.)
-        assert_eq!(
-            store.acquire_or_renew_leadership("successor", Duration::from_secs(30)).await.unwrap(),
-            Some(Lease { epoch: 1 }),
+        assert!(
+            c.acquire_or_renew_leadership("successor", Duration::from_secs(30))
+                .await
+                .unwrap()
+                .is_some(),
             "shutdown relinquished leadership, so a successor leads immediately",
         );
     }
 
-    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
-    async fn run_allocator_survives_a_fenced_tick(pool: PgPool) {
-        let store = Store::from_pool(pool);
+    #[tokio::test]
+    async fn run_allocator_survives_a_fenced_tick() {
+        let Some(c) = coord("cephor-test:run-fenced:").await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
         let node = NodeId::from_str("n1").unwrap();
-        store.upsert_node_state(&node, &observation()).await.unwrap();
+        c.upsert_node_state(&node, &observation()).await.unwrap();
         // A higher-epoch leader already wrote this node's allocation, so every tick
         // this instance runs is fenced when it writes its epoch-1 budget.
-        store
-            .write_allocations(
-                100,
-                std::slice::from_ref(&Allocation {
-                    node: node.clone(),
-                    budget: ByteRate::new(1),
-                }),
-            )
-            .await
-            .unwrap();
+        c.write_allocations(
+            100,
+            std::slice::from_ref(&Allocation {
+                node: node.clone(),
+                budget: ByteRate::new(1),
+            }),
+        )
+        .await
+        .unwrap();
 
         let config = tick_config("late");
         let ceiling = open_ceiling();
@@ -182,7 +200,7 @@ mod tests {
         // The loop must survive the fenced ticks (logged, not fatal) and shut down
         // cleanly — run a few ticks, then cancel.
         let runner = run_allocator(
-            &store,
+            &c,
             &ceiling,
             &config,
             ByteRate::new(190_000),
@@ -197,7 +215,7 @@ mod tests {
         run_result.unwrap();
 
         // The epoch-100 allocation is untouched: the fence held every tick.
-        let stored = store.load_allocation(&node, Duration::from_hours(1)).await.unwrap().unwrap();
+        let stored = c.load_allocation(&node).await.unwrap().unwrap();
         assert_eq!(stored.epoch, 100, "the higher-epoch allocation was never overwritten");
     }
 }

--- a/crates/hippius-drain-core/Cargo.toml
+++ b/crates/hippius-drain-core/Cargo.toml
@@ -13,8 +13,11 @@ default = []
 serde = ["dep:serde"]
 # Exposes deterministic test helpers (e.g. TestClock) to downstream test code.
 test-util = []
-# Postgres-backed central state store (heartbeats, allocations, GC claims).
+# Postgres-backed central state store (replication/claim/GC durable state).
 pg = ["dep:sqlx", "dep:tokio"]
+# Redis-backed ephemeral coordination (leader lease, heartbeats, allocations) +
+# the allocator tick that drives it. Loss-tolerant, TTL-expiring state kept off PG.
+coord = ["dep:redis", "dep:tokio", "dep:serde", "dep:serde_json"]
 # Enables GC of the shared CephFS pool folder. Off by default until the api
 # write-fence is confirmed (an owned task); SSD-local GC ships without it.
 gc-cephfs = []
@@ -22,8 +25,10 @@ gc-cephfs = []
 [dependencies]
 thiserror = { workspace = true }
 serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
+redis = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/hippius-drain-core/migrations/0009_drop_cephor_coordination_tables.sql
+++ b/crates/hippius-drain-core/migrations/0009_drop_cephor_coordination_tables.sql
@@ -1,0 +1,11 @@
+-- Goal 2: the loss-tolerant coordination state — leader lease, node heartbeats, and
+-- per-node allocations — moved off Postgres onto the redis-queues instance (TTL-keyed,
+-- epoch-fenced via Lua; see hippius_drain_core::Coordinator). These three tables churned
+-- the WAL on every ~2s leader tick (measured 6995x/3659x/2023x autovacuum on staging) and
+-- created a circular recovery dependency when Ceph — and thus PG's WAL fsync — degrades.
+-- Their state is ephemeral, so dropping them loses nothing: a fresh leader re-elects and
+-- the fleet re-heartbeats within a few ticks. Postgres keeps only the DURABLE drain state
+-- (replication status / claims, the landed-part log, GC claims).
+DROP TABLE IF EXISTS cephor_allocation;
+DROP TABLE IF EXISTS cephor_node_state;
+DROP TABLE IF EXISTS cephor_leader_lease;

--- a/crates/hippius-drain-core/src/coordination.rs
+++ b/crates/hippius-drain-core/src/coordination.rs
@@ -1,0 +1,559 @@
+//! Redis-backed ephemeral coordination: leader lease, node heartbeats, and per-node
+//! allocations.
+//!
+//! This is the loss-tolerant counterpart to the durable [`Store`](crate::Store). All three
+//! kinds of state are TTL-keyed — expiry IS the death signal, so there is no reaper: a node
+//! that stops heartbeating ages out of the fleet, a lease that is not renewed lapses, and a
+//! budget the leader stops refreshing decays to absent (the agent then decays toward its
+//! floor). Keeping this off Postgres spares it the ~2s leader-tick write churn (measured
+//! 6995x/3659x/2023x autovacuum on staging) and removes a circular recovery dependency:
+//! when Ceph degrades — the very scenario the drain exists for — PG's WAL fsync spikes, and
+//! the coordinator must not need PG to write down what it is doing.
+//!
+//! The F4 leader-epoch fence is preserved verbatim: the epoch lives in the lease value
+//! (bumped on every takeover via an `INCR` counter), and an allocation write is
+//! compare-and-set against each node's stored epoch in ONE atomic Lua `EVAL`, so a deposed
+//! or partitioned leader can never overwrite a live leader's budgets.
+
+use crate::alloc::Allocation;
+use crate::alloc::FleetView;
+use crate::alloc::NodeObservation;
+use crate::ids::NodeId;
+use crate::units::ByteRate;
+use crate::units::Bytes;
+use crate::units::DiskPressure;
+use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
+use serde::Deserialize;
+use serde::Serialize;
+use std::time::Duration;
+use thiserror::Error;
+
+/// The default key namespace for every coordination key on the shared redis-queues
+/// instance. Override per test via [`Coordinator::with_prefix`] for isolation.
+const DEFAULT_PREFIX: &str = "cephor:";
+
+/// Acquire-or-renew the singleton lease. `KEYS[1]`=lease, `KEYS[2]`=epoch counter;
+/// `ARGV[1]`=instance id, `ARGV[2]`=ttl secs. Returns the held epoch, or nil if another
+/// instance holds an unexpired lease. An absent (expired/fresh) lease bumps the epoch via
+/// `INCR` — a new leadership era — so a stale in-flight write from the prior era is fenced;
+/// renewing one's own still-valid lease keeps the epoch. Expiry is the database clock's, so
+/// agents' clock skew does not affect election.
+const LEASE_SCRIPT: &str = r"
+local cur = redis.call('GET', KEYS[1])
+if cur then
+  local v = cjson.decode(cur)
+  if v.instance == ARGV[1] then
+    redis.call('SET', KEYS[1], cur, 'EX', ARGV[2])
+    return v.epoch
+  end
+  return nil
+end
+local epoch = redis.call('INCR', KEYS[2])
+redis.call('SET', KEYS[1], cjson.encode({instance = ARGV[1], epoch = epoch}), 'EX', ARGV[2])
+return epoch
+";
+
+/// Relinquish the lease iff this instance still holds it. `KEYS[1]`=lease, `ARGV[1]`=instance.
+/// A no-op when a successor already took over (a deposed instance must not delete the live
+/// leader's lease). Always returns 1 — best-effort, the TTL is the backstop.
+const RELINQUISH_SCRIPT: &str = r"
+local cur = redis.call('GET', KEYS[1])
+if cur then
+  local v = cjson.decode(cur)
+  if v.instance == ARGV[1] then
+    redis.call('DEL', KEYS[1])
+  end
+end
+return 1
+";
+
+/// Fenced per-node allocation write. `KEYS`=the alloc keys (one per node); `ARGV[1]`=epoch,
+/// `ARGV[2]`=ttl secs, `ARGV[3..]`=the budget for each key (parallel to `KEYS`). Returns 0 —
+/// writing NOTHING — if ANY node's stored epoch is higher (this leader is deposed), else
+/// writes every key and returns 1. The two passes (check all, then write all) make the
+/// fence plan-wide and atomic: a split-brain leader cannot partially overwrite budgets.
+const WRITE_ALLOC_SCRIPT: &str = r"
+local epoch = tonumber(ARGV[1])
+local ttl = ARGV[2]
+for i = 1, #KEYS do
+  local cur = redis.call('GET', KEYS[i])
+  if cur then
+    local v = cjson.decode(cur)
+    if tonumber(v.epoch) > epoch then
+      return 0
+    end
+  end
+end
+for i = 1, #KEYS do
+  redis.call('SET', KEYS[i], cjson.encode({budget = ARGV[2 + i], epoch = epoch}), 'EX', ttl)
+end
+return 1
+";
+
+/// Errors from the Redis-backed coordinator.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CoordError {
+    /// A Redis command or connection failed.
+    #[error("redis error: {0}")]
+    Redis(#[from] redis::RedisError),
+    /// (De)serializing a stored value failed.
+    #[error("coordination serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+    /// A stored value violated its domain type's invariant when read back. The writers
+    /// only store in-range values, so this is corruption / drift, surfaced not panicked.
+    #[error("stored {field} value is not valid for its domain type")]
+    Invalid {
+        /// The field whose stored value was invalid.
+        field: &'static str,
+    },
+    /// An allocation write was rejected by the epoch fence: a higher-epoch leader exists,
+    /// so this instance is deposed. Surfaced (rather than a false `Ok`) so a split-brain
+    /// leader learns it lost. Mirrors the old PG `StoreError::Fenced`.
+    #[error("allocation write fenced: epoch {epoch} is no longer the leader")]
+    Fenced {
+        /// The (now-deposed) epoch whose write was rejected.
+        epoch: u64,
+    },
+}
+
+type Result<T> = core::result::Result<T, CoordError>;
+
+/// A held leadership lease.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Lease {
+    /// The fencing epoch for this leadership era. Every allocation write made while
+    /// holding this lease is stamped with it, so a deposed leader's lower-epoch writes
+    /// are rejected.
+    pub epoch: u64,
+}
+
+/// A node's current allocation, read back from the coordinator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StoredAllocation {
+    /// The allocated write rate.
+    pub budget: ByteRate,
+    /// The leader epoch that wrote it (for fencing checks).
+    pub epoch: u64,
+}
+
+/// The wire form of a node heartbeat. Stored as JSON under each node's TTL'd key; a DTO
+/// (not serde on the domain type) so deserialization runs through the validating
+/// conversions below rather than bypassing each newtype's invariant.
+#[derive(Serialize, Deserialize)]
+struct NodeStateJson {
+    pressure_bps: u16,
+    backlog_bytes: u64,
+    max_drain_rate_bps: u64,
+    observed_p99_ns: u64,
+    error_bps: u16,
+}
+
+impl NodeStateJson {
+    fn from_observation(observation: &NodeObservation) -> Self {
+        Self {
+            pressure_bps: observation.pressure.bps(),
+            backlog_bytes: observation.backlog.get(),
+            max_drain_rate_bps: observation.max_drain_rate.get(),
+            // p99 nanos: u128 -> u64 cannot overflow for any realistic latency; clamp defensively.
+            observed_p99_ns: u64::try_from(observation.observed_p99.as_nanos()).unwrap_or(u64::MAX),
+            error_bps: observation.error_bps,
+        }
+    }
+
+    fn into_observation(self) -> Result<NodeObservation> {
+        let pressure = DiskPressure::try_from(self.pressure_bps).map_err(|_| CoordError::Invalid { field: "pressure_bps" })?;
+        Ok(NodeObservation {
+            pressure,
+            backlog: Bytes::new(self.backlog_bytes),
+            max_drain_rate: ByteRate::new(self.max_drain_rate_bps),
+            observed_p99: Duration::from_nanos(self.observed_p99_ns),
+            error_bps: self.error_bps,
+        })
+    }
+}
+
+/// The wire form of a per-node allocation written by [`WRITE_ALLOC_SCRIPT`]. `budget` is a
+/// decimal string, not a JSON number, so a multi-gigabyte/sec budget keeps full `u64`
+/// precision through Lua's double-only number type.
+#[derive(Deserialize)]
+struct AllocJson {
+    budget: String,
+    epoch: u64,
+}
+
+/// Handle to the Redis-backed coordination state. Cheap to clone (the `ConnectionManager`
+/// is a shared multiplexed handle).
+#[derive(Clone)]
+pub struct Coordinator {
+    conn: ConnectionManager,
+    prefix: String,
+    /// TTL on each heartbeat key — the fleet-staleness window (the agent sets this from
+    /// `CEPHOR_HEARTBEAT_TTL_SECS`). Only [`upsert_node_state`](Self::upsert_node_state)
+    /// uses it; the allocator's coordinator leaves it at a default it never reads.
+    node_ttl: Duration,
+    /// TTL on each allocation key — past it the agent reads no allocation and decays toward
+    /// its floor (the allocator sets this from `CEPHOR_ALLOCATION_TTL_SECS`). Only
+    /// [`write_allocations`](Self::write_allocations) uses it.
+    alloc_ttl: Duration,
+}
+
+// Manual Debug: redis's `ConnectionManager` is not `Debug`, so derive can't apply.
+impl std::fmt::Debug for Coordinator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Coordinator")
+            .field("prefix", &self.prefix)
+            .field("node_ttl", &self.node_ttl)
+            .field("alloc_ttl", &self.alloc_ttl)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Coordinator {
+    /// Connects a multiplexed, auto-reconnecting manager to `url`.
+    ///
+    /// # Errors
+    ///
+    /// [`CoordError::Redis`] if the client cannot be opened or the connection established.
+    pub async fn connect(url: &str, node_ttl: Duration, alloc_ttl: Duration) -> Result<Self> {
+        let conn = ConnectionManager::new(redis::Client::open(url)?).await?;
+        Ok(Self::new(conn, node_ttl, alloc_ttl))
+    }
+
+    /// Builds a coordinator over an existing connection manager — used by the agent, which
+    /// shares one manager with its upload enqueuer (the same redis-queues instance).
+    #[must_use]
+    pub fn new(conn: ConnectionManager, node_ttl: Duration, alloc_ttl: Duration) -> Self {
+        Self {
+            conn,
+            prefix: DEFAULT_PREFIX.to_owned(),
+            node_ttl,
+            alloc_ttl,
+        }
+    }
+
+    /// Overrides the key namespace (tests isolate parallel runs with a unique prefix).
+    #[must_use]
+    pub fn with_prefix(mut self, prefix: &str) -> Self {
+        prefix.clone_into(&mut self.prefix);
+        self
+    }
+
+    fn leader_key(&self) -> String {
+        format!("{}leader", self.prefix)
+    }
+
+    fn epoch_key(&self) -> String {
+        format!("{}epoch", self.prefix)
+    }
+
+    fn nodes_key(&self) -> String {
+        format!("{}nodes", self.prefix)
+    }
+
+    fn node_key(&self, node: &NodeId) -> String {
+        format!("{}node:{}", self.prefix, node.as_str())
+    }
+
+    fn alloc_key(&self, node: &NodeId) -> String {
+        format!("{}alloc:{}", self.prefix, node.as_str())
+    }
+
+    /// Acquires or renews the singleton leadership lease for `instance_id`.
+    ///
+    /// Returns `Some(Lease)` when this instance holds leadership after the call (a fresh
+    /// acquisition, a takeover of an expired lease, or a renewal of its own — a takeover
+    /// bumps the epoch, a renewal keeps it), or `None` when another instance holds an
+    /// unexpired lease.
+    ///
+    /// # Errors
+    ///
+    /// [`CoordError::Redis`] on a command failure; [`CoordError::Invalid`] if the stored
+    /// epoch is out of range.
+    pub async fn acquire_or_renew_leadership(&self, instance_id: &str, ttl: Duration) -> Result<Option<Lease>> {
+        let mut conn = self.conn.clone();
+        let epoch: Option<i64> = redis::Script::new(LEASE_SCRIPT)
+            .key(self.leader_key())
+            .key(self.epoch_key())
+            .arg(instance_id)
+            .arg(ttl.as_secs().max(1))
+            .invoke_async(&mut conn)
+            .await?;
+        match epoch {
+            Some(epoch) => Ok(Some(Lease {
+                epoch: nonneg_u64("epoch", epoch)?,
+            })),
+            None => Ok(None),
+        }
+    }
+
+    /// Relinquishes leadership held by `instance_id` — the allocator's graceful-shutdown
+    /// handoff. Best-effort: a no-op if a successor already took over, and the lease TTL is
+    /// the backstop if this is skipped (crash / `SIGKILL` / partition).
+    ///
+    /// # Errors
+    ///
+    /// [`CoordError::Redis`] on a command failure.
+    pub async fn relinquish_leadership(&self, instance_id: &str) -> Result<()> {
+        let mut conn = self.conn.clone();
+        let _: i64 = redis::Script::new(RELINQUISH_SCRIPT)
+            .key(self.leader_key())
+            .arg(instance_id)
+            .invoke_async(&mut conn)
+            .await?;
+        Ok(())
+    }
+
+    /// Publishes (upserts) this node's heartbeat with a fresh TTL, indexing it in the
+    /// fleet set so [`load_fleet`](Self::load_fleet) need not scan the keyspace.
+    ///
+    /// # Errors
+    ///
+    /// [`CoordError::Serde`] if the observation cannot serialize; [`CoordError::Redis`]
+    /// on a command failure.
+    pub async fn upsert_node_state(&self, node: &NodeId, observation: &NodeObservation) -> Result<()> {
+        let payload = serde_json::to_string(&NodeStateJson::from_observation(observation))?;
+        let mut conn = self.conn.clone();
+        let _: () = conn.set_ex(self.node_key(node), payload, self.node_ttl.as_secs().max(1)).await?;
+        let _: () = conn.sadd(self.nodes_key(), node.as_str()).await?;
+        Ok(())
+    }
+
+    /// Loads every live heartbeat into a [`FleetView`]. A node whose key has TTL-expired is
+    /// pruned from the index set in passing, so a departed node drops out of the fleet
+    /// without a reaper.
+    ///
+    /// # Errors
+    ///
+    /// [`CoordError::Redis`] on a command failure; [`CoordError::Serde`]/[`CoordError::Invalid`]
+    /// if a stored heartbeat is malformed.
+    pub async fn load_fleet(&self) -> Result<FleetView> {
+        let mut conn = self.conn.clone();
+        let ids: Vec<String> = conn.smembers(self.nodes_key()).await?;
+        let mut fleet = FleetView::new();
+        if ids.is_empty() {
+            return Ok(fleet);
+        }
+        let keys: Vec<String> = ids.iter().map(|id| format!("{}node:{id}", self.prefix)).collect();
+        let values: Vec<Option<String>> = conn.mget(&keys).await?;
+        let mut expired: Vec<&str> = Vec::new();
+        for (id, value) in ids.iter().zip(values) {
+            match value {
+                Some(json) => {
+                    let node = NodeId::try_from(id.clone()).map_err(|_| CoordError::Invalid { field: "node_id" })?;
+                    let observation = serde_json::from_str::<NodeStateJson>(&json)?.into_observation()?;
+                    fleet.insert(node, observation);
+                }
+                None => expired.push(id),
+            }
+        }
+        if !expired.is_empty() {
+            let _: () = conn.srem(self.nodes_key(), expired).await?;
+        }
+        Ok(fleet)
+    }
+
+    /// Writes per-node allocations stamped with `epoch`, fenced atomically so a lower epoch
+    /// cannot overwrite a higher one (the deposed-leader guard). An empty plan is a no-op —
+    /// a node dropped from the plan is conserved by its key's TTL expiring (no zeroing pass
+    /// needed, unlike the old PG path).
+    ///
+    /// # Errors
+    ///
+    /// [`CoordError::Fenced`] if a higher-epoch leader exists (nothing was written);
+    /// [`CoordError::Redis`] on a command failure.
+    pub async fn write_allocations(&self, epoch: u64, allocations: &[Allocation]) -> Result<()> {
+        if allocations.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn.clone();
+        let script = redis::Script::new(WRITE_ALLOC_SCRIPT);
+        let mut invocation = script.prepare_invoke();
+        for allocation in allocations {
+            invocation.key(self.alloc_key(&allocation.node));
+        }
+        invocation.arg(epoch).arg(self.alloc_ttl.as_secs().max(1));
+        for allocation in allocations {
+            // Budget as a decimal string preserves full u64 precision past Lua's doubles.
+            invocation.arg(allocation.budget.get().to_string());
+        }
+        let written: i64 = invocation.invoke_async(&mut conn).await?;
+        if written == 0 {
+            return Err(CoordError::Fenced { epoch });
+        }
+        Ok(())
+    }
+
+    /// Reads a node's current allocation, if one exists (absent = TTL-expired or never
+    /// written, so the caller decays toward its floor).
+    ///
+    /// # Errors
+    ///
+    /// [`CoordError::Redis`] on a command failure; [`CoordError::Serde`]/[`CoordError::Invalid`]
+    /// if the stored value is malformed.
+    pub async fn load_allocation(&self, node: &NodeId) -> Result<Option<StoredAllocation>> {
+        let mut conn = self.conn.clone();
+        let value: Option<String> = conn.get(self.alloc_key(node)).await?;
+        match value {
+            None => Ok(None),
+            Some(json) => {
+                let allocation: AllocJson = serde_json::from_str(&json)?;
+                let budget = allocation.budget.parse::<u64>().map_err(|_| CoordError::Invalid { field: "budget" })?;
+                Ok(Some(StoredAllocation {
+                    budget: ByteRate::new(budget),
+                    epoch: allocation.epoch,
+                }))
+            }
+        }
+    }
+}
+
+/// Checked `i64 -> u64` for a value Redis stored as a (non-negative) integer.
+fn nonneg_u64(field: &'static str, value: i64) -> Result<u64> {
+    u64::try_from(value).map_err(|_| CoordError::Invalid { field })
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr, reason = "tests")]
+mod tests {
+    use super::Coordinator;
+    use crate::alloc::Allocation;
+    use crate::alloc::NodeObservation;
+    use crate::ids::NodeId;
+    use crate::units::ByteRate;
+    use crate::units::Bytes;
+    use crate::units::DiskPressure;
+    use core::str::FromStr;
+    use std::time::Duration;
+
+    /// A live test Redis URL, or `None` to skip (Rust has no fakeredis; these need a real
+    /// instance — `CEPHOR_TEST_REDIS_URL=redis://localhost:6382/0`). A skip prints a note so
+    /// a silent pass is not mistaken for coverage.
+    fn test_url() -> Option<String> {
+        std::env::var("CEPHOR_TEST_REDIS_URL").ok().filter(|value| !value.is_empty())
+    }
+
+    /// Builds a coordinator on the test Redis under a per-test prefix (parallel isolation),
+    /// or returns `None` to skip the test.
+    async fn coord(prefix: &str, node_ttl: Duration, alloc_ttl: Duration) -> Option<Coordinator> {
+        let url = test_url()?;
+        // Prefix with the process id so a re-run never collides with the prior run's
+        // still-TTL'd keys on a shared test Redis (the per-test `prefix` isolates within a run).
+        let coordinator = Coordinator::connect(&url, node_ttl, alloc_ttl)
+            .await
+            .expect("connect to the test redis")
+            .with_prefix(&format!("{}:{prefix}", std::process::id()));
+        Some(coordinator)
+    }
+
+    fn observation() -> NodeObservation {
+        NodeObservation {
+            pressure: DiskPressure::try_from(5_000).unwrap(),
+            backlog: Bytes::new(9_000_000),
+            max_drain_rate: ByteRate::new(5_000_000),
+            observed_p99: Duration::from_millis(10),
+            error_bps: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn lease_acquires_renews_keeping_the_epoch_and_blocks_a_second_holder() {
+        let Some(c) = coord("cephor-test:lease-renew:", Duration::from_secs(5), Duration::from_secs(5)).await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
+        let first = c
+            .acquire_or_renew_leadership("a", Duration::from_secs(30))
+            .await
+            .unwrap()
+            .expect("a leads");
+        // Renewing the OWN still-valid lease keeps the epoch.
+        let renew = c
+            .acquire_or_renew_leadership("a", Duration::from_secs(30))
+            .await
+            .unwrap()
+            .expect("a renews");
+        assert_eq!(renew.epoch, first.epoch, "renewal keeps the epoch");
+        // A second instance cannot lead while a holds an unexpired lease.
+        assert_eq!(
+            c.acquire_or_renew_leadership("b", Duration::from_secs(30)).await.unwrap(),
+            None,
+            "b is denied"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_expired_lease_is_taken_over_with_a_bumped_epoch() {
+        // A 1s lease that we let lapse: the next acquirer is a NEW era (epoch + 1), which
+        // fences any stale in-flight write from the previous era.
+        let Some(c) = coord("cephor-test:lease-takeover:", Duration::from_secs(5), Duration::from_secs(5)).await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
+        let first = c
+            .acquire_or_renew_leadership("a", Duration::from_secs(1))
+            .await
+            .unwrap()
+            .expect("a leads");
+        tokio::time::sleep(Duration::from_millis(1_200)).await;
+        let next = c
+            .acquire_or_renew_leadership("b", Duration::from_secs(30))
+            .await
+            .unwrap()
+            .expect("b takes over");
+        assert!(next.epoch > first.epoch, "takeover bumps the epoch ({} > {})", next.epoch, first.epoch);
+        // Relinquish lets a successor lead immediately rather than waiting the TTL.
+        c.relinquish_leadership("b").await.unwrap();
+        assert!(
+            c.acquire_or_renew_leadership("d", Duration::from_secs(30)).await.unwrap().is_some(),
+            "successor leads after relinquish"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_heartbeat_expires_out_of_the_fleet() {
+        // A 1s node TTL: present right after the upsert, gone after it lapses.
+        let Some(c) = coord("cephor-test:fleet-ttl:", Duration::from_secs(1), Duration::from_secs(5)).await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
+        let node = NodeId::from_str("n1").unwrap();
+        c.upsert_node_state(&node, &observation()).await.unwrap();
+        assert_eq!(c.load_fleet().await.unwrap().len(), 1, "the heartbeating node is in the fleet");
+        tokio::time::sleep(Duration::from_millis(1_200)).await;
+        assert_eq!(c.load_fleet().await.unwrap().len(), 0, "a node that stops heartbeating ages out");
+    }
+
+    #[tokio::test]
+    async fn an_allocation_round_trips_and_a_stale_epoch_write_is_fenced() {
+        let Some(c) = coord("cephor-test:alloc-fence:", Duration::from_secs(5), Duration::from_secs(30)).await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
+        let node = NodeId::from_str("n1").unwrap();
+        let alloc = |budget| Allocation {
+            node: node.clone(),
+            budget: ByteRate::new(budget),
+        };
+        // Epoch 5 writes a budget; it reads back with its epoch.
+        c.write_allocations(5, std::slice::from_ref(&alloc(1_000))).await.unwrap();
+        let stored = c.load_allocation(&node).await.unwrap().expect("budget written");
+        assert_eq!(stored.budget, ByteRate::new(1_000));
+        assert_eq!(stored.epoch, 5);
+        // A lower-epoch (deposed) leader's write is fenced and changes nothing.
+        let err = c.write_allocations(3, std::slice::from_ref(&alloc(2_000))).await.unwrap_err();
+        assert!(
+            matches!(err, super::CoordError::Fenced { epoch: 3 }),
+            "stale-epoch write fenced, got {err:?}"
+        );
+        assert_eq!(
+            c.load_allocation(&node).await.unwrap().unwrap().budget,
+            ByteRate::new(1_000),
+            "the fenced write did not land"
+        );
+        // A higher epoch (a new leader) may overwrite.
+        c.write_allocations(6, std::slice::from_ref(&alloc(2_000))).await.unwrap();
+        assert_eq!(c.load_allocation(&node).await.unwrap().unwrap().budget, ByteRate::new(2_000));
+    }
+}

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -8,6 +8,8 @@
 mod alloc;
 mod apipart;
 mod clock;
+#[cfg(feature = "coord")]
+mod coordination;
 mod enforce;
 mod error;
 mod gc;
@@ -20,7 +22,7 @@ mod ssd_reclaim;
 mod state;
 #[cfg(feature = "pg")]
 mod store;
-#[cfg(feature = "pg")]
+#[cfg(feature = "coord")]
 mod tick;
 mod units;
 
@@ -46,7 +48,9 @@ pub use units::{ByteRate, Bytes, DiskPressure};
 #[cfg(any(test, feature = "test-util"))]
 pub use clock::TestClock;
 
+#[cfg(feature = "coord")]
+pub use coordination::{CoordError, Coordinator, Lease, StoredAllocation};
 #[cfg(feature = "pg")]
-pub use store::{Lease, PendingPart, Store, StoreError, StoredAllocation, UploadContext};
-#[cfg(feature = "pg")]
+pub use store::{PendingPart, Store, StoreError, UploadContext};
+#[cfg(feature = "coord")]
 pub use tick::{CephCeilingSource, StaticCeiling, TickConfig, TickOutcome, run_tick};

--- a/crates/hippius-drain-core/src/partdrain.rs
+++ b/crates/hippius-drain-core/src/partdrain.rs
@@ -150,13 +150,25 @@ pub trait PartSource: Send + Sync {
 /// must be crash-atomic: once either returns `Ok`, a power loss leaves the complete
 /// file, never a torn one.
 pub trait PartPool: Send + Sync {
-    /// Durably copy `source` into the pool at the part's `chunk_<index>.bin`.
-    fn persist_chunk(&self, source: &Path, part: &PartKey, index: ChunkIndex) -> impl Future<Output = std::io::Result<()>> + Send;
+    /// Durably copy `source` into the pool at the part's `chunk_<index>.bin`,
+    /// returning the lowercase-hex SHA-256 of the bytes streamed during the copy.
+    /// The copy fsyncs the chunk file (`fdatasync`) but NOT the parent dir — the
+    /// single per-part dir-fsync is deferred to [`finalize_part`](PartPool::finalize_part),
+    /// so a 64-chunk part costs one dir-fsync, not 64.
+    fn persist_chunk(&self, source: &Path, part: &PartKey, index: ChunkIndex) -> impl Future<Output = std::io::Result<String>> + Send;
 
     /// Durably copy `source` into the pool at the part's `meta.json`. Called LAST,
     /// after every chunk is verified, so a reader's meta gate flips only when the
-    /// whole part is durably present.
+    /// whole part is durably present. Like [`persist_chunk`](PartPool::persist_chunk)
+    /// it does not fsync the dir — [`finalize_part`](PartPool::finalize_part) does.
     fn persist_meta(&self, source: &Path, part: &PartKey) -> impl Future<Output = std::io::Result<()>> + Send;
+
+    /// Fsync the part's directory once, after every chunk + meta has been renamed
+    /// into place, so all those directory entries become durable together. Meta is
+    /// renamed before this call, so chunks+meta flush atomically when the dir entry
+    /// flushes — a crash before this leaves the part `draining` (re-drained), losing
+    /// no durability since `mark_replicated` only commits after it succeeds.
+    fn finalize_part(&self, part: &PartKey) -> impl Future<Output = std::io::Result<()>> + Send;
 
     /// The lowercase-hex content hash of one pooled chunk (to verify the copy).
     fn chunk_hash(&self, part: &PartKey, index: ChunkIndex) -> impl Future<Output = std::io::Result<String>> + Send;
@@ -285,37 +297,50 @@ where
         return Ok(DrainOutcome::AlreadyReplicated);
     }
 
-    // Copy + byte-verify every chunk. A pooled chunk whose hash differs from its SSD
-    // source is a corrupt copy: mark the part Failed, drop the partial pool copy, and
-    // leave the SSD source intact — never commit it.
+    // Copy every chunk, hashing it ONCE during the copy stream (no SSD re-read). The
+    // copy-time hash is the source bytes as written, so a torn pool write is caught by
+    // re-reading the pool copy and comparing — but only for a SAMPLE (the first and last
+    // chunk), not every chunk: the per-chunk pool readback was a full second read of the
+    // slowest tier. Content-addressed naming makes writes idempotent + self-naming and the
+    // drain re-drives on any failure, so the interior chunks trust the copy; the sampled
+    // endpoints still catch a systematic copy/IO fault. A mismatch marks the part Failed,
+    // drops the partial pool copy, and leaves the SSD source intact — never commit it.
     let chunks = ssd.list_chunks(part).await.map_err(PartDrainError::io(DrainStep::Persist))?;
-    for index in chunks {
+    let (first, last) = (chunks.first().copied(), chunks.last().copied());
+    for index in &chunks {
+        let index = *index;
         let source = ssd.chunk_source(part, index).map_err(PartDrainError::io(DrainStep::Persist))?;
-        ceph.persist_chunk(&source, part, index)
+        let copy_hash = ceph
+            .persist_chunk(&source, part, index)
             .await
             .map_err(PartDrainError::io(DrainStep::Persist))?;
-        let source_hash = ssd.chunk_hash(part, index).await.map_err(PartDrainError::io(DrainStep::Hash))?;
-        let pool_hash = ceph.chunk_hash(part, index).await.map_err(PartDrainError::io(DrainStep::Hash))?;
-        if source_hash != pool_hash {
-            store
-                .mark_failed(claim, "chunk copy byte mismatch")
-                .await
-                .map_err(PartDrainError::store)?;
-            ceph.remove_part(part).await.map_err(PartDrainError::io(DrainStep::Cleanup))?;
-            return Err(PartDrainError::ChunkMismatch {
-                index,
-                source_hash: source_hash.into_boxed_str(),
-                pool_hash: pool_hash.into_boxed_str(),
-            });
+        if Some(index) == first || Some(index) == last {
+            let pool_hash = ceph.chunk_hash(part, index).await.map_err(PartDrainError::io(DrainStep::Hash))?;
+            if pool_hash != copy_hash {
+                store
+                    .mark_failed(claim, "chunk copy byte mismatch")
+                    .await
+                    .map_err(PartDrainError::store)?;
+                ceph.remove_part(part).await.map_err(PartDrainError::io(DrainStep::Cleanup))?;
+                return Err(PartDrainError::ChunkMismatch {
+                    index,
+                    source_hash: copy_hash.into_boxed_str(),
+                    pool_hash: pool_hash.into_boxed_str(),
+                });
+            }
         }
     }
 
-    // Persist meta LAST — only now, with every chunk durable and verified, may the
-    // reader's `meta.json` gate flip on the pool copy.
+    // Persist meta LAST — only now, with every chunk durably copied (and the sampled
+    // endpoints byte-verified), may the reader's `meta.json` gate flip on the pool copy.
     let meta_source = ssd.meta_source(part).map_err(PartDrainError::io(DrainStep::Persist))?;
     ceph.persist_meta(&meta_source, part)
         .await
         .map_err(PartDrainError::io(DrainStep::Persist))?;
+    // ONE dir-fsync for the whole part, now that every chunk + meta is renamed into place
+    // (Task 1: batch the fsync). Precedes commit/enqueue so the pool copy is durable before
+    // the SSD source can be removed.
+    ceph.finalize_part(part).await.map_err(PartDrainError::io(DrainStep::Persist))?;
     let verified = PartVerified(());
 
     // Enqueue the backend upload BEFORE committing (at-least-once): the part is now
@@ -382,6 +407,9 @@ mod tests {
         status: HashMap<String, ReplicationState>,
         fault: Fault,
         corrupt_persist: bool,
+        /// Specific chunk indices a persist corrupts (in addition to `corrupt_persist`),
+        /// so a test can corrupt only an interior chunk vs. a sampled endpoint.
+        corrupt_chunks: std::collections::HashSet<u32>,
         /// When set, the upload enqueue fails (to test the at-least-once seam).
         enqueue_fault: bool,
         /// Parts the enqueuer was asked to enqueue, in order.
@@ -428,6 +456,12 @@ mod tests {
             self
         }
 
+        /// Corrupt the persisted copy of one specific chunk index only.
+        fn corrupt_chunk(self, index: u32) -> Self {
+            self.world.lock().unwrap().corrupt_chunks.insert(index);
+            self
+        }
+
         fn enqueue_fault(self) -> Self {
             self.world.lock().unwrap().enqueue_fault = true;
             self
@@ -441,6 +475,7 @@ mod tests {
             let mut world = self.world.lock().unwrap();
             world.fault = Fault::None;
             world.corrupt_persist = false;
+            world.corrupt_chunks.clear();
         }
 
         fn status_of(&self, part: &PartKey) -> Option<ReplicationState> {
@@ -509,23 +544,30 @@ mod tests {
     }
 
     impl PartPool for Fakes {
-        fn persist_chunk(&self, _source: &Path, part: &PartKey, index: ChunkIndex) -> impl Future<Output = io::Result<()>> + Send {
+        fn persist_chunk(&self, _source: &Path, part: &PartKey, index: ChunkIndex) -> impl Future<Output = io::Result<String>> + Send {
             let part = part.clone();
             async move {
                 let mut world = self.world.lock().unwrap();
                 if world.fault == Fault::PersistChunk {
                     return Err(io::Error::other("persist chunk failed"));
                 }
-                let corrupt = world.corrupt_persist;
+                let corrupt = world.corrupt_persist || world.corrupt_chunks.contains(&index.get());
                 let source_hash = world
                     .ssd
                     .get(&key_of(&part))
                     .and_then(|s| s.chunks.get(&index.get()).cloned())
                     .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no ssd source"))?;
-                // A corrupt persist writes different bytes (hash) than the source.
-                let written = if corrupt { format!("corrupt-{}", index.get()) } else { source_hash };
+                // A corrupt persist writes different bytes (hash) than the source. The
+                // returned hash is the copy-time (source) hash either way — mirrors the
+                // real localfs, where the copy streams + hashes the source while a torn
+                // write only diverges on the pool re-read.
+                let written = if corrupt {
+                    format!("corrupt-{}", index.get())
+                } else {
+                    source_hash.clone()
+                };
                 world.pool.entry(key_of(&part)).or_default().chunks.insert(index.get(), written);
-                Ok(())
+                Ok(source_hash)
             }
         }
 
@@ -539,6 +581,12 @@ mod tests {
                 world.pool.entry(key_of(&part)).or_default().has_meta = true;
                 Ok(())
             }
+        }
+
+        async fn finalize_part(&self, _part: &PartKey) -> io::Result<()> {
+            // The in-memory pool needs no fsync; the real localfs dir-fsync is exercised
+            // by the e2e + localfs tests.
+            Ok(())
         }
 
         fn chunk_hash(&self, part: &PartKey, index: ChunkIndex) -> impl Future<Output = io::Result<String>> + Send {
@@ -674,6 +722,43 @@ mod tests {
         assert_eq!(fakes.status_of(&part), Some(ReplicationState::Failed));
         assert!(fakes.ssd_has(&part), "corrupt drain must NOT delete the SSD copy");
         assert!(fakes.pool_part(&part).is_none(), "the corrupt, never-committed pool copy is removed");
+    }
+
+    #[tokio::test]
+    async fn a_corrupt_last_chunk_is_caught_by_the_sampled_readback() {
+        // The sampled verify re-reads the first and last chunk. A torn LAST chunk must
+        // still trip ChunkMismatch even though the interior chunks are now trusted.
+        let part = part();
+        let fakes = Fakes::seeded(&part, &[(0, "h0"), (1, "h1"), (2, "h2")]).corrupt_chunk(2);
+
+        let err = drain_part(&fakes, &fakes, &fakes, &fakes, &claim(&part)).await.unwrap_err();
+
+        assert!(matches!(err, PartDrainError::ChunkMismatch { index, .. } if index == ChunkIndex::new(2)));
+        assert_eq!(fakes.status_of(&part), Some(ReplicationState::Failed));
+        assert!(fakes.ssd_has(&part), "corrupt drain must NOT delete the SSD copy");
+    }
+
+    #[tokio::test]
+    async fn a_corrupt_interior_chunk_is_not_caught_by_the_sampled_readback() {
+        // Pins the sampling trade-off: only the first + last chunk are re-read, so a torn
+        // INTERIOR chunk is trusted (content-addressed naming + re-drive cover it elsewhere).
+        // The drain therefore commits — the test documents what sampling deliberately skips.
+        let part = part();
+        let fakes = Fakes::seeded(&part, &[(0, "h0"), (1, "h1"), (2, "h2")]).corrupt_chunk(1);
+
+        let outcome = drain_part(&fakes, &fakes, &fakes, &fakes, &claim(&part)).await.unwrap();
+
+        assert_eq!(
+            outcome,
+            DrainOutcome::Replicated,
+            "an interior torn copy is not sampled, so the drain commits"
+        );
+        let pooled = fakes.pool_part(&part).expect("part landed on CephFS");
+        assert_eq!(
+            pooled.chunks.get(&1).map(String::as_str),
+            Some("corrupt-1"),
+            "the interior corruption went undetected"
+        );
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -1,4 +1,7 @@
-//! Postgres-backed central state: node heartbeats, allocations, and GC claims.
+//! Postgres-backed durable state: part replication status / claims, the landed-part
+//! log, GC claims, and upload context. The loss-tolerant coordination state (leader
+//! lease, node heartbeats, per-node allocations) lives in [`Coordinator`](crate::Coordinator)
+//! on Redis, not here.
 //!
 //! Uses runtime `sqlx` queries rather than the compile-checked `query!` macro,
 //! deliberately: this environment cannot produce a committable `.sqlx` offline
@@ -8,16 +11,14 @@
 //! exercise every query — so schema drift is caught at test time. Revisit
 //! `query!` once CI Postgres infra exists.
 
-use crate::alloc::{Allocation, FleetView, NodeObservation};
 use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
 use crate::gc::GcClaim;
-use crate::ids::{FileId, NodeId};
+use crate::ids::FileId;
 use crate::partdrain::{ClaimedPart, PartReplicationStore, PartVerified};
 use crate::reconcile::PartLandingLog;
 use crate::reconcile::PartStatus;
 use crate::ssd_reclaim::{PartStatusAge, ReclaimLog};
 use crate::state::ReplicationState;
-use crate::units::{ByteRate, Bytes, DiskPressure};
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -64,27 +65,9 @@ pub enum StoreError {
         /// The unrecognized status text.
         value: Box<str>,
     },
-    /// An allocation write was rejected by the epoch fence: a higher-epoch leader
-    /// exists, so this instance is deposed. Surfaced (rather than a false `Ok`) so
-    /// a split-brain leader learns it lost rather than reporting itself as acting.
-    #[error("allocation write fenced: epoch {epoch} is no longer the leader")]
-    Fenced {
-        /// The (now-deposed) epoch whose write was rejected.
-        epoch: u64,
-    },
 }
 
 type Result<T> = core::result::Result<T, StoreError>;
-
-/// Checked `u64 -> i64` for storing a byte count in a BIGINT.
-fn to_i64(value: u64) -> Result<i64> {
-    i64::try_from(value).map_err(|_| StoreError::OutOfRange { value })
-}
-
-/// Checked `i64 -> u64` for a column constrained non-negative.
-fn nonneg_u64(field: &'static str, value: i64) -> Result<u64> {
-    u64::try_from(value).map_err(|_| StoreError::Invalid { field, value })
-}
 
 /// Parses a stored status string back into a [`ReplicationState`]. The four
 /// literals match the `cephor_replication_status.status` CHECK constraint and
@@ -111,49 +94,6 @@ const RECLAIM_STATUS_BATCH: usize = 500;
 /// part — the fail-safe direction.
 fn age_from_secs(secs: f64) -> Duration {
     Duration::try_from_secs_f64(secs.max(0.0)).unwrap_or(Duration::ZERO)
-}
-
-#[derive(sqlx::FromRow)]
-struct NodeStateRow {
-    node_id: String,
-    pressure_bps: i32,
-    backlog_bytes: i64,
-    max_drain_rate: i64,
-    observed_p99_ns: i64,
-    error_bps: i32,
-}
-
-impl NodeStateRow {
-    fn into_domain(self) -> Result<(NodeId, NodeObservation)> {
-        let invalid = |field: &'static str, value: i64| StoreError::Invalid { field, value };
-        let node = NodeId::try_from(self.node_id).map_err(|_| invalid("node_id", 0))?;
-        let pressure_bps = u16::try_from(self.pressure_bps).map_err(|_| invalid("pressure_bps", i64::from(self.pressure_bps)))?;
-        let pressure = DiskPressure::try_from(pressure_bps).map_err(|_| invalid("pressure_bps", i64::from(self.pressure_bps)))?;
-        let error_bps = u16::try_from(self.error_bps).map_err(|_| invalid("error_bps", i64::from(self.error_bps)))?;
-        let observation = NodeObservation {
-            pressure,
-            backlog: Bytes::new(nonneg_u64("backlog_bytes", self.backlog_bytes)?),
-            max_drain_rate: ByteRate::new(nonneg_u64("max_drain_rate", self.max_drain_rate)?),
-            observed_p99: Duration::from_nanos(nonneg_u64("observed_p99_ns", self.observed_p99_ns)?),
-            error_bps,
-        };
-        Ok((node, observation))
-    }
-}
-
-#[derive(sqlx::FromRow)]
-struct AllocationRow {
-    budget_bytes: i64,
-    fencing_epoch: i64,
-}
-
-/// A node's current allocation, read back from the store.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct StoredAllocation {
-    /// The allocated write rate.
-    pub budget: ByteRate,
-    /// The leader epoch that wrote it (for fencing checks).
-    pub epoch: u64,
 }
 
 /// An advisory pending-part backlog item from [`Store::list_landed_pending_parts`].
@@ -224,15 +164,6 @@ impl ClaimedPartRow {
         .into_part()?;
         Ok(ClaimedPart::new(part, self.claim_seq))
     }
-}
-
-/// A held leadership lease.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Lease {
-    /// The fencing epoch for this leadership era. Every allocation write made
-    /// while holding this lease is stamped with it, so a deposed leader's
-    /// lower-epoch writes are rejected.
-    pub epoch: u64,
 }
 
 /// The default claim lease: a `draining` row whose claim is older than this is
@@ -332,148 +263,6 @@ impl Store {
         Ok(())
     }
 
-    /// Upserts a node's heartbeat with a server-stamped `updated_at`.
-    ///
-    /// # Errors
-    ///
-    /// [`StoreError::OutOfRange`] if a byte count exceeds i64; [`StoreError::Database`] on failure.
-    pub async fn upsert_node_state(&self, node: &NodeId, observation: &NodeObservation) -> Result<()> {
-        // p99 nanos: u128 -> i64 cannot overflow for any realistic latency; clamp defensively.
-        let p99_ns = i64::try_from(observation.observed_p99.as_nanos()).unwrap_or(i64::MAX);
-        sqlx::query(
-            "INSERT INTO cephor_node_state \
-                (node_id, pressure_bps, backlog_bytes, max_drain_rate, observed_p99_ns, error_bps, updated_at) \
-             VALUES ($1, $2, $3, $4, $5, $6, now()) \
-             ON CONFLICT (node_id) DO UPDATE SET \
-                pressure_bps = $2, backlog_bytes = $3, max_drain_rate = $4, \
-                observed_p99_ns = $5, error_bps = $6, updated_at = now()",
-        )
-        .bind(node.as_str())
-        .bind(i32::from(observation.pressure.bps()))
-        .bind(to_i64(observation.backlog.get())?)
-        .bind(to_i64(observation.max_drain_rate.get())?)
-        .bind(p99_ns)
-        .bind(i32::from(observation.error_bps))
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
-    /// Loads every heartbeat fresher than `stale_after` into a [`FleetView`].
-    ///
-    /// # Errors
-    ///
-    /// [`StoreError::Database`] on query failure; [`StoreError::Invalid`] if a stored row violates a domain invariant.
-    pub async fn load_fleet(&self, stale_after: Duration) -> Result<FleetView> {
-        let rows = sqlx::query_as::<_, NodeStateRow>(
-            "SELECT node_id, pressure_bps, backlog_bytes, max_drain_rate, observed_p99_ns, error_bps \
-             FROM cephor_node_state \
-             WHERE updated_at >= now() - make_interval(secs => $1)",
-        )
-        .bind(stale_after.as_secs_f64())
-        .fetch_all(&self.pool)
-        .await?;
-        let mut fleet = FleetView::new();
-        for row in rows {
-            let (node, observation) = row.into_domain()?;
-            fleet.insert(node, observation);
-        }
-        Ok(fleet)
-    }
-
-    /// Writes per-node allocations stamped with `epoch`, fenced so a lower epoch
-    /// cannot overwrite a higher one — a deposed leader's writes are ignored.
-    ///
-    /// # Errors
-    ///
-    /// [`StoreError::OutOfRange`] if a budget exceeds i64; [`StoreError::Database`] on failure.
-    pub async fn write_allocations(&self, epoch: u64, allocations: &[Allocation]) -> Result<()> {
-        // F6: an empty plan carries no fleet information, so it must be a no-op. The
-        // node-absence zeroing below uses `node_id <> ALL($present)`, which with an
-        // empty `present` matches EVERY row — so an empty plan would zero the whole
-        // live fleet's budgets on a transient empty view. Stale budgets are already
-        // handled on read (load_allocation treats un-refreshed rows as absent), so
-        // there is nothing an empty plan needs to do here.
-        if allocations.is_empty() {
-            return Ok(());
-        }
-        let epoch_i = to_i64(epoch)?;
-        let mut tx = self.pool.begin().await?;
-        let mut present: Vec<&str> = Vec::with_capacity(allocations.len());
-        for allocation in allocations {
-            let result = sqlx::query(
-                "INSERT INTO cephor_allocation (node_id, budget_bytes, fencing_epoch, updated_at) \
-                 VALUES ($1, $2, $3, now()) \
-                 ON CONFLICT (node_id) DO UPDATE SET \
-                    budget_bytes = $2, fencing_epoch = $3, updated_at = now() \
-                 WHERE cephor_allocation.fencing_epoch <= $3",
-            )
-            .bind(allocation.node.as_str())
-            .bind(to_i64(allocation.budget.get())?)
-            .bind(epoch_i)
-            .execute(&mut *tx)
-            .await?;
-            // A 0-row upsert means the ON CONFLICT fence (fencing_epoch <= $3)
-            // rejected the write: a higher-epoch leader exists, so this instance is
-            // deposed. Surface it (the early return drops the tx, rolling back)
-            // rather than committing a no-op and reporting a false success — the same
-            // discipline as claim_chunk's ClaimLost. The fence is plan-wide: if one
-            // node is fenced this leader has lost, so we abandon the rest.
-            if result.rows_affected() == 0 {
-                return Err(StoreError::Fenced { epoch });
-            }
-            present.push(allocation.node.as_str());
-        }
-        // Conserve the fleet-wide budget: a node absent from this plan has left the
-        // fleet, so zero its lingering allotment instead of leaving a stale (often
-        // large) budget that inflates the table-wide sum past the Ceph ceiling
-        // (audit M1). Fenced by `fencing_epoch <= $2` so a deposed leader cannot
-        // zero the acting leader's writes, mirroring the upsert fence. The row is
-        // kept (not deleted) so its epoch keeps fencing later writes; `updated_at`
-        // is set to the epoch sentinel so the agent reads it as stale and decays
-        // toward its floor rather than enforcing the zero.
-        sqlx::query(
-            "UPDATE cephor_allocation SET budget_bytes = 0, updated_at = to_timestamp(0) \
-             WHERE fencing_epoch <= $1 AND node_id <> ALL($2) AND budget_bytes <> 0",
-        )
-        .bind(epoch_i)
-        .bind(&present)
-        .execute(&mut *tx)
-        .await?;
-        tx.commit().await?;
-        Ok(())
-    }
-
-    /// Reads a node's current allocation, if one exists.
-    ///
-    /// # Errors
-    ///
-    /// [`StoreError::Database`] on failure; [`StoreError::Invalid`] if a stored value is out of domain range.
-    pub async fn load_allocation(&self, node: &NodeId, stale_after: Duration) -> Result<Option<StoredAllocation>> {
-        // A row not refreshed within `stale_after` is treated as absent: the leader
-        // has gone silent on this node (it left the fleet, or the node is
-        // partitioned), so the agent must fall back to decaying toward its floor
-        // rather than re-pinning a lingering budget. This is what makes the
-        // designed decay-toward-floor path reachable (audit M1). A departed row the
-        // allocator zeroed carries a sentinel-epoch `updated_at`, so it reads stale
-        // here regardless of its (zero) budget.
-        let row = sqlx::query_as::<_, AllocationRow>(
-            "SELECT budget_bytes, fencing_epoch FROM cephor_allocation \
-             WHERE node_id = $1 AND updated_at > now() - $2 * interval '1 second'",
-        )
-        .bind(node.as_str())
-        .bind(stale_after.as_secs_f64())
-        .fetch_optional(&self.pool)
-        .await?;
-        match row {
-            None => Ok(None),
-            Some(row) => Ok(Some(StoredAllocation {
-                budget: ByteRate::new(nonneg_u64("budget_bytes", row.budget_bytes)?),
-                epoch: nonneg_u64("fencing_epoch", row.fencing_epoch)?,
-            })),
-        }
-    }
-
     /// Claims a file for GC. Returns `Some(GcClaim)` if this caller won the claim,
     /// `None` if another agent already holds a live, incomplete claim — so the
     /// reclaim runs once. The returned [`GcClaim`] is the capability
@@ -529,68 +318,6 @@ impl Store {
             .fetch_optional(&self.pool)
             .await?;
         Ok(row.is_some_and(|(done,)| done))
-    }
-
-    /// Acquires or renews the singleton leadership lease for `instance_id`.
-    ///
-    /// Returns `Some(Lease)` when this instance holds leadership after the call
-    /// (a fresh acquisition, a takeover of an expired lease, or a renewal of its
-    /// own), or `None` when another instance holds an unexpired lease. Re-acquiring
-    /// any *expired* lease — including this instance's own, lapsed after a freeze —
-    /// bumps the epoch (a new leadership era), so a stale in-flight write from the
-    /// previous era is fenced; only renewing a still-valid own lease keeps the
-    /// epoch. All time comparisons use the database clock, so agents' clock skew
-    /// does not affect election.
-    ///
-    /// # Errors
-    ///
-    /// [`StoreError::Database`].
-    pub async fn acquire_or_renew_leadership(&self, instance_id: &str, ttl: Duration) -> Result<Option<Lease>> {
-        let row = sqlx::query_as::<_, (i64,)>(
-            "INSERT INTO cephor_leader_lease (only_row, instance_id, epoch, expires_at) \
-             VALUES (TRUE, $1, 1, now() + make_interval(secs => $2)) \
-             ON CONFLICT (only_row) DO UPDATE SET \
-                instance_id = $1, \
-                epoch = CASE WHEN cephor_leader_lease.instance_id = $1 AND cephor_leader_lease.expires_at >= now() \
-                             THEN cephor_leader_lease.epoch \
-                             ELSE cephor_leader_lease.epoch + 1 END, \
-                expires_at = now() + make_interval(secs => $2) \
-             WHERE cephor_leader_lease.expires_at < now() OR cephor_leader_lease.instance_id = $1 \
-             RETURNING epoch",
-        )
-        .bind(instance_id)
-        .bind(ttl.as_secs_f64())
-        .fetch_optional(&self.pool)
-        .await?;
-        match row {
-            Some((epoch,)) => Ok(Some(Lease {
-                epoch: nonneg_u64("epoch", epoch)?,
-            })),
-            None => Ok(None),
-        }
-    }
-
-    /// Relinquishes leadership held by `instance_id` — the allocator binary's
-    /// graceful-shutdown handoff (called on SIGTERM/SIGINT once the
-    /// `hippius-drain-allocator` runtime exists; today its entry point is a skeleton).
-    ///
-    /// Best-effort by design: deleting the lease lets a successor take over on its
-    /// next tick *immediately* rather than waiting out the TTL, but it is purely an
-    /// optimization. If the call is skipped — a crash, a `SIGKILL`, a network
-    /// partition, or simply the not-yet-built binary — the lease's `expires_at` TTL
-    /// is the backstop: the row ages out and `acquire_or_renew_leadership` hands a
-    /// new epoch to the next acquirer. So leadership is never permanently stranded
-    /// whether or not this runs; it only shortens the failover gap.
-    ///
-    /// # Errors
-    ///
-    /// [`StoreError::Database`].
-    pub async fn relinquish_leadership(&self, instance_id: &str) -> Result<()> {
-        sqlx::query("DELETE FROM cephor_leader_lease WHERE instance_id = $1 AND only_row")
-            .bind(instance_id)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
     }
 
     /// Records that a part has landed on SSD and awaits drain (the reconciler-only
@@ -965,60 +692,10 @@ impl ReclaimLog for Store {
 #[cfg(feature = "pg")]
 #[expect(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
 mod tests {
-    use super::{Store, StoreError, StoredAllocation};
-    use crate::alloc::{Allocation, NodeObservation};
-    use crate::ids::{FileId, NodeId};
-    use crate::units::{ByteRate, Bytes, DiskPressure};
+    use super::Store;
+    use crate::ids::FileId;
     use core::str::FromStr;
     use sqlx::postgres::PgPool;
-    use std::time::Duration;
-
-    fn observation(pressure_bps: u16, backlog: u64, rate: u64) -> NodeObservation {
-        NodeObservation {
-            pressure: DiskPressure::try_from(pressure_bps).unwrap(),
-            backlog: Bytes::new(backlog),
-            max_drain_rate: ByteRate::new(rate),
-            observed_p99: Duration::from_millis(12),
-            error_bps: 5,
-        }
-    }
-
-    #[sqlx::test]
-    async fn heartbeat_round_trips(pool: PgPool) {
-        let store = Store::from_pool(pool);
-        let node = NodeId::from_str("node-a").unwrap();
-        store.upsert_node_state(&node, &observation(4_200, 9_000_000, 5_000_000)).await.unwrap();
-
-        let fleet = store.load_fleet(Duration::from_hours(1)).await.unwrap();
-        let (id, obs) = fleet.iter().next().expect("node present");
-        assert_eq!(id.as_str(), "node-a");
-        assert_eq!(obs.pressure.bps(), 4_200);
-        assert_eq!(obs.backlog.get(), 9_000_000);
-        assert_eq!(obs.max_drain_rate.get(), 5_000_000);
-        assert_eq!(obs.error_bps, 5);
-    }
-
-    #[sqlx::test]
-    async fn upsert_replaces_prior_heartbeat(pool: PgPool) {
-        let store = Store::from_pool(pool);
-        let node = NodeId::from_str("node-a").unwrap();
-        store.upsert_node_state(&node, &observation(1_000, 1, 1)).await.unwrap();
-        store.upsert_node_state(&node, &observation(8_000, 2, 2)).await.unwrap();
-        let fleet = store.load_fleet(Duration::from_hours(1)).await.unwrap();
-        assert_eq!(fleet.len(), 1, "upsert must not create a second row");
-        assert_eq!(fleet.iter().next().unwrap().1.pressure.bps(), 8_000);
-    }
-
-    #[sqlx::test]
-    async fn stale_heartbeats_are_filtered_out(pool: PgPool) {
-        let store = Store::from_pool(pool);
-        let node = NodeId::from_str("node-a").unwrap();
-        store.upsert_node_state(&node, &observation(1_000, 1, 1)).await.unwrap();
-        // A zero freshness window excludes a row stamped even microseconds ago.
-        let fresh = store.load_fleet(Duration::ZERO).await.unwrap();
-        assert!(fresh.is_empty(), "row stamped before the query instant is stale at window 0");
-        assert_eq!(store.load_fleet(Duration::from_hours(1)).await.unwrap().len(), 1);
-    }
 
     #[sqlx::test]
     async fn claim_part_is_scoped_to_the_recording_node(pool: PgPool) {
@@ -1081,149 +758,6 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn allocation_write_and_read_back(pool: PgPool) {
-        let store = Store::from_pool(pool);
-        let node = NodeId::from_str("node-a").unwrap();
-        let alloc = Allocation {
-            node: node.clone(),
-            budget: ByteRate::new(123_456),
-        };
-        store.write_allocations(7, std::slice::from_ref(&alloc)).await.unwrap();
-        let fresh = Duration::from_hours(1);
-        assert_eq!(
-            store.load_allocation(&node, fresh).await.unwrap(),
-            Some(StoredAllocation {
-                budget: ByteRate::new(123_456),
-                epoch: 7
-            })
-        );
-        assert_eq!(store.load_allocation(&NodeId::from_str("absent").unwrap(), fresh).await.unwrap(), None);
-    }
-
-    #[sqlx::test]
-    async fn load_allocation_ignores_a_stale_row(pool: PgPool) {
-        // M1: a row not refreshed within the staleness window reads as absent, so
-        // the agent's decay-toward-floor path engages instead of re-pinning a
-        // lingering budget. Backdating updated_at is the only way to fast-forward
-        // the staleness clock deterministically.
-        let store = Store::from_pool(pool.clone());
-        let node = NodeId::from_str("node-a").unwrap();
-        let alloc = Allocation {
-            node: node.clone(),
-            budget: ByteRate::new(50_000_000),
-        };
-        store.write_allocations(1, std::slice::from_ref(&alloc)).await.unwrap();
-        sqlx::query("UPDATE cephor_allocation SET updated_at = now() - interval '1 hour' WHERE node_id = $1")
-            .bind(node.as_str())
-            .execute(&pool)
-            .await
-            .unwrap();
-        assert_eq!(
-            store.load_allocation(&node, Duration::from_secs(10)).await.unwrap(),
-            None,
-            "a row older than the staleness window reads as absent",
-        );
-    }
-
-    #[sqlx::test]
-    async fn write_allocations_zeroes_a_departed_node(pool: PgPool) {
-        // A node present one tick, gone the next: its budget is zeroed (table-wide
-        // conservation) and the sentinel updated_at makes it read as stale.
-        let store = Store::from_pool(pool);
-        let (a, b) = (NodeId::from_str("node-a").unwrap(), NodeId::from_str("node-b").unwrap());
-        let fresh = Duration::from_hours(1);
-        let plan = |budget| Allocation {
-            node: a.clone(),
-            budget: ByteRate::new(budget),
-        };
-        // Tick 1: both nodes present.
-        store
-            .write_allocations(
-                1,
-                &[
-                    plan(40_000_000),
-                    Allocation {
-                        node: b.clone(),
-                        budget: ByteRate::new(60_000_000),
-                    },
-                ],
-            )
-            .await
-            .unwrap();
-        // Tick 2: only A heartbeats; B departed. B's row must be zeroed and stale.
-        store.write_allocations(2, std::slice::from_ref(&plan(80_000_000))).await.unwrap();
-        assert_eq!(
-            store.load_allocation(&a, fresh).await.unwrap().map(|s| s.budget),
-            Some(ByteRate::new(80_000_000)),
-            "the present node keeps its fresh allocation",
-        );
-        assert_eq!(
-            store.load_allocation(&b, fresh).await.unwrap(),
-            None,
-            "the departed node's zeroed, sentinel-dated row reads as absent",
-        );
-    }
-
-    #[sqlx::test]
-    async fn write_allocations_with_an_empty_plan_is_a_noop(pool: PgPool) {
-        // F6: an empty plan carries no fleet info and must NOT run the node-absence
-        // zeroing (which, with no nodes present, matches every row and would wipe the
-        // live fleet's budgets). An existing budget survives an empty tick untouched.
-        let store = Store::from_pool(pool);
-        let node = NodeId::from_str("node-a").unwrap();
-        let fresh = Duration::from_hours(1);
-        store
-            .write_allocations(
-                1,
-                &[Allocation {
-                    node: node.clone(),
-                    budget: ByteRate::new(50_000_000),
-                }],
-            )
-            .await
-            .unwrap();
-        store.write_allocations(2, &[]).await.unwrap();
-        assert_eq!(
-            store.load_allocation(&node, fresh).await.unwrap().map(|s| s.budget),
-            Some(ByteRate::new(50_000_000)),
-            "an empty plan leaves existing budgets intact",
-        );
-    }
-
-    #[sqlx::test]
-    async fn lower_epoch_cannot_overwrite_a_higher_one(pool: PgPool) {
-        let store = Store::from_pool(pool);
-        let node = NodeId::from_str("node-a").unwrap();
-        let at = |epoch, budget| {
-            let a = Allocation {
-                node: node.clone(),
-                budget: ByteRate::new(budget),
-            };
-            (epoch, a)
-        };
-        let (e5, a5) = at(5, 500);
-        store.write_allocations(e5, std::slice::from_ref(&a5)).await.unwrap();
-        // A deposed leader (epoch 3) must not overwrite — and learns it was fenced
-        // rather than getting a false success (M4 split-brain visibility).
-        let (e3, a3) = at(3, 300);
-        let err = store.write_allocations(e3, std::slice::from_ref(&a3)).await.unwrap_err();
-        assert!(
-            matches!(err, StoreError::Fenced { epoch: 3 }),
-            "a fenced write surfaces StoreError::Fenced, got {err:?}",
-        );
-        let fresh = Duration::from_hours(1);
-        assert_eq!(
-            store.load_allocation(&node, fresh).await.unwrap().unwrap().epoch,
-            5,
-            "stale epoch was fenced out"
-        );
-        // A newer leader (epoch 6) takes over.
-        let (e6, a6) = at(6, 600);
-        store.write_allocations(e6, std::slice::from_ref(&a6)).await.unwrap();
-        assert_eq!(store.load_allocation(&node, fresh).await.unwrap().unwrap().budget, ByteRate::new(600));
-    }
-
-    #[sqlx::test]
     async fn gc_claim_is_exclusive_then_completes(pool: PgPool) {
         let store = Store::from_pool(pool);
         let file = FileId::from_str("file-1").unwrap();
@@ -1278,73 +812,6 @@ mod tests {
         assert!(
             store.claim_gc(&file).await.unwrap().is_none(),
             "a completed GC is terminal and never re-claimed, even when aged",
-        );
-    }
-
-    #[sqlx::test]
-    async fn leadership_is_exclusive_until_expiry(pool: PgPool) {
-        use super::Lease;
-        let store = Store::from_pool(pool);
-        let long = Duration::from_secs(30);
-        assert_eq!(store.acquire_or_renew_leadership("a", long).await.unwrap(), Some(Lease { epoch: 1 }));
-        // A different instance cannot take an unexpired lease.
-        assert_eq!(store.acquire_or_renew_leadership("b", long).await.unwrap(), None);
-        // The holder renews; the epoch is unchanged.
-        assert_eq!(store.acquire_or_renew_leadership("a", long).await.unwrap(), Some(Lease { epoch: 1 }));
-    }
-
-    #[sqlx::test]
-    async fn expired_lease_is_taken_over_with_a_new_epoch(pool: PgPool) {
-        use super::Lease;
-        let store = Store::from_pool(pool);
-        assert_eq!(
-            store.acquire_or_renew_leadership("a", Duration::from_millis(40)).await.unwrap(),
-            Some(Lease { epoch: 1 })
-        );
-        tokio::time::sleep(Duration::from_millis(120)).await;
-        // Taking over a *different* expired leader starts a new era -> epoch 2,
-        // so the deposed leader's writes can be fenced out.
-        assert_eq!(
-            store.acquire_or_renew_leadership("b", Duration::from_secs(30)).await.unwrap(),
-            Some(Lease { epoch: 2 })
-        );
-    }
-
-    #[sqlx::test]
-    async fn self_reacquire_after_expiry_starts_a_new_epoch(pool: PgPool) {
-        use super::Lease;
-        // M5: an instance that lets its OWN lease lapse (a long STW GC pause, a host
-        // freeze, an NTP step) and then re-acquires must start a NEW epoch — not
-        // keep the old one — so a stale in-flight write from the pre-freeze era is
-        // fenced by the `<=` allocation fence instead of degrading to last-writer-wins.
-        let store = Store::from_pool(pool.clone());
-        let long = Duration::from_secs(30);
-        assert_eq!(store.acquire_or_renew_leadership("a", long).await.unwrap(), Some(Lease { epoch: 1 }));
-        // Force its own lease to expire (backdate is the only deterministic way).
-        sqlx::query("UPDATE cephor_leader_lease SET expires_at = now() - interval '1 second'")
-            .execute(&pool)
-            .await
-            .unwrap();
-        assert_eq!(
-            store.acquire_or_renew_leadership("a", long).await.unwrap(),
-            Some(Lease { epoch: 2 }),
-            "re-acquiring one's own expired lease starts a new era",
-        );
-    }
-
-    #[sqlx::test]
-    async fn relinquish_frees_the_lease(pool: PgPool) {
-        use super::Lease;
-        let store = Store::from_pool(pool);
-        assert_eq!(
-            store.acquire_or_renew_leadership("a", Duration::from_secs(30)).await.unwrap(),
-            Some(Lease { epoch: 1 })
-        );
-        store.relinquish_leadership("a").await.unwrap();
-        // The row is gone, so the next acquirer starts a fresh lease at epoch 1.
-        assert_eq!(
-            store.acquire_or_renew_leadership("b", Duration::from_secs(30)).await.unwrap(),
-            Some(Lease { epoch: 1 })
         );
     }
 }

--- a/crates/hippius-drain-core/src/tick.rs
+++ b/crates/hippius-drain-core/src/tick.rs
@@ -3,10 +3,12 @@
 //! `run_tick` is the unit the `hippius-drain-allocator` binary calls on a timer: it
 //! contends for leadership and, when leader, reads the fleet, gets the Ceph
 //! ceiling, allocates (M2), and writes the budgets stamped with the lease epoch.
+//! Leadership, the fleet view, and the budgets all live in the Redis-backed
+//! [`Coordinator`] now (not Postgres) — see its module docs for the rationale.
 
 use crate::alloc::{AllocConfig, AllocationPlan, BudgetController, allocate};
+use crate::coordination::{CoordError, Coordinator, Lease};
 use crate::state::CephCeiling;
-use crate::store::{Lease, Store, StoreError};
 use std::time::Duration;
 
 /// A source of the current Ceph write-ceiling.
@@ -40,8 +42,6 @@ pub struct TickConfig {
     pub instance_id: String,
     /// How long an acquired lease stays valid.
     pub lease_ttl: Duration,
-    /// Heartbeats older than this are ignored when loading the fleet.
-    pub stale_after: Duration,
     /// Allocation tuning.
     pub alloc: AllocConfig,
 }
@@ -59,42 +59,55 @@ pub enum TickOutcome {
 /// Runs one allocation tick.
 ///
 /// Contends for leadership; if not leader, returns [`TickOutcome::NotLeader`]
-/// without touching allocations. If leader, reads the fleet, gets the ceiling,
-/// allocates from `prev`, and writes the budgets stamped with the lease epoch
-/// (so a deposed leader's stale-epoch writes are fenced out by the store).
+/// without touching allocations. If leader, reads the fleet (heartbeats that have
+/// not TTL-expired), gets the ceiling, allocates from `prev`, and writes the
+/// budgets stamped with the lease epoch (so a deposed leader's stale-epoch writes
+/// are fenced out by the coordinator).
 ///
 /// # Errors
 ///
-/// [`StoreError`] if any database step fails.
+/// [`CoordError`] if any coordination step fails — including [`CoordError::Fenced`]
+/// when this instance was deposed between acquiring its lease and writing.
 pub async fn run_tick<C: CephCeilingSource>(
-    store: &Store,
+    coord: &Coordinator,
     ceiling_source: &C,
     config: &TickConfig,
     prev: BudgetController,
-) -> Result<TickOutcome, StoreError> {
-    let Some(Lease { epoch }) = store.acquire_or_renew_leadership(&config.instance_id, config.lease_ttl).await? else {
+) -> Result<TickOutcome, CoordError> {
+    let Some(Lease { epoch }) = coord.acquire_or_renew_leadership(&config.instance_id, config.lease_ttl).await? else {
         return Ok(TickOutcome::NotLeader);
     };
-    let fleet = store.load_fleet(config.stale_after).await?;
+    let fleet = coord.load_fleet().await?;
     let ceiling = ceiling_source.ceiling().await;
     let plan = allocate(&fleet, ceiling, prev, &config.alloc);
-    store.write_allocations(epoch, &plan.allocations).await?;
+    coord.write_allocations(epoch, &plan.allocations).await?;
     Ok(TickOutcome::Led(plan))
 }
 
 #[cfg(test)]
-#[cfg(feature = "pg")]
-#[expect(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+#[expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr, reason = "tests")]
 mod tests {
     use super::{StaticCeiling, TickConfig, TickOutcome, run_tick};
     use crate::alloc::{AllocConfig, Allocation, BudgetController, NodeObservation};
+    use crate::coordination::{CoordError, Coordinator};
     use crate::ids::NodeId;
     use crate::state::CephCeiling;
-    use crate::store::{Store, StoreError};
     use crate::units::{ByteRate, Bytes, DiskPressure};
     use core::str::FromStr;
-    use sqlx::postgres::PgPool;
     use std::time::Duration;
+
+    /// A coordinator on the test Redis under a per-test prefix, or `None` to skip (Rust
+    /// has no fakeredis; set `CEPHOR_TEST_REDIS_URL=redis://localhost:6382/0`).
+    async fn coord(prefix: &str) -> Option<Coordinator> {
+        let url = std::env::var("CEPHOR_TEST_REDIS_URL").ok().filter(|value| !value.is_empty())?;
+        // Prefix with the process id so a re-run never collides with the prior run's
+        // still-TTL'd keys on a shared test Redis.
+        let coordinator = Coordinator::connect(&url, Duration::from_secs(30), Duration::from_secs(30))
+            .await
+            .expect("connect to the test redis")
+            .with_prefix(&format!("{}:{prefix}", std::process::id()));
+        Some(coordinator)
+    }
 
     fn alloc_config() -> AllocConfig {
         AllocConfig {
@@ -113,7 +126,6 @@ mod tests {
         TickConfig {
             instance_id: instance.to_owned(),
             lease_ttl: Duration::from_secs(30),
-            stale_after: Duration::from_hours(1),
             alloc: alloc_config(),
         }
     }
@@ -132,65 +144,69 @@ mod tests {
         StaticCeiling(CephCeiling::Open(ByteRate::new(1_000_000_000)))
     }
 
-    #[sqlx::test]
-    async fn leader_allocates_and_writes_budgets(pool: PgPool) {
-        let store = Store::from_pool(pool);
+    #[tokio::test]
+    async fn leader_allocates_and_writes_budgets() {
+        let Some(c) = coord("cephor-test:tick-leads:").await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
         let node = NodeId::from_str("n1").unwrap();
-        store.upsert_node_state(&node, &observation()).await.unwrap();
+        c.upsert_node_state(&node, &observation()).await.unwrap();
 
         let prev = BudgetController::new(ByteRate::new(190_000));
-        let outcome = run_tick(&store, &open_ceiling(), &tick_config("alloc-a"), prev).await.unwrap();
+        let outcome = run_tick(&c, &open_ceiling(), &tick_config("alloc-a"), prev).await.unwrap();
         assert!(matches!(outcome, TickOutcome::Led(_)), "first instance leads");
 
-        let stored = store
-            .load_allocation(&node, Duration::from_hours(1))
-            .await
-            .unwrap()
-            .expect("budget written");
+        let stored = c.load_allocation(&node).await.unwrap().expect("budget written");
         assert_eq!(stored.epoch, 1, "stamped with the lease epoch");
         assert!(stored.budget.get() > 0, "the only hungry node received budget");
     }
 
-    #[sqlx::test]
-    async fn a_deposed_leader_tick_surfaces_the_fence_not_a_false_led(pool: PgPool) {
-        // M4: a leader deposed between acquiring its lease and writing (a higher
-        // epoch already wrote this node's allocation) must NOT report Led for a tick
-        // whose writes were discarded — the fence surfaces as StoreError::Fenced.
-        let store = Store::from_pool(pool);
+    #[tokio::test]
+    async fn a_deposed_leader_tick_surfaces_the_fence_not_a_false_led() {
+        // M4: a leader deposed between acquiring its lease and writing (a higher epoch
+        // already wrote this node's allocation) must NOT report Led for a tick whose
+        // writes were discarded — the fence surfaces as CoordError::Fenced.
+        let Some(c) = coord("cephor-test:tick-fence:").await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
         let node = NodeId::from_str("n1").unwrap();
-        store.upsert_node_state(&node, &observation()).await.unwrap();
-        store
-            .write_allocations(
-                100,
-                std::slice::from_ref(&Allocation {
-                    node: node.clone(),
-                    budget: ByteRate::new(1),
-                }),
-            )
-            .await
-            .unwrap();
+        c.upsert_node_state(&node, &observation()).await.unwrap();
+        c.write_allocations(
+            100,
+            std::slice::from_ref(&Allocation {
+                node: node.clone(),
+                budget: ByteRate::new(1),
+            }),
+        )
+        .await
+        .unwrap();
 
         // This instance takes a fresh lease (epoch 1) but its write is fenced by the
-        // epoch-100 row, so run_tick surfaces the fence rather than a false Led.
+        // epoch-100 allocation, so run_tick surfaces the fence rather than a false Led.
         let prev = BudgetController::new(ByteRate::new(190_000));
-        let err = run_tick(&store, &open_ceiling(), &tick_config("late"), prev).await.unwrap_err();
+        let err = run_tick(&c, &open_ceiling(), &tick_config("late"), prev).await.unwrap_err();
         assert!(
-            matches!(err, StoreError::Fenced { epoch: 1 }),
+            matches!(err, CoordError::Fenced { epoch: 1 }),
             "a deposed tick surfaces the fence, got {err:?}"
         );
     }
 
-    #[sqlx::test]
-    async fn a_second_instance_does_not_lead_or_allocate(pool: PgPool) {
-        let store = Store::from_pool(pool);
+    #[tokio::test]
+    async fn a_second_instance_does_not_lead_or_allocate() {
+        let Some(c) = coord("cephor-test:tick-second:").await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
         let node = NodeId::from_str("n1").unwrap();
-        store.upsert_node_state(&node, &observation()).await.unwrap();
+        c.upsert_node_state(&node, &observation()).await.unwrap();
         let prev = BudgetController::new(ByteRate::new(190_000));
 
-        let first = run_tick(&store, &open_ceiling(), &tick_config("a"), prev).await.unwrap();
+        let first = run_tick(&c, &open_ceiling(), &tick_config("a"), prev).await.unwrap();
         assert!(matches!(first, TickOutcome::Led(_)));
 
-        let second = run_tick(&store, &open_ceiling(), &tick_config("b"), prev).await.unwrap();
+        let second = run_tick(&c, &open_ceiling(), &tick_config("b"), prev).await.unwrap();
         assert!(matches!(second, TickOutcome::NotLeader), "b cannot lead while a holds the lease");
     }
 }

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -269,10 +269,13 @@ services:
     environment:
       - CEPHOR_DATABASE_URL=postgresql://postgres:postgres@db:5432/hippius?sslmode=disable
       - CEPHOR_ALLOCATOR_INSTANCE_ID=e2e-allocator
+      - REDIS_QUEUES_URL=redis://redis-queues:6379
       - RUST_LOG=info
     depends_on:
       db:
         condition: service_healthy
+      redis-queues:
+        condition: service_started
     restart: unless-stopped
     networks:
       - hippius_net

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -106,6 +106,11 @@ spec:
               value: "300"
             - name: CEPHOR_RECLAIM_GRACE_SECS
               value: "3600"
+            # Max parts drained concurrently — the in-flight gate that lets the node
+            # overlap fsync latency across parts (the AIMD allocator only tunes bytes/s).
+            # Safe code default (4); set here for per-node tuning.
+            - name: CEPHOR_DRAIN_CONCURRENCY
+              value: "4"
             - name: RUST_LOG
               value: "info"
           volumeMounts:

--- a/k8s/staging/drain-allocator-deployment.yaml
+++ b/k8s/staging/drain-allocator-deployment.yaml
@@ -1,11 +1,13 @@
 # The hippius-drain allocator: the singleton, leader-elected budget allocator.
 #
 # One replica. The allocator does NOT need the SSD/CephFS mounts — it only reads the
-# fleet's heartbeats and writes per-node write-budgets in Postgres. It is also the
-# schema owner: on startup it applies the hippius-drain-core migrations (the cephor_*
-# tables) before contending for leadership, so the agents come up against a ready
-# schema (allocator-first deploy). A DB leader-lease fences any accidental second
-# instance, so even a brief rollout overlap allocates from exactly one leader.
+# fleet's heartbeats and writes per-node write-budgets. Leadership, heartbeats, and
+# budgets are TTL-keyed in redis-queues (epoch-fenced via Lua), NOT Postgres, so the
+# ~2s leader tick never touches the WAL. It is still the schema owner: on startup it
+# applies the hippius-drain-core migrations (the durable cephor_* tables) before
+# contending for leadership, so the agents come up against a ready schema
+# (allocator-first deploy). A Redis leader-lease (monotonic epoch) fences any accidental
+# second instance, so even a brief rollout overlap allocates from exactly one leader.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,6 +47,14 @@ spec:
                 secretKeyRef:
                   name: hippius-s3-secrets
                   key: DATABASE_URL
+            # Coordination state (leader lease / fleet heartbeats / per-node budgets) lives
+            # here, TTL-keyed — the same redis-queues instance the agents use. Reuse the
+            # api's secret.
+            - name: REDIS_QUEUES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: REDIS_QUEUES_URL
             - name: RUST_LOG
               value: "info"
             # Live ceph-mgr ceiling probe. Left unset for first bring-up so the


### PR DESCRIPTION
Goal 2 of the s3-2.1 scale-hardening roadmap. After the drain-direct cutover the Rust drain is the **sole upload producer**, so its fsync-bound ceiling now gates every Arion upload + chain publish. This PR attacks that ceiling and moves the drain's loss-tolerant coordination state off Postgres. Lands all four roadmap items in one PR.

## Changes (largest → smallest)

- **Coordination state → redis-queues (Task 4).** New `hippius_drain_core::Coordinator` holds the leader lease, node heartbeats, and per-node allocations as TTL-keyed Redis state on the existing redis-queues instance (`cephor:` namespace). Expiry is the death signal — no reaper. The F4 leader-epoch fence is preserved verbatim via an atomic Lua compare-and-set (a deposed/partitioned leader can never overwrite a live leader's budgets). Drops the three `cephor_*` tables (migration `0009`) and with them the ~2s leader-tick WAL churn (6995×/3659×/2023× autovacuum on staging) and the circular recovery dependency when Ceph — and thus PG's WAL fsync — degrades. The allocator and agent are rewired; `run_tick` now takes the `Coordinator`. Postgres keeps only the durable drain state (replication status / claims, landed-part log, GC claims).
- **Hash once + sampled readback (Task 2).** `persist_chunk` now computes the SHA during the copy stream and returns it, so the drain no longer re-reads the SSD source. The torn-copy check re-reads only the **first + last** chunk of each part (sampled) instead of a full second read of every chunk on the slowest tier; content-addressed naming + re-drive cover the interior chunks. `ChunkMismatch` plumbing kept.
- **Batch the fsync (Task 1).** The copy uses `fdatasync` (`sync_data`) per file and defers the directory fsync to a single per-part `PartPool::finalize_part`, replacing ~2 serialized fsyncs per chunk with one per part. Meta still renames before the dir-fsync, so chunks+meta become durable together; crash-before-finalize re-drains safely.
- **Env-tunable `DRAIN_CONCURRENCY` (Task 3).** New `CEPHOR_DRAIN_CONCURRENCY` knob (default 4, rejects 0) so the node can hide fsync latency behind more in-flight parts (the AIMD allocator only tunes bytes/s).
- **k8s + config.** `REDIS_QUEUES_URL` on the allocator deployment; `CEPHOR_DRAIN_CONCURRENCY` on the agent daemonset; `CEPHOR_HEARTBEAT_TTL_SECS` (agent) and `CEPHOR_ALLOCATION_TTL_SECS` (allocator) replace the obsolete PG-staleness knobs.

## Testing

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, and `cargo test --workspace --all-features` all pass (285 tests). Coordination correctness — lease acquire/renew/expire + epoch bump, heartbeat TTL expiry dropping a node, and the stale-epoch fence rejection — is covered by new tests in `coordination.rs`, `tick.rs`, `run.rs`, and the agent `runtime.rs`; they require a live test Redis (`CEPHOR_TEST_REDIS_URL`) since Rust has no fakeredis, and skip cleanly when unset. A new sampling test pins that a corrupt first/last chunk is caught while a corrupt interior chunk is (deliberately) not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)