### PR TITLE
fix: MPU reaper NULL-version crash + otel per-service name attribution

### DIFF
--- a/hippius_s3/services/mpu_cleanup.py
+++ b/hippius_s3/services/mpu_cleanup.py
@@ -44,17 +44,18 @@ class ReapResult:
     oldest_reaped_age_seconds: float | None
 
 
-async def fail_version_replication(db: Any, *, object_id: Any, object_version: int) -> None:
+async def fail_version_replication(db: Any, *, object_id: Any, object_version: int | None) -> None:
     """Mark one object version's active replication rows terminal ('failed').
 
     The central, node-agnostic churn-stopper: a 'failed' row is neither re-recorded by
     the reconciler nor re-claimed by the drain, so the per-node re-copy/re-defer loop
     halts on every node. Idempotent — rows already 'failed'/'replicated' are untouched.
+    A NULL ``object_version`` (legacy parts carry one) fails every version of the object.
     """
     await db.execute(
         get_query("fail_replication_status_for_version"),
         str(object_id),
-        int(object_version),
+        None if object_version is None else int(object_version),
     )
 
 

--- a/hippius_s3/sql/queries/fail_replication_status_for_version.sql
+++ b/hippius_s3/sql/queries/fail_replication_status_for_version.sql
@@ -7,7 +7,10 @@
 -- central caller) remain for the orphan GC to reclaim. Deleting the rows instead would
 -- be undone: each node's reconciler re-records a part it still sees on local SSD. Only
 -- 'pending'/'draining' rows are touched; a 'replicated' row is legitimately done.
--- Parameters: $1: object_id (text), $2: object_version (bigint)
+-- A NULL $2 fails every still-active row for the object regardless of version: an
+-- abandoned upload (address IS NULL) is junk at every version, and legacy parts can
+-- carry a NULL object_version, so keying on version alone would strand them.
+-- Parameters: $1: object_id (text), $2: object_version (bigint, NULL = all versions)
 UPDATE cephor_replication_status
 SET status = 'failed', updated_at = now(), claimed_at = NULL
-WHERE object_id = $1 AND version = $2 AND status IN ('pending', 'draining')
+WHERE object_id = $1 AND ($2::bigint IS NULL OR version = $2) AND status IN ('pending', 'draining')

--- a/k8s/base/otel-collector.yaml
+++ b/k8s/base/otel-collector.yaml
@@ -15,9 +15,12 @@ data:
     processors:
       resource:
         attributes:
+          # insert (not upsert) so a producer's own service.name (api/gateway via
+          # configure_otel, workers via OTEL_SERVICE_NAME, the Rust drain) survives;
+          # this only labels telemetry that arrives without a service.name.
           - key: service.name
             value: "hippius-s3"
-            action: upsert
+            action: insert
       batch:
         timeout: 1s
         send_batch_size: 1024

