### PR TITLE
fix(drain): raise AIMD target_p99 50ms→2000ms to unpin the fleet write-budget

### DIFF
--- a/crates/hippius-drain-allocator/src/config.rs
+++ b/crates/hippius-drain-allocator/src/config.rs
@@ -44,8 +44,20 @@ const DEFAULT_MAX_TOTAL_BPS: u64 = 1_000_000_000;
 const DEFAULT_ADDITIVE_INCREASE_BPS: u64 = 10_000_000;
 /// Multiplicative-decrease parts-per-thousand kept on back-off (800 => keep 80%).
 const DEFAULT_DECREASE_PERMILLE: u16 = 800;
-/// p99 latency (ms) above which the fleet is considered saturated.
-const DEFAULT_TARGET_P99_MS: u64 = 50;
+/// p99 *per-part* drain latency (ms) above which the fleet is considered saturated and the AIMD
+/// estimate backs off toward `min_total`.
+///
+/// This is the p99 of `drain_part` — a whole part's SSD→CephFS copy + fsync + readback-verify —
+/// NOT a small point op. Measured healthy p99 on staging is ~330–410 ms (breaker closed,
+/// `error_bps=0`). The former default of **50 ms** was physically unreachable for a multi-MB part
+/// copy, so `observed_p99 > target_p99` fired on EVERY tick → the fleet write-budget was pinned
+/// at the `min_total` 1 MB/s floor permanently, throttling the whole drain to ~1 MB/s regardless
+/// of Ceph health (measured live: `drain_fleet_estimate_bps = 1_000_000`). 2000 ms gives ~5×
+/// headroom over the healthy baseline: the AIMD ramps up while Ceph keeps p99 well under 2 s, and
+/// only a genuine multi-second slowdown throttles it. Tune per-cluster via
+/// `CEPHOR_ALLOC_TARGET_P99_MS`. (Future: compare against a rolling baseline rather than an
+/// absolute target; an absolute target must be set above the real per-part copy time.)
+const DEFAULT_TARGET_P99_MS: u64 = 2_000;
 /// Error rate (basis points) above which the fleet is considered saturated.
 const DEFAULT_MAX_ERROR_BPS: u16 = 100;
 /// Pressure (basis points) at/above which a node earns a reservation floor.

