### PR TITLE
fix(gateway,api): disable uvicorn --limit-max-requests worker recycling (intermittent 502s)

### DIFF
--- a/gateway/start-gateway.sh
+++ b/gateway/start-gateway.sh
@@ -5,13 +5,23 @@ UVICORN_HOST=${UVICORN_HOST:-0.0.0.0}
 UVICORN_PORT=${UVICORN_PORT:-8080}
 UVICORN_WORKERS=${UVICORN_WORKERS:-1}
 UVICORN_LOG_LEVEL=${UVICORN_LOG_LEVEL:-info}
-UVICORN_MAX_REQUESTS=${UVICORN_MAX_REQUESTS:-10000}
+UVICORN_MAX_REQUESTS=${UVICORN_MAX_REQUESTS:-0}
 UVICORN_MAX_REQUESTS_JITTER=${UVICORN_MAX_REQUESTS_JITTER:-1000}
 
 RELOAD_FLAG=""
 if [ "${DEBUG:-false}" = "true" ]; then
     RELOAD_FLAG="--reload"
     echo "DEBUG mode enabled - auto-reload is ON"
+fi
+
+# In-process worker recycling (--limit-max-requests) is OFF by default. It churns a
+# worker while the pod stays Ready, so the ATS edge / k8s Service routes a connection
+# into the ~1-6s restart window and gets a reset -> 502 "Next Hop Connection Failed".
+# Prod memory sits at ~10-15% of the pod limit with zero OOMs, so recycling bought
+# nothing. Set UVICORN_MAX_REQUESTS>0 to re-enable if a real leak ever appears.
+MAX_REQUESTS_ARGS=()
+if [ "${UVICORN_MAX_REQUESTS}" -gt 0 ] 2>/dev/null; then
+    MAX_REQUESTS_ARGS=(--limit-max-requests="$UVICORN_MAX_REQUESTS" --limit-max-requests-jitter="$UVICORN_MAX_REQUESTS_JITTER")
 fi
 
 echo "Starting hippius-s3-gateway via uvicorn (workers=$UVICORN_WORKERS, max_requests=$UVICORN_MAX_REQUESTS)"
@@ -22,8 +32,7 @@ uvicorn \
     --loop=uvloop \
     --log-level=$UVICORN_LOG_LEVEL \
     --access-log \
-    --limit-max-requests=$UVICORN_MAX_REQUESTS \
-    --limit-max-requests-jitter=$UVICORN_MAX_REQUESTS_JITTER \
+    "${MAX_REQUESTS_ARGS[@]+"${MAX_REQUESTS_ARGS[@]}"}" \
     --factory \
     $RELOAD_FLAG \
     gateway.main:factory

--- a/k8s/base/configmap-defaults.yaml
+++ b/k8s/base/configmap-defaults.yaml
@@ -65,7 +65,11 @@ data:
   HIPPIUS_OVH_KMS_CERT_PATH: "/kms_certs/client.crt"
   HIPPIUS_OVH_KMS_KEY_PATH: "/kms_certs/client.key"
   UVICORN_WORKERS: "4"
-  UVICORN_MAX_REQUESTS: "10000"
+  # In-process worker recycling disabled (0): --limit-max-requests churns a worker while
+  # the pod stays Ready, so the ATS edge routes into the restart window and gets a 502
+  # "Next Hop Connection Failed". Prod memory is flat at ~10-15% of the pod limit with
+  # zero OOMs, so it bought nothing. Re-enable (>0) only if a real leak appears.
+  UVICORN_MAX_REQUESTS: "0"
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
   OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: "cumulative"
   HIPPIUS_OBJECT_CACHE_FALLBACK_DIR: ""

--- a/start-api.sh
+++ b/start-api.sh
@@ -5,7 +5,7 @@ UVICORN_HOST=${UVICORN_HOST:-0.0.0.0}
 UVICORN_PORT=${UVICORN_PORT:-8000}
 UVICORN_WORKERS=${UVICORN_WORKERS:-1}
 UVICORN_LOG_LEVEL=${UVICORN_LOG_LEVEL:-info}
-UVICORN_MAX_REQUESTS=${UVICORN_MAX_REQUESTS:-10000}
+UVICORN_MAX_REQUESTS=${UVICORN_MAX_REQUESTS:-0}
 UVICORN_MAX_REQUESTS_JITTER=${UVICORN_MAX_REQUESTS_JITTER:-1000}
 
 echo "Running database migrations..."
