### PR TITLE
drain: production-readiness hardening (P1+P2 audit findings)

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -241,10 +241,22 @@ jobs:
         options: >-
           --health-cmd "pg_isready -U postgres" --health-interval 5s
           --health-timeout 5s --health-retries 12
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping" --health-interval 5s
+          --health-timeout 5s --health-retries 12
     env:
       # The drain's #[sqlx::test] cases auto-create per-test DBs against this and apply
       # the cephor_* migrations, so schema + queries (incl node-scoped claim) are exercised.
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      # The coordination/tick/allocator/runtime tests need a real Redis (no fakeredis in
+      # Rust) and are #[ignore]d so a redis-less local run shows them as ignored, not
+      # passed. One shared instance + DB 0 is enough: each test prefixes its keys with the
+      # process id + a per-test prefix, so parallel cases never collide.
+      CEPHOR_TEST_REDIS_URL: redis://localhost:6379/0
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust 1.95.0 (pinned to the builder toolchain)
@@ -257,8 +269,11 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Clippy (deny warnings)
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-      - name: Tests (pure + Postgres-backed sqlx tiers)
-        run: cargo test --workspace --all-features --locked
+      - name: Tests (pure + Postgres + Redis-gated coordination tiers)
+        # --include-ignored runs the #[ignore]d redis-gated coordination tests (fencing,
+        # leader election, lease/heartbeat expiry, budget apply/decay) now that a Redis
+        # service is present; without it CI covered none of them while showing green.
+        run: cargo test --workspace --all-features --locked -- --include-ignored
 
   rust-deny:
     name: Rust (cargo-deny supply chain)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Six separate services for blast-radius isolation:
 | `redis` | 6379 | General cache / short-lived state | Ephemeral |
 | `redis-accounts` | 6380 | Account credit cache | Persistent (AOF) |
 | `redis-chain` | 6381 | Blockchain operation cache | Persistent (AOF) |
-| `redis-queues` | 6382 | Work queues + chunk pub/sub notifications | Persistent, 2GB, LRU |
+| `redis-queues` | 6382 | Work queues + chunk pub/sub notifications + drain coordination (`cephor:*`) | Persistent, 2GB, **noeviction** (holds queue + coordination data — must not evict; a full instance fails writes loudly) |
 | `redis-rate-limiting` | 6383 | Rate limit counters | Ephemeral, 1GB |
 | `redis-acl` | 6384 | ACL cache | Ephemeral, 2GB, LRU |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +627,9 @@ dependencies = [
  "futures",
  "hippius-drain-core",
  "nix",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "proptest",
  "redis",
  "serde",
@@ -640,6 +649,9 @@ name = "hippius-drain-allocator"
 version = "0.1.0"
 dependencies = [
  "hippius-drain-core",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "reqwest",
  "thiserror",
  "tokio",
@@ -754,6 +766,19 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1075,6 +1100,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "js-sys",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1186,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1165,6 +1263,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1855,6 +1976,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,11 +2020,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,13 @@ nix = { version = "=0.31.3", default-features = false, features = ["fs"] }
 reqwest = { version = "=0.13.4", default-features = false }
 # Mock HTTP server for the probe's edge tests (dev-only).
 wiremock = "=0.6.5"
+# OTLP metrics export for the drain binaries (mirrors hippius_s3/otel_setup.py: gRPC OTLP
+# to the otel-collector on :4317, 10s PeriodicReader). Behind each binary's `otel` feature.
+# grpc-tonic (not http-proto) matches the collector's gRPC receiver; default-features=false
+# keeps the reqwest/HTTP exporter + TLS backends out (the in-cluster link is plaintext).
+opentelemetry = { version = "=0.31.0", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "=0.31.0", default-features = false, features = ["metrics", "rt-tokio"] }
+opentelemetry-otlp = { version = "=0.31.0", default-features = false, features = ["grpc-tonic", "metrics"] }
 
 # Strict crate-level lints, shared across every member via `[lints] workspace = true`.
 # These crates perform no unsafe operations, so unsafe_code is forbidden workspace-wide;

--- a/crates/hippius-drain-agent/Cargo.toml
+++ b/crates/hippius-drain-agent/Cargo.toml
@@ -6,10 +6,19 @@ rust-version.workspace = true
 license.workspace = true
 description = "cephor per-node drain daemon (runs as a DaemonSet on each ingest SSD node)"
 
+# `otel` (on by default) exports drain metrics via OTLP; `--no-default-features` yields a
+# dependency-light build with no exporter.
+[features]
+default = ["otel"]
+otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
+
 # The daemon talks to Postgres for the durable drain state (`pg`) and to the
 # Redis-backed coordinator for heartbeats + allocation pulls (`coord`).
 [dependencies]
 hippius-drain-core = { workspace = true, features = ["pg", "coord"] }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -57,6 +57,10 @@ const DEFAULT_RECLAIM_POLL: Duration = Duration::from_mins(5);
 /// eviction (a diagnosis / abort-settle window).
 const DEFAULT_RECLAIM_GRACE: Duration = Duration::from_hours(1);
 
+/// Default path of the liveness file the runtime touches each heartbeat tick; the
+/// k8s `livenessProbe` checks its freshness. Container-local `/tmp` is always writable.
+const DEFAULT_LIVENESS_FILE: &str = "/tmp/hippius-drain-agent.alive";
+
 /// The daemon's startup configuration.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -107,6 +111,9 @@ pub struct Config {
     /// Maximum parts the drain worker processes concurrently — the in-flight gate
     /// that lets the node overlap fsync latency across parts.
     pub drain_concurrency: u32,
+    /// Path of the liveness file the runtime touches each heartbeat tick; a k8s
+    /// `livenessProbe` checks its freshness to restart a wedged (not crashed) pod.
+    pub liveness_file: PathBuf,
 }
 
 /// A failure parsing the daemon configuration from the environment.
@@ -216,6 +223,7 @@ impl Config {
             reclaim_poll: duration_secs(&get, "CEPHOR_RECLAIM_POLL_SECS", DEFAULT_RECLAIM_POLL)?,
             reclaim_grace: duration_secs(&get, "CEPHOR_RECLAIM_GRACE_SECS", DEFAULT_RECLAIM_GRACE)?,
             drain_concurrency: positive_u32_or(&get, "CEPHOR_DRAIN_CONCURRENCY", DEFAULT_DRAIN_CONCURRENCY)?,
+            liveness_file: path_or(&get, "CEPHOR_LIVENESS_FILE", DEFAULT_LIVENESS_FILE),
         })
     }
 }
@@ -287,6 +295,14 @@ fn required_path(get: &impl Fn(&str) -> Option<String>, var: &'static str) -> Re
     }
 }
 