--- a/crates/hippius-drain-allocator/src/run.rs
+++ b/crates/hippius-drain-allocator/src/run.rs
@@ -138,7 +138,7 @@ mod tests {
             max_total: ByteRate::new(1_000_000_000),
             additive_increase: ByteRate::new(10_000),
             decrease_permille: 800,
-            target_p99: Duration::from_millis(50),
+            target_p99: Duration::from_secs(2),
             max_error_bps: 100,
             critical_pressure: DiskPressure::try_from(9_000).unwrap(),
             reservation_floor: ByteRate::new(50_000),

--- a/crates/hippius-drain-core/src/alloc.rs
+++ b/crates/hippius-drain-core/src/alloc.rs
@@ -364,6 +364,63 @@ mod tests {
         plan.iter().find(|a| a.node == wanted).map_or(0, |a| a.budget.get())
     }
 
+    fn node_p99(id: &str, p99: Duration, backlog: u64) -> (NodeId, NodeObservation) {
+        (
+            NodeId::from_str(id).unwrap(),
+            NodeObservation {
+                pressure: DiskPressure::try_from(3_000).unwrap(),
+                backlog: Bytes::new(backlog),
+                max_drain_rate: ByteRate::new(1_000_000_000),
+                observed_p99: p99,
+                error_bps: 0,
+            },
+        )
+    }
+
+    fn config_target_p99(ms: u64) -> AllocConfig {
+        AllocConfig {
+            target_p99: Duration::from_millis(ms),
+            ..config()
+        }
+    }
+
+    #[test]
+    fn a_healthy_slow_fleet_ramps_the_estimate_up() {
+        // Regression for the drain throttle deadlock: a whole-part SSD->CephFS drain has a p99 of
+        // hundreds of ms even when perfectly healthy (measured ~330-410 ms on staging). With a
+        // realistic target (2 s) a 400 ms p99 is NOT saturation, so the AIMD must ramp the estimate
+        // UP by additive_increase — not back off to min_total. Under the old 50 ms target this
+        // fleet backed off every tick, pinning the whole fleet budget at the 1 MB/s floor.
+        let fleet = fleet_of(&[node_p99("a", Duration::from_millis(400), 10_000_000_000)]);
+        let cfg = config_target_p99(2_000);
+        let plan = allocate(
+            &fleet,
+            CephCeiling::Open(ByteRate::new(1_000_000_000)),
+            BudgetController::new(ByteRate::new(190_000)),
+            &cfg,
+        );
+        assert_eq!(
+            plan.controller.total().get(),
+            190_000 + cfg.additive_increase.get(),
+            "a healthy-but-slow fleet (p99 below the realistic target) ramps up by additive_increase",
+        );
+    }
+
+    #[test]
+    fn a_genuinely_saturated_fleet_still_backs_off() {
+        // The other side of the fix: a p99 ABOVE the (realistic) target IS saturation and must back
+        // off multiplicatively toward min_total — proving raising the target did not disable back-off.
+        let fleet = fleet_of(&[node_p99("a", Duration::from_secs(3), 10_000_000_000)]);
+        let cfg = config_target_p99(2_000);
+        let plan = allocate(
+            &fleet,
+            CephCeiling::Open(ByteRate::new(1_000_000_000)),
+            BudgetController::new(ByteRate::new(190_000)),
+            &cfg,
+        );
+        assert!(plan.controller.total().get() < 190_000, "a p99 above the target backs the estimate off");
+    }
+
     #[test]
     fn empty_fleet_yields_no_allocations() {
         let plan = allocate(

--- a/crates/hippius-drain-core/src/tick.rs
+++ b/crates/hippius-drain-core/src/tick.rs
@@ -115,7 +115,7 @@ mod tests {
             max_total: ByteRate::new(1_000_000_000),
             additive_increase: ByteRate::new(10_000),
             decrease_permille: 800,
-            target_p99: Duration::from_millis(50),
+            target_p99: Duration::from_secs(2),
             max_error_bps: 100,
             critical_pressure: DiskPressure::try_from(9_000).unwrap(),
             reservation_floor: ByteRate::new(50_000),


### PR DESCRIPTION
## Summary

The drain fleet is throttled to **~1 MB/s** regardless of Ceph health. Root cause: the allocator's AIMD write-budget controller treats the fleet as *saturated* whenever any node's observed per-part drain p99 exceeds `target_p99`, and `target_p99` was set to **50 ms** — but `observed_p99` is the p99 of `drain_part`, i.e. a *whole part's* SSD→CephFS copy + fsync + readback-verify, whose **healthy** baseline on staging is **~330–410 ms**.

So `observed_p99 > target_p99` fired on **every tick**, the controller multiplicatively backed off every time, and the fleet write-budget was pinned permanently at the `min_total` **1 MB/s floor**.

Measured live on staging while investigating:
- `drain_fleet_estimate_bps = 1_000_000` (exactly the floor)
- `drain_breaker_open = 0` (Ceph healthy)
- node `observed_p99_ns` ≈ 328 ms / 409 ms, `error_bps = 0`

## Fix

Raise `DEFAULT_TARGET_P99_MS` from `50` → `2000` (~5× the healthy per-part baseline). The AIMD now additive-increases (+10 MB/s/tick, 5 s ticks) from the floor toward `max_total` (1 GB/s) while Ceph keeps p99 under 2 s, and only a genuine multi-second slowdown throttles it. From the pinned floor the estimate ramps to ~100 MB/s in ~50 s.

Env-tunable per-cluster via `CEPHOR_ALLOC_TARGET_P99_MS` (unchanged mechanism).

## Changes
- `crates/hippius-drain-allocator/src/config.rs` — `DEFAULT_TARGET_P99_MS` 50 → 2000, with a doc comment explaining the throttle deadlock and the measured baseline.
- `crates/hippius-drain-core/src/alloc.rs` — two regression tests: a healthy-but-slow fleet (p99 400 ms, target 2 s) ramps up by `additive_increase`; a genuinely saturated fleet (p99 3 s) still backs off (proving the raise did not disable back-off). Plus `node_p99` / `config_target_p99` test helpers.

## Testing
- `cargo test -p hippius-drain-core -p hippius-drain-allocator` — green (both new tests pass).
- `cargo clippy` clean, `cargo fmt --check` clean.

## Note
This is an absolute target and must always sit above the real per-part copy time. A follow-up should compare `observed_p99` against a **rolling baseline** rather than a fixed threshold, so the controller adapts if part sizes or CephFS latency shift.

## Conclusion
One-line config change (plus tests) that lifts the drain from a hard 1 MB/s cap to Ceph-limited throughput — the single highest-impact drain-throughput fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)