### PR TITLE
fix(append): drain-direct — persist address, stop double-producing the upload

### DIFF
--- a/hippius_s3/api/s3/extensions/append.py
+++ b/hippius_s3/api/s3/extensions/append.py
@@ -23,8 +23,8 @@ from fastapi import Response
 from hippius_s3.api.s3 import errors
 from hippius_s3.config import get_config
 from hippius_s3.utils import get_query
+from hippius_s3.writer.db import set_object_version_address
 from hippius_s3.writer.object_writer import ObjectWriter
-from hippius_s3.writer.queue import enqueue_upload as writer_enqueue_upload
 from hippius_s3.writer.types import AppendPreconditionFailed
 from hippius_s3.writer.types import EmptyAppendError
 from hippius_s3.writer.types import ObjectNotFound
@@ -142,24 +142,23 @@ async def handle_append(
     object_version = int(result.get("object_version", 1))
     new_append_version = int(result.get("new_append_version", 0))
 
-    # Enqueue background publish of this part via the pinner worker (writer helper)
-    try:
-        await writer_enqueue_upload(
-            address=request.state.account.main_account,
-            bucket_name=bucket_name,
-            object_key=object_key,
-            object_id=object_id,
-            object_version=int(object_version),
-            upload_id=str(result["upload_id"]),
-            chunk_ids=[int(next_part)],
-            ray_id=getattr(request.state, "ray_id", "no-ray-id"),
+    # Drain-direct (s3-2.1 PR-11): the api does NOT enqueue the backend upload. It
+    # persists the main-account address on this version; the Rust drain reads it and
+    # LPUSHes the appended part's UploadChainRequest itself once the part replicates to
+    # ceph, so the drain is the sole upload producer. The version already carries an
+    # address from the object's original create, so this is normally idempotent — but it
+    # also corrects a legacy pre-cutover version whose address is NULL, which the drain
+    # would otherwise defer forever (leaving the appended part un-backed).
+    await set_object_version_address(
+        request.app.state.postgres_pool,
+        object_id=str(object_id),
+        object_version=int(object_version),
+        address=request.state.account.main_account,
+    )
+    with contextlib.suppress(Exception):
+        logger.info(
+            f"APPEND persisted upload address object_id={object_id} v={int(object_version)} part={int(next_part)}"
         )
-        with contextlib.suppress(Exception):
-            logger.info(
-                f"APPEND enqueued background publish object_id={object_id} part={int(next_part)} upload_id={str(result.get('upload_id', ''))}"
-            )
-    except Exception:
-        logger.exception("Failed to enqueue append publish request")
 
     # Successful append: return the new append version so clients can avoid a HEAD
     resp = Response(

--- a/tests/unit/test_append_drain_direct.py
+++ b/tests/unit/test_append_drain_direct.py
@@ -1,0 +1,129 @@
+"""Regression guard for the S4 append drain-direct fix.
+
+Before: `handle_append` called `writer_enqueue_upload` at append time, so an appended
+part was produced by BOTH the api and (on replication) the Rust drain — a double-produce
+that only the idempotent uploader hid, and which stranded legacy (`address IS NULL`)
+versions the drain would defer forever.
+
+After: append persists the main-account address via `set_object_version_address` (exactly
+like PUT/MPU) and enqueues nothing — the drain becomes the sole upload producer.
+
+These tests pin that wiring: address is persisted for the appended part's version, and no
+upload is enqueued from the append path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from hippius_s3.api.s3.extensions import append as append_mod
+
+
+OBJ = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+ADDRESS = "5FmainAccountAddressSS58"
+
+
+def _request(pool: Any) -> MagicMock:
+    req = MagicMock()
+    req.headers = {"x-amz-meta-append-if-version": "3"}
+    req.app.state.postgres_pool = pool
+    req.app.state.fs_store = MagicMock()
+    req.state.account.main_account = ADDRESS
+    req.state.seed_phrase = "seed words"
+    req.state.ray_id = "ray-123"
+    return req
+
+
+def _append_result() -> dict:
+    return {
+        "object_id": OBJ,
+        "part_number": 4,
+        "etag": "d41d8cd98f00b204e9800998ecf8427e",
+        "object_version": 1,
+        "new_append_version": 4,
+        "size_bytes": 7,
+        "upload_id": "11111111-2222-3333-4444-555555555555",
+    }
+
+
+async def _noop_body():  # pragma: no cover - not consumed by the mocked writer
+    yield b""
+
+
+@pytest.mark.asyncio
+async def test_append_persists_address_and_does_not_enqueue():
+    """The happy path: address is written for (object_id, cov); nothing is enqueued."""
+    pool = MagicMock()
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=None)
+    redis.setex = AsyncMock()
+
+    writer = MagicMock()
+    writer.append_stream = AsyncMock(return_value=_append_result())
+
+    with (
+        patch.object(append_mod, "ObjectWriter", return_value=writer),
+        patch.object(append_mod, "set_object_version_address", AsyncMock()) as set_addr,
+    ):
+        resp = await append_mod.handle_append(
+            _request(pool),
+            MagicMock(),
+            redis,
+            bucket={"bucket_id": "b1"},
+            bucket_id="b1",
+            bucket_name="bucket",
+            object_key="log/a.txt",
+            body_iter=_noop_body(),
+        )
+
+    assert resp.status_code == 200
+    # Address persisted for the appended part's version — the drain's enqueue signal.
+    set_addr.assert_awaited_once()
+    _, kwargs = set_addr.await_args
+    assert kwargs["object_id"] == OBJ
+    assert kwargs["object_version"] == 1
+    assert kwargs["address"] == ADDRESS
+    # The pool (not a txn conn) is passed positionally, mirroring PUT/MPU.
+    assert set_addr.await_args.args[0] is pool
+
+
+@pytest.mark.asyncio
+async def test_append_has_no_enqueue_symbol():
+    """The append module must not import/use any upload-enqueue helper — the drain is
+    the sole producer. Guards against a future re-introduction of the double-produce."""
+    assert not hasattr(append_mod, "writer_enqueue_upload")
+    assert not hasattr(append_mod, "enqueue_upload")
+    assert hasattr(append_mod, "set_object_version_address")
+
+
+@pytest.mark.asyncio
+async def test_append_address_failure_bubbles_up():
+    """If persisting the address fails, the error must bubble (no silent swallow) — a
+    part with no address is never enqueued by the drain, so this must surface, not hide."""
+    pool = MagicMock()
+    redis = MagicMock()
+    redis.get = AsyncMock(return_value=None)
+
+    writer = MagicMock()
+    writer.append_stream = AsyncMock(return_value=_append_result())
+
+    with (
+        patch.object(append_mod, "ObjectWriter", return_value=writer),
+        patch.object(append_mod, "set_object_version_address", AsyncMock(side_effect=RuntimeError("db down"))),
+        pytest.raises(RuntimeError, match="db down"),
+    ):
+        await append_mod.handle_append(
+            _request(pool),
+            MagicMock(),
+            redis,
+            bucket={"bucket_id": "b1"},
+            bucket_id="b1",
+            bucket_name="bucket",
+            object_key="log/a.txt",
+            body_iter=_noop_body(),
+        )


### PR DESCRIPTION
## Summary

S4 append was the last write path still enqueuing the backend upload from the api (`writer_enqueue_upload`), while PUT/MPU switched to the drain-direct model (write `object_versions.address`, let the Rust drain enqueue on replication). Because append adds a part to the object's **existing** `current_object_version` — which already carries `address` from the original create — the drain **also** enqueues the appended part. So every append double-produced its upload, hidden only by the idempotent uploader, and violated the post-cutover "drain is the sole upload producer" invariant.

This routes append through `set_object_version_address` (exactly like PUT/MPU) and enqueues nothing.

## Why it's more than cosmetic
Scrutinizing the path surfaced a latent correctness gap: appending to a **legacy pre-cutover** version whose `address IS NULL` would leave the drain deferring that part **forever** (not-ready), so a bare "delete the enqueue" would strand legacy appends with no backend upload. Persisting the address is idempotent for post-cutover objects and *corrective* for legacy ones — the drain can then back the part up in all cases.

## Changes
- `hippius_s3/api/s3/extensions/append.py`: swap `writer_enqueue_upload(...)` for `set_object_version_address(pool, object_id, object_version=cov, address=main_account)`; drop the now-unused import. Errors bubble (a part with no address is never enqueued by the drain, so a failure must surface, not be swallowed).
- `tests/unit/test_append_drain_direct.py` (new): asserts address is persisted for the appended part's version, that the module exposes no upload-enqueue symbol (guards re-introduction), and that an address-write failure bubbles.

## Testing
- New unit tests pass; ruff + ty + pip-audit green via pre-commit.
- E2E `test_AppendObject` exercises the end-to-end (append → backends ready), now satisfied by the drain rather than the api enqueue — same flow PUT/MPU already use.

## Conclusion
Restores the sole-producer invariant, removes redundant upload work per append, and closes a legacy-object correctness gap — a small, surgical change mirroring the existing PUT/MPU pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)