### PR TITLE
perf/safety: MPU reaper activity-gate + faster backlog drain

### DIFF
--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -274,11 +274,14 @@ class Config:
     object_cache_dir: str = env("HIPPIUS_OBJECT_CACHE_DIR:/var/lib/hippius/object_cache")
     object_cache_fallback_dir: str = env("HIPPIUS_OBJECT_CACHE_FALLBACK_DIR:", convert=str)
     fs_cache_gc_max_age_seconds: int = env("HIPPIUS_FS_CACHE_GC_MAX_AGE_SECONDS:604800", convert=int)  # 7 days
-    mpu_stale_seconds: int = env("HIPPIUS_MPU_STALE_SECONDS:86400", convert=int)  # 1 day
+    # An MPU is "abandoned" only after this long with NO part activity (not just since
+    # initiation) — a user can pause a multipart upload and resume it, so the window must
+    # exceed a realistic pause. 2 days gives leeway over a full-day pause + resume.
+    mpu_stale_seconds: int = env("HIPPIUS_MPU_STALE_SECONDS:172800", convert=int)  # 2 days
     # How often the abandoned-multipart-upload reaper sweeps. The reaper auto-aborts
     # never-finalized uploads older than mpu_stale_seconds (address never written),
     # purging their SSD parts + drain replication rows so the drain stops re-deferring.
-    mpu_reaper_interval_seconds: int = env("HIPPIUS_MPU_REAPER_INTERVAL_SECONDS:3600", convert=int)  # hourly
+    mpu_reaper_interval_seconds: int = env("HIPPIUS_MPU_REAPER_INTERVAL_SECONDS:120", convert=int)  # every 2 min
     # Bounded concurrency for the janitor's per-part DB checks + deletes. The
     # cleanup loops are DB-roundtrip bound; this is how many parts are processed
     # in parallel (each over its own pooled connection).

--- a/hippius_s3/sql/queries/list_abandoned_versions.sql
+++ b/hippius_s3/sql/queries/list_abandoned_versions.sql
@@ -1,12 +1,16 @@
 -- Abandoned multipart uploads: a version whose parts landed but whose
 -- object_versions.address was never written (the api writes it at PUT/MPU-complete),
--- and whose upload was initiated more than $1 seconds ago. A completed or simple
--- upload always has a non-NULL address, so it is never matched; the NULL-address +
--- age pair is what distinguishes a genuinely abandoned upload (the drain would defer
--- its enqueue as not-ready forever) from a still-in-flight one. is_completed=false is
--- a belt-and-suspenders guard so a completed upload can never be selected.
--- Returns one row per (upload_id, object_id, object_version) to reap, plus age_seconds
--- (how long ago the upload was initiated) so the reaper can report its lag.
+-- initiated more than $1 seconds ago AND with no part uploaded in the last $1 seconds.
+-- A completed or simple upload always has a non-NULL address, so it is never matched;
+-- the NULL-address + age pair distinguishes a genuinely abandoned upload (the drain
+-- would defer its enqueue as not-ready forever) from a still-in-flight one.
+-- The last-activity gate is the safety valve: a user may initiate an MPU, upload parts
+-- slowly, pause for days, then resume + complete. Keying on initiated_at alone would
+-- reap that upload mid-flight; requiring NO part in the last $1 seconds means any part
+-- upload resets the clock, so only a genuinely inactive upload is reaped.
+-- is_completed=false is a belt-and-suspenders guard so a completed upload can't be
+-- selected. Returns one row per (upload_id, object_id, object_version) to reap, plus
+-- age_seconds (how long ago the upload was initiated) so the reaper can report its lag.
 -- Parameters: $1: stale_seconds (int)
 SELECT DISTINCT mu.upload_id, p.object_id, p.object_version,
        EXTRACT(EPOCH FROM (now() - mu.initiated_at))::float8 AS age_seconds
