### PR TITLE
chore(janitor): lower FS cache GC age from 7d to 24h since last access

### DIFF
--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -273,7 +273,8 @@ class Config:
     # Object parts filesystem cache configuration
     object_cache_dir: str = env("HIPPIUS_OBJECT_CACHE_DIR:/var/lib/hippius/object_cache")
     object_cache_fallback_dir: str = env("HIPPIUS_OBJECT_CACHE_FALLBACK_DIR:", convert=str)
-    fs_cache_gc_max_age_seconds: int = env("HIPPIUS_FS_CACHE_GC_MAX_AGE_SECONDS:604800", convert=int)  # 7 days
+    # 24h since last access — reads bump mtime (os.utime sets both atime+mtime), so this gates on idle time.
+    fs_cache_gc_max_age_seconds: int = env("HIPPIUS_FS_CACHE_GC_MAX_AGE_SECONDS:86400", convert=int)
     mpu_stale_seconds: int = env("HIPPIUS_MPU_STALE_SECONDS:86400", convert=int)  # 1 day
     # Bounded concurrency for the janitor's per-part DB checks + deletes. The
     # cleanup loops are DB-roundtrip bound; this is how many parts are processed

--- a/k8s/production/local-cache-configmap-patch.yaml
+++ b/k8s/production/local-cache-configmap-patch.yaml
@@ -5,3 +5,5 @@ metadata:
 data:
   HIPPIUS_OBJECT_CACHE_DIR: "/var/lib/hippius/local_object_cache"
   HIPPIUS_OBJECT_CACHE_FALLBACK_DIR: "/var/lib/hippius/object_cache"
+  # Evict cache parts idle for 24h (mtime is bumped on every read, so this is "since last access").
+  HIPPIUS_FS_CACHE_GC_MAX_AGE_SECONDS: "86400"


### PR DESCRIPTION
## Summary

The NVMe object cache (`local_object_cache`) is running ~70% full. The janitor's normal-pressure GC only evicts fully-replicated parts older than `HIPPIUS_FS_CACHE_GC_MAX_AGE_SECONDS`, which defaulted to **7 days**. This lowers it to **24 hours**, so the cache trends toward a ~1-day working set and drains the NVMe.

Because `fs_store.get_chunk` refreshes atime/mtime on every read (`os.utime(path, None)` sets both to now), the mtime-based age gate already measures **time since last access** — so this is "evict parts idle for 24h", not "evict 24h after creation".

## Changes

- **`hippius_s3/config.py`** — `HIPPIUS_FS_CACHE_GC_MAX_AGE_SECONDS` default `604800` → `86400`.
- **`k8s/production/local-cache-configmap-patch.yaml`** — set `HIPPIUS_FS_CACHE_GC_MAX_AGE_SECONDS: "86400"` explicitly on the prod `hippius-s3-defaults` ConfigMap (operative for prod; takes effect on janitor restart, no image rebuild needed).

## Safety

- **Replication remains an absolute gate** — a part not replicated to every required backend is never evicted, regardless of age or disk pressure.
- The 3h hot-retention window is unchanged and subsumed under normal pressure (24h > 3h).
- Trade-off: parts idle >24h that are re-requested are re-fetched from the backend via the download pipeline. Intended, to keep the NVMe bounded.

## Conclusion

Tightens the cache eviction window to keep the NVMe cache from filling, with no change to the replication safety invariant.