### PR TITLE
fix(reader): enqueue downloads on the envelope-race version fallback (cold read)

### DIFF
--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -44,6 +44,123 @@ class StreamContext:
     upload_id: str
 
 
+async def _enqueue_missing_downloads(
+    db: Any,
+    redis: Any,
+    info: dict,
+    *,
+    object_version: int,
+    storage_version: int,
+    plan: list[ChunkPlanItem],
+    exist_results: list[bool],
+    address: str,
+    cfg: Any,
+) -> None:
+    """Enqueue a DownloadChainRequest for the chunks in `plan` that are missing from the FS cache.
+
+    Coalesces concurrent misses per (object_id, version, part) via a Redis NX lock so only one
+    streamer enqueues; the rest wait on the downloader's pub/sub notification. Shared by the primary
+    read path AND the envelope-race version fallback — the fallback used to return a `pipeline`
+    source without enqueuing anything, so a cold read of the fallback version hung on pub/sub until
+    the wait timed out.
+    """
+    object_id = info["object_id"]
+    indices_by_part: dict[int, set[int]] = {}
+    for item, cached in zip(plan, exist_results, strict=True):
+        if not cached:
+            indices_by_part.setdefault(int(item.part_number), set()).add(int(item.chunk_index))
+    if not indices_by_part:
+        return
+
+    # Coalesce concurrent misses on the same part: only one streamer
+    # actually enqueues a download request per (object_id, version, part).
+    # Others will just wait on the pub/sub notification emitted by the
+    # downloader. The lock TTL covers crashed-streamer / crashed-downloader
+    # cases — on TTL expiry, the next miss re-enqueues.
+    lock_ttl = int(getattr(cfg, "download_coalesce_lock_ttl_seconds", 120))
+    ray_token = str(info.get("ray_id") or "anonymous")
+    acquired_parts: set[int] = set()
+    for pn in list(indices_by_part.keys()):
+        lock_key = f"download_in_progress:{object_id}:v:{object_version}:part:{pn}"
+        try:
+            acquired = await redis.set(lock_key, ray_token, nx=True, ex=lock_ttl)
+        except Exception:
+            # Redis hiccup — fail open: behave as if we acquired the lock
+            # so the download still happens. Worst case is a duplicate
+            # enqueue, which the downloader deduplicates via chunk_exists.
+            acquired = True
+        if acquired:
+            acquired_parts.add(pn)
+        else:
+            logger.debug(
+                "download coalesced: another streamer is fetching object_id=%s v=%s part=%s (lock held)",
+                object_id,
+                object_version,
+                pn,
+            )
+
+    # If every missing part is already being fetched by someone else,
+    # we don't enqueue anything — we just fall through to stream_plan,
+    # which will wait on pub/sub for each chunk.
+    dl_parts: list[PartToDownload] = []
+    # CIDs are optional.
+    # - If per-chunk CIDs exist in part_chunks, include them so the IPFS downloader can fetch from IPFS.
+    # - Otherwise, keep cid=None so other backends (deterministic addressing) can handle it.
+    for pn, idxs in indices_by_part.items():
+        if pn not in acquired_parts:
+            continue
+        include = {int(i) for i in idxs}
+        by_index: dict[int, tuple[str | None, int | None]] = {}
+        try:
+            from hippius_s3.utils import get_query  # local import
+
+            rows = await db.fetch(
+                get_query("get_part_chunks_by_object_and_number"),
+                object_id,
+                object_version,
+                int(pn),
+            )
+            for r in rows or []:
+                ci = int(r[0])
+                if ci not in include:
+                    continue
+                cid_raw = r[1]
+                cid_val = str(cid_raw).strip() if cid_raw is not None else None
+                if cid_val and cid_val.lower() in {"", "none", "pending"}:
+                    cid_val = None
+                clen = int(r[2]) if (len(r) > 2 and r[2] is not None) else None
+                by_index[ci] = (cid_val, clen)
+        except Exception:
+            # If chunk metadata isn't present (common for CID-less objects), keep cid=None
+            by_index = {}
+
+        specs: list[PartChunkSpec] = []
+        for ci in sorted(include):
+            cid_val, clen = by_index.get(int(ci), (None, None))
+            specs.append(PartChunkSpec(index=int(ci), cid=cid_val, cipher_size_bytes=clen))
+
+        dl_parts.append(PartToDownload(part_number=int(pn), chunks=specs))
+    if dl_parts:
+        db_backends = await resolve_object_backends(db, object_id, object_version)
+        req = DownloadChainRequest(
+            request_id=f"{object_id}::shared",
+            object_id=object_id,
+            object_version=object_version,
+            object_storage_version=int(storage_version),
+            object_key=info.get("object_key", ""),
+            bucket_name=info.get("bucket_name", ""),
+            address=address,
+            subaccount=address,
+            substrate_url=cfg.substrate_url,
+            size=int(info.get("size_bytes") or 0),
+            multipart=bool(info.get("multipart")),
+            chunks=dl_parts,
+            ray_id=info.get("ray_id"),
+            download_backends=db_backends if db_backends else None,
+        )
+        await enqueue_download_request(req)
+
+
 async def build_stream_context(
     db: Any,
     redis: Any,
@@ -75,93 +192,17 @@ async def build_stream_context(
             idx_set.add(int(item.chunk_index))
 
     if source == "pipeline":
-        # Coalesce concurrent misses on the same part: only one streamer
-        # actually enqueues a download request per (object_id, version, part).
-        # Others will just wait on the pub/sub notification emitted by the
-        # downloader. The lock TTL covers crashed-streamer / crashed-downloader
-        # cases — on TTL expiry, the next miss re-enqueues.
-        lock_ttl = int(getattr(cfg, "download_coalesce_lock_ttl_seconds", 120))
-        ray_token = str(info.get("ray_id") or "anonymous")
-        acquired_parts: set[int] = set()
-        for pn in list(indices_by_part.keys()):
-            lock_key = f"download_in_progress:{info['object_id']}:v:{ov}:part:{pn}"
-            try:
-                acquired = await redis.set(lock_key, ray_token, nx=True, ex=lock_ttl)
-            except Exception:
-                # Redis hiccup — fail open: behave as if we acquired the lock
-                # so the download still happens. Worst case is a duplicate
-                # enqueue, which the downloader deduplicates via chunk_exists.
-                acquired = True
-            if acquired:
-                acquired_parts.add(pn)
-            else:
-                logger.debug(
-                    "download coalesced: another streamer is fetching object_id=%s v=%s part=%s (lock held)",
-                    info["object_id"],
-                    ov,
-                    pn,
-                )
-
-        # If every missing part is already being fetched by someone else,
-        # we don't enqueue anything — we just fall through to stream_plan,
-        # which will wait on pub/sub for each chunk.
-        dl_parts: list[PartToDownload] = []
-        # CIDs are optional.
-        # - If per-chunk CIDs exist in part_chunks, include them so the IPFS downloader can fetch from IPFS.
-        # - Otherwise, keep cid=None so other backends (deterministic addressing) can handle it.
-        for pn, idxs in indices_by_part.items():
-            if pn not in acquired_parts:
-                continue
-            include = {int(i) for i in idxs}
-            by_index: dict[int, tuple[str | None, int | None]] = {}
-            try:
-                from hippius_s3.utils import get_query  # local import
-
-                rows = await db.fetch(
-                    get_query("get_part_chunks_by_object_and_number"),
-                    info["object_id"],
-                    int(info.get("object_version") or info.get("current_object_version") or 1),
-                    int(pn),
-                )
-                for r in rows or []:
-                    ci = int(r[0])
-                    if ci not in include:
-                        continue
-                    cid_raw = r[1]
-                    cid_val = str(cid_raw).strip() if cid_raw is not None else None
-                    if cid_val and cid_val.lower() in {"", "none", "pending"}:
-                        cid_val = None
-                    clen = int(r[2]) if (len(r) > 2 and r[2] is not None) else None
-                    by_index[ci] = (cid_val, clen)
-            except Exception:
-                # If chunk metadata isn't present (common for CID-less objects), keep cid=None
-                by_index = {}
-
-            specs: list[PartChunkSpec] = []
-            for ci in sorted(include):
-                cid_val, clen = by_index.get(int(ci), (None, None))
-                specs.append(PartChunkSpec(index=int(ci), cid=cid_val, cipher_size_bytes=clen))
-
-            dl_parts.append(PartToDownload(part_number=int(pn), chunks=specs))
-        if dl_parts:
-            db_backends = await resolve_object_backends(db, info["object_id"], ov)
-            req = DownloadChainRequest(
-                request_id=f"{info['object_id']}::shared",
-                object_id=info["object_id"],
-                object_version=int(info.get("object_version") or info.get("current_object_version") or 1),
-                object_storage_version=int(storage_version),
-                object_key=info.get("object_key", ""),
-                bucket_name=info.get("bucket_name", ""),
-                address=address,
-                subaccount=address,
-                substrate_url=cfg.substrate_url,
-                size=int(info.get("size_bytes") or 0),
-                multipart=bool(info.get("multipart")),
-                chunks=dl_parts,
-                ray_id=info.get("ray_id"),
-                download_backends=db_backends if db_backends else None,
-            )
-            await enqueue_download_request(req)
+        await _enqueue_missing_downloads(
+            db,
+            redis,
+            info,
+            object_version=ov,
+            storage_version=storage_version,
+            plan=plan,
+            exist_results=exist_results,
+            address=address,
+            cfg=cfg,
+        )
 
     object_version = int(info.get("object_version") or info.get("current_object_version") or 1)
     bucket_id = str(info.get("bucket_id") or "")
@@ -204,6 +245,20 @@ async def build_stream_context(
                 checks = [(int(item.part_number), int(item.chunk_index)) for item in plan]
                 exist_results = await obj_cache.chunks_exist_batch(info["object_id"], object_version, checks)
                 source = "cache" if all(exist_results) else "pipeline"
+                if source == "pipeline":
+                    # Cold read of the fallback version: enqueue the missing chunks so the streamer's
+                    # pub/sub wait is actually fulfilled instead of hanging until it times out.
+                    await _enqueue_missing_downloads(
+                        db,
+                        redis,
+                        info,
+                        object_version=object_version,
+                        storage_version=storage_version,
+                        plan=plan,
+                        exist_results=exist_results,
+                        address=address,
+                        cfg=cfg,
+                    )
                 kek_bytes = await get_bucket_kek_bytes(bucket_id=bucket_id, kek_id=kek_id)
                 aad = f"hippius-dek:{bucket_id}:{info['object_id']}:{object_version}".encode("utf-8")
                 key_bytes = unwrap_dek(kek=kek_bytes, wrapped_dek=bytes(wrapped_dek), aad=aad)

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -64,6 +64,10 @@ async def _enqueue_missing_downloads(
     source without enqueuing anything, so a cold read of the fallback version hung on pub/sub until
     the wait timed out.
     """
+    if redis is None:
+        # No coalescing backend available (only unit callers pass None). Match the old fallback
+        # behavior of not enqueuing rather than crashing on redis.set — the streamer still waits.
+        return
     object_id = info["object_id"]
     indices_by_part: dict[int, set[int]] = {}
     for item, cached in zip(plan, exist_results, strict=True):

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -64,10 +64,6 @@ async def _enqueue_missing_downloads(
     source without enqueuing anything, so a cold read of the fallback version hung on pub/sub until
     the wait timed out.
     """
-    if redis is None:
-        # No coalescing backend available (only unit callers pass None). Match the old fallback
-        # behavior of not enqueuing rather than crashing on redis.set — the streamer still waits.
-        return
     object_id = info["object_id"]
     indices_by_part: dict[int, set[int]] = {}
     for item, cached in zip(plan, exist_results, strict=True):

--- a/tests/unit/test_envelope_race_fallback.py
+++ b/tests/unit/test_envelope_race_fallback.py
@@ -296,10 +296,12 @@ async def test_warm_fallback_does_not_enqueue():
 @pytest.mark.asyncio
 async def test_cold_fallback_with_none_redis_does_not_crash():
     """A cold fallback read with redis=None (unit callers) must not crash on redis.set — the
-    helper short-circuits and simply doesn't enqueue (the streamer still waits)."""
+    coalesce lock's try/except fails open (behaves as acquired), so the download is still enqueued.
+    The main read path relies on this same fail-open behavior for redis=None."""
     with _PATCHES[0] as m0, _PATCHES[1] as m1, _PATCHES[2] as m2, _PATCHES[3] as m3, \
          _PATCHES[4] as m4, _PATCHES[5] as m5, _PATCHES[6] as m6, \
-         patch("hippius_s3.services.object_reader.enqueue_download_request", new_callable=AsyncMock) as m_enqueue:
+         patch("hippius_s3.services.object_reader.enqueue_download_request", new_callable=AsyncMock) as m_enqueue, \
+         patch("hippius_s3.services.object_reader.resolve_object_backends", new_callable=AsyncMock, return_value=[]):
         _apply_patches([m0, m1, m2, m3, m4, m5, m6])
         m3.return_value.download_coalesce_lock_ttl_seconds = 120
         m3.return_value.substrate_url = ""
@@ -315,7 +317,9 @@ async def test_cold_fallback_with_none_redis_does_not_crash():
 
         assert ctx.object_version == 4
         assert ctx.source == "pipeline"
-        m_enqueue.assert_not_awaited()
+        # fail-open on the None redis.set: the fallback version is still enqueued (no crash)
+        enqueued_versions = [call.args[0].object_version for call in m_enqueue.await_args_list]
+        assert 4 in enqueued_versions
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_envelope_race_fallback.py
+++ b/tests/unit/test_envelope_race_fallback.py
@@ -294,6 +294,31 @@ async def test_warm_fallback_does_not_enqueue():
 
 
 @pytest.mark.asyncio
+async def test_cold_fallback_with_none_redis_does_not_crash():
+    """A cold fallback read with redis=None (unit callers) must not crash on redis.set — the
+    helper short-circuits and simply doesn't enqueue (the streamer still waits)."""
+    with _PATCHES[0] as m0, _PATCHES[1] as m1, _PATCHES[2] as m2, _PATCHES[3] as m3, \
+         _PATCHES[4] as m4, _PATCHES[5] as m5, _PATCHES[6] as m6, \
+         patch("hippius_s3.services.object_reader.enqueue_download_request", new_callable=AsyncMock) as m_enqueue:
+        _apply_patches([m0, m1, m2, m3, m4, m5, m6])
+        m3.return_value.download_coalesce_lock_ttl_seconds = 120
+        m3.return_value.substrate_url = ""
+
+        prev_info = _make_info(object_version=4, kek_id="kek-1", wrapped_dek=b"\x00" * 32)
+        db = FakeDB(fetchrow_returns=prev_info)
+        obj_cache = FakeObjCache([False])  # cold
+        info = _make_info(object_version=5, kek_id=None, wrapped_dek=None)
+
+        from hippius_s3.services.object_reader import build_stream_context
+
+        ctx = await build_stream_context(db, None, obj_cache, info, rng=None, address="addr1")
+
+        assert ctx.object_version == 4
+        assert ctx.source == "pipeline"
+        m_enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_fallback_queries_correct_version():
     """The fallback query uses version-1, not version-2 or some other number."""
     with _PATCHES[0] as m0, _PATCHES[1] as m1, _PATCHES[2] as m2, _PATCHES[3] as m3, \

--- a/tests/unit/test_envelope_race_fallback.py
+++ b/tests/unit/test_envelope_race_fallback.py
@@ -236,6 +236,64 @@ async def test_fallback_logs_warning(caplog):
 
 
 @pytest.mark.asyncio
+async def test_cold_fallback_enqueues_download():
+    """Regression (A1): a cold read of the fallback version (chunks NOT on FS) must enqueue a
+    DownloadChainRequest. Previously the fallback returned a `pipeline` source without enqueuing
+    anything, so the streamer hung on pub/sub until the wait timed out."""
+    with _PATCHES[0] as m0, _PATCHES[1] as m1, _PATCHES[2] as m2, _PATCHES[3] as m3, \
+         _PATCHES[4] as m4, _PATCHES[5] as m5, _PATCHES[6] as m6, \
+         patch("hippius_s3.services.object_reader.enqueue_download_request", new_callable=AsyncMock) as m_enqueue, \
+         patch("hippius_s3.services.object_reader.resolve_object_backends", new_callable=AsyncMock, return_value=[]):
+        _apply_patches([m0, m1, m2, m3, m4, m5, m6])
+        m3.return_value.download_coalesce_lock_ttl_seconds = 120
+        m3.return_value.substrate_url = ""
+
+        prev_info = _make_info(object_version=4, kek_id="kek-1", wrapped_dek=b"\x00" * 32)
+        db = FakeDB(fetchrow_returns=prev_info)
+        obj_cache = FakeObjCache([False])  # fallback version's chunk is cold (not on FS)
+        info = _make_info(object_version=5, kek_id=None, wrapped_dek=None)
+
+        redis = AsyncMock()
+        redis.set = AsyncMock(return_value=True)
+
+        from hippius_s3.services.object_reader import build_stream_context
+
+        ctx = await build_stream_context(db, redis, obj_cache, info, rng=None, address="addr1")
+
+        assert ctx.object_version == 4
+        assert ctx.source == "pipeline"
+        # The download must be enqueued for the version actually served (v4). Before the fix the
+        # fallback enqueued nothing, so the streamer waited on v4 chunks that were never fetched.
+        enqueued_versions = [call.args[0].object_version for call in m_enqueue.await_args_list]
+        assert 4 in enqueued_versions, "the fallback version must be enqueued for download"
+
+
+@pytest.mark.asyncio
+async def test_warm_fallback_does_not_enqueue():
+    """A warm fallback (chunks already on FS) must NOT enqueue — no wasted download work."""
+    with _PATCHES[0] as m0, _PATCHES[1] as m1, _PATCHES[2] as m2, _PATCHES[3] as m3, \
+         _PATCHES[4] as m4, _PATCHES[5] as m5, _PATCHES[6] as m6, \
+         patch("hippius_s3.services.object_reader.enqueue_download_request", new_callable=AsyncMock) as m_enqueue, \
+         patch("hippius_s3.services.object_reader.resolve_object_backends", new_callable=AsyncMock, return_value=[]):
+        _apply_patches([m0, m1, m2, m3, m4, m5, m6])
+        m3.return_value.download_coalesce_lock_ttl_seconds = 120
+        m3.return_value.substrate_url = ""
+
+        prev_info = _make_info(object_version=4, kek_id="kek-1", wrapped_dek=b"\x00" * 32)
+        db = FakeDB(fetchrow_returns=prev_info)
+        obj_cache = FakeObjCache([True])  # fallback version's chunk is warm
+        info = _make_info(object_version=5, kek_id=None, wrapped_dek=None)
+
+        from hippius_s3.services.object_reader import build_stream_context
+
+        ctx = await build_stream_context(db, AsyncMock(), obj_cache, info, rng=None, address="addr1")
+
+        assert ctx.object_version == 4
+        assert ctx.source == "cache"
+        m_enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_fallback_queries_correct_version():
     """The fallback query uses version-1, not version-2 or some other number."""
     with _PATCHES[0] as m0, _PATCHES[1] as m1, _PATCHES[2] as m2, _PATCHES[3] as m3, \


### PR DESCRIPTION
## Summary

When a GET hits an object that is mid-overwrite — the current version briefly has NULL `kek_id`/`wrapped_dek` — `build_stream_context` falls back to the previous version to avoid a 500. That fallback path correctly recomputed the chunk plan and cache state, setting `source="pipeline"` when the previous version's chunks were **not** in the FS cache… but it **never enqueued a `DownloadChainRequest`** for those chunks.

So a **cold read of the fallback version** (chunks on a backend but not in this pod's local FS cache) returned a `pipeline` StreamContext, and the streamer then waited on pub/sub for chunks that nobody ever fetched — hanging until `HIPPIUS_CACHE_TTL` (up to an hour) elapsed. This is the "cold-read of a pending object breaking the stream" the readiness harness flagged (F4/A1).

## Fix

The primary read path's coalesce → CID-resolve → enqueue logic is factored into a shared `_enqueue_missing_downloads` helper, now called from **both** the primary path and the fallback path. A cold fallback read enqueues the missing chunks against the version actually being served (the fallback version), so the streamer's wait is fulfilled.

The extraction also de-duplicates ~90 lines that were previously inline in only the main path.

## Changes
- `hippius_s3/services/object_reader.py` — extract `_enqueue_missing_downloads`; call it from the main path (behavior unchanged) and, new, from the envelope-race fallback path.
- `tests/unit/test_envelope_race_fallback.py` — cold fallback enqueues a download for the fallback version; warm fallback does not enqueue.

## Testing
- `pytest tests/unit/test_envelope_race_fallback.py tests/unit/test_download_coalescing.py tests/unit/test_stream_context_batch.py tests/unit/services` — all green (18 + 16).
- `ruff check` / `ruff format --check` clean.

## Out of scope (noted follow-up)
The related **A2** item — the downloader returning `True` (skip) on a NULL `backend_identifier` — is **intentional multi-backend behavior** ("this backend doesn't hold the chunk, try the next"), so it's left untouched. The deeper follow-up is bounding the streamer's pub/sub wait for a genuinely un-drained (not-on-any-backend) pending object so it surfaces a fast retryable 503 instead of the 1h `HIPPIUS_CACHE_TTL` ceiling; tracked separately.

## Conclusion
Closes the cold-fallback stream hang (F4/A1) with a focused, low-risk refactor and keeps the fix at the right altitude by sharing one enqueue mechanism across both read paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)