--- a/tests/integration/test_fail_replication_sql.py
+++ b/tests/integration/test_fail_replication_sql.py
@@ -1,0 +1,112 @@
+"""Truth table for `fail_replication_status_for_version.sql`, against real Postgres.
+
+The reaper calls this to mark an abandoned upload's replication rows terminal ('failed')
+so the per-node drain stops re-copying/re-deferring them. Getting the version predicate
+wrong means either wedging on a NULL-version row (the staging regression: legacy parts
+carry a NULL object_version) or failing rows for the wrong version. The unit tests drive
+`fail_version_replication` with a fake db, so the SQL predicate itself — the
+`$2 IS NULL → all versions` branch and the `status IN (...)` gate — is only exercised here.
+
+Runs the real `get_query("fail_replication_status_for_version")` against a TEMP table
+shadowing `cephor_replication_status` for the session.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import AsyncGenerator
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from hippius_s3.utils import get_query
+
+
+pytestmark = pytest.mark.asyncio
+
+_DB_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/hippius?sslmode=disable")
+
+
+@pytest_asyncio.fixture
+async def conn() -> AsyncGenerator[asyncpg.Connection, None]:
+    try:
+        c = await asyncpg.connect(_DB_URL)
+    except (OSError, asyncpg.PostgresError) as e:
+        pytest.skip(f"integration Postgres unavailable ({e}); run `docker compose up -d postgres`")
+
+    await c.execute(
+        """
+        CREATE TEMP TABLE cephor_replication_status (
+            object_id  text        NOT NULL,
+            version    bigint,
+            status     text        NOT NULL,
+            claimed_at timestamptz,
+            updated_at timestamptz
+        ) ON COMMIT PRESERVE ROWS;
+        """
+    )
+    try:
+        yield c
+    finally:
+        await c.close()
+
+
+async def _row(conn: asyncpg.Connection, object_id: str, version: int | None, status: str) -> None:
+    await conn.execute(
+        "INSERT INTO cephor_replication_status (object_id, version, status, claimed_at, updated_at) "
+        "VALUES ($1, $2, $3, now(), now())",
+        object_id,
+        version,
+        status,
+    )
+
+
+async def _fail(conn: asyncpg.Connection, object_id: str, version: int | None) -> None:
+    await conn.execute(get_query("fail_replication_status_for_version"), object_id, version)
+
+
+async def _statuses(conn: asyncpg.Connection, object_id: str) -> list[tuple]:
+    rows = await conn.fetch(
+        "SELECT version, status FROM cephor_replication_status WHERE object_id = $1 ORDER BY version NULLS FIRST",
+        object_id,
+    )
+    return [(r["version"], r["status"]) for r in rows]
+
+
+async def test_specific_version_fails_only_that_version(conn):
+    o = str(uuid.uuid4())
+    await _row(conn, o, 1, "pending")
+    await _row(conn, o, 2, "draining")
+    await _fail(conn, o, 1)
+    assert set(await _statuses(conn, o)) == {(1, "failed"), (2, "draining")}
+
+
+async def test_null_version_fails_every_version(conn):
+    # The regression fix: NULL $2 must fail all still-active rows for the object,
+    # including a genuinely NULL-version legacy row.
+    o = str(uuid.uuid4())
+    await _row(conn, o, 1, "pending")
+    await _row(conn, o, 2, "draining")
+    await _row(conn, o, None, "pending")
+    await _fail(conn, o, None)
+    assert set(await _statuses(conn, o)) == {(1, "failed"), (2, "failed"), (None, "failed")}
+
+
+async def test_only_pending_and_draining_are_touched(conn):
+    o = str(uuid.uuid4())
+    await _row(conn, o, 1, "replicated")
+    await _row(conn, o, 2, "failed")
+    await _row(conn, o, 3, "pending")
+    await _fail(conn, o, None)
+    assert set(await _statuses(conn, o)) == {(1, "replicated"), (2, "failed"), (3, "failed")}
+
+
+async def test_other_objects_are_untouched(conn):
+    o, other = str(uuid.uuid4()), str(uuid.uuid4())
+    await _row(conn, o, 1, "pending")
+    await _row(conn, other, 1, "pending")
+    await _fail(conn, o, None)
+    assert await _statuses(conn, o) == [(1, "failed")]
+    assert await _statuses(conn, other) == [(1, "pending")]

--- a/tests/unit/test_mpu_reaper.py
+++ b/tests/unit/test_mpu_reaper.py
@@ -72,6 +72,29 @@ async def test_fail_version_replication_marks_the_rows_failed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fail_version_replication_passes_null_version_through() -> None:
+    # Legacy parts can carry a NULL object_version; the helper must bind NULL (not crash
+    # on int(None)) so the query fails every version of the abandoned object.
+    db = FakeDb()
+    await mpu_cleanup.fail_version_replication(db, object_id="obj-1", object_version=None)
+    assert len(db.executed) == 1
+    _, args = db.executed[0]
+    assert args == ("obj-1", None), "a NULL version is bound through, not int()-cast"
+
+
+@pytest.mark.asyncio
+async def test_reaper_handles_abandoned_row_with_null_object_version() -> None:
+    # The regression that wedged the staging reaper: an abandoned row whose object_version
+    # is NULL must still be reaped, not raise TypeError on int(None).
+    rows = [{"upload_id": "u1", "object_id": "obj-1", "object_version": None, "age_seconds": 90000.0}]
+    db = FakeDb(rows)
+    result = await mpu_cleanup.reap_abandoned_uploads(db, stale_seconds=86400, dlq_object_ids=set())
+    assert result.count == 1
+    fail_args = [args for query, args in db.executed if "'failed'" in query]
+    assert fail_args == [("obj-1", None)], "the NULL-version row is marked terminal without crashing"
+
+
+@pytest.mark.asyncio
 async def test_reaper_marks_each_abandoned_version_and_deletes_its_mpu_row() -> None:
     rows = [
         {"upload_id": "u1", "object_id": "obj-1", "object_version": 1, "age_seconds": 90000.0},


### PR DESCRIPTION
## Summary

Two issues found during the s3-2.1 staging audit (`s3-2.1-review-0.md`), both only visible against real data.

- **P1 — MPU reaper dead on arrival.** The reaper crashed every cycle with `int() argument must be … not 'NoneType'` (`mpu_cleanup.py`) because `list_abandoned_versions` returns `parts.object_version`, which is **NULL for 20,610 legacy rows** on staging — 2,699 of the 29,891 abandoned candidates. The loop aborted on the first such row, so **~30k abandoned MPUs were never reaped** and the drain kept re-claiming / re-copying / re-deferring their parts fleet-wide (`drain_ssd_backlog_bytes` ≈ **608 GB + 724 GB**). The feature was a no-op in prod.
- **P2 — per-service metric attribution broken.** The otel-collector `resource` processor did `service.name → "hippius-s3", action: upsert` on every metric/log, collapsing **all** series to `service_name="hippius-s3"` (even api/gateway, which set explicit names). This nullified PR #221's per-worker `OTEL_SERVICE_NAME`.

## Changes (biggest → smallest)

- **`fail_replication_status_for_version.sql`** — fail every version of the object when `$2` (version) is NULL: `AND ($2::bigint IS NULL OR version = $2)`. An abandoned upload is junk at every version, and legacy parts carry NULL versions.
- **`mpu_cleanup.py`** — `fail_version_replication` accepts `object_version: int | None` and binds NULL through instead of `int(None)`.
- **`k8s/base/otel-collector.yaml`** — `resource` processor `action: upsert → insert`, so a producer's own `service.name` (api/gateway via `configure_otel`, workers via `OTEL_SERVICE_NAME`, the Rust drain) survives; the constant only labels telemetry that arrives without one.
- **Tests** — 2 new unit cases (NULL-version reap doesn't crash; helper binds NULL through) + a new integration truth-table (`test_fail_replication_sql.py`, 4 cases against real Postgres: specific-version vs NULL-all-versions, only `pending`/`draining` touched, other objects untouched).

## Verification

- `pytest tests/unit/test_mpu_reaper.py` → 8 passed. `pytest tests/integration/test_fail_replication_sql.py tests/integration/test_mpu_reaper_sql.py` → 11 passed (real PG). ruff + pre-commit clean.
- **Post-deploy re-audit planned** (per `claude-s3-staging-audit.md`): confirm `mpu_reaper_cycles_total{success="true"}` advances and the abandoned count drops; confirm `group by (service_name)(…)` shows distinct names.

## Conclusion

P1 makes the reaper actually work (and stops the drain churn — reclaiming the ~1.3 TB SSD bytes is the separate, still-deferred orphan-GC). P2 is a one-line collector change that makes the observability we just shipped attributable per-service. Dashboards need no change (they filter `service_namespace`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)