### PR TITLE
feat(auth): deprecation message for seed-phrase credentials

### DIFF
--- a/gateway/services/auth_orchestrator.py
+++ b/gateway/services/auth_orchestrator.py
@@ -92,12 +92,14 @@ async def authenticate_request(request: Request) -> AuthResult:
     if credential.startswith("hip_"):
         return await _authenticate_access_key_header(request, credential, logger)
 
-    # Seed phrase authentication is no longer supported
-    logger.warning(f"Invalid credential format (not hip_ access key): {credential[:8]}***")
+    # A well-formed SigV4 header with a non-hip_ credential is the shape the removed
+    # seed-phrase auth used — surface a deprecation pointer to tokens rather than a bare
+    # "invalid key" so migrating users know what changed and where to go.
+    logger.warning(f"Seed-phrase / non-hip_ credential rejected: {credential[:8]}***")
     return AuthResult(
         error_response=s3_error_response(
             code="InvalidAccessKeyId",
-            message='Please provide a valid "hip_*" access key. See https://docs.hippius.com/storage/s3/integration#authentication for more information.',  # noqa: Q003
+            message="Seed phrase authentication is deprecated. Use https://docs.hippius.com/storage/s3/integration to get started using tokens.",
             status_code=status.HTTP_403_FORBIDDEN,
         )
     )

--- a/tests/unit/gateway/test_auth_router_middleware.py
+++ b/tests/unit/gateway/test_auth_router_middleware.py
@@ -172,6 +172,25 @@ async def test_invalid_credential_format_returns_403(auth_router_app: Any) -> No
 
 
 @pytest.mark.asyncio
+async def test_seed_phrase_credential_returns_deprecation_message(auth_router_app: Any) -> None:
+    """A well-formed SigV4 header with a non-hip_ credential (the removed seed-phrase shape)
+    is rejected with a deprecation pointer to token docs, not a bare invalid-key error."""
+    # base64-ish non-hip_ credential — the shape seed-phrase auth used as the access key id
+    auth_header = (
+        "AWS4-HMAC-SHA256 Credential=d29yZCB3b3JkIHdvcmQ/20250101/us-east-1/s3/aws4_request, "
+        "SignedHeaders=host;x-amz-date, Signature=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=auth_router_app), base_url="http://test") as client:
+        response = await client.put("/test", headers={"Authorization": auth_header}, content=b"test data")
+
+    assert response.status_code == 403
+    assert b"InvalidAccessKeyId" in response.content
+    assert b"Seed phrase authentication is deprecated" in response.content
+    assert b"docs.hippius.com/storage/s3/integration" in response.content
+
+
+@pytest.mark.asyncio
 async def test_access_key_with_invalid_signature_returns_403(auth_router_app: Any) -> None:
     """Test that access key with invalid signature returns 403"""
     test_access_key = "hip_test_key_12345"


### PR DESCRIPTION
## Summary

#215 removed seed-phrase authentication. Since then, a well-formed SigV4 request carrying a **non-`hip_` credential** (exactly the shape seed-phrase auth used — a base64 mnemonic as the access-key id) was rejected with the generic *"provide a valid hip_ access key"* error. That doesn't tell a migrating user what actually changed.

This returns a **seed-phrase-specific deprecation message** on that path, pointing to the token docs:

> Seed phrase authentication is deprecated. Use https://docs.hippius.com/storage/s3/integration to get started using tokens.

## Changes
- `gateway/services/auth_orchestrator.py` — the non-`hip_` SigV4 credential branch now returns the deprecation message (still `403` / `InvalidAccessKeyId`, so S3 clients handle it normally). Only this branch changed; the no-credentials and malformed-header cases keep their existing generic messages.
- `tests/unit/gateway/test_auth_router_middleware.py` — new `test_seed_phrase_credential_returns_deprecation_message`: a well-formed SigV4 header with a non-`hip_` credential returns 403 + the deprecation text + the docs URL.

## Verification
`pytest tests/unit/gateway/test_auth_router_middleware.py` → 15 passed. ruff + format clean.

## Note
Targets `main`. It'll flow to `staging` on the next sync (staging already has the #215 removal via the in-flight main→staging merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)