+/// Resolves an optional path variable, falling back to `default` when unset or blank.
+fn path_or(get: &impl Fn(&str) -> Option<String>, var: &'static str, default: &str) -> PathBuf {
+    match get(var) {
+        Some(value) if !value.trim().is_empty() => PathBuf::from(value),
+        _ => PathBuf::from(default),
+    }
+}
+
 /// Resolves a required variable, treating unset and empty as the same failure
 /// (an empty `DATABASE_URL` is as unusable as a missing one).
 fn required(get: &impl Fn(&str) -> Option<String>, var: &'static str) -> Result<String, ConfigError> {
@@ -336,6 +352,16 @@ mod tests {
         assert_eq!(config.pool_root, PathBuf::from("/mnt/pool"));
         assert_eq!(config.ssd_root, PathBuf::from("/mnt/ssd"));
         assert_eq!(config.drain_poll, DEFAULT_DRAIN_POLL);
+    }
+
+    #[test]
+    fn liveness_file_defaults_and_is_overridable() {
+        let config = Config::from_lookup(lookup(&required_only())).unwrap();
+        assert_eq!(config.liveness_file, PathBuf::from("/tmp/hippius-drain-agent.alive"));
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_LIVENESS_FILE", "/var/run/agent.alive"));
+        let overridden = Config::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(overridden.liveness_file, PathBuf::from("/var/run/agent.alive"));
     }
 
     #[test]

--- a/crates/hippius-drain-agent/src/lib.rs
+++ b/crates/hippius-drain-agent/src/lib.rs
@@ -8,6 +8,8 @@ pub mod config;
 pub mod disk;
 pub mod enqueue;
 pub mod localfs;
+#[cfg(feature = "otel")]
+pub mod metrics;
 pub mod runtime;
 pub mod supervisor;
 pub mod worker;

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -456,9 +456,20 @@ impl PartPool for LocalFs {
     }
 
     async fn finalize_part(&self, part: &PartKey) -> io::Result<()> {
-        // One fsync of the part dir, after every chunk + meta rename has landed, so all
-        // those directory entries become durable together (Task 1: batch the fsync).
-        sync_parent_dir(&part_dir(&self.root, part)).await
+        // Fsync the part dir first (all chunk + meta renames become durable together —
+        // Task 1's batched fsync), THEN each ancestor up to the pool root. A part-dir fsync
+        // alone leaves the part reachable only via parent dir entries a crash could still
+        // lose (the new version/object dirs this drain just created), so the ancestor walk
+        // is what makes "committed => durably reachable on CephFS" hold — not merely
+        // "chunks fsynced". Fsyncing an already-durable dir is a near-noop, so the extra
+        // two/three syncs are negligible next to the per-chunk data fsyncs.
+        let part_path = part_dir(&self.root, part);
+        let version_path = part_path.parent().unwrap_or(self.root.as_path());
+        let object_path = version_path.parent().unwrap_or(self.root.as_path());
+        sync_parent_dir(&part_path).await?;
+        sync_parent_dir(version_path).await?;
+        sync_parent_dir(object_path).await?;
+        sync_parent_dir(self.root.as_path()).await
     }
 
     async fn chunk_hash(&self, part: &PartKey, index: ChunkIndex) -> io::Result<String> {
@@ -946,6 +957,28 @@ mod part_tests {
         assert!(ssd_dir.path().join(part.relative_dir()).exists(), "SSD copy kept");
         assert!(!pool_dir.path().join(part.relative_dir()).exists(), "nothing committed to the pool");
         assert_eq!(store.status_of(&part), Some(ReplicationState::Pending));
+    }
+
+    #[tokio::test]
+    async fn finalize_part_fsyncs_the_new_part_version_and_object_dirs() {
+        // WI-15: finalize walks the fresh object/version/part dir chain (created by the
+        // first drain of a new object). It must succeed against a freshly-created deep tree
+        // and be a cheap no-op on a second call over the now-durable tree.
+        let ssd_dir = TempDir::new().unwrap();
+        let pool_dir = TempDir::new().unwrap();
+        let part = part_key(5, 1);
+        seed_ssd_part(ssd_dir.path(), &part, &[(0, b"bytes")]);
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let source = ssd.chunk_source(&part, ChunkIndex::new(0)).unwrap();
+        ceph.persist_chunk(&source, &part, ChunkIndex::new(0)).await.unwrap();
+        ceph.persist_meta(&ssd.meta_source(&part).unwrap(), &part).await.unwrap();
+
+        ceph.finalize_part(&part).await.unwrap();
+        let part_path = pool_dir.path().join(part.relative_dir());
+        assert!(part_path.join("chunk_0.bin").exists() && part_path.join("meta.json").exists());
+        // A second finalize over an already-durable tree is a cheap no-op, not an error.
+        ceph.finalize_part(&part).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -13,8 +13,8 @@
 //! `<object_id>` folder).
 
 use hippius_drain_core::{
-    CephFs, ChunkIndex, DiscoveredPart, FileId, META_FILE_NAME, PartKey, PartPool, PartRemover, PartScan, PartSource, SsdCache, chunk_file_name,
-    parse_part_dir,
+    CephFs, ChunkIndex, DiscoveredPart, FileId, META_FILE_NAME, PartKey, PartMeta, PartPool, PartRemover, PartScan, PartSource, SsdCache,
+    chunk_file_name, parse_part_dir,
 };
 use sha2::{Digest, Sha256};
 use std::ffi::OsStr;
@@ -398,6 +398,16 @@ async fn part_has_meta(part_path: &Path) -> io::Result<bool> {
     }
 }
 
+/// The subset of the api's `meta.json` the drain reads. Only `num_chunks` gates the
+/// completeness check today; `chunk_size`/`size_bytes` are carried for a future size
+/// assertion and to fail-closed (via `InvalidData`) if the schema drifts.
+#[derive(serde::Deserialize)]
+struct MetaJson {
+    chunk_size: u64,
+    num_chunks: u32,
+    size_bytes: u64,
+}
+
 impl PartSource for LocalSsd {
     async fn list_chunks(&self, part: &PartKey) -> io::Result<Vec<ChunkIndex>> {
         list_chunk_indices(&part_dir(&self.root, part)).await
@@ -409,6 +419,20 @@ impl PartSource for LocalSsd {
 
     fn meta_source(&self, part: &PartKey) -> io::Result<PathBuf> {
         Ok(part_dir(&self.root, part).join(META_FILE_NAME))
+    }
+
+    async fn part_meta(&self, part: &PartKey) -> io::Result<PartMeta> {
+        let bytes = fs::read(part_dir(&self.root, part).join(META_FILE_NAME)).await?;
+        // A malformed manifest is corruption, not a not-ready shortfall, so it maps to
+        // InvalidData (non-benign) — the completeness `IncompleteSource` is only for a
+        // well-formed meta whose declared chunk count exceeds what is on disk.
+        let parsed: MetaJson =
+            serde_json::from_slice(&bytes).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, format!("malformed meta.json: {err}")))?;
+        Ok(PartMeta {
+            chunk_size: parsed.chunk_size,
+            num_chunks: parsed.num_chunks,
+            size_bytes: parsed.size_bytes,
+        })
     }
 
     async fn chunk_hash(&self, part: &PartKey, index: ChunkIndex) -> io::Result<String> {
@@ -628,8 +652,8 @@ mod part_tests {
     use core::future::Future;
     use core::str::FromStr;
     use hippius_drain_core::{
-        ChunkIndex, ClaimedPart, DrainOutcome, ObjectId, PartKey, PartNumber, PartPool, PartRemover, PartReplicationStore, PartScan, PartSource,
-        PartVerified, ReplicationState, UploadEnqueuer, Version, drain_part,
+        ChunkIndex, ClaimedPart, DrainOutcome, ObjectId, PartDrainError, PartKey, PartNumber, PartPool, PartRemover, PartReplicationStore, PartScan,
+        PartSource, PartVerified, ReplicationState, UploadEnqueuer, Version, drain_part,
     };
     use sha2::{Digest, Sha256};
     use std::collections::HashMap;
@@ -666,7 +690,9 @@ mod part_tests {
         for &(index, bytes) in chunks {
             std::fs::write(dir.join(format!("chunk_{index}.bin")), bytes).unwrap();
         }
-        std::fs::write(dir.join("meta.json"), br#"{"chunk_size":4,"num_chunks":1,"size_bytes":4}"#).unwrap();
+        // num_chunks must match the seeded set, or the drain's completeness gate rejects it.
+        let meta = format!(r#"{{"chunk_size":4,"num_chunks":{},"size_bytes":4}}"#, chunks.len());
+        std::fs::write(dir.join("meta.json"), meta).unwrap();
     }
 
     /// Minimal in-memory part replication store for the end-to-end drain tests; it
@@ -887,6 +913,39 @@ mod part_tests {
         assert!(pool_part.join("meta.json").exists(), "meta marker copied last");
         assert!(!ssd_part.exists(), "SSD part unlinked only after a verified, committed copy exists");
         assert_eq!(store.status_of(&part), Some(ReplicationState::Replicated));
+    }
+
+    #[tokio::test]
+    async fn end_to_end_drain_of_a_part_whose_meta_overdeclares_defers_and_keeps_the_ssd_copy() {
+        // WI-1 against the real FS: meta claims 2 chunks but only chunk 0 is on disk (a
+        // chunk removed after meta landed). The drain must defer with the SSD copy intact
+        // and nothing committed to the pool.
+        let ssd_dir = TempDir::new().unwrap();
+        let pool_dir = TempDir::new().unwrap();
+        let part = part_key(5, 1);
+        seed_ssd_part(ssd_dir.path(), &part, &[(0, b"only chunk")]);
+        // Overwrite the (matching) meta with one that over-declares num_chunks.
+        std::fs::write(
+            ssd_dir.path().join(part.relative_dir()).join("meta.json"),
+            br#"{"chunk_size":4,"num_chunks":2,"size_bytes":8}"#,
+        )
+        .unwrap();
+
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = MemPartStore::default();
+        store.set(&part, ReplicationState::Pending);
+        let claim = ClaimedPart::new(part.clone(), 0);
+
+        let err = drain_part(&ceph, &ssd, &store, &NoopEnqueuer, &claim).await.unwrap_err();
+
+        assert!(
+            matches!(err, PartDrainError::IncompleteSource { declared: 2, present: 1 }),
+            "got: {err:?}"
+        );
+        assert!(ssd_dir.path().join(part.relative_dir()).exists(), "SSD copy kept");
+        assert!(!pool_dir.path().join(part.relative_dir()).exists(), "nothing committed to the pool");
+        assert_eq!(store.status_of(&part), Some(ReplicationState::Pending));
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-agent/src/main.rs
+++ b/crates/hippius-drain-agent/src/main.rs
@@ -106,6 +106,7 @@ async fn main() -> Result<ExitCode, StartupError> {
     tracing::info!(
         pool_root = %config.pool_root.display(),
         ssd_root = %config.ssd_root.display(),
+        upload_backends = ?config.upload_backends,
         "hippius-drain-agent started"
     );
     let report = runtime.run(shutdown_signal()).await;

--- a/crates/hippius-drain-agent/src/main.rs
+++ b/crates/hippius-drain-agent/src/main.rs
@@ -11,7 +11,7 @@ use hippius_drain_agent::enqueue::RedisEnqueuer;
 use hippius_drain_agent::localfs::{LocalFs, LocalSsd};
 use hippius_drain_agent::runtime::{AgentRuntime, RateControl, default_enforcer};
 use hippius_drain_agent::supervisor::{RunReport, ShutdownTrigger};
-use hippius_drain_core::{Bytes, Coordinator, Store, StoreError};
+use hippius_drain_core::{Bytes, Coordinator, DEFAULT_REDIS_TIMEOUT, Store, StoreError};
 use std::process::ExitCode;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -65,7 +65,13 @@ async fn main() -> Result<ExitCode, StartupError> {
     // upload-queue Redis (the api no longer enqueues at PUT). A multiplexed, auto-
     // reconnecting manager shared across the concurrent drains AND the coordinator below
     // (same redis-queues instance — one connection, cloned).
-    let redis = redis::aio::ConnectionManager::new(redis::Client::open(config.redis_queues_url.as_str())?).await?;
+    // Bound every command on the shared manager (coordinator + enqueuer) with a response
+    // timeout so a hung redis-queues surfaces as a retryable error rather than wedging a
+    // worker loop; the connection timeout bounds the manager's reconnect after a blip.
+    let redis_config = redis::aio::ConnectionManagerConfig::new()
+        .set_response_timeout(DEFAULT_REDIS_TIMEOUT)
+        .set_connection_timeout(DEFAULT_REDIS_TIMEOUT);
+    let redis = redis::aio::ConnectionManager::new_with_config(redis::Client::open(config.redis_queues_url.as_str())?, redis_config).await?;
     let enqueuer = Arc::new(RedisEnqueuer::new(Arc::clone(&store), redis.clone(), config.upload_backends.clone()));
 
     // The Redis-backed coordinator: the heartbeat worker upserts this node's state under

--- a/crates/hippius-drain-agent/src/main.rs
+++ b/crates/hippius-drain-agent/src/main.rs
@@ -10,7 +10,9 @@ use hippius_drain_agent::config::{Config, ConfigError};
 use hippius_drain_agent::enqueue::RedisEnqueuer;
 use hippius_drain_agent::localfs::{LocalFs, LocalSsd};
 use hippius_drain_agent::runtime::{AgentRuntime, RateControl, default_enforcer};
+use hippius_drain_agent::supervisor::{RunReport, ShutdownTrigger};
 use hippius_drain_core::{Bytes, Coordinator, Store, StoreError};
+use std::process::ExitCode;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use thiserror::Error;
@@ -31,8 +33,17 @@ enum StartupError {
     Redis(#[from] redis::RedisError),
 }
 
+/// Whether a supervised run ended in a fault — a worker exited during normal
+/// operation (panic / early return), or a straggler had to be force-aborted. A
+/// clean `Signal`/`NoWorkers` shutdown is not a fault. The process maps this to a
+/// non-zero exit so Kubernetes restarts the pod and the crash is alertable,
+/// rather than an exit-0 that reads as a clean SIGTERM.
+fn faulted(report: &RunReport) -> bool {
+    matches!(report.trigger, ShutdownTrigger::WorkerExited(_)) || !report.clean
+}
+
 #[tokio::main]
-async fn main() -> Result<(), StartupError> {
+async fn main() -> Result<ExitCode, StartupError> {
     init_tracing();
 
     let config = Config::from_env()?;
@@ -92,7 +103,10 @@ async fn main() -> Result<(), StartupError> {
     );
     let report = runtime.run(shutdown_signal()).await;
     tracing::info!(trigger = ?report.trigger, clean = report.clean, "hippius-drain-agent stopped");
-    Ok(())
+    // A worker fault exits non-zero so k8s restarts the pod and the fault is alertable;
+    // a clean shutdown exits zero. (`exit = deny` lints out std::process::exit, so main
+    // returns the ExitCode.)
+    Ok(if faulted(&report) { ExitCode::FAILURE } else { ExitCode::SUCCESS })
 }
 
 /// Installs the global tracing subscriber, honoring `RUST_LOG` (default `info`).
@@ -128,5 +142,53 @@ async fn shutdown_signal() {
     tokio::select! {
         () = interrupt => {}
         () = terminate => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::faulted;
+    use hippius_drain_agent::supervisor::{RunReport, ShutdownTrigger, WorkerName};
+
+    #[test]
+    fn a_clean_signal_shutdown_is_not_a_fault() {
+        let report = RunReport {
+            trigger: ShutdownTrigger::Signal,
+            exits: vec![],
+            clean: true,
+        };
+        assert!(!faulted(&report), "a clean SIGTERM shutdown exits zero");
+    }
+
+    #[test]
+    fn no_workers_is_not_a_fault() {
+        let report = RunReport {
+            trigger: ShutdownTrigger::NoWorkers,
+            exits: vec![],
+            clean: true,
+        };
+        assert!(!faulted(&report));
+    }
+
+    #[test]
+    fn a_worker_exit_is_a_fault_even_if_the_winddown_was_clean() {
+        // WI-7: a panicked/early-exited worker escalates to shutdown; even a clean
+        // wind-down of the peers must exit non-zero so k8s restarts the pod.
+        let report = RunReport {
+            trigger: ShutdownTrigger::WorkerExited(WorkerName::new("drain")),
+            exits: vec![],
+            clean: true,
+        };
+        assert!(faulted(&report));
+    }
+
+    #[test]
+    fn an_unclean_winddown_is_a_fault() {
+        let report = RunReport {
+            trigger: ShutdownTrigger::Signal,
+            exits: vec![],
+            clean: false,
+        };
+        assert!(faulted(&report), "a force-aborted straggler is a fault");
     }
 }

--- a/crates/hippius-drain-agent/src/main.rs
+++ b/crates/hippius-drain-agent/src/main.rs
@@ -82,9 +82,13 @@ async fn main() -> Result<ExitCode, StartupError> {
     // The enforcer starts at the floor (conservative) with a one-second burst of
     // the node's capability; the allocation-pull worker raises it to the leader's
     // budget on its first tick.
-    let enforcer = default_enforcer(config.floor_rate, Bytes::new(config.max_drain_rate.get()), config.drain_concurrency);
+    let enforcer = Arc::new(Mutex::new(default_enforcer(
+        config.floor_rate,
+        Bytes::new(config.max_drain_rate.get()),
+        config.drain_concurrency,
+    )));
     let rate_control = RateControl {
-        enforcer: Arc::new(Mutex::new(enforcer)),
+        enforcer: Arc::clone(&enforcer),
         node: config.node_id.clone(),
         floor: config.floor_rate,
         half_life: config.decay_half_life,
@@ -103,6 +107,11 @@ async fn main() -> Result<ExitCode, StartupError> {
     .with_rate_control(rate_control)
     .with_liveness(config.liveness_file.clone());
 
+    // OTLP metrics read the runtime's live snapshot + the shared enforcer (for the breaker
+    // gauge); grabbed before `run` consumes the runtime. Held until after shutdown to flush.
+    #[cfg(feature = "otel")]
+    let metrics = hippius_drain_agent::metrics::init("hippius-drain-agent", &runtime.snapshot(), Some(&enforcer));
+
     tracing::info!(
         pool_root = %config.pool_root.display(),
         ssd_root = %config.ssd_root.display(),
@@ -111,6 +120,10 @@ async fn main() -> Result<ExitCode, StartupError> {
     );
     let report = runtime.run(shutdown_signal()).await;
     tracing::info!(trigger = ?report.trigger, clean = report.clean, "hippius-drain-agent stopped");
+    #[cfg(feature = "otel")]
+    if let Some(metrics) = metrics {
+        metrics.shutdown();
+    }
     // A worker fault exits non-zero so k8s restarts the pod and the fault is alertable;
     // a clean shutdown exits zero. (`exit = deny` lints out std::process::exit, so main
     // returns the ExitCode.)

--- a/crates/hippius-drain-agent/src/main.rs
+++ b/crates/hippius-drain-agent/src/main.rs
@@ -94,7 +94,8 @@ async fn main() -> Result<ExitCode, StartupError> {
     )
     .with_coordinator(coordinator)
     .with_heartbeat(config.heartbeat_config())
-    .with_rate_control(rate_control);
+    .with_rate_control(rate_control)
+    .with_liveness(config.liveness_file.clone());
 
     tracing::info!(
         pool_root = %config.pool_root.display(),

--- a/crates/hippius-drain-agent/src/metrics.rs
+++ b/crates/hippius-drain-agent/src/metrics.rs
@@ -1,0 +1,123 @@
+//! OTLP metrics export for the drain agent (feature `otel`).
+//!
+//! Mirrors `hippius_s3/otel_setup.py`: a gRPC OTLP exporter pushing to the
+//! otel-collector on a periodic reader, with `service.name` set on the resource (the
+//! collector turns the OTLP resource attributes — merged from `OTEL_RESOURCE_ATTRIBUTES`
+//! — into Prometheus labels). Every value is read from the already-computed
+//! [`SnapshotCell`] / [`Enforcer`], so a metric scrape never measures anything itself.
+
+use hippius_drain_core::Enforcer;
+use hippius_drain_core::SnapshotCell;
+use opentelemetry_otlp::MetricExporter;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::PeriodicReader;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::PoisonError;
+use std::time::Duration;
+use std::time::Instant;
+
+/// How often the reader collects + pushes metrics (matches the Python worker cadence).
+const EXPORT_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Owns the meter provider (for a final flush on shutdown) and keeps the observable
+/// instruments alive for the process lifetime — their callbacks fire on the reader thread,
+/// so the handles must outlive `init`.
+pub struct MetricsHandle {
+    provider: SdkMeterProvider,
+    _instruments: Vec<Box<dyn std::any::Any>>,
+}
+
+// `_instruments` holds `Box<dyn Any>` (no Debug); a manual impl satisfies the workspace's
+// missing-Debug lint without leaking the opaque instrument handles.
+impl std::fmt::Debug for MetricsHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetricsHandle").finish_non_exhaustive()
+    }
+}
+
+impl MetricsHandle {
+    /// Flush and shut the exporter down on process exit (a best-effort final export).
+    pub fn shutdown(self) {
+        if let Err(err) = self.provider.shutdown() {
+            tracing::warn!(error = %err, "meter provider shutdown failed");
+        }
+    }
+}
+
+/// Whether metrics export is enabled (`ENABLE_MONITORING` truthy), mirroring the Python
+/// `otel_setup` guard so a dev/test run without a collector exports nothing.
+fn monitoring_enabled() -> bool {
+    std::env::var("ENABLE_MONITORING").is_ok_and(|value| matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes"))
+}
+
+/// Builds the OTLP gRPC meter provider and installs it globally, or returns `None` on a
+/// build failure (logged, non-fatal — the daemon runs without metrics rather than aborting).
+fn build_provider(service_name: &'static str) -> Option<SdkMeterProvider> {
+    let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").unwrap_or_else(|_| "http://otel-collector:4317".to_owned());
+    let exporter = match MetricExporter::builder().with_tonic().with_endpoint(endpoint).build() {
+        Ok(exporter) => exporter,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to build the OTLP metric exporter; metrics disabled");
+            return None;
+        }
+    };
+    let reader = PeriodicReader::builder(exporter).with_interval(EXPORT_INTERVAL).build();
+    let resource = Resource::builder().with_service_name(service_name).build();
+    let provider = SdkMeterProvider::builder().with_reader(reader).with_resource(resource).build();
+    opentelemetry::global::set_meter_provider(provider.clone());
+    Some(provider)
+}
+
+/// Builds the meter provider and registers the agent's metrics, or returns `None` when
+/// monitoring is disabled or the exporter cannot be built. `enforcer` is `None` for an
+/// ungated drain (no breaker to observe).
+#[must_use]
+pub fn init(service_name: &'static str, snapshot: &Arc<SnapshotCell>, enforcer: Option<&Arc<Mutex<Enforcer>>>) -> Option<MetricsHandle> {
+    if !monitoring_enabled() {
+        return None;
+    }
+    let provider = build_provider(service_name)?;
+    let meter = opentelemetry::global::meter("hippius-drain-agent");
+    let mut instruments: Vec<Box<dyn std::any::Any>> = Vec::new();
+
+    // Throughput: parts committed Replicated (monotonic counter).
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_counter("drain_parts_replicated_total")
+            .with_callback(move |observer| observer.observe(snap.load().drained, &[]))
+            .build(),
+    ));
+
+    // Saturation: undrained SSD bytes (gauge). Backlog growth is what fills the SSD and
+    // 503s every PUT on the node, so it is the key operational drain gauge.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_gauge("drain_ssd_backlog_bytes")
+            .with_callback(move |observer| observer.observe(snap.backlog(), &[]))
+            .build(),
+    ));
+
+    // Silent-failure alarm: the Ceph breaker (trips at debug-level today) as a 0/1 gauge.
+    if let Some(enforcer) = enforcer {
+        let enforcer = Arc::clone(enforcer);
+        instruments.push(Box::new(
+            meter
+                .u64_observable_gauge("drain_breaker_open")
+                .with_callback(move |observer| {
+                    let open = enforcer.lock().unwrap_or_else(PoisonError::into_inner).breaker_open(Instant::now());
+                    observer.observe(u64::from(open), &[]);
+                })
+                .build(),
+        ));
+    }
+
+    Some(MetricsHandle {
+        provider,
+        _instruments: instruments,
+    })
+}

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -21,8 +21,8 @@ use crate::localfs::{LocalFs, LocalSsd};
 use crate::supervisor::{RunReport, Supervisor, WorkerName};
 use crate::worker::drain_until_empty;
 use hippius_drain_core::{
-    BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, Coordinator, Enforcer, NodeId, NodeObservation, SnapshotCell, Store,
-    SystemClock, TokenBucket, UploadEnqueuer, decay_rate, reclaim_ssd, reconcile_parts,
+    BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, CoordError, Coordinator, Enforcer, NodeId, NodeObservation,
+    SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket, UploadEnqueuer, decay_rate, reclaim_ssd, reconcile_parts,
 };
 use std::future::Future;
 use std::sync::{Arc, Mutex, PoisonError};
@@ -250,10 +250,33 @@ fn apply_rate(enforcer: &Arc<Mutex<Enforcer>>, rate: ByteRate) {
     enforcer.lock().unwrap_or_else(PoisonError::into_inner).set_rate(rate);
 }
 
+/// The enforcer action for one allocation-pull outcome, separated from the async
+/// loop so the "a failed pull decays like silence" policy is unit-testable without
+/// a live Redis. `Decay` deliberately covers BOTH a TTL-expired allocation
+/// (`Ok(None)`) and a failed pull (`Err`): a sustained pull failure must not hold
+/// the last budget and keep the node draining full-rate into a possibly-degraded
+/// Ceph — the exact incident the rate control exists to dampen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PullAction {
+    /// A fresh budget landed: adopt it as the new decay base.
+    Adopt(ByteRate),
+    /// No budget (TTL-expired) or the pull failed: decay the current base toward floor.
+    Decay,
+}
+
+/// Maps an allocation-pull result to its enforcer action. A fresh budget is
+/// adopted; silence (`Ok(None)`) and any failure (`Err`) both decay.
+fn pull_action(pull: &Result<Option<StoredAllocation>, CoordError>) -> PullAction {
+    match pull {
+        Ok(Some(allocation)) => PullAction::Adopt(allocation.budget),
+        Ok(None) | Err(_) => PullAction::Decay,
+    }
+}
+
 /// Pulls this node's leader-assigned budget into the shared enforcer each
-/// `poll`, decaying toward `floor` when the allocator goes silent so a stale
-/// allocation cannot keep the node hammering Ceph. The async `load_allocation`
-/// runs *unlocked*; only the synchronous `set_rate` takes the lock.
+/// `poll`, decaying toward `floor` when the allocator goes silent OR the pull
+/// fails, so a stale allocation cannot keep the node hammering Ceph. The async
+/// `load_allocation` runs *unlocked*; only the synchronous `set_rate` takes the lock.
 async fn run_alloc(token: CancellationToken, coord: Arc<Coordinator>, rate_control: RateControl, clock: Arc<dyn Clock>) {
     let RateControl {
         enforcer,
@@ -270,14 +293,17 @@ async fn run_alloc(token: CancellationToken, coord: Arc<Coordinator>, rate_contr
     let mut base = floor;
     let mut allocated_at = clock.now();
     loop {
-        match coord.load_allocation(&node).await {
-            Ok(Some(allocation)) => {
-                base = allocation.budget;
+        let pull = coord.load_allocation(&node).await;
+        if let Err(err) = &pull {
+            tracing::warn!(error = %err, "allocation pull failed; decaying toward the floor");
+        }
+        match pull_action(&pull) {
+            PullAction::Adopt(budget) => {
+                base = budget;
                 allocated_at = clock.now();
                 apply_rate(&enforcer, base);
             }
-            Ok(None) => apply_rate(&enforcer, decay_rate(base, floor, clock.now().duration_since(allocated_at), half_life)),
-            Err(err) => tracing::warn!(error = %err, "allocation pull failed; keeping the current budget"),
+            PullAction::Decay => apply_rate(&enforcer, decay_rate(base, floor, clock.now().duration_since(allocated_at), half_life)),
         }
         tokio::select! {
             () = token.cancelled() => return,
@@ -461,13 +487,13 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr, reason = "tests")]
 mod tests {
-    use super::{AgentRuntime, HeartbeatConfig, RateControl, RuntimeConfig, default_enforcer};
+    use super::{AgentRuntime, HeartbeatConfig, PullAction, RateControl, RuntimeConfig, default_enforcer, pull_action};
     use crate::localfs::{LocalFs, LocalSsd};
     use crate::supervisor::ShutdownTrigger;
     use core::str::FromStr;
     use hippius_drain_core::{
-        Allocation, ByteRate, Bytes, Clock, Coordinator, NodeId, ObjectId, PartKey, PartNumber, PartReplicationStore, ReplicationState, SnapshotCell,
-        Store, TestClock, UploadEnqueuer, Version,
+        Allocation, ByteRate, Bytes, Clock, CoordError, Coordinator, NodeId, ObjectId, PartKey, PartNumber, PartReplicationStore, ReplicationState,
+        SnapshotCell, Store, StoredAllocation, TestClock, UploadEnqueuer, Version,
     };
 
     /// A coordinator on the test Redis under a per-test prefix, or `None` to skip the
@@ -501,6 +527,27 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     const UUID: &str = "466916c0-d61b-4518-b81b-9576b574270a";
+
+    #[test]
+    fn pull_action_adopts_a_fresh_budget() {
+        let allocation = StoredAllocation {
+            budget: ByteRate::new(500_000),
+            epoch: 7,
+        };
+        assert_eq!(pull_action(&Ok(Some(allocation))), PullAction::Adopt(ByteRate::new(500_000)));
+    }
+
+    #[test]
+    fn pull_action_decays_on_a_ttl_expired_allocation() {
+        assert_eq!(pull_action(&Ok(None)), PullAction::Decay);
+    }
+
+    #[test]
+    fn pull_action_decays_on_a_failed_pull() {
+        // WI-6: an Err (e.g. a sustained redis-queues outage) must decay toward the floor
+        // like silence, NOT hold the last budget and keep hammering a degraded Ceph.
+        assert_eq!(pull_action(&Err(CoordError::Invalid { field: "test" })), PullAction::Decay);
+    }
 
     fn part_at(version: u32, number: u32) -> PartKey {
         PartKey::new(ObjectId::from_str(UUID).unwrap(), Version::new(version), PartNumber::new(number))

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -589,6 +589,7 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn the_allocation_worker_applies_the_leaders_budget(pool: PgPool) {
         let Some(coord) = test_coord("cephor-test:rt-applies:", Duration::from_secs(30), Duration::from_secs(30)).await else {
             eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
@@ -657,6 +658,7 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn the_allocation_worker_decays_on_an_injected_clock(pool: PgPool) {
         // #33: run_alloc reads the injected Clock for its decay timing. Load a budget
         // (base jumps above the floor, allocated_at = clock.now()), then let the
@@ -758,6 +760,7 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn the_heartbeat_worker_upserts_this_node_into_the_fleet(pool: PgPool) {
         let Some(coord) = test_coord("cephor-test:rt-hb:", Duration::from_secs(30), Duration::from_secs(30)).await else {
             eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -207,6 +207,10 @@ async fn heartbeat_once(ssd: &LocalSsd, coord: &Coordinator, node: &NodeId, max_
     // Pressure (allocator weight), backlog (SSD used bytes — the undrained work),
     // and error rate (from the drain counters) are real. p99 latency stays neutral
     // until per-drain timing is wired (the saturation signal, not a demand signal).
+    // Publish the backlog to the metrics gauge here, where the (blocking) disk probe has
+    // already produced used_bytes — the metrics layer reads it wait-free off the exporter
+    // thread, so it must never run statvfs itself.
+    snapshot.record_backlog(usage.used_bytes);
     let observation = NodeObservation {
         pressure: usage.pressure,
         backlog: Bytes::new(usage.used_bytes),

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -25,9 +25,18 @@ use hippius_drain_core::{
     SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket, UploadEnqueuer, decay_rate, reclaim_ssd, reconcile_parts,
 };
 use std::future::Future;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
+
+/// Best-effort liveness touch: rewriting the file bumps its mtime, which the k8s exec
+/// probe checks for freshness. Errors are ignored — a transient FS blip must not kill an
+/// otherwise-healthy process; a persistent failure ages the mtime out and the probe fails,
+/// which is the correct outcome (restart a wedged pod).
+fn touch_liveness(path: &Path) {
+    let _ = std::fs::write(path, b"ok");
+}
 
 /// Consecutive Ceph-write failures before the circuit breaker opens.
 const BREAKER_FAILURES: u32 = 5;
@@ -341,6 +350,9 @@ pub struct AgentRuntime<E: UploadEnqueuer> {
     /// The time source the allocation-pull worker reads for its decay timing.
     /// Defaults to [`SystemClock`]; tests inject a [`hippius_drain_core::TestClock`].
     clock: Arc<dyn Clock>,
+    /// Opt-in liveness file the heartbeat worker touches each tick, for the k8s probe.
+    /// `None` (tests / drain-only e2e) writes no file.
+    liveness_path: Option<Arc<PathBuf>>,
 }
 
 impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
@@ -359,6 +371,7 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
             rate_control: None,
             coord: None,
             clock: Arc::new(SystemClock),
+            liveness_path: None,
         }
     }
 
@@ -395,6 +408,15 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
     #[must_use]
     pub fn with_heartbeat(mut self, heartbeat: HeartbeatConfig) -> Self {
         self.heartbeat = Some(heartbeat);
+        self
+    }
+
+    /// Sets the liveness file the heartbeat worker touches each tick, so a k8s
+    /// `livenessProbe` can restart a wedged (not crashed) pod. Without it (tests /
+    /// drain-only e2e) no file is written.
+    #[must_use]
+    pub fn with_liveness(mut self, path: PathBuf) -> Self {
+        self.liveness_path = Some(Arc::new(path));
         self
     }
 
@@ -460,11 +482,27 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
         // is never in the fleet.
         if let (Some(heartbeat), Some(coord)) = (self.heartbeat, self.coord.as_ref()) {
             let (ssd, coord, snapshot) = (Arc::clone(&self.ssd), Arc::clone(coord), Arc::clone(&self.snapshot));
+            let liveness = self.liveness_path.clone();
             let HeartbeatConfig { node, max_drain_rate, poll } = heartbeat;
             supervisor.spawn(WorkerName::new("heartbeat"), move |token| {
                 run_periodic(token, poll, move || {
-                    let (ssd, coord, node, snapshot) = (Arc::clone(&ssd), Arc::clone(&coord), node.clone(), Arc::clone(&snapshot));
+                    let (ssd, coord, node, snapshot, liveness) = (
+                        Arc::clone(&ssd),
+                        Arc::clone(&coord),
+                        node.clone(),
+                        Arc::clone(&snapshot),
+                        liveness.clone(),
+                    );
                     async move {
+                        // Touch liveness FIRST, before the (blocking, possibly early-returning)
+                        // disk probe, so a healthy runtime keeps the k8s probe fresh even when a
+                        // statvfs blip short-circuits heartbeat_once. The heartbeat cadence is a
+                        // bounded, quick tick independent of drain-backlog duration, so it is a
+                        // truer runtime-liveness signal than the drain loop (which can legitimately
+                        // run long under a large backlog).
+                        if let Some(path) = liveness.as_deref() {
+                            touch_liveness(path);
+                        }
                         heartbeat_once(&ssd, &coord, &node, max_drain_rate, &snapshot).await;
                     }
                 })

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -11,7 +11,7 @@ use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
 use hippius_drain_core::{
     BreakerSignal, DrainDecision, DrainOutcome, Enforcer, PartDrainError, PartKey, PartSource, SnapshotCell, Store, StoreError, UploadEnqueuer,
-    drain_part,
+    breaker_signal_for, drain_part,
 };
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Instant;
@@ -165,11 +165,14 @@ pub async fn drain_next<E: UploadEnqueuer>(
     // healthy pool and halt ALL draining on the node (stalling unrelated parts). Only a
     // genuine copy/verify/commit I/O error is a Ceph-write failure. A deferred part is
     // returned to `pending` (backed off) below, so a later re-drain retries it.
-    let signal = match &result {
-        Ok(_) => BreakerSignal::CephSuccess,
-        Err(err) if err.is_benign_deferral() => BreakerSignal::Deferred,
-        Err(_) => BreakerSignal::CephFailure,
-    };
+    // A benign deferral (enqueue not ready / vanished source / incomplete part) AND a
+    // store/claim-coordination error (a Postgres blip on commit, or PartClaimLost from a
+    // lease-expiry re-claim) both leave the breaker untouched; only a genuine Ceph-write
+    // failure trips it. The policy lives in core (breaker_signal_for) so it stays with the
+    // error type and is unit-tested there. A store error maps to Deferred for the breaker
+    // but is RELEASED (not defer-backed-off) below, since only a genuine not-ready deferral
+    // should back off.
+    let signal = breaker_signal_for(&result);
     if let Some(enforcer) = enforcer {
         // record_outcome releases the permit, so the guard is dismissed afterwards.
         enforcer
@@ -210,8 +213,11 @@ pub async fn drain_next<E: UploadEnqueuer>(
         // Best-effort: if the release/defer itself fails — likely the same store outage
         // that failed the drain — the lease-TTL re-claim is the backstop, so we keep
         // surfacing the original drain error.
-        let returned = match signal {
-            BreakerSignal::Deferred => store.defer_part(claim.part()).await,
+        // Back off (defer_part) ONLY a genuine not-ready deferral, so the drain doesn't
+        // spin re-claiming the same not-ready part; a store/claim error (which also maps
+        // to the Deferred breaker signal) or a Ceph-write failure releases promptly.
+        let returned = match &result {
+            Err(err) if err.is_benign_deferral() => store.defer_part(claim.part()).await,
             _ => store.release_part(claim.part()).await,
         };
         if let Err(release_err) = returned {

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -357,7 +357,9 @@ mod tests {
         for (index, bytes) in chunks.iter().enumerate() {
             std::fs::write(dir.join(format!("chunk_{index}.bin")), bytes).unwrap();
         }
-        std::fs::write(dir.join("meta.json"), br#"{"chunk_size":16,"num_chunks":1,"size_bytes":16}"#).unwrap();
+        // num_chunks must match the seeded set, or the drain's completeness gate rejects it.
+        let meta = format!(r#"{{"chunk_size":16,"num_chunks":{},"size_bytes":16}}"#, chunks.len());
+        std::fs::write(dir.join("meta.json"), meta).unwrap();
         store.record_landed_part(part).await.unwrap();
     }
 

--- a/crates/hippius-drain-allocator/Cargo.toml
+++ b/crates/hippius-drain-allocator/Cargo.toml
@@ -10,8 +10,10 @@ description = "cephor singleton allocator (leader-elected; allocates the global 
 # real near-full; `--no-default-features` drops `reqwest` and falls back to the
 # static ceiling, keeping a dependency-light build provable.
 [features]
-default = ["http"]
+default = ["http", "otel"]
 http = ["dep:reqwest"]
+# OTLP metrics export; `--no-default-features` drops it for a dependency-light build.
+otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
 
 # The allocator owns schema provisioning (`pg`) and contends for the leader lease /
 # reads the fleet / writes budgets via the Redis-backed coordinator (`coord`).
@@ -23,6 +25,10 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 # The probe's HTTP client; gated behind `http` so a no-default-features build omits it.
 reqwest = { workspace = true, optional = true }
+# OTLP metrics export, gated behind `otel`.
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
 
 [dev-dependencies]
 # CancellationToken drives the shutdown signal in the run-loop tests.

--- a/crates/hippius-drain-allocator/src/config.rs
+++ b/crates/hippius-drain-allocator/src/config.rs
@@ -8,8 +8,13 @@
 
 use hippius_drain_core::{AllocConfig, ByteRate, CephCeiling, CephThresholds, DiskPressure, StaticCeiling, TickConfig};
 use std::num::ParseIntError;
+use std::path::PathBuf;
 use std::time::Duration;
 use thiserror::Error;
+
+/// Default path of the liveness file the tick loop touches each iteration; the k8s
+/// `livenessProbe` checks its freshness. Container-local `/tmp` is always writable.
+const DEFAULT_LIVENESS_FILE: &str = "/tmp/hippius-drain-allocator.alive";
 
 /// Leader-lease TTL when `CEPHOR_LEADER_LEASE_TTL_SECS` is unset. Several ticks
 /// long so a brief stall does not lose leadership, short enough to fail over.
@@ -87,6 +92,9 @@ pub struct AllocatorConfig {
     pub ceph_thresholds: CephThresholds,
     /// Per-scrape timeout for the live probe.
     pub ceph_probe_timeout: Duration,
+    /// Path of the liveness file the tick loop touches each iteration; a k8s
+    /// `livenessProbe` checks its freshness to restart a wedged (not crashed) allocator.
+    pub liveness_file: PathBuf,
 }
 
 /// A failure parsing the allocator configuration from the environment.
@@ -192,6 +200,7 @@ impl AllocatorConfig {
             ceph_mgr_metrics_url: optional(&get, "CEPHOR_CEPH_MGR_METRICS_URL"),
             ceph_thresholds: ceph_thresholds(&get)?,
             ceph_probe_timeout: duration_secs(&get, "CEPHOR_CEPH_PROBE_TIMEOUT_SECS", DEFAULT_PROBE_TIMEOUT)?,
+            liveness_file: path_or(&get, "CEPHOR_LIVENESS_FILE", DEFAULT_LIVENESS_FILE),
         })
     }
 }
@@ -221,6 +230,14 @@ fn required(get: &impl Fn(&str) -> Option<String>, var: &'static str) -> Result<
 /// absent — a blank mgr URL must not select the probe with an unusable endpoint.
 fn optional(get: &impl Fn(&str) -> Option<String>, var: &'static str) -> Option<String> {
     get(var).filter(|value| !value.trim().is_empty())
+}
+
+/// Resolves an optional path variable, falling back to `default` when unset or blank.
+fn path_or(get: &impl Fn(&str) -> Option<String>, var: &'static str, default: &str) -> PathBuf {
+    match get(var) {
+        Some(value) if !value.trim().is_empty() => PathBuf::from(value),
+        _ => PathBuf::from(default),
+    }
 }
 
 /// Resolves an optional integer variable, falling back to `default` when unset.
@@ -321,6 +338,16 @@ mod tests {
         );
         // The first-tick estimate defaults to the AIMD floor.
         assert_eq!(config.initial_total, ByteRate::new(DEFAULT_MIN_TOTAL_BPS));
+    }
+
+    #[test]
+    fn liveness_file_defaults_and_is_overridable() {
+        let config = AllocatorConfig::from_lookup(lookup(&required_only())).unwrap();
+        assert_eq!(config.liveness_file, std::path::PathBuf::from("/tmp/hippius-drain-allocator.alive"));
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_LIVENESS_FILE", "/var/run/allocator.alive"));
+        let overridden = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(overridden.liveness_file, std::path::PathBuf::from("/var/run/allocator.alive"));
     }
 
     #[test]

--- a/crates/hippius-drain-allocator/src/config.rs
+++ b/crates/hippius-drain-allocator/src/config.rs
@@ -62,6 +62,12 @@ const DEFAULT_CEPH_FULL_BPS: u16 = 9_500;
 /// is unset — short relative to the tick so a hung mgr decays rather than stalls.
 const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// How long a terminal (`replicated`/`failed`) replication row is kept before the periodic
+/// GC prunes it, when `CEPHOR_STATUS_RETENTION_SECS` is unset. A week comfortably exceeds
+/// the janitor cycle + any abort-settle window, so a `failed` row is never pruned before
+/// the reclaim path has had a chance to act on it.
+const DEFAULT_STATUS_RETENTION: Duration = Duration::from_hours(7 * 24);
+
 /// The allocator's startup configuration.
 #[derive(Debug, Clone)]
 pub struct AllocatorConfig {
@@ -95,6 +101,9 @@ pub struct AllocatorConfig {
     /// Path of the liveness file the tick loop touches each iteration; a k8s
     /// `livenessProbe` checks its freshness to restart a wedged (not crashed) allocator.
     pub liveness_file: PathBuf,
+    /// How long a terminal (`replicated`/`failed`) replication row is kept before the
+    /// periodic GC sweep prunes it (`CEPHOR_STATUS_RETENTION_SECS`).
+    pub status_retention: Duration,
 }
 
 /// A failure parsing the allocator configuration from the environment.
@@ -201,6 +210,7 @@ impl AllocatorConfig {
             ceph_thresholds: ceph_thresholds(&get)?,
             ceph_probe_timeout: duration_secs(&get, "CEPHOR_CEPH_PROBE_TIMEOUT_SECS", DEFAULT_PROBE_TIMEOUT)?,
             liveness_file: path_or(&get, "CEPHOR_LIVENESS_FILE", DEFAULT_LIVENESS_FILE),
+            status_retention: duration_secs(&get, "CEPHOR_STATUS_RETENTION_SECS", DEFAULT_STATUS_RETENTION)?,
         })
     }
 }
@@ -305,7 +315,7 @@ fn duration_millis(get: &impl Fn(&str) -> Option<String>, var: &'static str, def
 mod tests {
     use super::{
         AllocatorConfig, ConfigError, DEFAULT_ALLOCATION_TTL, DEFAULT_CRITICAL_PRESSURE_BPS, DEFAULT_DECREASE_PERMILLE, DEFAULT_MAX_TOTAL_BPS,
-        DEFAULT_MIN_TOTAL_BPS, DEFAULT_TICK,
+        DEFAULT_MIN_TOTAL_BPS, DEFAULT_STATUS_RETENTION, DEFAULT_TICK,
     };
     use hippius_drain_core::{ByteRate, CephCeiling, DiskPressure};
 
@@ -338,6 +348,16 @@ mod tests {
         );
         // The first-tick estimate defaults to the AIMD floor.
         assert_eq!(config.initial_total, ByteRate::new(DEFAULT_MIN_TOTAL_BPS));
+    }
+
+    #[test]
+    fn status_retention_defaults_to_a_week_and_is_overridable() {
+        let config = AllocatorConfig::from_lookup(lookup(&required_only())).unwrap();
+        assert_eq!(config.status_retention, DEFAULT_STATUS_RETENTION);
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_STATUS_RETENTION_SECS", "3600"));
+        let overridden = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(overridden.status_retention, std::time::Duration::from_hours(1));
     }
 
     #[test]

--- a/crates/hippius-drain-allocator/src/lib.rs
+++ b/crates/hippius-drain-allocator/src/lib.rs
@@ -8,6 +8,8 @@
 //! and the loop are unit-/integration-testable without the process entry point.
 
 pub mod config;
+#[cfg(feature = "otel")]
+pub mod metrics;
 #[cfg(feature = "http")]
 pub mod probe;
 pub mod run;

--- a/crates/hippius-drain-allocator/src/main.rs
+++ b/crates/hippius-drain-allocator/src/main.rs
@@ -94,6 +94,7 @@ async fn drive<C: CephCeilingSource>(coord: &Coordinator, ceiling: &C, config: &
         &config.tick_config(),
         config.initial_total,
         config.tick_interval,
+        Some(config.liveness_file.as_path()),
         shutdown_signal(),
     )
     .await

--- a/crates/hippius-drain-allocator/src/main.rs
+++ b/crates/hippius-drain-allocator/src/main.rs
@@ -8,8 +8,9 @@
 //! [`StaticCeiling`](hippius_drain_core::StaticCeiling) from config is the fallback.
 
 use hippius_drain_allocator::config::{AllocatorConfig, ConfigError};
-use hippius_drain_allocator::run::run_allocator;
+use hippius_drain_allocator::run::{AllocatorMetrics, Observability, run_allocator};
 use hippius_drain_core::{CephCeilingSource, CoordError, Coordinator, Store, StoreError};
+use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
 
@@ -73,19 +74,29 @@ async fn main() -> Result<(), StartupError> {
     // — not Postgres — so the ~2s leader tick never touches the WAL.
     let coordinator = Coordinator::connect(&config.redis_queues_url, ALLOCATOR_NODE_TTL, config.alloc_ttl).await?;
 
+    // Plain-atomic gauges the tick loop updates; the OTLP exporter (feature `otel`) reads
+    // them. Always created (cheap) so the loop's signature is uniform with or without otel.
+    let alloc_metrics = Arc::new(AllocatorMetrics::default());
+    #[cfg(feature = "otel")]
+    let metrics = hippius_drain_allocator::metrics::init("hippius-drain-allocator", &alloc_metrics);
+
     tracing::info!(
         instance = %config.instance_id,
         tick_secs = config.tick_interval.as_secs(),
         "hippius-drain-allocator started"
     );
-    run_with_ceiling_source(&coordinator, &config).await?;
+    run_with_ceiling_source(&coordinator, &config, alloc_metrics.as_ref()).await?;
     tracing::info!("hippius-drain-allocator stopped");
+    #[cfg(feature = "otel")]
+    if let Some(metrics) = metrics {
+        metrics.shutdown();
+    }
     Ok(())
 }
 
 /// Selects the ceiling source — the live mgr probe when a URL is configured (and the
 /// `http` feature is built), else the static ceiling — and runs the allocator on it.
-async fn run_with_ceiling_source(coord: &Coordinator, config: &AllocatorConfig) -> Result<(), StartupError> {
+async fn run_with_ceiling_source(coord: &Coordinator, config: &AllocatorConfig, metrics: &AllocatorMetrics) -> Result<(), StartupError> {
     #[cfg(feature = "http")]
     if let Some(url) = config.ceph_mgr_metrics_url.clone() {
         // The decay floor is the AIMD floor: while the probe is blind, the fleet
@@ -98,24 +109,28 @@ async fn run_with_ceiling_source(coord: &Coordinator, config: &AllocatorConfig) 
             config.ceph_probe_timeout,
         )?;
         tracing::info!(mgr_url = %url, "driving the budget from the live ceph-mgr ceiling probe");
-        drive(coord, &probe, config).await;
+        drive(coord, &probe, config, metrics).await;
         return Ok(());
     }
     tracing::info!("no ceph mgr url configured; using the static ceiling");
-    drive(coord, &config.ceiling(), config).await;
+    drive(coord, &config.ceiling(), config, metrics).await;
     Ok(())
 }
 
 /// Runs the allocator loop on `ceiling`, logging (not failing on) a shutdown
 /// relinquish error — the lease TTL recovers it, so the process still exits cleanly.
-async fn drive<C: CephCeilingSource>(coord: &Coordinator, ceiling: &C, config: &AllocatorConfig) {
+async fn drive<C: CephCeilingSource>(coord: &Coordinator, ceiling: &C, config: &AllocatorConfig, metrics: &AllocatorMetrics) {
+    let obs = Observability {
+        liveness: Some(config.liveness_file.as_path()),
+        metrics,
+    };
     if let Err(err) = run_allocator(
         coord,
         ceiling,
         &config.tick_config(),
         config.initial_total,
         config.tick_interval,
-        Some(config.liveness_file.as_path()),
+        &obs,
         shutdown_signal(),
     )
     .await

--- a/crates/hippius-drain-allocator/src/main.rs
+++ b/crates/hippius-drain-allocator/src/main.rs
@@ -18,6 +18,10 @@ use thiserror::Error;
 /// satisfy the shared [`Coordinator`] constructor.
 const ALLOCATOR_NODE_TTL: Duration = Duration::from_secs(30);
 
+/// How often the terminal-row GC sweep runs (coarse — the table grows slowly and each
+/// sweep is one bounded DELETE).
+const STATUS_GC_INTERVAL: Duration = Duration::from_hours(1);
+
 /// A failure bringing the allocator up. Each variant maps to a distinct operator
 /// fix: a bad environment, an unreachable store / coordination redis, or an
 /// unbuildable probe client.
@@ -47,6 +51,23 @@ async fn main() -> Result<(), StartupError> {
     // — sqlx records applied migrations under an advisory lock, so a restart or a
     // brief multi-replica overlap during rollout re-runs nothing.
     store.migrate().await?;
+
+    // Terminal-row GC: a best-effort background sweep pruning aged replicated/failed rows
+    // so cephor_replication_status does not grow unbounded and bloat the hot claim/reconcile
+    // scans. The DELETE is idempotent, so a mid-cycle abort on shutdown just re-runs next
+    // startup; the allocator is a singleton (replicas:1, Recreate), so a single sweeper runs.
+    // `store` is moved here — it is only needed for the migrate above and this sweep.
+    let gc_retention = config.status_retention;
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(STATUS_GC_INTERVAL).await;
+            match store.gc_terminal_status_rows(gc_retention).await {
+                Ok(0) => {}
+                Ok(pruned) => tracing::info!(pruned, "gc'd terminal replication rows"),
+                Err(err) => tracing::warn!(error = %err, "terminal-row gc failed; retrying next cycle"),
+            }
+        }
+    });
 
     // Leadership, the fleet view, and the budgets live in Redis (TTL-keyed, epoch-fenced)
     // — not Postgres — so the ~2s leader tick never touches the WAL.

--- a/crates/hippius-drain-allocator/src/metrics.rs
+++ b/crates/hippius-drain-allocator/src/metrics.rs
@@ -1,0 +1,102 @@
+//! OTLP metrics export for the allocator (feature `otel`).
+//!
+//! Mirrors `hippius_s3/otel_setup.py` (gRPC OTLP to the otel-collector, periodic reader,
+//! `service.name` on the resource). The two gauges read the plain-atomic
+//! [`AllocatorMetrics`](crate::run::AllocatorMetrics) the tick loop updates, so a scrape
+//! never touches the loop's state.
+
+use crate::run::AllocatorMetrics;
+use opentelemetry_otlp::MetricExporter;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::PeriodicReader;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+/// How often the reader collects + pushes metrics (matches the Python worker cadence).
+const EXPORT_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Owns the meter provider (for a final flush) and keeps the observable instruments alive
+/// for the process lifetime — their callbacks fire on the reader thread.
+pub struct MetricsHandle {
+    provider: SdkMeterProvider,
+    _instruments: Vec<Box<dyn std::any::Any>>,
+}
+
+// `_instruments` holds `Box<dyn Any>` (no Debug); a manual impl satisfies the workspace's
+// missing-Debug lint without leaking the opaque instrument handles.
+impl std::fmt::Debug for MetricsHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetricsHandle").finish_non_exhaustive()
+    }
+}
+
+impl MetricsHandle {
+    /// Flush and shut the exporter down on process exit (a best-effort final export).
+    pub fn shutdown(self) {
+        if let Err(err) = self.provider.shutdown() {
+            tracing::warn!(error = %err, "meter provider shutdown failed");
+        }
+    }
+}
+
+/// Whether metrics export is enabled (`ENABLE_MONITORING` truthy).
+fn monitoring_enabled() -> bool {
+    std::env::var("ENABLE_MONITORING").is_ok_and(|value| matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes"))
+}
+
+/// Builds the OTLP gRPC meter provider and installs it globally, or returns `None` on a
+/// build failure (logged, non-fatal).
+fn build_provider(service_name: &'static str) -> Option<SdkMeterProvider> {
+    let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").unwrap_or_else(|_| "http://otel-collector:4317".to_owned());
+    let exporter = match MetricExporter::builder().with_tonic().with_endpoint(endpoint).build() {
+        Ok(exporter) => exporter,
+        Err(err) => {
+            tracing::warn!(error = %err, "failed to build the OTLP metric exporter; metrics disabled");
+            return None;
+        }
+    };
+    let reader = PeriodicReader::builder(exporter).with_interval(EXPORT_INTERVAL).build();
+    let resource = Resource::builder().with_service_name(service_name).build();
+    let provider = SdkMeterProvider::builder().with_reader(reader).with_resource(resource).build();
+    opentelemetry::global::set_meter_provider(provider.clone());
+    Some(provider)
+}
+
+/// Builds the meter provider and registers the allocator's gauges (`drain_leader`,
+/// `drain_fleet_estimate_bps`), or returns `None` when monitoring is disabled or the
+/// exporter cannot be built. Both gauges read the shared [`AllocatorMetrics`].
+#[must_use]
+pub fn init(service_name: &'static str, metrics: &Arc<AllocatorMetrics>) -> Option<MetricsHandle> {
+    if !monitoring_enabled() {
+        return None;
+    }
+    let provider = build_provider(service_name)?;
+    let meter = opentelemetry::global::meter("hippius-drain-allocator");
+    let mut instruments: Vec<Box<dyn std::any::Any>> = Vec::new();
+
+    // Is this instance the leader (did leader election converge)? 0/1 gauge.
+    let m = Arc::clone(metrics);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_gauge("drain_leader")
+            .with_callback(move |observer| observer.observe(m.leader.load(Ordering::Relaxed), &[]))
+            .build(),
+    ));
+
+    // The fleet write-budget estimate handed out on the last led tick.
+    let m = Arc::clone(metrics);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_gauge("drain_fleet_estimate_bps")
+            .with_callback(move |observer| observer.observe(m.fleet_estimate_bps.load(Ordering::Relaxed), &[]))
+            .build(),
+    ));
+
+    Some(MetricsHandle {
+        provider,
+        _instruments: instruments,
+    })
+}

--- a/crates/hippius-drain-allocator/src/run.rs
+++ b/crates/hippius-drain-allocator/src/run.rs
@@ -2,7 +2,15 @@
 
 use hippius_drain_core::{BudgetController, ByteRate, CephCeilingSource, CoordError, Coordinator, TickConfig, TickOutcome, run_tick};
 use std::future::Future;
+use std::path::Path;
 use std::time::Duration;
+
+/// Best-effort liveness touch (see the agent runtime for the rationale): rewriting the
+/// file bumps its mtime, which the k8s exec probe checks for freshness. Errors are
+/// ignored — a persistent failure ages the mtime out and the probe restarts the pod.
+fn touch_liveness(path: &Path) {
+    let _ = std::fs::write(path, b"ok");
+}
 
 /// Runs the allocator's tick loop until `shutdown` resolves.
 ///
@@ -30,11 +38,17 @@ pub async fn run_allocator<C: CephCeilingSource>(
     config: &TickConfig,
     initial: ByteRate,
     tick: Duration,
+    liveness: Option<&Path>,
     shutdown: impl Future<Output = ()>,
 ) -> Result<(), CoordError> {
     let mut controller = BudgetController::new(initial);
     tokio::pin!(shutdown);
     loop {
+        // Touch liveness each tick (the tick is bounded and quick) so a k8s probe
+        // restarts a wedged — not crashed — loop, e.g. one blocked on a hung Redis.
+        if let Some(path) = liveness {
+            touch_liveness(path);
+        }
         match run_tick(coord, ceiling, config, controller).await {
             Ok(TickOutcome::Led(plan)) => {
                 tracing::debug!(
@@ -144,6 +158,7 @@ mod tests {
             &config,
             ByteRate::new(190_000),
             Duration::from_millis(10),
+            None,
             shutdown.cancelled(),
         );
         let driver = async {
@@ -207,6 +222,7 @@ mod tests {
             &config,
             ByteRate::new(190_000),
             Duration::from_millis(10),
+            None,
             shutdown.cancelled(),
         );
         let driver = async {

--- a/crates/hippius-drain-allocator/src/run.rs
+++ b/crates/hippius-drain-allocator/src/run.rs
@@ -3,6 +3,7 @@
 use hippius_drain_core::{BudgetController, ByteRate, CephCeilingSource, CoordError, Coordinator, TickConfig, TickOutcome, run_tick};
 use std::future::Future;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 /// Best-effort liveness touch (see the agent runtime for the rationale): rewriting the
@@ -10,6 +11,27 @@ use std::time::Duration;
 /// ignored — a persistent failure ages the mtime out and the probe restarts the pod.
 fn touch_liveness(path: &Path) {
     let _ = std::fs::write(path, b"ok");
+}
+
+/// The allocator's plain-atomic gauges, always compiled (no `otel` dep). The tick loop
+/// writes them; the OTLP gauge callbacks (feature `otel`) read them, so the metrics layer
+/// never has to reach into the loop's state.
+#[derive(Debug, Default)]
+pub struct AllocatorMetrics {
+    /// 1 while this instance led the last tick, else 0 (`drain_leader`).
+    pub leader: AtomicU64,
+    /// The fleet write-budget estimate in bytes/s from the last led tick (`drain_fleet_estimate_bps`).
+    pub fleet_estimate_bps: AtomicU64,
+}
+
+/// Loop-level observability inputs, bundled so `run_allocator` stays under the argument
+/// count lint: the liveness file to touch each tick and the gauges to update.
+#[derive(Debug)]
+pub struct Observability<'a> {
+    /// Liveness file touched each tick (`None` in tests).
+    pub liveness: Option<&'a Path>,
+    /// Gauges the loop updates (leadership + fleet estimate).
+    pub metrics: &'a AllocatorMetrics,
 }
 
 /// Runs the allocator's tick loop until `shutdown` resolves.
@@ -38,7 +60,7 @@ pub async fn run_allocator<C: CephCeilingSource>(
     config: &TickConfig,
     initial: ByteRate,
     tick: Duration,
-    liveness: Option<&Path>,
+    obs: &Observability<'_>,
     shutdown: impl Future<Output = ()>,
 ) -> Result<(), CoordError> {
     let mut controller = BudgetController::new(initial);
@@ -46,25 +68,34 @@ pub async fn run_allocator<C: CephCeilingSource>(
     loop {
         // Touch liveness each tick (the tick is bounded and quick) so a k8s probe
         // restarts a wedged — not crashed — loop, e.g. one blocked on a hung Redis.
-        if let Some(path) = liveness {
+        if let Some(path) = obs.liveness {
             touch_liveness(path);
         }
         match run_tick(coord, ceiling, config, controller).await {
             Ok(TickOutcome::Led(plan)) => {
+                let estimate = plan.controller.total().get();
                 tracing::debug!(
-                    fleet_estimate = plan.controller.total().get(),
+                    fleet_estimate = estimate,
                     feasible = plan.feasible,
                     nodes = plan.allocations.len(),
                     "led allocation tick"
                 );
+                obs.metrics.leader.store(1, Ordering::Relaxed);
+                obs.metrics.fleet_estimate_bps.store(estimate, Ordering::Relaxed);
                 // Carry the evolved AIMD state into the next tick.
                 controller = plan.controller;
             }
-            Ok(TickOutcome::NotLeader) => tracing::debug!("another instance holds leadership this tick"),
+            Ok(TickOutcome::NotLeader) => {
+                tracing::debug!("another instance holds leadership this tick");
+                obs.metrics.leader.store(0, Ordering::Relaxed);
+            }
             // The coordinator fenced this instance's stale-epoch write: a higher-epoch
             // leader exists, so this instance is deposed. Expected handoff, not an
             // alert. Keep the carried controller so a re-win resumes from a sane rate.
-            Err(CoordError::Fenced { epoch }) => tracing::info!(epoch, "allocation fenced; leadership has moved on"),
+            Err(CoordError::Fenced { epoch }) => {
+                tracing::info!(epoch, "allocation fenced; leadership has moved on");
+                obs.metrics.leader.store(0, Ordering::Relaxed);
+            }
             Err(err) => tracing::warn!(error = %err, "allocation tick failed; retrying next tick"),
         }
         tokio::select! {
@@ -80,7 +111,7 @@ pub async fn run_allocator<C: CephCeilingSource>(
 #[cfg(test)]
 #[expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr, reason = "tests")]
 mod tests {
-    use super::run_allocator;
+    use super::{AllocatorMetrics, Observability, run_allocator};
     use core::str::FromStr;
     use hippius_drain_core::{
         AllocConfig, Allocation, ByteRate, Bytes, CephCeiling, Coordinator, DiskPressure, NodeId, NodeObservation, StaticCeiling, TickConfig,
@@ -149,6 +180,11 @@ mod tests {
         let config = tick_config("alloc-1");
         let ceiling = open_ceiling();
         let shutdown = CancellationToken::new();
+        let metrics = AllocatorMetrics::default();
+        let obs = Observability {
+            liveness: None,
+            metrics: &metrics,
+        };
 
         // Run the loop concurrently with a driver that waits for a budget to land,
         // then signals shutdown — joined (not spawned) so `&c` is shared by ref.
@@ -158,7 +194,7 @@ mod tests {
             &config,
             ByteRate::new(190_000),
             Duration::from_millis(10),
-            None,
+            &obs,
             shutdown.cancelled(),
         );
         let driver = async {
@@ -213,6 +249,11 @@ mod tests {
         let config = tick_config("late");
         let ceiling = open_ceiling();
         let shutdown = CancellationToken::new();
+        let metrics = AllocatorMetrics::default();
+        let obs = Observability {
+            liveness: None,
+            metrics: &metrics,
+        };
 
         // The loop must survive the fenced ticks (logged, not fatal) and shut down
         // cleanly — run a few ticks, then cancel.
@@ -222,7 +263,7 @@ mod tests {
             &config,
             ByteRate::new(190_000),
             Duration::from_millis(10),
-            None,
+            &obs,
             shutdown.cancelled(),
         );
         let driver = async {

--- a/crates/hippius-drain-allocator/src/run.rs
+++ b/crates/hippius-drain-allocator/src/run.rs
@@ -123,6 +123,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn run_allocator_leads_writes_a_budget_then_relinquishes() {
         let Some(c) = coord("cephor-test:run-leads:").await else {
             eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
@@ -174,6 +175,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn run_allocator_survives_a_fenced_tick() {
         let Some(c) = coord("cephor-test:run-fenced:").await else {
             eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");

--- a/crates/hippius-drain-core/src/apipart.rs
+++ b/crates/hippius-drain-core/src/apipart.rs
@@ -124,6 +124,22 @@ numeric_newtype!(
 /// so a reader's `meta.json` gate flips only once the whole part is on `CephFS`.
 pub const META_FILE_NAME: &str = "meta.json";
 
+/// The api's `meta.json` part manifest (`chunk_size`/`num_chunks`/`size_bytes`),
+/// written last by the ingest path. The drain reads `num_chunks` to assert the copied
+/// chunk set is complete before it commits + unlinks the SSD copy — meta being present
+/// is not by itself proof every `chunk_<i>.bin` is still on disk (a chunk could be
+/// removed after meta landed). `chunk_size`/`size_bytes` are carried for a future size
+/// assertion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PartMeta {
+    /// Declared chunk size in bytes.
+    pub chunk_size: u64,
+    /// Declared number of `chunk_<0..num_chunks>.bin` files.
+    pub num_chunks: u32,
+    /// Declared total plaintext size in bytes.
+    pub size_bytes: u64,
+}
+
 /// The drain unit: one part of one object version.
 ///
 /// Names the `<object_id>/v<version>/part_<n>/` directory the api writes and the

--- a/crates/hippius-drain-core/src/coordination.rs
+++ b/crates/hippius-drain-core/src/coordination.rs
@@ -458,6 +458,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn lease_acquires_renews_keeping_the_epoch_and_blocks_a_second_holder() {
         let Some(c) = coord("cephor-test:lease-renew:", Duration::from_secs(5), Duration::from_secs(5)).await else {
             eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
@@ -484,6 +485,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn an_expired_lease_is_taken_over_with_a_bumped_epoch() {
         // A 1s lease that we let lapse: the next acquirer is a NEW era (epoch + 1), which
         // fences any stale in-flight write from the previous era.
@@ -512,6 +514,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn a_heartbeat_expires_out_of_the_fleet() {
         // A 1s node TTL: present right after the upsert, gone after it lapses.
         let Some(c) = coord("cephor-test:fleet-ttl:", Duration::from_secs(1), Duration::from_secs(5)).await else {
@@ -526,6 +529,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn an_allocation_round_trips_and_a_stale_epoch_write_is_fenced() {
         let Some(c) = coord("cephor-test:alloc-fence:", Duration::from_secs(5), Duration::from_secs(30)).await else {
             eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");

--- a/crates/hippius-drain-core/src/coordination.rs
+++ b/crates/hippius-drain-core/src/coordination.rs
@@ -33,6 +33,13 @@ use thiserror::Error;
 /// instance. Override per test via [`Coordinator::with_prefix`] for isolation.
 const DEFAULT_PREFIX: &str = "cephor:";
 
+/// Per-command response timeout (and per-attempt connection timeout) for the coordinator's
+/// Redis manager. Bounds every command so a reachable-but-blocked redis-queues (an fsync
+/// stall, a BGSAVE, a half-open TCP after a blip) surfaces as a retryable error instead of
+/// hanging the allocator tick / agent heartbeat / allocation-pull loop indefinitely — the
+/// error-retry paths only fire on an `Err`, never on a silent hang.
+pub const DEFAULT_REDIS_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Acquire-or-renew the singleton lease. `KEYS[1]`=lease, `KEYS[2]`=epoch counter;
 /// `ARGV[1]`=instance id, `ARGV[2]`=ttl secs. Returns the held epoch, or nil if another
 /// instance holds an unexpired lease. An absent (expired/fresh) lease bumps the epoch via
@@ -217,7 +224,14 @@ impl Coordinator {
     ///
     /// [`CoordError::Redis`] if the client cannot be opened or the connection established.
     pub async fn connect(url: &str, node_ttl: Duration, alloc_ttl: Duration) -> Result<Self> {
-        let conn = ConnectionManager::new(redis::Client::open(url)?).await?;
+        // Bound every command with a response timeout ([`DEFAULT_REDIS_TIMEOUT`]) so a
+        // reachable-but-blocked redis-queues surfaces as a retryable error rather than
+        // hanging a coordination loop; the connection timeout bounds the manager's
+        // (re)connect after a blip.
+        let config = redis::aio::ConnectionManagerConfig::new()
+            .set_response_timeout(DEFAULT_REDIS_TIMEOUT)
+            .set_connection_timeout(DEFAULT_REDIS_TIMEOUT);
+        let conn = ConnectionManager::new_with_config(redis::Client::open(url)?, config).await?;
         Ok(Self::new(conn, node_ttl, alloc_ttl))
     }
 

--- a/crates/hippius-drain-core/src/coordination.rs
+++ b/crates/hippius-drain-core/src/coordination.rs
@@ -560,4 +560,61 @@ mod tests {
         c.write_allocations(6, std::slice::from_ref(&alloc(2_000))).await.unwrap();
         assert_eq!(c.load_allocation(&node).await.unwrap().unwrap().budget, ByteRate::new(2_000));
     }
+
+    #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
+    async fn a_fresh_lease_after_a_lost_leadership_key_fences_the_deposed_leaders_late_write() {
+        // Models redis losing/evicting the lease key under memory pressure: the deposed
+        // leader keeps its stale epoch, a successor takes over with a strictly higher
+        // epoch, and the deposed leader's late allocation write must still be fenced. The
+        // fence anchor is the epoch COUNTER, not the lease key, so a lost lease alone must
+        // never let a zombie leader corrupt allocations (F3, lease-key-loss variant).
+        let Some(c) = coord("cephor-test:lost-lease-fence:", Duration::from_secs(30), Duration::from_secs(30)).await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
+        let node = NodeId::from_str("n1").unwrap();
+        let alloc = |budget| Allocation {
+            node: node.clone(),
+            budget: ByteRate::new(budget),
+        };
+
+        // A leads (epoch e) and writes a budget.
+        let a = c
+            .acquire_or_renew_leadership("a", Duration::from_secs(30))
+            .await
+            .unwrap()
+            .expect("a leads");
+        c.write_allocations(a.epoch, std::slice::from_ref(&alloc(1_000))).await.unwrap();
+
+        // Redis loses the lease key (eviction / flush) — but the epoch counter survives.
+        let mut conn = c.conn.clone();
+        let _: i64 = redis::cmd("DEL").arg(c.leader_key()).query_async(&mut conn).await.unwrap();
+
+        // B sees no lease and takes over with a strictly higher epoch (the counter persisted).
+        let b = c
+            .acquire_or_renew_leadership("b", Duration::from_secs(30))
+            .await
+            .unwrap()
+            .expect("b takes over the lost lease");
+        assert!(
+            b.epoch > a.epoch,
+            "takeover after a lost lease still bumps the epoch ({} > {})",
+            b.epoch,
+            a.epoch
+        );
+        c.write_allocations(b.epoch, std::slice::from_ref(&alloc(2_000))).await.unwrap();
+
+        // The deposed leader A (still holding its stale epoch) tries to write: fenced.
+        let err = c.write_allocations(a.epoch, std::slice::from_ref(&alloc(9_999))).await.unwrap_err();
+        assert!(
+            matches!(err, super::CoordError::Fenced { epoch } if epoch == a.epoch),
+            "deposed leader fenced, got {err:?}"
+        );
+        assert_eq!(
+            c.load_allocation(&node).await.unwrap().unwrap().budget,
+            ByteRate::new(2_000),
+            "only the new leader's budget stands after a lost-lease takeover",
+        );
+    }
 }

--- a/crates/hippius-drain-core/src/enforce.rs
+++ b/crates/hippius-drain-core/src/enforce.rs
@@ -37,8 +37,14 @@ pub enum BreakerState {
     /// The single trial is in flight: it was admitted but its outcome is not yet
     /// recorded, so further requests are denied until `record_success` (closes) or
     /// `record_failure` (reopens) resolves it — this is what bounds the half-open
-    /// phase to exactly one probe rather than a stampede.
-    Probing,
+    /// phase to exactly one probe rather than a stampede. Carries `until`: a deadline
+    /// (the cooldown) after which a probe whose outcome was never recorded — a
+    /// cancelled/unwound drain that skipped `record_outcome` — auto-reopens, so the
+    /// breaker can never wedge in `Probing` and deny all drains on the node forever.
+    Probing {
+        /// The instant after which an unresolved probe auto-reopens the breaker.
+        until: Instant,
+    },
 }
 
 /// A circuit breaker over the agent's observed Ceph write outcomes.
@@ -63,10 +69,17 @@ impl CircuitBreaker {
     /// The current phase (after applying any time-based transition from `now`).
     #[must_use]
     pub fn state(&mut self, now: Instant) -> BreakerState {
-        if let BreakerState::Open { until } = self.state
-            && now >= until
-        {
-            self.state = BreakerState::HalfOpen;
+        match self.state {
+            BreakerState::Open { until } if now >= until => self.state = BreakerState::HalfOpen,
+            // A probe whose outcome was never recorded (a cancelled/unwound drain skipped
+            // record_outcome) auto-reopens once its deadline passes, so the breaker cannot
+            // wedge in Probing and deny every drain on the node forever.
+            BreakerState::Probing { until } if now >= until => {
+                self.state = BreakerState::Open {
+                    until: now.checked_add(self.config.cooldown).unwrap_or(now),
+                };
+            }
+            _ => {}
         }
         self.state
     }
@@ -77,12 +90,16 @@ impl CircuitBreaker {
     #[must_use]
     pub fn allows(&mut self, now: Instant) -> bool {
         match self.state(now) {
-            BreakerState::Open { .. } | BreakerState::Probing => false,
+            BreakerState::Open { .. } | BreakerState::Probing { .. } => false,
             BreakerState::Closed => true,
             BreakerState::HalfOpen => {
                 // Consume the single trial: admit this one and move to Probing, so a
                 // concurrent second request is denied until record_outcome resolves it.
-                self.state = BreakerState::Probing;
+                // Stamp a deadline (reusing the cooldown) so an unresolved probe reopens
+                // via state() rather than wedging the breaker.
+                self.state = BreakerState::Probing {
+                    until: now.checked_add(self.config.cooldown).unwrap_or(now),
+                };
                 true
             }
         }
@@ -100,7 +117,7 @@ impl CircuitBreaker {
     /// `Closed`, the breaker opens once consecutive failures reach the threshold.
     pub fn record_failure(&mut self, now: Instant) {
         self.consecutive_failures = self.consecutive_failures.saturating_add(1);
-        let trip = matches!(self.state, BreakerState::HalfOpen | BreakerState::Probing)
+        let trip = matches!(self.state, BreakerState::HalfOpen | BreakerState::Probing { .. })
             || (matches!(self.state, BreakerState::Closed) && self.consecutive_failures >= self.config.failure_threshold);
         if trip {
             // `now + cooldown` would panic on `Instant` overflow — invisible to the
@@ -523,7 +540,7 @@ mod tests {
         // consumes it into Probing (in flight); a success closes the breaker.
         assert_eq!(b.state(after), BreakerState::HalfOpen);
         assert!(b.allows(after), "the trial request is admitted");
-        assert_eq!(b.state(after), BreakerState::Probing, "the trial is now in flight");
+        assert!(matches!(b.state(after), BreakerState::Probing { .. }), "the trial is now in flight");
         b.record_success();
         assert_eq!(b.state(after), BreakerState::Closed);
         assert!(b.allows(after));
@@ -540,6 +557,28 @@ mod tests {
         assert!(b.allows(after)); // half-open trial
         b.record_failure(after); // trial fails
         assert!(!b.allows(after), "a failed trial reopens the breaker");
+    }
+
+    #[test]
+    fn a_probe_whose_outcome_is_never_recorded_auto_reopens_after_the_deadline() {
+        // WI-9: a cancelled/unwound drain can admit the half-open trial (-> Probing) but
+        // never record its outcome. Without a deadline the breaker would deny ALL drains on
+        // the node forever. Past the probe deadline (the cooldown) it must reopen, then
+        // become probe-able again — never wedge.
+        let now = t0();
+        let mut b = breaker();
+        for _ in 0..3 {
+            b.record_failure(now);
+        }
+        let after = now + Duration::from_secs(5);
+        assert!(b.allows(after), "the trial is admitted (-> Probing)");
+        assert!(matches!(b.state(after), BreakerState::Probing { .. }));
+        // Outcome never recorded. Past the probe deadline the breaker must NOT stay Probing.
+        let stale = after + Duration::from_secs(5);
+        assert!(matches!(b.state(stale), BreakerState::Open { .. }), "a stale probe reopened");
+        // And after another cooldown it half-opens again — fully recovered, never wedged.
+        let recovered = stale + Duration::from_secs(5);
+        assert!(b.allows(recovered), "the breaker becomes probe-able again");
     }
 
     #[test]

--- a/crates/hippius-drain-core/src/enforce.rs
+++ b/crates/hippius-drain-core/src/enforce.rs
@@ -351,6 +351,15 @@ impl Enforcer {
         self.bucket.rate()
     }
 
+    /// Whether the Ceph breaker is currently open (the `drain_breaker_open` metric read).
+    /// Takes `&mut` because reading the breaker applies its time-based `Open→HalfOpen`
+    /// transition at `now`, exactly like an admission check; the metrics layer calls this
+    /// under the shared enforcer lock.
+    #[must_use]
+    pub fn breaker_open(&mut self, now: Instant) -> bool {
+        matches!(self.breaker.state(now), BreakerState::Open { .. })
+    }
+
     /// Admits a drain of `bytes` at `now` through all three gates in order:
     /// breaker → bandwidth → concurrency. Tokens spent at the bandwidth gate are
     /// refunded if the concurrency gate then denies, so a rejected drain costs
@@ -557,6 +566,22 @@ mod tests {
         assert!(b.allows(after)); // half-open trial
         b.record_failure(after); // trial fails
         assert!(!b.allows(after), "a failed trial reopens the breaker");
+    }
+
+    #[test]
+    fn breaker_open_reflects_the_breaker_state() {
+        // The drain_breaker_open metric read: false while closed, true once tripped.
+        let now = t0();
+        let mut e = Enforcer::new(
+            breaker(),
+            TokenBucket::new(ByteRate::new(1_000_000), Bytes::new(1_000_000), now),
+            ConcurrencyLimiter::new(4),
+        );
+        assert!(!e.breaker_open(now), "a closed breaker reads not-open");
+        for _ in 0..3 {
+            e.record_outcome(BreakerSignal::CephFailure, now);
+        }
+        assert!(e.breaker_open(now), "the breaker reads open after the failure threshold");
     }
 
     #[test]

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -40,7 +40,7 @@ pub use partdrain::{
     ClaimedPart, DrainOutcome, DrainStep, PartDrainError, PartPool, PartReplicationStore, PartSource, PartVerified, UploadEnqueuer,
     breaker_signal_for, drain_part,
 };
-pub use reconcile::{DiscoveredPart, PartLandingLog, PartScan, ReconcileError, ReconcileReport, reconcile_parts};
+pub use reconcile::{DiscoveredPart, PartLandingLog, PartScan, PartStatus, ReconcileError, ReconcileReport, reconcile_parts};
 pub use snapshot::{AgentSnapshot, SnapshotCell};
 pub use ssd_reclaim::{PartRemover, PartStatusAge, ReclaimError, ReclaimLog, ReclaimReport, reclaim_ssd};
 pub use state::{CephCeiling, PressureZone, ReplicationState};

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -37,7 +37,8 @@ pub use gc::{CephFs, GcClaim, GcError, GcOutcome, GcTarget, SsdCache, gc_object}
 pub use ids::{FileId, NodeId};
 pub use mgr::{CephReport, CephThresholds, ProbeParseError, classify, decay, parse_prometheus_metrics};
 pub use partdrain::{
-    ClaimedPart, DrainOutcome, DrainStep, PartDrainError, PartPool, PartReplicationStore, PartSource, PartVerified, UploadEnqueuer, drain_part,
+    ClaimedPart, DrainOutcome, DrainStep, PartDrainError, PartPool, PartReplicationStore, PartSource, PartVerified, UploadEnqueuer,
+    breaker_signal_for, drain_part,
 };
 pub use reconcile::{DiscoveredPart, PartLandingLog, PartScan, ReconcileError, ReconcileReport, reconcile_parts};
 pub use snapshot::{AgentSnapshot, SnapshotCell};

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -27,7 +27,7 @@ mod tick;
 mod units;
 
 pub use alloc::{AllocConfig, Allocation, AllocationPlan, BudgetController, FleetView, NodeObservation, allocate};
-pub use apipart::{ChunkIndex, META_FILE_NAME, ObjectId, PartKey, PartNumber, PartPathError, Version, chunk_file_name, parse_part_dir};
+pub use apipart::{ChunkIndex, META_FILE_NAME, ObjectId, PartKey, PartMeta, PartNumber, PartPathError, Version, chunk_file_name, parse_part_dir};
 pub use clock::{Clock, SystemClock};
 pub use enforce::{
     BreakerConfig, BreakerSignal, BreakerState, CircuitBreaker, ConcurrencyLimiter, DenyReason, DrainDecision, Enforcer, TokenBucket, decay_rate,

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -50,7 +50,7 @@ pub use units::{ByteRate, Bytes, DiskPressure};
 pub use clock::TestClock;
 
 #[cfg(feature = "coord")]
-pub use coordination::{CoordError, Coordinator, Lease, StoredAllocation};
+pub use coordination::{CoordError, Coordinator, DEFAULT_REDIS_TIMEOUT, Lease, StoredAllocation};
 #[cfg(feature = "pg")]
 pub use store::{PendingPart, Store, StoreError, UploadContext};
 #[cfg(feature = "coord")]

--- a/crates/hippius-drain-core/src/partdrain.rs
+++ b/crates/hippius-drain-core/src/partdrain.rs
@@ -18,6 +18,7 @@
 //! path. [`PartVerified`] makes "commit before verify" a compile error.
 
 use crate::apipart::{ChunkIndex, PartKey, PartMeta};
+use crate::enforce::BreakerSignal;
 use crate::state::ReplicationState;
 use core::future::Future;
 use std::path::{Path, PathBuf};
@@ -320,9 +321,40 @@ impl PartDrainError {
         }
     }
 
+    /// Whether this failure is genuine evidence of `CephFS`-write unhealth — the only
+    /// class that should trip the node-global Ceph breaker. True for a real pool I/O error
+    /// (non-ENOENT `Io`) and a chunk byte-mismatch (a torn/corrupt pool write). A
+    /// `Store`/claim-coordination error is a Postgres-domain fault, NOT Ceph unhealth, so
+    /// it is excluded — it must not halt draining of a healthy pool; and `Enqueue` /
+    /// `IncompleteSource` are benign deferrals (see [`is_benign_deferral`](Self::is_benign_deferral)).
+    #[must_use]
+    pub fn is_ceph_write_failure(&self) -> bool {
+        match self {
+            Self::Io { source, .. } => source.kind() != std::io::ErrorKind::NotFound,
+            Self::ChunkMismatch { .. } => true,
+            Self::Store(_) | Self::Enqueue(_) | Self::IncompleteSource { .. } => false,
+        }
+    }
+
     /// Tag an I/O error with the step at which it struck.
     fn io(step: DrainStep) -> impl FnOnce(std::io::Error) -> Self {
         move |source| Self::Io { step, source }
+    }
+}
+
+/// The circuit-breaker signal for a completed drain outcome — the one place that decides
+/// which failures count as `CephFS` unhealth. `Ok` succeeds; a benign deferral (enqueue
+/// not ready / vanished source / incomplete part) AND a store/claim-coordination error
+/// both leave the breaker untouched ([`BreakerSignal::Deferred`]); only a genuine
+/// Ceph-write failure trips it. Lives with the error type (not the agent) so the policy is
+/// unit-testable and the agent worker is a thin caller.
+#[must_use]
+pub fn breaker_signal_for(result: &Result<DrainOutcome, PartDrainError>) -> BreakerSignal {
+    match result {
+        Ok(_) => BreakerSignal::CephSuccess,
+        Err(err) if err.is_benign_deferral() => BreakerSignal::Deferred,
+        Err(err) if err.is_ceph_write_failure() => BreakerSignal::CephFailure,
+        Err(_) => BreakerSignal::Deferred,
     }
 }
 
@@ -442,9 +474,11 @@ where
 #[expect(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
 mod tests {
     use super::{
-        ClaimedPart, DrainOutcome, DrainStep, PartDrainError, PartPool, PartReplicationStore, PartSource, PartVerified, UploadEnqueuer, drain_part,
+        ClaimedPart, DrainOutcome, DrainStep, PartDrainError, PartPool, PartReplicationStore, PartSource, PartVerified, UploadEnqueuer,
+        breaker_signal_for, drain_part,
     };
     use crate::apipart::{ChunkIndex, ObjectId, PartKey, PartMeta, PartNumber, Version};
+    use crate::enforce::BreakerSignal;
     use crate::state::ReplicationState;
     use core::future::Future;
     use core::str::FromStr;
@@ -500,6 +534,70 @@ mod tests {
         assert!(!mismatch.is_benign_deferral(), "a chunk byte-mismatch is not a benign deferral");
         let store_err = PartDrainError::store(io::Error::from(io::ErrorKind::Other));
         assert!(!store_err.is_benign_deferral(), "a store rejection is not a benign deferral");
+    }
+
+    #[test]
+    fn is_ceph_write_failure_only_for_real_pool_io_and_mismatch() {
+        // WI-10: only genuine Ceph-write faults trip the node-global breaker. A real pool
+        // I/O error and a byte-mismatch do; a store/claim error, an enqueue deferral, an
+        // ENOENT vanished source, and an incomplete SSD part do NOT (they are not evidence
+        // the pool is unhealthy).
+        let real_io = PartDrainError::Io {
+            step: DrainStep::Persist,
+            source: io::Error::from(io::ErrorKind::Other),
+        };
+        assert!(real_io.is_ceph_write_failure(), "a real pool I/O error is a Ceph-write failure");
+        let mismatch = PartDrainError::ChunkMismatch {
+            index: ChunkIndex::new(0),
+            source_hash: "aaa".into(),
+            pool_hash: "bbb".into(),
+        };
+        assert!(mismatch.is_ceph_write_failure(), "a torn-copy byte mismatch is a Ceph-write failure");
+
+        let vanished = PartDrainError::Io {
+            step: DrainStep::Persist,
+            source: io::Error::from(io::ErrorKind::NotFound),
+        };
+        assert!(!vanished.is_ceph_write_failure(), "an ENOENT vanished source is not a Ceph failure");
+        let store_err = PartDrainError::store(io::Error::from(io::ErrorKind::Other));
+        assert!(
+            !store_err.is_ceph_write_failure(),
+            "a store/claim error is a Postgres-domain fault, not Ceph"
+        );
+        let enqueue = PartDrainError::enqueue(io::Error::from(io::ErrorKind::ConnectionRefused));
+        assert!(!enqueue.is_ceph_write_failure(), "an enqueue deferral is not a Ceph failure");
+        let incomplete = PartDrainError::IncompleteSource { declared: 3, present: 2 };
+        assert!(!incomplete.is_ceph_write_failure(), "an incomplete SSD part is not a Ceph failure");
+    }
+
+    #[test]
+    fn breaker_signal_classifies_the_three_domains() {
+        // WI-10: Ok -> success; benign deferrals AND store/claim errors -> Deferred
+        // (breaker untouched); only a genuine Ceph-write failure -> CephFailure.
+        assert_eq!(breaker_signal_for(&Ok(DrainOutcome::Replicated)), BreakerSignal::CephSuccess);
+        assert_eq!(
+            breaker_signal_for(&Err(PartDrainError::enqueue(io::Error::from(io::ErrorKind::ConnectionRefused)))),
+            BreakerSignal::Deferred,
+            "an enqueue deferral does not trip the breaker",
+        );
+        assert_eq!(
+            breaker_signal_for(&Err(PartDrainError::IncompleteSource { declared: 3, present: 2 })),
+            BreakerSignal::Deferred,
+            "an incomplete part does not trip the breaker",
+        );
+        assert_eq!(
+            breaker_signal_for(&Err(PartDrainError::store(io::Error::from(io::ErrorKind::Other)))),
+            BreakerSignal::Deferred,
+            "a store/claim error (PG blip) must NOT trip the Ceph breaker",
+        );
+        assert_eq!(
+            breaker_signal_for(&Err(PartDrainError::Io {
+                step: DrainStep::Persist,
+                source: io::Error::from(io::ErrorKind::Other),
+            })),
+            BreakerSignal::CephFailure,
+            "a real pool I/O error trips the breaker",
+        );
     }
 
     /// The step (if any) at which the fakes inject an I/O failure.

--- a/crates/hippius-drain-core/src/partdrain.rs
+++ b/crates/hippius-drain-core/src/partdrain.rs
@@ -17,11 +17,17 @@
 //! pool copy is complete and committed — is unlinked only on the post-commit `Ok`
 //! path. [`PartVerified`] makes "commit before verify" a compile error.
 
-use crate::apipart::{ChunkIndex, PartKey};
+use crate::apipart::{ChunkIndex, PartKey, PartMeta};
 use crate::state::ReplicationState;
 use core::future::Future;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
+
+/// How many times a chunk's copy+verify is retried before the part is marked `Failed`.
+/// A byte mismatch is usually a transient torn write on the slowest tier; a small
+/// bounded retry recovers it without terminally discarding a healthy part, and an
+/// exhausted retry is real corruption. Kept small so a genuinely-bad chunk fails promptly.
+const CHUNK_COPY_ATTEMPTS: u32 = 3;
 
 /// Which durability checkpoint an I/O error struck, for diagnostics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -136,6 +142,16 @@ pub trait PartSource: Send + Sync {
     /// As [`chunk_source`](PartSource::chunk_source).
     fn meta_source(&self, part: &PartKey) -> std::io::Result<PathBuf>;
 
+    /// Parse the part's `meta.json` manifest from SSD, so the drain can assert the copied
+    /// chunk set matches the declared `num_chunks` before it commits — a part whose chunks
+    /// were partly removed after its meta landed must never drain a truncated object.
+    ///
+    /// # Errors
+    ///
+    /// An [`io::Error`](std::io::Error): `NotFound` if the meta is absent (a benign
+    /// not-ready deferral), or `InvalidData` if it is malformed.
+    fn part_meta(&self, part: &PartKey) -> impl Future<Output = std::io::Result<PartMeta>> + Send;
+
     /// The lowercase-hex content hash of one source chunk (to verify the copy).
     fn chunk_hash(&self, part: &PartKey, index: ChunkIndex) -> impl Future<Output = std::io::Result<String>> + Send;
 
@@ -249,6 +265,18 @@ pub enum PartDrainError {
     /// `draining` and a later re-drain re-enqueues it — no upload is lost.
     #[error("enqueuing the backend upload failed")]
     Enqueue(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// The SSD part's `meta.json` declares more (or different) chunks than are present on
+    /// disk — the part is incomplete (its chunks were partly removed after meta landed, or
+    /// an ingest crash left it torn). It is NOT committed and NOT unlinked; the SSD copy is
+    /// left intact and the part is deferred for a later re-drain. Benign for the breaker:
+    /// an SSD-source shortfall is not a `CephFS`-write failure.
+    #[error("part is incomplete: meta declares {declared} chunks but {present} are present on SSD")]
+    IncompleteSource {
+        /// The `num_chunks` the meta declared.
+        declared: u32,
+        /// The number of `chunk_<i>.bin` files actually present on SSD.
+        present: u32,
+    },
 }
 
 impl PartDrainError {
@@ -286,7 +314,7 @@ impl PartDrainError {
     #[must_use]
     pub fn is_benign_deferral(&self) -> bool {
         match self {
-            Self::Enqueue(_) => true,
+            Self::Enqueue(_) | Self::IncompleteSource { .. } => true,
             Self::Io { source, .. } => source.kind() == std::io::ErrorKind::NotFound,
             _ => false,
         }
@@ -327,42 +355,64 @@ where
         return Ok(DrainOutcome::AlreadyReplicated);
     }
 
-    // Copy every chunk, hashing it ONCE during the copy stream (no SSD re-read). The
-    // copy-time hash is the source bytes as written, so a torn pool write is caught by
-    // re-reading the pool copy and comparing — but only for a SAMPLE (the first and last
-    // chunk), not every chunk: the per-chunk pool readback was a full second read of the
-    // slowest tier. Content-addressed naming makes writes idempotent + self-naming and the
-    // drain re-drives on any failure, so the interior chunks trust the copy; the sampled
-    // endpoints still catch a systematic copy/IO fault. A mismatch marks the part Failed,
-    // drops the partial pool copy, and leaves the SSD source intact — never commit it.
     let chunks = ssd.list_chunks(part).await.map_err(PartDrainError::io(DrainStep::Persist))?;
-    let (first, last) = (chunks.first().copied(), chunks.last().copied());
+
+    // Completeness gate: meta.json is the api's part-complete marker, but a part whose
+    // chunks were partly removed after meta landed still scans as "has files". Read the
+    // manifest and assert the on-disk set is EXACTLY {0..num_chunks} before copying, so a
+    // truncated part is deferred (SSD copy intact) rather than committed + unlinked. Since
+    // list_chunks returns ascending indices, the enumerate check also rejects a hole (e.g.
+    // {0,1,3} against num_chunks=3), not just a short count.
+    let meta = ssd.part_meta(part).await.map_err(PartDrainError::io(DrainStep::Persist))?;
+    let present = u32::try_from(chunks.len()).unwrap_or(u32::MAX);
+    let complete = present == meta.num_chunks && chunks.iter().enumerate().all(|(i, c)| c.get() == u32::try_from(i).unwrap_or(u32::MAX));
+    if !complete {
+        return Err(PartDrainError::IncompleteSource {
+            declared: meta.num_chunks,
+            present,
+        });
+    }
+
+    // Copy every chunk, hashing it ONCE during the copy stream, then verify EVERY chunk by
+    // re-reading the pooled copy and comparing. Parts are PATH-addressed (no self-verifying
+    // content address) and there is no re-drive after a Replicated commit, so an unread
+    // interior chunk could commit a torn pool write. A byte mismatch is usually a transient
+    // torn write on the slowest tier, so the copy+verify is retried up to
+    // CHUNK_COPY_ATTEMPTS times before terminally failing; a re-persist is idempotent (a
+    // fresh tmp + atomic rename). An exhausted retry marks the part Failed, drops the
+    // partial pool copy, and leaves the SSD source intact — never commit it.
     for index in &chunks {
         let index = *index;
         let source = ssd.chunk_source(part, index).map_err(PartDrainError::io(DrainStep::Persist))?;
-        let copy_hash = ceph
-            .persist_chunk(&source, part, index)
-            .await
-            .map_err(PartDrainError::io(DrainStep::Persist))?;
-        if Some(index) == first || Some(index) == last {
+        let mut mismatch: Option<(String, String)> = None;
+        for _ in 0..CHUNK_COPY_ATTEMPTS {
+            let copy_hash = ceph
+                .persist_chunk(&source, part, index)
+                .await
+                .map_err(PartDrainError::io(DrainStep::Persist))?;
             let pool_hash = ceph.chunk_hash(part, index).await.map_err(PartDrainError::io(DrainStep::Hash))?;
-            if pool_hash != copy_hash {
-                store
-                    .mark_failed(claim, "chunk copy byte mismatch")
-                    .await
-                    .map_err(PartDrainError::store)?;
-                ceph.remove_part(part).await.map_err(PartDrainError::io(DrainStep::Cleanup))?;
-                return Err(PartDrainError::ChunkMismatch {
-                    index,
-                    source_hash: copy_hash.into_boxed_str(),
-                    pool_hash: pool_hash.into_boxed_str(),
-                });
+            if pool_hash == copy_hash {
+                mismatch = None;
+                break;
             }
+            mismatch = Some((copy_hash, pool_hash));
+        }
+        if let Some((source_hash, pool_hash)) = mismatch {
+            store
+                .mark_failed(claim, "chunk copy byte mismatch")
+                .await
+                .map_err(PartDrainError::store)?;
+            ceph.remove_part(part).await.map_err(PartDrainError::io(DrainStep::Cleanup))?;
+            return Err(PartDrainError::ChunkMismatch {
+                index,
+                source_hash: source_hash.into_boxed_str(),
+                pool_hash: pool_hash.into_boxed_str(),
+            });
         }
     }
 
-    // Persist meta LAST — only now, with every chunk durably copied (and the sampled
-    // endpoints byte-verified), may the reader's `meta.json` gate flip on the pool copy.
+    // Persist meta LAST — only now, with every chunk durably copied and byte-verified,
+    // may the reader's `meta.json` gate flip on the pool copy.
     let meta_source = ssd.meta_source(part).map_err(PartDrainError::io(DrainStep::Persist))?;
     ceph.persist_meta(&meta_source, part)
         .await
@@ -394,7 +444,7 @@ mod tests {
     use super::{
         ClaimedPart, DrainOutcome, DrainStep, PartDrainError, PartPool, PartReplicationStore, PartSource, PartVerified, UploadEnqueuer, drain_part,
     };
-    use crate::apipart::{ChunkIndex, ObjectId, PartKey, PartNumber, Version};
+    use crate::apipart::{ChunkIndex, ObjectId, PartKey, PartMeta, PartNumber, Version};
     use crate::state::ReplicationState;
     use core::future::Future;
     use core::str::FromStr;
@@ -420,6 +470,11 @@ mod tests {
         // Not-ready upload context is likewise benign (in-progress MPU / Redis blip).
         let not_ready = PartDrainError::enqueue(io::Error::from(io::ErrorKind::ConnectionRefused));
         assert!(not_ready.is_benign_deferral(), "an enqueue failure is a benign deferral");
+
+        // An incomplete SSD part (chunks removed after meta landed) is benign — the pool
+        // is healthy; the part just isn't whole yet. It defers, not trips the breaker.
+        let incomplete = PartDrainError::IncompleteSource { declared: 3, present: 2 };
+        assert!(incomplete.is_benign_deferral(), "an incomplete SSD part is a benign deferral");
 
         // Every OTHER I/O error is a genuine Ceph-write failure and MUST still trip the
         // breaker — the whole point of the breaker is to react to a degrading pool.
@@ -467,6 +522,10 @@ mod tests {
     struct PartState {
         chunks: BTreeMap<u32, String>,
         has_meta: bool,
+        /// The `num_chunks` the part's meta declares. `None` ⇒ it matches the chunks
+        /// actually present (a complete part); `Some(n)` lets a test declare more than are
+        /// on disk to exercise the completeness gate.
+        declared_chunks: Option<u32>,
     }
 
     /// The shared in-memory world. A chunk maps to the content hash its bytes would
@@ -481,6 +540,9 @@ mod tests {
         /// Specific chunk indices a persist corrupts (in addition to `corrupt_persist`),
         /// so a test can corrupt only an interior chunk vs. a sampled endpoint.
         corrupt_chunks: std::collections::HashSet<u32>,
+        /// Chunk index -> how many more persist attempts corrupt it, then succeed. Models a
+        /// TRANSIENT torn write recovered by the bounded copy-retry (decremented per persist).
+        corrupt_attempts: HashMap<u32, u32>,
         /// When set, the upload enqueue fails (to test the at-least-once seam).
         enqueue_fault: bool,
         /// Parts the enqueuer was asked to enqueue, in order.
@@ -530,6 +592,22 @@ mod tests {
         /// Corrupt the persisted copy of one specific chunk index only.
         fn corrupt_chunk(self, index: u32) -> Self {
             self.world.lock().unwrap().corrupt_chunks.insert(index);
+            self
+        }
+
+        /// Corrupt chunk `index`'s persisted copy for its first `times` persist attempts,
+        /// then let it succeed — a transient torn write the bounded retry should recover.
+        fn corrupt_chunk_for(self, index: u32, times: u32) -> Self {
+            self.world.lock().unwrap().corrupt_attempts.insert(index, times);
+            self
+        }
+
+        /// Declare the part's meta `num_chunks` as `n` regardless of how many chunks were
+        /// seeded, to exercise the completeness gate against a truncated on-disk set.
+        fn declare_chunks(self, n: u32) -> Self {
+            for state in self.world.lock().unwrap().ssd.values_mut() {
+                state.declared_chunks = Some(n);
+            }
             self
         }
 
@@ -586,6 +664,23 @@ mod tests {
             Ok(part.relative_dir().join("meta.json"))
         }
 
+        fn part_meta(&self, part: &PartKey) -> impl Future<Output = io::Result<PartMeta>> + Send {
+            let part = part.clone();
+            async move {
+                let world = self.world.lock().unwrap();
+                let state = world
+                    .ssd
+                    .get(&key_of(&part))
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no ssd part"))?;
+                let present = u32::try_from(state.chunks.len()).unwrap_or(u32::MAX);
+                Ok(PartMeta {
+                    chunk_size: 4,
+                    num_chunks: state.declared_chunks.unwrap_or(present),
+                    size_bytes: 4,
+                })
+            }
+        }
+
         fn chunk_hash(&self, part: &PartKey, index: ChunkIndex) -> impl Future<Output = io::Result<String>> + Send {
             let part = part.clone();
             async move {
@@ -622,7 +717,12 @@ mod tests {
                 if world.fault == Fault::PersistChunk {
                     return Err(io::Error::other("persist chunk failed"));
                 }
-                let corrupt = world.corrupt_persist || world.corrupt_chunks.contains(&index.get());
+                let corrupt_static = world.corrupt_persist || world.corrupt_chunks.contains(&index.get());
+                let transient_left = world.corrupt_attempts.get(&index.get()).copied().unwrap_or(0);
+                if transient_left > 0 {
+                    world.corrupt_attempts.insert(index.get(), transient_left - 1);
+                }
+                let corrupt = corrupt_static || transient_left > 0;
                 let source_hash = world
                     .ssd
                     .get(&key_of(&part))
@@ -796,9 +896,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_corrupt_last_chunk_is_caught_by_the_sampled_readback() {
-        // The sampled verify re-reads the first and last chunk. A torn LAST chunk must
-        // still trip ChunkMismatch even though the interior chunks are now trusted.
+    async fn a_corrupt_last_chunk_is_caught_by_full_readback() {
+        // Every chunk is re-read and verified; a persistently torn LAST chunk trips ChunkMismatch.
         let part = part();
         let fakes = Fakes::seeded(&part, &[(0, "h0"), (1, "h1"), (2, "h2")]).corrupt_chunk(2);
 
@@ -810,26 +909,76 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_corrupt_interior_chunk_is_not_caught_by_the_sampled_readback() {
-        // Pins the sampling trade-off: only the first + last chunk are re-read, so a torn
-        // INTERIOR chunk is trusted (content-addressed naming + re-drive cover it elsewhere).
-        // The drain therefore commits — the test documents what sampling deliberately skips.
+    async fn a_corrupt_interior_chunk_is_caught_by_full_readback() {
+        // WI-2: every chunk is re-read from the pool, not just the endpoints, so a
+        // persistently torn INTERIOR chunk is caught and the part is failed with its SSD
+        // copy intact — never committed.
         let part = part();
         let fakes = Fakes::seeded(&part, &[(0, "h0"), (1, "h1"), (2, "h2")]).corrupt_chunk(1);
 
+        let err = drain_part(&fakes, &fakes, &fakes, &fakes, &claim(&part)).await.unwrap_err();
+
+        assert!(matches!(err, PartDrainError::ChunkMismatch { index, .. } if index == ChunkIndex::new(1)));
+        assert_eq!(fakes.status_of(&part), Some(ReplicationState::Failed));
+        assert!(fakes.ssd_has(&part), "a corrupt interior drain must NOT delete the SSD copy");
+        assert!(fakes.pool_part(&part).is_none(), "the partial pool copy was dropped");
+    }
+
+    #[tokio::test]
+    async fn a_transient_torn_copy_is_recovered_by_the_bounded_retry() {
+        // WI-3: chunk 1's copy tears on its first two persist attempts, then succeeds
+        // within CHUNK_COPY_ATTEMPTS. The drain must recover and commit, not fail.
+        let part = part();
+        let fakes = Fakes::seeded(&part, &[(0, "h0"), (1, "h1")]).corrupt_chunk_for(1, 2);
+
         let outcome = drain_part(&fakes, &fakes, &fakes, &fakes, &claim(&part)).await.unwrap();
 
-        assert_eq!(
-            outcome,
-            DrainOutcome::Replicated,
-            "an interior torn copy is not sampled, so the drain commits"
-        );
+        assert_eq!(outcome, DrainOutcome::Replicated, "a transient torn copy retries to success");
+        assert_eq!(fakes.status_of(&part), Some(ReplicationState::Replicated));
         let pooled = fakes.pool_part(&part).expect("part landed on CephFS");
         assert_eq!(
             pooled.chunks.get(&1).map(String::as_str),
-            Some("corrupt-1"),
-            "the interior corruption went undetected"
+            Some("h1"),
+            "the retry landed the correct bytes"
         );
+    }
+
+    #[tokio::test]
+    async fn an_incomplete_part_defers_without_committing_or_unlinking() {
+        // WI-1: meta declares 3 chunks but only 0,1 are on SSD. The drain must defer
+        // (benign) — never commit, never unlink — so the only complete copy is not lost.
+        let part = part();
+        let fakes = Fakes::seeded(&part, &[(0, "h0"), (1, "h1")]).declare_chunks(3);
+
+        let err = drain_part(&fakes, &fakes, &fakes, &fakes, &claim(&part)).await.unwrap_err();
+
+        assert!(
+            matches!(err, PartDrainError::IncompleteSource { declared: 3, present: 2 }),
+            "got: {err:?}"
+        );
+        assert!(
+            err.is_benign_deferral(),
+            "an incomplete SSD part is a benign deferral, not a Ceph failure"
+        );
+        assert_eq!(fakes.status_of(&part), Some(ReplicationState::Pending), "must NOT commit");
+        assert!(fakes.ssd_has(&part), "must NOT unlink the SSD copy");
+        assert!(fakes.pool_part(&part).is_none(), "nothing was copied to the pool");
+    }
+
+    #[tokio::test]
+    async fn a_missing_interior_index_is_caught_even_when_the_count_matches() {
+        // The set {0,1,3} has the same count as num_chunks=3 but a hole at 2 — the
+        // contiguity check must still reject it.
+        let part = part();
+        let fakes = Fakes::seeded(&part, &[(0, "h0"), (1, "h1"), (3, "h3")]).declare_chunks(3);
+
+        let err = drain_part(&fakes, &fakes, &fakes, &fakes, &claim(&part)).await.unwrap_err();
+
+        assert!(
+            matches!(err, PartDrainError::IncompleteSource { declared: 3, present: 3 }),
+            "got: {err:?}"
+        );
+        assert_eq!(fakes.status_of(&part), Some(ReplicationState::Pending), "a hole must NOT commit");
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-core/src/reconcile.rs
+++ b/crates/hippius-drain-core/src/reconcile.rs
@@ -15,6 +15,7 @@
 use crate::apipart::PartKey;
 use crate::state::ReplicationState;
 use core::future::Future;
+use std::collections::HashMap;
 use thiserror::Error;
 
 /// What one reconcile pass found, tallied by the part's prior status. `scanned`
@@ -128,6 +129,23 @@ pub trait PartLandingLog: Send + Sync {
     /// The part's status (state + adoptability), or `None` when the store has no row.
     fn status(&self, part: &PartKey) -> impl Future<Output = Result<Option<PartStatus>, Self::Error>> + Send;
 
+    /// The status of many parts in as few round-trips as the store allows — the batched
+    /// counterpart to [`status`](Self::status), so the reconciler (the sole drain trigger)
+    /// issues O(batches) queries per scan instead of one per part. A part with no row is
+    /// simply absent from the map. The default loops `status` (for the in-memory fakes);
+    /// the Postgres [`Store`](crate::Store) overrides it with a chunked `UNNEST` query.
+    fn statuses(&self, parts: &[PartKey]) -> impl Future<Output = Result<HashMap<PartKey, PartStatus>, Self::Error>> + Send {
+        async move {
+            let mut out = HashMap::with_capacity(parts.len());
+            for part in parts {
+                if let Some(status) = self.status(part).await? {
+                    out.insert(part.clone(), status);
+                }
+            }
+            Ok(out)
+        }
+    }
+
     /// Record a part as landed (`pending`). Idempotent: a part that already has a row
     /// is left untouched UNLESS it is a NULL-node row, which it adopts to this node —
     /// so the reconciler can both recover a dropped trigger and adopt a legacy row.
@@ -152,10 +170,16 @@ where
     L: PartLandingLog,
 {
     let parts = scanner.scan_parts().await.map_err(ReconcileError::Scan)?;
+    // One batched status read per scan instead of one query per part — the reconciler is
+    // the sole drain trigger, so on a large backlog the per-part read was O(N) round-trips
+    // against the ceph-backed Postgres every cycle. record_landed stays per-part: it is
+    // only hit on the None / adoptable arms (the minority), not the common already-known row.
+    let keys: Vec<PartKey> = parts.iter().map(|discovered| discovered.part.clone()).collect();
+    let statuses = log.statuses(&keys).await.map_err(ReconcileError::log)?;
     let mut report = ReconcileReport::default();
-    for discovered in parts {
+    for discovered in &parts {
         report.scanned += 1;
-        match log.status(&discovered.part).await.map_err(ReconcileError::log)? {
+        match statuses.get(&discovered.part) {
             None => {
                 log.record_landed(&discovered.part).await.map_err(ReconcileError::log)?;
                 report.recovered += 1;

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -126,6 +126,11 @@ pub struct SnapshotCell {
     deferred: AtomicU64,
     reconciler_recovered: AtomicU64,
     reclaimed: AtomicU64,
+    /// Current SSD backlog (undrained bytes) — a LEVEL, not a monotonic counter, so it
+    /// has its own atomic (set, not accumulated) rather than living in [`AgentSnapshot`].
+    /// The heartbeat worker writes it (`usage.used_bytes`) each tick; the metrics layer
+    /// reads it as a gauge. Kept off the wait-free `load` path so a scrape never blocks.
+    backlog_bytes: AtomicU64,
     /// Recent drain latencies, behind a `Mutex` because a percentile needs the
     /// whole window (no single atomic suffices). Off the wait-free `load` path.
     latency: Mutex<LatencyWindow>,
@@ -162,6 +167,17 @@ impl SnapshotCell {
     /// Adds `n` to the SSD-reclaim total (terminal parts the reclaim worker unlinked).
     pub fn record_reclaimed(&self, n: u64) {
         self.reclaimed.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Records the current SSD backlog (undrained bytes). A gauge: `store`, not add.
+    pub fn record_backlog(&self, bytes: u64) {
+        self.backlog_bytes.store(bytes, Ordering::Relaxed);
+    }
+
+    /// The last-recorded SSD backlog in bytes (the metrics `drain_ssd_backlog_bytes` gauge).
+    #[must_use]
+    pub fn backlog(&self) -> u64 {
+        self.backlog_bytes.load(Ordering::Relaxed)
     }
 
     /// Records a completed drain's latency for the windowed p99 estimate.
@@ -218,6 +234,16 @@ mod tests {
         }
         // 100 samples (1..=100ms): nearest-rank p99 is the 99th value = 99ms.
         assert_eq!(cell.p99(), Duration::from_millis(99));
+    }
+
+    #[test]
+    fn backlog_is_a_settable_gauge_not_a_counter() {
+        let cell = SnapshotCell::new();
+        assert_eq!(cell.backlog(), 0, "a fresh cell reports no backlog");
+        cell.record_backlog(4096);
+        assert_eq!(cell.backlog(), 4096);
+        cell.record_backlog(100);
+        assert_eq!(cell.backlog(), 100, "backlog is a level: a later record replaces, not accumulates");
     }
 
     #[test]

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -579,18 +579,23 @@ impl PartReplicationStore for Store {
     }
 
     async fn mark_failed(&self, claim: &ClaimedPart, _reason: &str) -> Result<()> {
-        // Terminal sink: a corrupt part is marked Failed regardless of its prior
-        // state, and an already-absent row is a harmless no-op (idempotent). Clear
-        // claimed_at for consistency with release_part — a failed part holds no live
-        // claim, so its claim timestamp must not linger (F18).
+        // Guarded on `draining` AND this claim's fencing token, mirroring mark_replicated:
+        // only the agent that still holds THIS claim may terminally fail the part. A fenced
+        // stale claimant (its claim re-won after the lease) matches zero rows and MUST NOT
+        // flip the live re-claimed part to `failed`. Zero rows is a harmless no-op here
+        // (unlike mark_replicated) because mark_failed authorizes no SSD unlink — so it is
+        // NOT surfaced as PartClaimLost, which also keeps it idempotent (a second call
+        // finds status='failed', not 'draining'). Clear claimed_at, like release_part, so a
+        // failed part holds no lingering live-claim timestamp (F18).
         let part = claim.part();
         sqlx::query(
             "UPDATE cephor_replication_status SET status = 'failed', updated_at = now(), claimed_at = NULL \
-             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+             WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'draining' AND claim_seq = $4",
         )
         .bind(part.object().as_str())
         .bind(i64::from(part.version().get()))
         .bind(i64::from(part.part().get()))
+        .bind(claim.claim_seq())
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -1085,6 +1090,38 @@ mod part_tests {
         );
         store.mark_replicated(&second, &PartVerified::for_test()).await.unwrap();
         assert_eq!(store.status(&p).await.unwrap(), Some(ReplicationState::Replicated));
+    }
+
+    #[sqlx::test]
+    async fn mark_failed_by_a_fenced_stale_claimant_does_not_fail_the_live_part(pool: PgPool) {
+        // WI-3: the mark_failed counterpart of the mark_replicated fence. A stale claimant
+        // whose claim was re-won after the lease must NOT flip the live re-claimed part to
+        // `failed` — its guarded UPDATE matches zero rows (a harmless no-op, not an error,
+        // since mark_failed authorizes no SSD unlink).
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+        let first = store.claim_part().await.unwrap().expect("the pending part is claimable");
+
+        sqlx::query("UPDATE cephor_replication_status SET claimed_at = now() - interval '1 hour' WHERE object_id = $1")
+            .bind(p.object().as_str())
+            .execute(&pool)
+            .await
+            .unwrap();
+        let second = store.claim_part().await.unwrap().expect("the stale claim is re-won past the lease");
+        assert_ne!(first.claim_seq(), second.claim_seq(), "the re-claim gets a fresh fencing token");
+
+        // The fenced (stale) claimant tries to fail the part — a no-op, not an error.
+        store.mark_failed(&first, "chunk copy byte mismatch").await.unwrap();
+        assert_eq!(
+            store.status(&p).await.unwrap(),
+            Some(ReplicationState::Draining),
+            "the live re-claimed part is untouched by the fenced claimant's mark_failed",
+        );
+
+        // The live claimant can still fail it.
+        store.mark_failed(&second, "chunk copy byte mismatch").await.unwrap();
+        assert_eq!(store.status(&p).await.unwrap(), Some(ReplicationState::Failed));
     }
 
     #[sqlx::test]

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -263,6 +263,28 @@ impl Store {
         Ok(())
     }
 
+    /// Deletes terminal (`replicated`/`failed`) replication rows older than `retention`,
+    /// returning how many were removed. Terminal rows are inert — nothing returns one to a
+    /// live state (`release_part`/`defer_part` are guarded on `status='draining'`) — so
+    /// aged ones are pure debris that bloat the hot `claim_part` / reconcile scans. NEVER
+    /// touches `pending`/`draining` (live) rows. Idempotent and safe to run concurrently:
+    /// a row deleted by one sweep simply is not matched by another.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Database`] if the delete fails.
+    pub async fn gc_terminal_status_rows(&self, retention: Duration) -> Result<u64> {
+        let affected = sqlx::query(
+            "DELETE FROM cephor_replication_status \
+             WHERE status IN ('replicated', 'failed') AND updated_at < now() - (interval '1 second' * $1)",
+        )
+        .bind(retention.as_secs_f64())
+        .execute(&self.pool)
+        .await?
+        .rows_affected();
+        Ok(affected)
+    }
+
     /// Claims a file for GC. Returns `Some(GcClaim)` if this caller won the claim,
     /// `None` if another agent already holds a live, incomplete claim — so the
     /// reclaim runs once. The returned [`GcClaim`] is the capability
@@ -888,6 +910,46 @@ mod part_tests {
 
     /// Forces a part's row to a terminal status with a backdated `updated_at`, so the
     /// reclaim age reads deterministically older than any plausible grace.
+    #[sqlx::test]
+    async fn gc_terminal_status_rows_prunes_only_aged_terminal_rows(pool: PgPool) {
+        // WI-17: prune aged replicated/failed rows; keep a FRESH terminal row and any
+        // pending/draining (live) row regardless of age.
+        let store = Store::from_pool(pool.clone());
+        let fresh = part(UUID_A, 5, 1);
+        let old_replicated = part(UUID_A, 5, 2);
+        let old_failed = part(UUID_A, 5, 3);
+        let pending = part(UUID_A, 5, 4);
+        for p in [&fresh, &old_replicated, &old_failed, &pending] {
+            store.record_landed_part(p).await.unwrap();
+        }
+        // Fresh: replicated but updated_at ~now, so it is younger than the retention.
+        sqlx::query("UPDATE cephor_replication_status SET status = 'replicated' WHERE object_id = $1 AND version = $2 AND part_number = $3")
+            .bind(fresh.object().as_str())
+            .bind(i64::from(fresh.version().get()))
+            .bind(i64::from(fresh.part().get()))
+            .execute(&pool)
+            .await
+            .unwrap();
+        force_terminal(&pool, &old_replicated, "replicated").await; // backdated 2h
+        force_terminal(&pool, &old_failed, "failed").await; // backdated 2h
+
+        let pruned = store.gc_terminal_status_rows(Duration::from_hours(1)).await.unwrap();
+
+        assert_eq!(pruned, 2, "only the two aged terminal rows are pruned");
+        assert_eq!(
+            store.status(&fresh).await.unwrap(),
+            Some(ReplicationState::Replicated),
+            "a fresh terminal row is kept"
+        );
+        assert_eq!(store.status(&old_replicated).await.unwrap(), None, "the aged replicated row was pruned");
+        assert_eq!(store.status(&old_failed).await.unwrap(), None, "the aged failed row was pruned");
+        assert_eq!(
+            store.status(&pending).await.unwrap(),
+            Some(ReplicationState::Pending),
+            "a live pending row is never pruned"
+        );
+    }
+
     async fn force_terminal(pool: &PgPool, part: &PartKey, status: &str) {
         sqlx::query(
             "UPDATE cephor_replication_status SET status = $4, updated_at = now() - interval '2 hours' \

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -633,6 +633,51 @@ impl PartLandingLog for Store {
         }
     }
 
+    async fn statuses(&self, parts: &[PartKey]) -> Result<HashMap<PartKey, PartStatus>> {
+        // The batched status read: one query per ~500 parts (chunked so a pathological
+        // backlog never builds one giant IN-list), matching by PK tuple via UNNEST'd
+        // parallel arrays. Selects the same (status, adoptability) as `status`. A part with
+        // no row simply does not come back, so the caller treats it as absent.
+        let mut out = HashMap::with_capacity(parts.len());
+        for batch in parts.chunks(RECLAIM_STATUS_BATCH) {
+            let mut object_ids: Vec<&str> = Vec::with_capacity(batch.len());
+            let mut versions: Vec<i64> = Vec::with_capacity(batch.len());
+            let mut part_numbers: Vec<i64> = Vec::with_capacity(batch.len());
+            for part in batch {
+                object_ids.push(part.object().as_str());
+                versions.push(i64::from(part.version().get()));
+                part_numbers.push(i64::from(part.part().get()));
+            }
+            let rows = sqlx::query_as::<_, (String, i64, i64, String, bool)>(
+                "SELECT object_id, version, part_number, status, (status = 'pending' AND node_id IS NULL) \
+                 FROM cephor_replication_status \
+                 WHERE (object_id, version, part_number) IN \
+                       (SELECT * FROM UNNEST($1::text[], $2::bigint[], $3::bigint[]))",
+            )
+            .bind(&object_ids)
+            .bind(&versions)
+            .bind(&part_numbers)
+            .fetch_all(&self.pool)
+            .await?;
+            for (object_id, version, part_number, status, adoptable) in rows {
+                let part = PartRow {
+                    object_id,
+                    version,
+                    part_number,
+                }
+                .into_part()?;
+                out.insert(
+                    part,
+                    PartStatus {
+                        state: state_from_db(&status)?,
+                        adoptable,
+                    },
+                );
+            }
+        }
+        Ok(out)
+    }
+
     async fn record_landed(&self, part: &PartKey) -> Result<()> {
         Store::record_landed_part(self, part).await
     }
@@ -887,6 +932,39 @@ mod part_tests {
         assert!(replicated_status.age >= Duration::from_hours(1), "the backdated row reads ~2h old");
 
         assert_eq!(states.get(&failed).expect("failed part present").state, ReplicationState::Failed);
+    }
+
+    #[sqlx::test]
+    async fn statuses_batches_state_and_adoptability_matching_per_part_status(pool: PgPool) {
+        // WI-13: the batched reconciler read returns the same (state, adoptability) as the
+        // per-part status() for known parts, and omits a part with no row.
+        let store = Store::from_pool(pool.clone());
+        let pending = part(UUID_A, 5, 1);
+        let replicated = part(UUID_A, 5, 2);
+        let absent = part(UUID_B, 7, 1);
+
+        store.record_landed_part(&pending).await.unwrap();
+        store.record_landed_part(&replicated).await.unwrap();
+        force_terminal(&pool, &replicated, "replicated").await;
+
+        let batched = <Store as crate::reconcile::PartLandingLog>::statuses(&store, &[pending.clone(), replicated.clone(), absent.clone()])
+            .await
+            .unwrap();
+
+        assert_eq!(batched.len(), 2, "the part with no row is omitted (treated as absent)");
+        assert!(!batched.contains_key(&absent));
+        assert_eq!(batched.get(&pending).expect("pending present").state, ReplicationState::Pending);
+        assert_eq!(batched.get(&replicated).expect("replicated present").state, ReplicationState::Replicated);
+        // The batched result agrees with the single-part path it replaces.
+        let single = <Store as crate::reconcile::PartLandingLog>::status(&store, &pending)
+            .await
+            .unwrap()
+            .expect("pending present");
+        assert_eq!(
+            batched.get(&pending).unwrap().adoptable,
+            single.adoptable,
+            "batched adoptability matches per-part status()",
+        );
     }
 
     #[sqlx::test]

--- a/crates/hippius-drain-core/src/tick.rs
+++ b/crates/hippius-drain-core/src/tick.rs
@@ -145,6 +145,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn leader_allocates_and_writes_budgets() {
         let Some(c) = coord("cephor-test:tick-leads:").await else {
             eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
@@ -163,6 +164,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn a_deposed_leader_tick_surfaces_the_fence_not_a_false_led() {
         // M4: a leader deposed between acquiring its lease and writing (a higher epoch
         // already wrote this node's allocation) must NOT report Led for a tick whose
@@ -194,6 +196,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
     async fn a_second_instance_does_not_lead_or_allocate() {
         let Some(c) = coord("cephor-test:tick-second:").await else {
             eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");

--- a/k8s/base/redis-statefulsets.yaml
+++ b/k8s/base/redis-statefulsets.yaml
@@ -224,8 +224,14 @@ spec:
             - redis-server
             - --maxmemory
             - 2gb
+            # noeviction (NOT allkeys-lru): redis-queues holds the drain's coordination
+            # keys (the cephor:* leader lease + epoch fence) AND the upload work queues.
+            # Evicting either is data loss — a reset epoch deadlocks the allocator (drain
+            # audit F3), and a dropped UploadChainRequest is a lost upload (the drain is the
+            # sole producer). A genuinely-full queue must fail writes LOUDLY (OOM) so it is
+            # alerted on, not silently drop data. Alert on redis-queues memory usage.
             - --maxmemory-policy
-            - allkeys-lru
+            - noeviction
             - --appendonly
             - "yes"
             - --appendfsync

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -142,6 +142,26 @@ spec:
               value: "4"
             - name: RUST_LOG
               value: "info"
+            # OTLP metrics -> otel-collector -> Prometheus -> Grafana (feature `otel`, on by
+            # default). The collector turns these resource attrs into Prometheus labels; the
+            # dashboard's var-namespace filters on service_namespace, so drain_* series land
+            # under the staging namespace. Mirrors the janitor deployment's env.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ENVIRONMENT
+              value: "staging"
+            - name: ENABLE_MONITORING
+              value: "true"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector:4317"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment=$(ENVIRONMENT),service.namespace=$(K8S_NAMESPACE),service.instance.id=$(POD_NAME)"
           volumeMounts:
             - name: local-ingest
               mountPath: /var/lib/hippius/local_object_cache

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -64,6 +64,27 @@ spec:
           volumeMounts:
             - name: local-ingest
               mountPath: /var/lib/hippius/local_object_cache
+        # Block until the allocator has provisioned the cephor_* schema (it owns the
+        # migrations). Without this gate a fresh-namespace `apply` lets the agent start
+        # against missing tables and CrashLoop until the allocator catches up. Strengthens
+        # mpu-reaper's port-check to an actual schema check (to_regclass is NULL, not an
+        # error, for an absent table).
+        - name: wait-for-cephor-schema
+          image: postgres:16-alpine
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres-rw -p 5432; do echo "waiting for postgres"; sleep 3; done
+              until [ "$(psql "$CEPHOR_DATABASE_URL" -tAc "SELECT to_regclass('public.cephor_replication_status') IS NOT NULL")" = "t" ]; do
+                echo "waiting for the cephor schema (allocator migration)"; sleep 3
+              done
+          env:
+            - name: CEPHOR_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: DATABASE_URL
       containers:
         - name: agent
           image: ghcr.io/thenervelab/hippius-s3/drain:latest
@@ -96,8 +117,16 @@ spec:
                 secretKeyRef:
                   name: hippius-s3-secrets
                   key: REDIS_QUEUES_URL
+            # Sourced from the shared secret (like every Python worker), NOT a literal:
+            # the drain is the sole upload producer, so if a backup backend is added to the
+            # secret the drain must fan out to it too — a hardcoded "arion" would silently
+            # under-replicate (never enqueue the new backend, so the janitor replication gate
+            # never clears -> unbounded cache growth).
             - name: HIPPIUS_UPLOAD_BACKENDS
-              value: "arion"
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_UPLOAD_BACKENDS
             # SSD-ingest reclaim worker: clean up broken/abandoned uploads (failed parts
             # the drain skips forever) + orphan write-temps, once aged, so abandoned-upload
             # junk does not accumulate on the node-local disk. Both have safe code defaults

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -125,6 +125,20 @@ spec:
             limits:
               cpu: 1000m
               memory: 1Gi
+          # The agent touches this file each heartbeat tick (~10s); a stale file means a
+          # wedged (not crashed) runtime — e.g. a broken redis ConnectionManager — so k8s
+          # restarts the pod. The agent is the sole upload producer, so a silent hang would
+          # otherwise stop this node's uploads with no recovery.
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - 'f=/tmp/hippius-drain-agent.alive; test -f "$f" && [ $(( $(date +%s) - $(stat -c %Y "$f") )) -lt 40 ]'
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: local-ingest
           hostPath:

--- a/k8s/staging/drain-allocator-deployment.yaml
+++ b/k8s/staging/drain-allocator-deployment.yaml
@@ -57,6 +57,24 @@ spec:
                   key: REDIS_QUEUES_URL
             - name: RUST_LOG
               value: "info"
+            # OTLP metrics -> otel-collector -> Prometheus -> Grafana (feature `otel`, on by
+            # default). service_namespace is what the dashboard's var-namespace filters on.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ENVIRONMENT
+              value: "staging"
+            - name: ENABLE_MONITORING
+              value: "true"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector:4317"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment=$(ENVIRONMENT),service.namespace=$(K8S_NAMESPACE),service.instance.id=$(POD_NAME)"
             # Live ceph-mgr ceiling probe. Left unset for first bring-up so the
             # allocator uses its static ceiling; enable once cross-namespace reach to
             # rook-ceph is confirmed:

--- a/k8s/staging/drain-allocator-deployment.yaml
+++ b/k8s/staging/drain-allocator-deployment.yaml
@@ -69,3 +69,17 @@ spec:
             limits:
               cpu: 250m
               memory: 256Mi
+          # The allocator touches this file each tick (~2s); a stale file means a wedged
+          # (not crashed) tick loop — e.g. blocked on a hung Redis — so k8s restarts it. A
+          # hung leader stops refreshing per-node budgets and the whole fleet decays to
+          # floor, so a silent hang must not persist. initialDelay covers startup migrations.
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - 'f=/tmp/hippius-drain-allocator.alive; test -f "$f" && [ $(( $(date +%s) - $(stat -c %Y "$f") )) -lt 30 ]'
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3


### PR DESCRIPTION
Production-readiness hardening for the Rust `hippius-drain` service — every **P1 and P2** finding from the 2026-07-01 audit + the remaining handoff PRs (R1–R4, R5/R6 partial). The drain is the sole upload producer on staging (hard cutover, no flag), so these were live risks, not latent. 15 commits, each through the full gate (`fmt` + `clippy -D warnings` + tests with the coordination tier running).

### Changes (largest first)

- **Data integrity** — the drain no longer deletes the SSD source unless the part is complete against `meta.json` *and* every chunk is byte-verified (with a bounded retry for transient torn writes); `mark_failed` is now claim-fenced. Closes the silent-truncation edge.
- **Metrics → Grafana (the release blocker)** — OTLP gRPC exporter (feature `otel`, default-on) on both binaries; minimal set: `drain_parts_replicated_total`, `drain_ssd_backlog_bytes`, `drain_breaker_open` (agent) + `drain_leader`, `drain_fleet_estimate_bps` (allocator). Manifests get the OTEL resource env so series land under `service_namespace`.
- **redis-queues → `noeviction`** — `allkeys-lru` could evict the epoch fence (→ allocator deadlock) *and* queued `UploadChainRequest`s (→ silent lost uploads). Fully closes the fence-eviction finding on a single AOF instance.
- **CI runs the coordination tier** — the `rust` job had no Redis, so ~12 fencing/election/lease tests skipped silently green. Adds a Redis service, `#[ignore]`s the gated tests, runs `--include-ignored`.
- **Liveness + fault visibility** — exec `livenessProbe` (via a touched file) on both binaries; the agent now exits non-zero on a worker fault (was exit 0).
- **Breaker hardening** — `Probing` gets a deadline so it can't wedge; non-Ceph (Postgres/claim) errors no longer trip the Ceph breaker.
- **Coordination resilience** — per-command Redis response timeout (a hung redis becomes a retryable error); the allocation-pull `Err` arm decays toward the floor instead of holding the last budget.
- **DB/scale hygiene** — batched reconciler `status()` (O(batches) not O(parts)); periodic terminal-row GC; ancestor-dir fsync so a committed part is durably reachable.
- **Deploy hardening** — `HIPPIUS_UPLOAD_BACKENDS` sourced from the secret (was a hardcoded literal → silent under-replication risk); a `wait-for-cephor-schema` initContainer gates agents on the allocator's migrations.

### Deploy notes

- **redis-queues needs a restart** for the `noeviction` policy to take effect, and its memory should be **alerted on** (a full instance now fails writes loudly instead of silently dropping data — intended).
- New OTel deps (opentelemetry 0.31, tonic/prost) — Apache-2.0/MIT, all in the `deny.toml` allow-list.
- Manifest changes are `k8s/staging` except the redis policy (`k8s/base`, so it reaches prod on next apply — intended).

### Deferred (follow-ups, by design)

- **WI-18** — R5/R6 polish (AIMD smoothing to be tuned *after* scale data; readiness probes; lints; `securityContext`).
- **WI-19** — scale/chaos validation (needs team-set SLO numbers + the `hippius-benchmarks` GB-scale run; the e2e chaos-correctness suite is coming as a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