@@ -17,6 +17,16 @@ if [ "${DEBUG:-false}" = "true" ]; then
     echo "DEBUG mode enabled - auto-reload is ON"
 fi
 
+# In-process worker recycling (--limit-max-requests) is OFF by default. It churns a
+# worker while the pod stays Ready, so the edge/k8s Service routes a connection into
+# the ~1-6s restart window and gets a reset -> 502 "Next Hop Connection Failed". Prod
+# memory sits at ~10-15% of the pod limit with zero OOMs, so recycling bought nothing.
+# Set UVICORN_MAX_REQUESTS>0 to re-enable if a real leak ever appears.
+MAX_REQUESTS_ARGS=()
+if [ "${UVICORN_MAX_REQUESTS}" -gt 0 ] 2>/dev/null; then
+    MAX_REQUESTS_ARGS=(--limit-max-requests="$UVICORN_MAX_REQUESTS" --limit-max-requests-jitter="$UVICORN_MAX_REQUESTS_JITTER")
+fi
+
 echo "Starting hippius-s3-api via uvicorn (workers=$UVICORN_WORKERS, max_requests=$UVICORN_MAX_REQUESTS)"
 uvicorn \
     --host=$UVICORN_HOST \
@@ -25,8 +35,7 @@ uvicorn \
     --loop=uvloop \
     --log-level=$UVICORN_LOG_LEVEL \
     --access-log \
-    --limit-max-requests=$UVICORN_MAX_REQUESTS \
-    --limit-max-requests-jitter=$UVICORN_MAX_REQUESTS_JITTER \
+    "${MAX_REQUESTS_ARGS[@]+"${MAX_REQUESTS_ARGS[@]}"}" \
     --factory \
     $RELOAD_FLAG \
     hippius_s3.main:factory


### PR DESCRIPTION
## Summary

The gateway and api run `uvicorn --limit-max-requests=10000`, which recycles a worker **in-place** every ~10k requests. Because the pod stays `Ready` during the recycle (the container never restarts), the ATS edge / k8s Service routes a connection into the **~1–6 s window where the worker's listen socket is down** (or hits uvicorn's [accept-but-not-parsed RST race](https://github.com/Kludex/uvicorn/discussions/2315)) → the client gets a reset → **502 "Next Hop Connection Failed"**.

Diagnosed from a failed scheduled prod smoke test (`assert 502 == 200`, 9/10 passed); it also shows up as a steady low rate of edge 502s — **469 gateway + 442 api recycles / 16 h**, each a small connection-failure window.

## Why remove it — memory investigation (no leak)

`--limit-max-requests` was insurance against a memory leak that **does not exist**. Over 18 h in prod (Prometheus + `kubectl top`):

| | gateway (limit 4Gi) | api (limit 8Gi) |
|---|---|---|
| Usage | flat ~430Mi (**~10%**) | sawtooth 570–1200Mi (**7–15%**) |
| Trough baseline / 18h | flat | **stable** — ends where it started (request-driven, not cumulative) |
| OOMKills / restarts (10 pods) | **0 / 0** | **0 / 0** |

The recycle caps memory that isn't growing — pure cost (the 502s), zero benefit.

## Change
- `start-api.sh` / `gateway/start-gateway.sh`: make `--limit-max-requests` **opt-in** — default `UVICORN_MAX_REQUESTS=0` omits the flags (portable, `set -u`-safe empty-array expansion). Knob kept for future re-enable.
- `k8s/base/configmap-defaults.yaml`: `UVICORN_MAX_REQUESTS: "10000"` → `"0"`.

Memory `limits` (4Gi/8Gi, 6–9× headroom) + daily rolling deploys remain the lifecycle backstop; a k8s OOM restart drains via endpoints first, unlike the in-process worker RST.

## Not gunicorn
Considered and rejected: `uvicorn.workers.UvicornWorker` is deprecated, it's against the FastAPI/k8s single-process-per-pod model, and it would **not** fix the recycle RST race (we already run `--workers=4` + `--limit-max-requests-jitter` and the 502s happen anyway; a real-world report shows the same 502s under gunicorn until `--max-requests` is removed).

## Conclusion
A config-only fix that eliminates the recycle-induced edge 502s, backed by prod memory evidence showing no leak. Reaches prod via the `k8s-production` deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)