@@ -17,5 +21,10 @@ LEFT JOIN object_versions ov
 WHERE COALESCE(mu.is_completed, false) = false
   AND (ov.address IS NULL OR ov.object_id IS NULL)
   AND mu.initiated_at < now() - make_interval(secs => $1)
+  AND NOT EXISTS (
+        SELECT 1 FROM parts pr
+        WHERE pr.upload_id = mu.upload_id
+          AND pr.uploaded_at >= now() - make_interval(secs => $1)
+      )
 ORDER BY mu.upload_id
-LIMIT 200
+LIMIT 2000

--- a/tests/integration/test_mpu_reaper_sql.py
+++ b/tests/integration/test_mpu_reaper_sql.py
@@ -46,9 +46,10 @@ async def conn() -> AsyncGenerator[asyncpg.Connection, None]:
         ) ON COMMIT PRESERVE ROWS;
 
         CREATE TEMP TABLE parts (
-            upload_id      uuid   NOT NULL,
-            object_id      uuid   NOT NULL,
-            object_version bigint NOT NULL
+            upload_id      uuid        NOT NULL,
+            object_id      uuid        NOT NULL,
+            object_version bigint      NOT NULL,
+            uploaded_at    timestamptz
         ) ON COMMIT PRESERVE ROWS;
 
         CREATE TEMP TABLE object_versions (
@@ -74,12 +75,18 @@ async def _mpu(conn: asyncpg.Connection, upload_id: str, *, completed: bool | No
     )
 
 
-async def _part(conn: asyncpg.Connection, upload_id: str, object_id: str, version: int) -> None:
+async def _part(
+    conn: asyncpg.Connection, upload_id: str, object_id: str, version: int, *, uploaded_age_seconds: int = 7200
+) -> None:
+    # uploaded_age_seconds defaults to 2h ago (stale, since the tests use _STALE=3600) so
+    # existing cases reap as before; pass a small value to model a still-active upload.
     await conn.execute(
-        "INSERT INTO parts (upload_id, object_id, object_version) VALUES ($1::uuid, $2::uuid, $3)",
+        "INSERT INTO parts (upload_id, object_id, object_version, uploaded_at) "
+        "VALUES ($1::uuid, $2::uuid, $3, now() - make_interval(secs => $4))",
         upload_id,
         object_id,
         version,
+        uploaded_age_seconds,
     )
 
 
@@ -135,6 +142,25 @@ async def test_fresh_upload_is_not_listed(conn):
     await _part(conn, u, o, 1)
     await _ov(conn, o, 1, address=None)
     assert await _abandoned(conn) == set()
+
+
+async def test_old_upload_with_recent_part_activity_is_not_listed(conn):
+    # The resume-after-a-pause safety case: initiated long ago, but a part was uploaded
+    # within the stale window → still active → must NOT be reaped.
+    u, o = str(uuid.uuid4()), str(uuid.uuid4())
+    await _mpu(conn, u, completed=False, age_seconds=7200)
+    await _part(conn, u, o, 1, uploaded_age_seconds=60)  # part uploaded a minute ago
+    await _ov(conn, o, 1, address=None)
+    assert await _abandoned(conn) == set()
+
+
+async def test_old_upload_with_only_stale_parts_is_listed(conn):
+    # Initiated long ago AND no part touched within the stale window → genuinely abandoned.
+    u, o = str(uuid.uuid4()), str(uuid.uuid4())
+    await _mpu(conn, u, completed=False, age_seconds=7200)
+    await _part(conn, u, o, 1, uploaded_age_seconds=7200)
+    await _ov(conn, o, 1, address=None)
+    assert (u, o, 1) in await _abandoned(conn)
 
 
 async def test_multipart_upload_dedups_to_one_row_per_version(conn):

--- a/tests/integration/test_mpu_reaper_sql.py
+++ b/tests/integration/test_mpu_reaper_sql.py
@@ -49,7 +49,7 @@ async def conn() -> AsyncGenerator[asyncpg.Connection, None]:
             upload_id      uuid        NOT NULL,
             object_id      uuid        NOT NULL,
             object_version bigint      NOT NULL,
-            uploaded_at    timestamptz
+            uploaded_at    timestamptz NOT NULL
         ) ON COMMIT PRESERVE ROWS;
 
         CREATE TEMP TABLE object_versions (
@@ -161,6 +161,18 @@ async def test_old_upload_with_only_stale_parts_is_listed(conn):
     await _part(conn, u, o, 1, uploaded_age_seconds=7200)
     await _ov(conn, o, 1, address=None)
     assert (u, o, 1) in await _abandoned(conn)
+
+
+async def test_one_recent_part_protects_an_upload_with_other_stale_parts(conn):
+    # The core of the activity gate: NOT EXISTS is per-upload, so a single recent part
+    # (a resumed upload adding part N) protects the whole upload even though earlier parts
+    # are stale. Without this, a slow/resumed MPU would be reaped mid-flight.
+    u, o = str(uuid.uuid4()), str(uuid.uuid4())
+    await _mpu(conn, u, completed=False, age_seconds=7200)
+    await _part(conn, u, o, 1, uploaded_age_seconds=7200)  # early part, stale
+    await _part(conn, u, o, 1, uploaded_age_seconds=60)  # just-added part, recent
+    await _ov(conn, o, 1, address=None)
+    assert await _abandoned(conn) == set()
 
 
 async def test_multipart_upload_dedups_to_one_row_per_version(conn):


### PR DESCRIPTION
## Summary

Follow-up to the s3-2.1 staging audit (`s3-2.1-review-1.md`). Now that the reaper works (PR #222), it needs to (a) not reap uploads a user paused and is resuming, and (b) drain the ~30k historical backlog faster than 200/hour.

## The safety bug this fixes

`multipart_uploads` has **no `updated_at`** — the reaper gated on `initiated_at` (create time). So a user who initiates a multipart upload, uploads some parts, pauses >1 day, then resumes + completes would be **aborted mid-flight** (on resume: `NoSuchUpload`). The janitor doesn't touch MPU rows, so only the reaper was the risk. `parts.uploaded_at` exists, so we can gate on real activity instead.

For context, AWS's `AbortIncompleteMultipartUpload` lifecycle rule is **days-since-initiation** (not activity) and defaults to *never* (opt-in per bucket, recommended 7 days). Our activity-based gate is safer than AWS's equivalent for slow-but-active uploads.

## Changes (biggest → smallest)

- **`list_abandoned_versions.sql`** — add a last-activity gate: `AND NOT EXISTS (SELECT 1 FROM parts pr WHERE pr.upload_id = mu.upload_id AND pr.uploaded_at >= now() - make_interval(secs => $1))`. An upload is reaped only if no part landed within the stale window; any `UploadPart` resets the clock. Also `LIMIT 200 → 2000`.
- **`config.py`** — `HIPPIUS_MPU_STALE_SECONDS` 86400 (1d) → **172800 (2d)** for pause/resume leeway; `HIPPIUS_MPU_REAPER_INTERVAL_SECONDS` 3600 → **120** to drain the backlog in minutes, then idle on a cheap indexed query.
- **`test_mpu_reaper_sql.py`** — parts helper carries `uploaded_at`; 2 new cases: an old upload with a recent part is **not** listed; an old upload with only stale parts **is** listed.

## Verification

- `pytest tests/unit/test_mpu_reaper.py` → 8 passed. `pytest tests/integration/test_mpu_reaper_sql.py tests/integration/test_fail_replication_sql.py` → 13 passed (real PG). ruff + pre-commit clean.
- Staging backlog stays eligible (all abandoned uploads' last part is >4 months old, well past 2 days), so the drain still clears.

## Conclusion

Makes the reaper safe for legitimate slow/resumed multipart uploads while draining the existing benchmark-litter backlog fast. `HIPPIUS_MPU_STALE_SECONDS` remains an env knob to raise toward AWS's 7-day guidance for tenants with very-slow large uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)