### PR TITLE
tune(drain): cut defer-backoff + poll 5s→1s to lower replication lag

### DIFF
--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -140,6 +140,21 @@ spec:
             # Safe code default (4); set here for per-node tuning.
             - name: CEPHOR_DRAIN_CONCURRENCY
               value: "4"
+            # Replication-lag tuning (measured 2026-07-02: p50 4.6s / p99 5.9s, clustered at
+            # ~5s). The lag was NOT the drain budget (unpinned to ~1 GB/s by the target_p99 fix)
+            # — it was these two 5s timers:
+            #   - CEPHOR_DEFER_BACKOFF_SECS: an MPU part lands BEFORE its Complete writes
+            #     object_versions.address, so the drain's first claim defers ("upload context
+            #     not ready") and re-parks the part for this long. 5s -> 1s cuts the dominant
+            #     component of the observed lag.
+            #   - CEPHOR_DRAIN_POLL_SECS: the backstop poll floor (the chunk_landed trigger wakes
+            #     the worker sooner; this only bounds a missed-event/idle wake). Cheap to lower:
+            #     the claim query is a partial-index (node_id, landed_at) WHERE status='pending'
+            #     lookup, so 1s polling scans only the small active-pending set, not the parts table.
+            - name: CEPHOR_DEFER_BACKOFF_SECS
+              value: "1"
+            - name: CEPHOR_DRAIN_POLL_SECS
+              value: "1"
             - name: RUST_LOG
               value: "info"
             # OTLP metrics -> otel-collector -> Prometheus -> Grafana (feature `otel`, on by


### PR DESCRIPTION
## Summary

After #227 unpinned the drain fleet write-budget (1 MB/s → ~1 GB/s), the remaining replication lag on staging measured **p50 4.6 s / p99 5.9 s**, clustered tightly at ~5 s. That is **not** a throughput limit (the drain had ~700× headroom and `breaker_open=0`) — it's two 5-second timers on the drain-agent:

- **`CEPHOR_DEFER_BACKOFF_SECS` (the dominant component).** An MPU part lands on SSD *before* its Complete call writes `object_versions.address`. The drain's first claim sees the address isn't finalized, logs *"upload context not ready"*, and **re-parks the part for 5 s**. So nearly every MPU part eats one 5 s defer. (Simple PUTs write the address up front and don't.)
- **`CEPHOR_DRAIN_POLL_SECS` (backstop).** The drain is event-driven — a `chunk_landed` trigger wakes the worker; the 5 s poll is only a floor for a missed-event/idle wake.

## Change
Set both to **1 s** on the staging drain-agent DaemonSet.

## Why this is cheap (not "too heavy")
The claim query is `UPDATE … FOR UPDATE SKIP LOCKED LIMIT 1` backed by the **partial index** `cephor_replication_status_pending (node_id, landed_at) WHERE status='pending'`. It scans only the small actively-pending set, never the ~94 M-row `parts` table. Polling 1 s adds negligible Postgres load even at prod scale.

## Expected result
Replication-lag p99 ~5.9 s → **~1–2 s**. Will re-run the stress-test harness post-deploy and record the before/after.

## Scope
Staging-only (`k8s/staging/drain-agent-daemonset.yaml`); both vars have safe code defaults (5 s) so prod is unchanged until we promote. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)