### PR TITLE
S3 2.1 drain prod-readiness — Vertical B (R3/C13/C7/C11/C8 + S10/S11 + T4 rig + inv-guard)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ CLAUDE.md
 
 # Rust (workspace at repo root; Cargo.lock is committed for the binary crates)
 /target/
+stress-test/results/

--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -68,6 +68,10 @@ const DEFAULT_RECLAIM_GRACE: Duration = Duration::from_hours(1);
 /// k8s `livenessProbe` checks its freshness. Container-local `/tmp` is always writable.
 const DEFAULT_LIVENESS_FILE: &str = "/tmp/hippius-drain-agent.alive";
 
+/// Default path of the readiness file the runtime touches only while the drain is progressing
+/// (C8); the k8s `readinessProbe` checks its freshness to mark a wedged node `NotReady`.
+const DEFAULT_READINESS_FILE: &str = "/tmp/hippius-drain-agent.ready";
+
 /// The daemon's startup configuration.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -130,6 +134,9 @@ pub struct Config {
     /// Path of the liveness file the runtime touches each heartbeat tick; a k8s
     /// `livenessProbe` checks its freshness to restart a wedged (not crashed) pod.
     pub liveness_file: PathBuf,
+    /// Path of the readiness file the runtime touches only while the drain is progressing (C8);
+    /// a k8s `readinessProbe` checks its freshness to mark a wedged node `NotReady`.
+    pub readiness_file: PathBuf,
 }
 
 /// A failure parsing the daemon configuration from the environment.
@@ -263,6 +270,7 @@ impl Config {
             orphan_reclaim_grace: duration_secs(&get, "CEPHOR_ORPHAN_RECLAIM_GRACE_SECS", DEFAULT_ORPHAN_RECLAIM_GRACE)?,
             drain_concurrency: positive_u32_or(&get, "CEPHOR_DRAIN_CONCURRENCY", DEFAULT_DRAIN_CONCURRENCY)?,
             liveness_file: path_or(&get, "CEPHOR_LIVENESS_FILE", DEFAULT_LIVENESS_FILE),
+            readiness_file: path_or(&get, "CEPHOR_READINESS_FILE", DEFAULT_READINESS_FILE),
         })
     }
 }
@@ -407,6 +415,16 @@ mod tests {
         pairs.push(("CEPHOR_LIVENESS_FILE", "/var/run/agent.alive"));
         let overridden = Config::from_lookup(lookup(&pairs)).unwrap();
         assert_eq!(overridden.liveness_file, PathBuf::from("/var/run/agent.alive"));
+    }
+
+    #[test]
+    fn readiness_file_defaults_and_is_overridable() {
+        let config = Config::from_lookup(lookup(&required_only())).unwrap();
+        assert_eq!(config.readiness_file, PathBuf::from("/tmp/hippius-drain-agent.ready"));
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_READINESS_FILE", "/var/run/agent.ready"));
+        let overridden = Config::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(overridden.readiness_file, PathBuf::from("/var/run/agent.ready"));
     }
 
     #[test]

--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -52,6 +52,13 @@ const DEFAULT_HEARTBEAT_TTL: Duration = Duration::from_secs(30);
 /// Reclaim scan period when `CEPHOR_RECLAIM_POLL_SECS` is unset: the SSD-ingest GC
 /// runs less often than the drain — eviction is a backstop, not a hot path.
 const DEFAULT_RECLAIM_POLL: Duration = Duration::from_mins(5);
+/// Orphan-reclaim grace when `CEPHOR_ORPHAN_RECLAIM_GRACE_SECS` is unset: how long a
+/// no-DB-backing part (its object hard-deleted) is kept on SSD before eviction. Longer
+/// than the `failed` grace because this age is the FS `meta.json` mtime (a deleted object
+/// has no DB row to date), so a generous window absorbs the agent-clock dependence and
+/// any delete-racing-recreate window. A deleted object never returns, so there is no cost
+/// to waiting.
+const DEFAULT_ORPHAN_RECLAIM_GRACE: Duration = Duration::from_hours(24);
 /// Reclaim grace when `CEPHOR_RECLAIM_GRACE_SECS` is unset: how long a `failed`
 /// (abandoned-upload) part — and an orphan write-temp — is kept on SSD before
 /// eviction (a diagnosis / abort-settle window).
@@ -103,11 +110,20 @@ pub struct Config {
     /// Backends to enqueue each part's upload to (`{backend}_upload_requests`), from
     /// `HIPPIUS_UPLOAD_BACKENDS` (comma-list). Defaults to `["arion"]`.
     pub upload_backends: Vec<String>,
+    /// `HIPPIUS_BACKUP_BACKENDS` (comma-list). Defaults to EMPTY — a backup backend is a
+    /// deliberate opt-in. The janitor gate requires coverage on `upload_backends ∪
+    /// backup_backends` before reclaiming a part, so the enqueuer MUST push to the same
+    /// union ([`enqueue_backends`](Config::enqueue_backends)) — otherwise a configured
+    /// backup backend is required-but-never-enqueued and the gate deadlocks (C10).
+    pub backup_backends: Vec<String>,
     /// How often the SSD-reclaim worker scans for `failed` (abandoned-upload) parts.
     pub reclaim_poll: Duration,
     /// How long a `failed` part (and an orphan write-temp) is kept on SSD before
     /// eviction (a diagnosis / abort-settle window).
     pub reclaim_grace: Duration,
+    /// How long a no-DB-backing part (its object hard-deleted) is kept on SSD before the
+    /// orphan reclaim evicts it. Keyed on the part's FS `meta.json` age, so set generously.
+    pub orphan_reclaim_grace: Duration,
     /// Maximum parts the drain worker processes concurrently — the in-flight gate
     /// that lets the node overlap fsync latency across parts.
     pub drain_concurrency: u32,
@@ -183,9 +199,30 @@ impl Config {
             reconcile_poll: self.reconcile_poll,
             reclaim_poll: self.reclaim_poll,
             reclaim_grace: self.reclaim_grace,
+            orphan_reclaim_grace: self.orphan_reclaim_grace,
             grace: self.grace,
             drain_concurrency: self.drain_concurrency,
         }
+    }
+
+    /// The backends the drain enqueuer must push a replicated part to: `upload_backends`
+    /// unioned with `backup_backends`, deduped, upload order preserved.
+    ///
+    /// This MUST equal the set the janitor's replication gate requires
+    /// (`is_replicated_on_all_backends` unions the per-version `upload_backends` with
+    /// `HIPPIUS_BACKUP_BACKENDS` the same way). If the enqueuer pushed only to
+    /// `upload_backends`, a configured backup backend would be required by the gate but
+    /// never enqueued, so the part could never reach full coverage and the janitor would
+    /// never reclaim its SSD copy — a permanent leak/deadlock (C10).
+    #[must_use]
+    pub fn enqueue_backends(&self) -> Vec<String> {
+        let mut backends = self.upload_backends.clone();
+        for backup in &self.backup_backends {
+            if !backends.contains(backup) {
+                backends.push(backup.clone());
+            }
+        }
+        backends
     }
 
     /// The [`HeartbeatConfig`](crate::runtime::HeartbeatConfig) for this node.
@@ -220,8 +257,10 @@ impl Config {
             heartbeat_ttl: duration_secs(&get, "CEPHOR_HEARTBEAT_TTL_SECS", DEFAULT_HEARTBEAT_TTL)?,
             redis_queues_url: required(&get, "REDIS_QUEUES_URL")?,
             upload_backends: parse_backends(&get, "HIPPIUS_UPLOAD_BACKENDS"),
+            backup_backends: parse_optional_backends(&get, "HIPPIUS_BACKUP_BACKENDS"),
             reclaim_poll: duration_secs(&get, "CEPHOR_RECLAIM_POLL_SECS", DEFAULT_RECLAIM_POLL)?,
             reclaim_grace: duration_secs(&get, "CEPHOR_RECLAIM_GRACE_SECS", DEFAULT_RECLAIM_GRACE)?,
+            orphan_reclaim_grace: duration_secs(&get, "CEPHOR_ORPHAN_RECLAIM_GRACE_SECS", DEFAULT_ORPHAN_RECLAIM_GRACE)?,
             drain_concurrency: positive_u32_or(&get, "CEPHOR_DRAIN_CONCURRENCY", DEFAULT_DRAIN_CONCURRENCY)?,
             liveness_file: path_or(&get, "CEPHOR_LIVENESS_FILE", DEFAULT_LIVENESS_FILE),
         })
@@ -232,14 +271,20 @@ impl Config {
 /// dropping empties. Defaults to `["arion"]` when unset or empty (mirrors the Python
 /// `config.upload_backends` default).
 fn parse_backends(get: &impl Fn(&str) -> Option<String>, var: &'static str) -> Vec<String> {
-    let parsed: Vec<String> = get(var)
+    let parsed = parse_optional_backends(get, var);
+    if parsed.is_empty() { vec!["arion".to_owned()] } else { parsed }
+}
+
+/// Parses a comma-separated backend list with an EMPTY default (no fallback backend) —
+/// for `HIPPIUS_BACKUP_BACKENDS`, where "unset" must mean "no backup", never `["arion"]`.
+fn parse_optional_backends(get: &impl Fn(&str) -> Option<String>, var: &'static str) -> Vec<String> {
+    get(var)
         .unwrap_or_default()
         .split(',')
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_owned)
-        .collect();
-    if parsed.is_empty() { vec!["arion".to_owned()] } else { parsed }
+        .collect()
 }
 
 /// Resolves a required identifier variable into a validated [`NodeId`].
@@ -321,8 +366,8 @@ fn duration_secs(get: &impl Fn(&str) -> Option<String>, var: &'static str, defau
 mod tests {
     use super::{
         Config, ConfigError, DEFAULT_ALLOCATION_POLL, DEFAULT_CLAIM_LEASE, DEFAULT_DECAY_HALF_LIFE, DEFAULT_DRAIN_CONCURRENCY, DEFAULT_DRAIN_POLL,
-        DEFAULT_FLOOR_RATE_BPS, DEFAULT_HEARTBEAT_POLL, DEFAULT_HEARTBEAT_TTL, DEFAULT_MAX_DRAIN_RATE_BPS, DEFAULT_RECLAIM_GRACE,
-        DEFAULT_RECLAIM_POLL,
+        DEFAULT_FLOOR_RATE_BPS, DEFAULT_HEARTBEAT_POLL, DEFAULT_HEARTBEAT_TTL, DEFAULT_MAX_DRAIN_RATE_BPS, DEFAULT_ORPHAN_RECLAIM_GRACE,
+        DEFAULT_RECLAIM_GRACE, DEFAULT_RECLAIM_POLL,
     };
     use core::str::FromStr;
     use hippius_drain_core::{ByteRate, NodeId};
@@ -445,6 +490,7 @@ mod tests {
         let config = Config::from_lookup(lookup(&required_only())).unwrap();
         assert_eq!(config.reclaim_poll, DEFAULT_RECLAIM_POLL);
         assert_eq!(config.reclaim_grace, DEFAULT_RECLAIM_GRACE);
+        assert_eq!(config.orphan_reclaim_grace, DEFAULT_ORPHAN_RECLAIM_GRACE);
     }
 
     #[test]
@@ -452,9 +498,11 @@ mod tests {
         let mut pairs = required_only();
         pairs.push(("CEPHOR_RECLAIM_POLL_SECS", "120"));
         pairs.push(("CEPHOR_RECLAIM_GRACE_SECS", "600"));
+        pairs.push(("CEPHOR_ORPHAN_RECLAIM_GRACE_SECS", "7200"));
         let config = Config::from_lookup(lookup(&pairs)).unwrap();
         assert_eq!(config.reclaim_poll, Duration::from_mins(2));
         assert_eq!(config.reclaim_grace, Duration::from_mins(10));
+        assert_eq!(config.orphan_reclaim_grace, Duration::from_hours(2));
     }
 
     #[test]
@@ -627,5 +675,46 @@ mod tests {
         pairs.push(("HIPPIUS_UPLOAD_BACKENDS", " arion , ovh "));
         let config = Config::from_lookup(lookup(&pairs)).unwrap();
         assert_eq!(config.upload_backends, vec!["arion".to_owned(), "ovh".to_owned()]);
+    }
+
+    #[test]
+    fn backup_backends_default_to_empty_not_arion() {
+        // Unlike upload_backends (which defaults to ["arion"]), backup must default EMPTY:
+        // a spurious default backup backend would make the janitor gate require coverage
+        // the enqueuer then has to satisfy for no reason.
+        let config = Config::from_lookup(lookup(&required_only())).unwrap();
+        assert!(config.backup_backends.is_empty(), "no HIPPIUS_BACKUP_BACKENDS -> no backup backends");
+    }
+
+    #[test]
+    fn backup_backends_parse_a_trimmed_comma_list() {
+        let mut pairs = required_only();
+        pairs.push(("HIPPIUS_BACKUP_BACKENDS", " ipfs , s3backup "));
+        let config = Config::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(config.backup_backends, vec!["ipfs".to_owned(), "s3backup".to_owned()]);
+    }
+
+    #[test]
+    fn enqueue_backends_is_the_deduped_ordered_union_of_upload_and_backup() {
+        // C10: the enqueuer must push to every backend the janitor gate requires
+        // (upload ∪ backup). Upload order is preserved; a backup already in upload is not
+        // duplicated; a genuinely new backup backend is appended.
+        let mut pairs = required_only();
+        pairs.push(("HIPPIUS_UPLOAD_BACKENDS", "arion,ipfs"));
+        pairs.push(("HIPPIUS_BACKUP_BACKENDS", "ipfs,s3backup")); // ipfs overlaps, s3backup is new
+        let config = Config::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(
+            config.enqueue_backends(),
+            vec!["arion".to_owned(), "ipfs".to_owned(), "s3backup".to_owned()],
+            "upload order kept, overlap deduped, new backup appended",
+        );
+    }
+
+    #[test]
+    fn enqueue_backends_with_no_backup_is_just_upload() {
+        let mut pairs = required_only();
+        pairs.push(("HIPPIUS_UPLOAD_BACKENDS", "arion"));
+        let config = Config::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(config.enqueue_backends(), vec!["arion".to_owned()]);
     }
 }

--- a/crates/hippius-drain-agent/src/lib.rs
+++ b/crates/hippius-drain-agent/src/lib.rs
@@ -10,6 +10,7 @@ pub mod enqueue;
 pub mod localfs;
 #[cfg(feature = "otel")]
 pub mod metrics;
+pub mod readiness;
 pub mod runtime;
 pub mod supervisor;
 pub mod worker;

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -387,13 +387,17 @@ fn plain_name(name: &OsStr) -> Option<String> {
     Some(raw.to_owned())
 }
 
-/// Whether a part dir holds its `meta.json` marker. The api writes meta last, so its
-/// presence means the part is complete and safe to drain (an incomplete part is
-/// skipped by the scan).
-async fn part_has_meta(part_path: &Path) -> io::Result<bool> {
+/// The age of a part's `meta.json` marker (`now() - mtime`), or `None` when the marker is
+/// absent. The api writes meta last, so its presence means the part is complete and safe
+/// to drain (an incomplete part is skipped by the scan); its mtime is the part's landing
+/// age, carried on [`DiscoveredPart`] for the reclaim's orphan grace (a deleted-object
+/// part has no DB row to date). `ZERO` on clock skew — the fail-safe direction (reads
+/// young, so a borderline orphan is kept rather than reclaimed early).
+async fn part_meta_age(part_path: &Path) -> io::Result<Option<Duration>> {
     match fs::metadata(part_path.join(META_FILE_NAME)).await {
-        Ok(meta) => Ok(meta.is_file()),
-        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Ok(meta) if meta.is_file() => Ok(Some(file_age(&meta))),
+        Ok(_) => Ok(None),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
         Err(err) => Err(err),
     }
 }
@@ -519,12 +523,12 @@ async fn scan_version_dir(path: &Path, object: &str, version: &str, out: &mut Ve
         let Some(part) = plain_name(&entry.file_name()) else {
             continue;
         };
-        if !part_has_meta(&entry.path()).await? {
+        let Some(age) = part_meta_age(&entry.path()).await? else {
             continue;
-        }
+        };
         let rel = Path::new(object).join(version).join(&part);
         if let Ok(key) = parse_part_dir(&rel) {
-            out.push(DiscoveredPart { part: key });
+            out.push(DiscoveredPart { part: key, age });
         }
     }
     Ok(())
@@ -670,7 +674,7 @@ mod part_tests {
     use std::collections::HashMap;
     use std::io;
     use std::sync::Mutex;
-    use std::time::Duration;
+    use std::time::{Duration, SystemTime};
     use tempfile::TempDir;
 
     /// A no-op upload enqueuer for the localfs drain test.
@@ -894,6 +898,28 @@ mod part_tests {
         assert!(
             ssd.scan_parts().await.unwrap().is_empty(),
             "a missing cache root is an empty cache, not an error"
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_carries_the_meta_mtime_age_for_the_orphan_grace() {
+        // The reclaim's orphan grace keys on this FS age (a deleted-object part has no DB
+        // row to date). Backdate the meta.json mtime and assert the scan reports it, so a
+        // future regression that hardcodes ZERO (which would reclaim every orphan
+        // instantly) is caught.
+        let dir = TempDir::new().unwrap();
+        let part = part_key(5, 1);
+        seed_ssd_part(dir.path(), &part, &[(0, b"a")]);
+        let meta = dir.path().join(part.relative_dir()).join("meta.json");
+        let handle = std::fs::OpenOptions::new().write(true).open(&meta).unwrap();
+        handle.set_modified(SystemTime::now() - Duration::from_hours(2)).unwrap();
+
+        let discovered = LocalSsd::new(dir.path()).scan_parts().await.unwrap();
+        assert_eq!(discovered.len(), 1);
+        assert!(
+            discovered[0].age >= Duration::from_hours(1),
+            "the scanned age reflects the backdated meta mtime, not a hardcoded zero (got {:?})",
+            discovered[0].age,
         );
     }
 

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -20,6 +20,7 @@ use sha2::{Digest, Sha256};
 use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
 use tokio::fs;
 use tokio::io::AsyncReadExt;
@@ -257,18 +258,32 @@ async fn stream_copy_hash(source: &Path, dest: &Path) -> io::Result<String> {
     Ok(hex_lower(hasher.finalize().as_slice()))
 }
 
+/// A monotonic per-process counter that, with the pid, makes each write temp unique —
+/// so two tasks persisting the SAME `name` concurrently never share a temp file (C11).
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// The write-temp name for `name`: the agent's `.tmp-` prefix (recognized by
+/// [`is_temp_name`] and the orphan sweep) plus a per-writer `pid.counter` suffix, so
+/// two concurrent persists of the same part write to DISTINCT temps.
+fn temp_name(name: &str) -> String {
+    format!(".tmp-{name}.{}.{}", std::process::id(), TEMP_SEQ.fetch_add(1, Ordering::Relaxed))
+}
+
 /// Atomically place `source`'s bytes into `dir` as `name`, returning the lowercase-hex
 /// SHA-256 of the bytes streamed during the copy: stream into a temp inside `dir`
 /// (`fdatasync`'d), rename into place, then — only when `sync_dir` is set — fsync `dir`.
-/// A crash leaves either no file or the complete one. The single-writer-per-part claim
-/// makes the `.tmp-<name>` temp collision-free (mirrors the within-folder atomic rename).
+/// A crash leaves either no file or the complete one. The temp is suffixed per-writer
+/// ([`temp_name`]), so two tasks draining the SAME part concurrently — a re-claim after a
+/// lease lapses under slow Ceph, which the single-writer claim does NOT prevent (`claim_seq`
+/// fences the COMMIT, not the in-flight copy) — write to distinct temps; last rename wins,
+/// harmless since the bytes are deterministic per (part, chunk).
 ///
 /// The directory fsync is deferred (`sync_dir = false` for chunks + meta) so the whole
 /// part costs ONE dir-fsync via [`sync_parent_dir`], not one per file — the caller drives
 /// it through `PartPool::finalize_part` after every rename lands.
 async fn copy_into(dir: &Path, name: &str, source: &Path, sync_dir: bool) -> io::Result<String> {
     let dest = dir.join(name);
-    let tmp = dir.join(format!(".tmp-{name}"));
+    let tmp = dir.join(temp_name(name));
     fs::create_dir_all(dir).await?;
     // Arm temp cleanup before the copy: any failure or cancellation before the rename
     // must not leave a `.tmp-*` orphan in the pool (the drop-guard idiom, RfR ch.1).
@@ -570,7 +585,7 @@ impl PartRemover for LocalSsd {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::{LocalSsd, TmpGuard, hex_lower, safe_component};
+    use super::{LocalSsd, TmpGuard, hex_lower, is_temp_name, safe_component, temp_name};
     use core::str::FromStr;
     use hippius_drain_core::{FileId, SsdCache};
     use proptest::prelude::*;
@@ -580,6 +595,20 @@ mod tests {
 
     fn fid(raw: &str) -> FileId {
         FileId::from_str(raw).unwrap()
+    }
+
+    #[test]
+    fn temp_name_is_unique_per_writer_and_still_recognized_as_a_temp() {
+        // C11: two persists of the SAME name must get DISTINCT temp files. Sharing one temp
+        // is a real tear risk when a lapsed lease under slow Ceph lets two tasks drain one
+        // part at once (claim_seq fences the commit, not the in-flight copy).
+        let a = temp_name("chunk_0.bin");
+        let b = temp_name("chunk_0.bin");
+        assert_ne!(a, b, "two temps for the same name must differ");
+        for t in [&a, &b] {
+            assert!(t.starts_with(".tmp-"), "keeps the agent temp prefix: {t}");
+            assert!(is_temp_name(t), "the orphan sweep still recognizes it as a temp: {t}");
+        }
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-agent/src/main.rs
+++ b/crates/hippius-drain-agent/src/main.rs
@@ -72,7 +72,10 @@ async fn main() -> Result<ExitCode, StartupError> {
         .set_response_timeout(DEFAULT_REDIS_TIMEOUT)
         .set_connection_timeout(DEFAULT_REDIS_TIMEOUT);
     let redis = redis::aio::ConnectionManager::new_with_config(redis::Client::open(config.redis_queues_url.as_str())?, redis_config).await?;
-    let enqueuer = Arc::new(RedisEnqueuer::new(Arc::clone(&store), redis.clone(), config.upload_backends.clone()));
+    // Enqueue to upload ∪ backup backends — the SAME union the janitor's replication gate
+    // requires before it will reclaim a part (C10). Pushing only to upload_backends would
+    // strand any configured backup backend as required-but-never-enqueued.
+    let enqueuer = Arc::new(RedisEnqueuer::new(Arc::clone(&store), redis.clone(), config.enqueue_backends()));
 
     // The Redis-backed coordinator: the heartbeat worker upserts this node's state under
     // `heartbeat_ttl`, and the allocation-pull worker reads its budget. The agent never
@@ -116,6 +119,8 @@ async fn main() -> Result<ExitCode, StartupError> {
         pool_root = %config.pool_root.display(),
         ssd_root = %config.ssd_root.display(),
         upload_backends = ?config.upload_backends,
+        backup_backends = ?config.backup_backends,
+        enqueue_backends = ?config.enqueue_backends(),
         "hippius-drain-agent started"
     );
     let report = runtime.run(shutdown_signal()).await;

--- a/crates/hippius-drain-agent/src/main.rs
+++ b/crates/hippius-drain-agent/src/main.rs
@@ -108,7 +108,8 @@ async fn main() -> Result<ExitCode, StartupError> {
     .with_coordinator(coordinator)
     .with_heartbeat(config.heartbeat_config())
     .with_rate_control(rate_control)
-    .with_liveness(config.liveness_file.clone());
+    .with_liveness(config.liveness_file.clone())
+    .with_readiness(config.readiness_file.clone());
 
     // OTLP metrics read the runtime's live snapshot + the shared enforcer (for the breaker
     // gauge); grabbed before `run` consumes the runtime. Held until after shutdown to flush.

--- a/crates/hippius-drain-agent/src/metrics.rs
+++ b/crates/hippius-drain-agent/src/metrics.rs
@@ -92,13 +92,26 @@ pub fn init(service_name: &'static str, snapshot: &Arc<SnapshotCell>, enforcer: 
             .build(),
     ));
 
-    // Saturation: undrained SSD bytes (gauge). Backlog growth is what fills the SSD and
-    // 503s every PUT on the node, so it is the key operational drain gauge.
+    // Backlog: undrained SSD bytes (gauge) — the DB-sourced true drain demand (pending +
+    // draining part bytes), NOT raw disk occupancy, so the A21/orphan leak no longer
+    // inflates it (WI-20c). The heartbeat writes it from Store::node_backlog_bytes.
     let snap = Arc::clone(snapshot);
     instruments.push(Box::new(
         meter
             .u64_observable_gauge("drain_ssd_backlog_bytes")
             .with_callback(move |observer| observer.observe(snap.backlog(), &[]))
+            .build(),
+    ));
+
+    // Saturation: SSD disk fill fraction (0.0..=1.0). This is what crosses the api's
+    // fs_cache_pressure cutoff and 503s every PUT on the node, so it is the operational
+    // alert signal — and unlike the backlog it rises with a leak even at zero drain demand.
+    // Sourced from the heartbeat's statvfs probe (bps in the snapshot), scaled to a fraction.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .f64_observable_gauge("drain_ssd_pressure")
+            .with_callback(move |observer| observer.observe(f64::from(snap.disk_pressure_bps()) / 10_000.0, &[]))
             .build(),
     ));
 

--- a/crates/hippius-drain-agent/src/readiness.rs
+++ b/crates/hippius-drain-agent/src/readiness.rs
@@ -1,0 +1,123 @@
+//! The drain-readiness signal (C8).
+//!
+//! Liveness (the heartbeat's file touch) only proves the process is *alive* — but a drain wedged
+//! on a hung `CephFS` write, or one whose breaker is open with pending work, keeps heartbeating
+//! while draining nothing, so the pod stays "healthy" while it makes no progress. Readiness closes
+//! that gap: a k8s `readinessProbe` reads a file the heartbeat touches ONLY while the drain is
+//! actually progressing (or idle), so a wedged node goes `NotReady` — surfacing in pod status and
+//! gating a rolling update from marching over stuck nodes.
+//!
+//! [`ReadinessTracker`] is the pure verdict: it folds the cumulative `drained` counter (monotonic)
+//! and the current `backlog` level (undrained bytes) from the agent snapshot, and reports READY
+//! unless there is a backlog that has made no drained progress for longer than a stall window. The
+//! tracker stays Ready through a legitimately long-but-progressing drain (the counter keeps
+//! advancing) and through idle (no backlog), so it does not flap those healthy cases.
+
+use std::time::Duration;
+use std::time::Instant;
+
+/// Tracks drain progress across heartbeats to decide k8s readiness. Not `Clock`-injected: the
+/// wiring passes a real [`Instant`] (like the liveness file mtime), while [`observe`] takes `now`
+/// explicitly so the verdict logic is unit-tested with hand-built instants.
+///
+/// [`observe`]: ReadinessTracker::observe
+#[derive(Debug)]
+pub struct ReadinessTracker {
+    last_processed: u64,
+    last_progress: Instant,
+    stall: Duration,
+}
+
+impl ReadinessTracker {
+    /// A tracker seeded at `now` that reports `NotReady` once a backlog sits `stall`-long without
+    /// the drain loop processing a single part.
+    #[must_use]
+    pub fn new(now: Instant, stall: Duration) -> Self {
+        Self {
+            last_processed: 0,
+            last_progress: now,
+            stall,
+        }
+    }
+
+    /// Folds one heartbeat observation and returns whether the drain is READY.
+    ///
+    /// READY iff the backlog is empty (idle is healthy) OR the `processed` counter has advanced
+    /// within `stall` (the loop is cycling). `NotReady` iff there is a backlog but `processed` has
+    /// not advanced for longer than `stall` — the loop is WEDGED (blocked on a hung `CephFS` op).
+    ///
+    /// `processed` is the cumulative count of parts the drain loop HANDLED — committed
+    /// (`drained`) + `failed` + `deferred` — NOT just committed, so a node legitimately deferring
+    /// not-ready/orphan backlog or failing fast on a degraded pool still reads as cycling (its
+    /// loop is alive); only a loop that has stopped handling parts at all reads as wedged.
+    /// `backlog` is the current undrained bytes.
+    pub fn observe(&mut self, processed: u64, backlog: u64, now: Instant) -> bool {
+        if processed > self.last_processed {
+            self.last_processed = processed;
+            self.last_progress = now;
+        }
+        if backlog == 0 {
+            // Idle is healthy; refresh the clock so a later backlog gets a FULL stall window
+            // before it can read as wedged (rather than inheriting a stale idle gap).
+            self.last_progress = now;
+            return true;
+        }
+        now.duration_since(self.last_progress) < self.stall
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReadinessTracker;
+    use std::time::Duration;
+    use std::time::Instant;
+
+    const STALL: Duration = Duration::from_mins(1);
+
+    fn at(base: Instant, secs: u64) -> Instant {
+        base + Duration::from_secs(secs)
+    }
+
+    #[test]
+    fn idle_is_always_ready() {
+        let t0 = Instant::now();
+        let mut r = ReadinessTracker::new(t0, STALL);
+        assert!(r.observe(0, 0, t0), "no backlog is ready");
+        assert!(r.observe(0, 0, at(t0, 300)), "still idle after a long gap is ready");
+    }
+
+    #[test]
+    fn a_long_but_progressing_drain_stays_ready() {
+        let t0 = Instant::now();
+        let mut r = ReadinessTracker::new(t0, STALL);
+        // Backlog present the whole time, but `drained` advances each tick — never flap NotReady.
+        assert!(r.observe(10, 1_000, at(t0, 30)));
+        assert!(r.observe(20, 1_000, at(t0, 90)));
+        assert!(r.observe(30, 1_000, at(t0, 150)));
+    }
+
+    #[test]
+    fn a_stalled_backlog_goes_not_ready_past_the_window() {
+        let t0 = Instant::now();
+        let mut r = ReadinessTracker::new(t0, STALL);
+        assert!(r.observe(10, 1_000, at(t0, 5)), "just progressed -> ready");
+        assert!(r.observe(10, 1_000, at(t0, 50)), "no progress but within the window -> still ready");
+        assert!(!r.observe(10, 1_000, at(t0, 120)), "no progress past the stall window -> NotReady");
+    }
+
+    #[test]
+    fn progress_after_a_stall_recovers_readiness() {
+        let t0 = Instant::now();
+        let mut r = ReadinessTracker::new(t0, STALL);
+        assert!(!r.observe(0, 1_000, at(t0, 120)), "backlog with no progress from the start -> NotReady");
+        assert!(r.observe(5, 1_000, at(t0, 125)), "the counter advancing again -> ready");
+    }
+
+    #[test]
+    fn clearing_the_backlog_recovers_readiness() {
+        let t0 = Instant::now();
+        let mut r = ReadinessTracker::new(t0, STALL);
+        assert!(!r.observe(0, 1_000, at(t0, 120)), "wedged with a backlog -> NotReady");
+        assert!(r.observe(0, 0, at(t0, 121)), "backlog cleared -> ready");
+    }
+}

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -73,6 +73,9 @@ pub struct RuntimeConfig {
     /// How long a `failed` part (and an orphan write-temp) is kept before the reclaim
     /// worker unlinks it — a diagnosis / abort-settle window.
     pub reclaim_grace: Duration,
+    /// How long a no-DB-backing part (its object hard-deleted) is kept before the orphan
+    /// reclaim unlinks it. Keyed on the part's FS `meta.json` age, so set generously.
+    pub orphan_reclaim_grace: Duration,
     /// How long workers get to finish an in-flight tick after cancellation
     /// before the supervisor force-aborts them.
     pub grace: Duration,
@@ -184,7 +187,7 @@ async fn run_drain<E: UploadEnqueuer>(token: CancellationToken, period: Duration
 /// Probes SSD disk pressure off the async runtime (statvfs blocks) and upserts
 /// this node's heartbeat. Probe or upsert failures are logged and skipped — the
 /// next tick retries; a missed heartbeat only ages the node out of the fleet.
-async fn heartbeat_once(ssd: &LocalSsd, coord: &Coordinator, node: &NodeId, max_drain_rate: ByteRate, snapshot: &SnapshotCell) {
+async fn heartbeat_once(ssd: &LocalSsd, store: &Store, coord: &Coordinator, node: &NodeId, max_drain_rate: ByteRate, snapshot: &SnapshotCell) {
     let root = ssd.root().to_path_buf();
     // statvfs is a blocking syscall — never run it on an executor thread (axiom
     // r4r_ch10_01); spawn_blocking moves it to the blocking pool.
@@ -204,13 +207,25 @@ async fn heartbeat_once(ssd: &LocalSsd, coord: &Coordinator, node: &NodeId, max_
     // at a glance; the allocator still consumes the raw pressure, not the zone.
     tracing::debug!(node = %node, zone = ?usage.pressure.zone(), pressure_bps = usage.pressure.bps(), "heartbeat disk pressure");
 
-    // Pressure (allocator weight), backlog (SSD used bytes — the undrained work),
-    // and error rate (from the drain counters) are real. p99 latency stays neutral
-    // until per-drain timing is wired (the saturation signal, not a demand signal).
-    // Publish the backlog to the metrics gauge here, where the (blocking) disk probe has
-    // already produced used_bytes — the metrics layer reads it wait-free off the exporter
-    // thread, so it must never run statvfs itself.
-    snapshot.record_backlog(usage.used_bytes);
+    // Publish the disk saturation to the drain_ssd_pressure gauge here, where the
+    // (blocking) statvfs probe already produced it — the metrics layer reads it wait-free
+    // off the exporter thread and must never run statvfs itself.
+    snapshot.record_disk_pressure(usage.pressure.bps());
+
+    // The drain_ssd_backlog_bytes gauge is the TRUE undrained work — the DB sum of this
+    // node's pending/draining part bytes — NOT raw disk occupancy (usage.used_bytes), which
+    // the A21/orphan leak overcounts by hundreds of GB with no drain demand (WI-20c). On a
+    // query error, leave the last-recorded backlog rather than zeroing it (a transient blip
+    // must not read as "drained"); the next tick refreshes it.
+    match store.node_backlog_bytes(node.as_str()).await {
+        Ok(bytes) => snapshot.record_backlog(bytes),
+        Err(err) => tracing::warn!(error = %err, "backlog query failed; keeping the last value"),
+    }
+
+    // The allocator observation keeps SSD occupancy as its demand weight (a leak-inflated
+    // value is a conservative over-demand, not a safety issue; refining it is coordination
+    // work). Pressure is the allocator weight; error rate is from the drain counters; p99
+    // stays neutral until per-drain timing is wired.
     let observation = NodeObservation {
         pressure: usage.pressure,
         backlog: Bytes::new(usage.used_bytes),
@@ -224,18 +239,27 @@ async fn heartbeat_once(ssd: &LocalSsd, coord: &Coordinator, node: &NodeId, max_
 }
 
 /// One reclaim pass: evict `failed` (broken/abandoned-upload) SSD parts older than
-/// `grace`, then sweep orphan write-temps older than `grace`.
+/// `grace` and no-DB-backing (deleted-object) orphans older than `orphan_grace`, then
+/// sweep orphan write-temps older than `grace`.
 ///
 /// Reclaim and sweep errors are logged and skipped; the next tick retries, and no part
-/// is ever removed without a successful status read (fail-safe).
-async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, grace: Duration) {
-    match reclaim_ssd(ssd, ssd, store, grace).await {
+/// is ever removed without a successful status read (fail-safe). The store is both the
+/// replication log and the object-backing log for the reclaim.
+async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, grace: Duration, orphan_grace: Duration) {
+    match reclaim_ssd(ssd, ssd, store, store, grace, orphan_grace).await {
         Ok(report) => {
-            snapshot.record_reclaimed(report.reclaimed);
+            // Both dispositions free SSD bytes, so the reclaimed gauge counts their sum.
+            snapshot.record_reclaimed(report.reclaimed + report.reclaimed_orphan);
             if report.reclaimed > 0 {
                 // Aggregate, not per-part: an abandoned MPU reclaims many parts at once,
                 // so a per-part line would spam.
                 tracing::info!(reclaimed = report.reclaimed, "reclaimed broken/abandoned-upload SSD parts");
+            }
+            if report.reclaimed_orphan > 0 {
+                tracing::info!(
+                    reclaimed_orphan = report.reclaimed_orphan,
+                    "reclaimed no-DB-backing (deleted-object) SSD orphans"
+                );
             }
             // The one signal that the (deliberately un-handled) replicated crash-orphan
             // leak is actually occurring — otherwise invisible. Warn so it surfaces.
@@ -472,11 +496,12 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
         let (ssd, store, snapshot) = (Arc::clone(&self.ssd), Arc::clone(&self.store), Arc::clone(&self.snapshot));
         let reclaim_poll = self.config.reclaim_poll;
         let reclaim_grace = self.config.reclaim_grace;
+        let orphan_reclaim_grace = self.config.orphan_reclaim_grace;
         supervisor.spawn(WorkerName::new("ssd_reclaim"), move |token| {
             run_periodic(token, reclaim_poll, move || {
                 let (ssd, store, snapshot) = (Arc::clone(&ssd), Arc::clone(&store), Arc::clone(&snapshot));
                 async move {
-                    reclaim_once(&ssd, &store, &snapshot, reclaim_grace).await;
+                    reclaim_once(&ssd, &store, &snapshot, reclaim_grace, orphan_reclaim_grace).await;
                 }
             })
         });
@@ -485,13 +510,19 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
         // so the allocator can weight it. Needs the coordinator; without it the node
         // is never in the fleet.
         if let (Some(heartbeat), Some(coord)) = (self.heartbeat, self.coord.as_ref()) {
-            let (ssd, coord, snapshot) = (Arc::clone(&self.ssd), Arc::clone(coord), Arc::clone(&self.snapshot));
+            let (ssd, store, coord, snapshot) = (
+                Arc::clone(&self.ssd),
+                Arc::clone(&self.store),
+                Arc::clone(coord),
+                Arc::clone(&self.snapshot),
+            );
             let liveness = self.liveness_path.clone();
             let HeartbeatConfig { node, max_drain_rate, poll } = heartbeat;
             supervisor.spawn(WorkerName::new("heartbeat"), move |token| {
                 run_periodic(token, poll, move || {
-                    let (ssd, coord, node, snapshot, liveness) = (
+                    let (ssd, store, coord, node, snapshot, liveness) = (
                         Arc::clone(&ssd),
+                        Arc::clone(&store),
                         Arc::clone(&coord),
                         node.clone(),
                         Arc::clone(&snapshot),
@@ -507,7 +538,7 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
                         if let Some(path) = liveness.as_deref() {
                             touch_liveness(path);
                         }
-                        heartbeat_once(&ssd, &coord, &node, max_drain_rate, &snapshot).await;
+                        heartbeat_once(&ssd, &store, &coord, &node, max_drain_rate, &snapshot).await;
                     }
                 })
             });
@@ -610,6 +641,14 @@ mod tests {
         std::fs::write(dir.join("meta.json"), br#"{"chunk_size":20,"num_chunks":1,"size_bytes":20}"#).unwrap();
     }
 
+    /// Backdates a seeded part's `meta.json` mtime by 2h so the scan reports it aged past
+    /// a sub-2h orphan grace (the orphan reclaim keys on this FS age).
+    fn backdate_meta_2h(ssd_root: &Path, part: &PartKey) {
+        let meta = ssd_root.join(part.relative_dir()).join("meta.json");
+        let handle = std::fs::OpenOptions::new().write(true).open(&meta).unwrap();
+        handle.set_modified(std::time::SystemTime::now() - Duration::from_hours(2)).unwrap();
+    }
+
     async fn all_replicated(store: &Store, parts: &[PartKey]) -> bool {
         for part in parts {
             let status = <Store as PartReplicationStore>::status(store, part).await.unwrap();
@@ -667,6 +706,7 @@ mod tests {
                 reconcile_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
+                orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
             },
@@ -738,6 +778,7 @@ mod tests {
                 reconcile_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
+                orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
             },
@@ -827,6 +868,7 @@ mod tests {
                 reconcile_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
+                orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
             },
@@ -889,6 +931,7 @@ mod tests {
                 reconcile_poll: Duration::from_millis(20),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
+                orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
             },
@@ -934,6 +977,7 @@ mod tests {
                 reconcile_poll: Duration::from_millis(50),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
+                orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
             },
@@ -985,7 +1029,7 @@ mod tests {
         force_terminal_2h(&pool, &replicated, "replicated").await;
 
         let ssd = LocalSsd::new(ssd_dir.path());
-        super::reclaim_once(&ssd, &store, &snapshot, Duration::from_secs(1)).await;
+        super::reclaim_once(&ssd, &store, &snapshot, Duration::from_secs(1), Duration::from_secs(1)).await;
 
         assert!(
             !ssd_dir.path().join(failed.relative_dir()).exists(),
@@ -1021,10 +1065,58 @@ mod tests {
 
         let ssd = LocalSsd::new(ssd_dir.path());
         // Zero grace so the just-written temp is past the (no-)window.
-        super::reclaim_once(&ssd, &store, &snapshot, Duration::ZERO).await;
+        super::reclaim_once(&ssd, &store, &snapshot, Duration::ZERO, Duration::ZERO).await;
 
         assert!(!orphan.exists(), "reclaim_once swept the orphan temp");
         assert_eq!(snapshot.load().reclaimed, 0, "no failed part -> nothing reclaimed, only the temp swept");
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn reclaim_once_evicts_a_no_db_backing_orphan_of_a_deleted_object(pool: PgPool) {
+        // WI-20b end-to-end through reclaim_once: a complete SSD part with NO replication
+        // row AND no object_versions row (its object was hard-deleted), aged past the
+        // orphan grace, is reclaimed. A live sibling (with an object_versions row) is kept.
+        // object_versions is the only app table the backing read touches, stood up here
+        // since the drain-core migrations are cephor-only.
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let store = Store::from_pool(pool.clone());
+        let snapshot = SnapshotCell::new();
+        sqlx::query(
+            "CREATE TABLE object_versions (object_id uuid NOT NULL, object_version bigint NOT NULL, \
+             PRIMARY KEY (object_id, object_version))",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // The deleted-object orphan: on SSD, no cephor row, no object_versions row, aged 2h.
+        let orphan = part_at(5, 1);
+        seed_ssd_dir(ssd_dir.path(), &orphan);
+        backdate_meta_2h(ssd_dir.path(), &orphan);
+
+        // A live sibling: same shape but its object_versions row exists -> backed -> kept.
+        let live = part_at(7, 1);
+        seed_ssd_dir(ssd_dir.path(), &live);
+        backdate_meta_2h(ssd_dir.path(), &live);
+        sqlx::query("INSERT INTO object_versions (object_id, object_version) VALUES ($1::uuid, $2)")
+            .bind(live.object().as_str())
+            .bind(i64::from(live.version().get()))
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let ssd = LocalSsd::new(ssd_dir.path());
+        super::reclaim_once(&ssd, &store, &snapshot, Duration::from_secs(1), Duration::from_hours(1)).await;
+
+        assert!(
+            !ssd_dir.path().join(orphan.relative_dir()).exists(),
+            "the aged no-DB-backing orphan of a deleted object was evicted",
+        );
+        assert!(
+            ssd_dir.path().join(live.relative_dir()).exists(),
+            "a part whose object_versions row still exists is kept (mid-upload / live object)",
+        );
+        assert_eq!(snapshot.load().reclaimed, 1, "exactly the deleted-object orphan was counted");
     }
 
     /// Forces a part's row to `status` with `updated_at` backdated 2h, so the reclaim

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -22,7 +22,7 @@ use crate::supervisor::{RunReport, Supervisor, WorkerName};
 use crate::worker::drain_until_empty;
 use hippius_drain_core::{
     BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, CoordError, Coordinator, Enforcer, NodeId, NodeObservation,
-    SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket, UploadEnqueuer, decay_rate, reclaim_ssd, reconcile_parts,
+    SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket, UploadEnqueuer, decay_rate, jittered, reclaim_ssd, reconcile_parts,
 };
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -97,7 +97,7 @@ where
         tick().await;
         tokio::select! {
             () = token.cancelled() => return,
-            () = tokio::time::sleep(period) => {}
+            () = tokio::time::sleep(jittered(period)) => {}
         }
     }
 }
@@ -179,7 +179,7 @@ async fn run_drain<E: UploadEnqueuer>(token: CancellationToken, period: Duration
 
         tokio::select! {
             () = token.cancelled() => return,
-            () = tokio::time::sleep(period) => {}
+            () = tokio::time::sleep(jittered(period)) => {}
         }
     }
 }
@@ -344,7 +344,7 @@ async fn run_alloc(token: CancellationToken, coord: Arc<Coordinator>, rate_contr
         }
         tokio::select! {
             () = token.cancelled() => return,
-            () = tokio::time::sleep(poll) => {}
+            () = tokio::time::sleep(jittered(poll)) => {}
         }
     }
 }

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -18,6 +18,7 @@
 
 use crate::disk::disk_usage;
 use crate::localfs::{LocalFs, LocalSsd};
+use crate::readiness::ReadinessTracker;
 use crate::supervisor::{RunReport, Supervisor, WorkerName};
 use crate::worker::drain_until_empty;
 use hippius_drain_core::{
@@ -37,6 +38,21 @@ use tokio_util::sync::CancellationToken;
 fn touch_liveness(path: &Path) {
     let _ = std::fs::write(path, b"ok");
 }
+
+/// Best-effort readiness touch (C8): the heartbeat rewrites this file ONLY while the drain is
+/// progressing (or idle), so a k8s `readinessProbe` checking its mtime marks a WEDGED node
+/// `NotReady`. Unlike liveness (process-alive), a stale readiness file means the drain loop has
+/// stopped handling parts despite a backlog — surfacing the wedge and gating a rolling update
+/// from stepping over stuck nodes. Errors ignored, like liveness.
+fn touch_readiness(path: &Path) {
+    let _ = std::fs::write(path, b"ready");
+}
+
+/// How long a backlog may sit with the drain loop processing NOTHING before the node reads
+/// `NotReady` (C8). Comfortably longer than the gap between per-part progress on a healthy — even
+/// slow — drain, so a legitimately long drain never flaps; short enough that a truly hung loop is
+/// caught within a couple of heartbeats.
+const READINESS_STALL: Duration = Duration::from_mins(2);
 
 /// Consecutive Ceph-write failures before the circuit breaker opens.
 const BREAKER_FAILURES: u32 = 5;
@@ -381,6 +397,9 @@ pub struct AgentRuntime<E: UploadEnqueuer> {
     /// Opt-in liveness file the heartbeat worker touches each tick, for the k8s probe.
     /// `None` (tests / drain-only e2e) writes no file.
     liveness_path: Option<Arc<PathBuf>>,
+    /// Opt-in readiness file the heartbeat worker touches only while the drain is progressing
+    /// (C8), for the k8s `readinessProbe`. `None` writes no file.
+    readiness_path: Option<Arc<PathBuf>>,
 }
 
 impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
@@ -400,6 +419,7 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
             coord: None,
             clock: Arc::new(SystemClock),
             liveness_path: None,
+            readiness_path: None,
         }
     }
 
@@ -445,6 +465,15 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
     #[must_use]
     pub fn with_liveness(mut self, path: PathBuf) -> Self {
         self.liveness_path = Some(Arc::new(path));
+        self
+    }
+
+    /// Sets the readiness file the heartbeat worker touches only while the drain is progressing
+    /// (C8), so a k8s `readinessProbe` marks a WEDGED node `NotReady` (a hung `CephFS` write
+    /// stalls draining while liveness stays fresh). Without it no file is written.
+    #[must_use]
+    pub fn with_readiness(mut self, path: PathBuf) -> Self {
+        self.readiness_path = Some(Arc::new(path));
         self
     }
 
@@ -517,16 +546,22 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
                 Arc::clone(&self.snapshot),
             );
             let liveness = self.liveness_path.clone();
+            let readiness = self.readiness_path.clone();
+            // Shared across ticks: the heartbeat is the single writer, so contention/poisoning
+            // is nil, but a Mutex keeps the FnMut closure's cross-tick state sound.
+            let readiness_tracker = Arc::new(Mutex::new(ReadinessTracker::new(Instant::now(), READINESS_STALL)));
             let HeartbeatConfig { node, max_drain_rate, poll } = heartbeat;
             supervisor.spawn(WorkerName::new("heartbeat"), move |token| {
                 run_periodic(token, poll, move || {
-                    let (ssd, store, coord, node, snapshot, liveness) = (
+                    let (ssd, store, coord, node, snapshot, liveness, readiness, readiness_tracker) = (
                         Arc::clone(&ssd),
                         Arc::clone(&store),
                         Arc::clone(&coord),
                         node.clone(),
                         Arc::clone(&snapshot),
                         liveness.clone(),
+                        readiness.clone(),
+                        Arc::clone(&readiness_tracker),
                     );
                     async move {
                         // Touch liveness FIRST, before the (blocking, possibly early-returning)
@@ -539,6 +574,22 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
                             touch_liveness(path);
                         }
                         heartbeat_once(&ssd, &store, &coord, &node, max_drain_rate, &snapshot).await;
+                        // C8 readiness: heartbeat_once just refreshed the backlog. The drain is
+                        // PROGRESSING iff it handled any part (committed + failed + deferred) since
+                        // the last tick; touch readiness only when progressing or idle, so a wedged
+                        // loop (hung Ceph) lets the file go stale -> NotReady.
+                        if let Some(path) = readiness.as_deref() {
+                            let snap = snapshot.load();
+                            let processed = snap.drained.saturating_add(snap.failed).saturating_add(snap.deferred);
+                            let ready = readiness_tracker.lock().unwrap_or_else(PoisonError::into_inner).observe(
+                                processed,
+                                snapshot.backlog(),
+                                Instant::now(),
+                            );
+                            if ready {
+                                touch_readiness(path);
+                            }
+                        }
                     }
                 })
             });

--- a/crates/hippius-drain-allocator/src/metrics.rs
+++ b/crates/hippius-drain-allocator/src/metrics.rs
@@ -66,8 +66,8 @@ fn build_provider(service_name: &'static str) -> Option<SdkMeterProvider> {
 }
 
 /// Builds the meter provider and registers the allocator's gauges (`drain_leader`,
-/// `drain_fleet_estimate_bps`), or returns `None` when monitoring is disabled or the
-/// exporter cannot be built. Both gauges read the shared [`AllocatorMetrics`].
+/// `drain_fleet_estimate_bps`, `drain_leader_epoch`), or returns `None` when monitoring is
+/// disabled or the exporter cannot be built. Every gauge reads the shared [`AllocatorMetrics`].
 #[must_use]
 pub fn init(service_name: &'static str, metrics: &Arc<AllocatorMetrics>) -> Option<MetricsHandle> {
     if !monitoring_enabled() {
@@ -92,6 +92,17 @@ pub fn init(service_name: &'static str, metrics: &Arc<AllocatorMetrics>) -> Opti
         meter
             .u64_observable_gauge("drain_fleet_estimate_bps")
             .with_callback(move |observer| observer.observe(m.fleet_estimate_bps.load(Ordering::Relaxed), &[]))
+            .build(),
+    ));
+
+    // The lease epoch this instance last led under. `max(drain_leader_epoch)` over the fleet
+    // is monotonic by construction (INCR at election), so alerting on a decrease catches a
+    // redis epoch-counter reset that would otherwise silently break the write-fence (S10/S11).
+    let m = Arc::clone(metrics);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_gauge("drain_leader_epoch")
+            .with_callback(move |observer| observer.observe(m.leader_epoch.load(Ordering::Relaxed), &[]))
             .build(),
     ));
 

--- a/crates/hippius-drain-allocator/src/run.rs
+++ b/crates/hippius-drain-allocator/src/run.rs
@@ -22,6 +22,10 @@ pub struct AllocatorMetrics {
     pub leader: AtomicU64,
     /// The fleet write-budget estimate in bytes/s from the last led tick (`drain_fleet_estimate_bps`).
     pub fleet_estimate_bps: AtomicU64,
+    /// The lease epoch this instance last LED under (`drain_leader_epoch`); left at its last
+    /// led value while not leading. `max()` across the fleet is monotonic by construction, so
+    /// a decrease flags a redis epoch-counter reset that would silently break the write-fence.
+    pub leader_epoch: AtomicU64,
 }
 
 /// Loop-level observability inputs, bundled so `run_allocator` stays under the argument
@@ -72,9 +76,10 @@ pub async fn run_allocator<C: CephCeilingSource>(
             touch_liveness(path);
         }
         match run_tick(coord, ceiling, config, controller).await {
-            Ok(TickOutcome::Led(plan)) => {
+            Ok(TickOutcome::Led { plan, epoch }) => {
                 let estimate = plan.controller.total().get();
                 tracing::debug!(
+                    epoch,
                     fleet_estimate = estimate,
                     feasible = plan.feasible,
                     nodes = plan.allocations.len(),
@@ -82,6 +87,7 @@ pub async fn run_allocator<C: CephCeilingSource>(
                 );
                 obs.metrics.leader.store(1, Ordering::Relaxed);
                 obs.metrics.fleet_estimate_bps.store(estimate, Ordering::Relaxed);
+                obs.metrics.leader_epoch.store(epoch, Ordering::Relaxed);
                 // Carry the evolved AIMD state into the next tick.
                 controller = plan.controller;
             }

--- a/crates/hippius-drain-allocator/src/run.rs
+++ b/crates/hippius-drain-allocator/src/run.rs
@@ -1,6 +1,6 @@
 //! The allocator's tick loop: drive [`run_tick`] on a timer until shutdown.
 
-use hippius_drain_core::{BudgetController, ByteRate, CephCeilingSource, CoordError, Coordinator, TickConfig, TickOutcome, run_tick};
+use hippius_drain_core::{BudgetController, ByteRate, CephCeilingSource, CoordError, Coordinator, TickConfig, TickOutcome, jittered, run_tick};
 use std::future::Future;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -100,7 +100,7 @@ pub async fn run_allocator<C: CephCeilingSource>(
         }
         tokio::select! {
             () = &mut shutdown => break,
-            () = tokio::time::sleep(tick) => {}
+            () = tokio::time::sleep(jittered(tick)) => {}
         }
     }
     // Best-effort handoff; the lease TTL is the backstop if it fails (the caller

--- a/crates/hippius-drain-allocator/tests/alloc_stress.rs
+++ b/crates/hippius-drain-allocator/tests/alloc_stress.rs
@@ -1,0 +1,191 @@
+//! T4 rig B — allocator failover soak under leadership churn.
+//!
+//! Complements the DETERMINISTIC R3 failpoint proof (the
+//! `r3_a_tick_paused_at_ceiling_is_fenced_when_a_successor_takes_over_mid_tick` unit test in
+//! `hippius-drain-core::tick`, which isolates the exact stale-write window). This rig instead
+//! hammers real concurrent failover at scale: N allocator loops contend for one coordinator on
+//! the test Redis, and leadership is CHURNED many times (kill the current leader, respawn it).
+//! Each round it asserts the fleet **re-converges on a new leader that advances the epoch**,
+//! the landed budget's epoch **never rolls backward**, and every allocator **shuts down
+//! cleanly** — i.e. no deadlock, no lost leadership, and no split-brain rollback under churn.
+//!
+//! NOTE: this rig does not, on its own, isolate the R3 *current-era* fence — the per-alloc-key
+//! fence already prevents an alloc-key epoch rollback, so the failpoint unit test is what proves
+//! the R3-specific window. This rig is the load/failover soak around it.
+//!
+//! Needs a live Redis (Rust has no fakeredis): `CEPHOR_TEST_REDIS_URL=redis://localhost:6382/0`.
+//! Ignored by default; run with `cargo test -p hippius-drain-allocator --test alloc_stress -- --include-ignored`.
+//! The toxiproxy redis-pathology cells (Rig A) run against the compose proxy — validated at
+//! integration, not here.
+
+#![expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr, reason = "integration test")]
+
+use hippius_drain_allocator::run::{AllocatorMetrics, Observability, run_allocator};
+use hippius_drain_core::{AllocConfig, ByteRate, Bytes, CephCeiling, Coordinator, DiskPressure, NodeId, NodeObservation, StaticCeiling, TickConfig};
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+const ALLOCATORS: usize = 4;
+const ROUNDS: usize = 10;
+const LEASE: Duration = Duration::from_millis(500);
+const TICK: Duration = Duration::from_millis(25);
+const INITIAL: ByteRate = ByteRate::new(190_000);
+
+fn alloc_config() -> AllocConfig {
+    AllocConfig {
+        min_total: ByteRate::new(1_000),
+        max_total: ByteRate::new(1_000_000_000),
+        additive_increase: ByteRate::new(10_000),
+        decrease_permille: 800,
+        target_p99: Duration::from_secs(2),
+        max_error_bps: 100,
+        critical_pressure: DiskPressure::try_from(9_000).unwrap(),
+        reservation_floor: ByteRate::new(50_000),
+    }
+}
+
+fn observation() -> NodeObservation {
+    NodeObservation {
+        pressure: DiskPressure::try_from(5_000).unwrap(),
+        backlog: Bytes::new(9_000_000),
+        max_drain_rate: ByteRate::new(5_000_000),
+        observed_p99: Duration::from_millis(10),
+        error_bps: 0,
+    }
+}
+
+/// One running allocator instance: its cancellation handle, its `leader` gauge, and the
+/// task's join handle (so a churn round can kill it and wait for it to wind down).
+struct Instance {
+    token: CancellationToken,
+    metrics: Arc<AllocatorMetrics>,
+    handle: JoinHandle<Result<(), hippius_drain_core::CoordError>>,
+}
+
+/// Spawns one allocator loop. `id` is unique per (slot, respawn) so a restarted instance is
+/// a logically fresh process (never renews a prior era's lease).
+fn spawn_allocator(coord: &Coordinator, id: String) -> Instance {
+    let coord = coord.clone(); // Coordinator: Clone shares the multiplexed connection.
+    let token = CancellationToken::new();
+    let metrics = Arc::new(AllocatorMetrics::default());
+    let task_token = token.clone();
+    let task_metrics = Arc::clone(&metrics);
+    let handle = tokio::spawn(async move {
+        let config = TickConfig {
+            instance_id: id,
+            lease_ttl: LEASE,
+            alloc: alloc_config(),
+        };
+        let ceiling = StaticCeiling(CephCeiling::Open(ByteRate::new(1_000_000_000)));
+        let obs = Observability {
+            liveness: None,
+            metrics: &task_metrics,
+        };
+        run_allocator(&coord, &ceiling, &config, INITIAL, TICK, &obs, task_token.cancelled()).await
+    });
+    Instance { token, metrics, handle }
+}
+
+/// The epoch currently stamped on the node's landed allocation, or 0 if none written yet.
+async fn landed_epoch(coord: &Coordinator, node: &NodeId) -> u64 {
+    coord.load_allocation(node).await.unwrap().map_or(0, |allocation| allocation.epoch)
+}
+
+/// Polls `f` until it returns `Some`, or `None` after `timeout`. Sleeps `TICK` between tries.
+async fn poll_until<T, F, Fut>(timeout: Duration, mut f: F) -> Option<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Option<T>>,
+{
+    let deadline = Duration::from_millis(u64::try_from(timeout.as_millis()).unwrap());
+    let mut waited = Duration::ZERO;
+    loop {
+        if let Some(value) = f().await {
+            return Some(value);
+        }
+        if waited >= deadline {
+            return None;
+        }
+        tokio::time::sleep(TICK).await;
+        waited += TICK;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires CEPHOR_TEST_REDIS_URL"]
+async fn many_allocators_churning_leadership_never_roll_the_epoch_backward() {
+    let Ok(url) = std::env::var("CEPHOR_TEST_REDIS_URL") else {
+        eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+        return;
+    };
+    if url.is_empty() {
+        eprintln!("skipping: CEPHOR_TEST_REDIS_URL empty");
+        return;
+    }
+    // Unique prefix per process so a re-run never collides with the prior run's TTL'd keys.
+    let coord = Coordinator::connect(&url, Duration::from_secs(30), Duration::from_secs(30))
+        .await
+        .expect("connect to the test redis")
+        .with_prefix(&format!("cephor-test:alloc-stress:{}:", std::process::id()));
+
+    let node = NodeId::try_from("n1".to_owned()).unwrap();
+    coord.upsert_node_state(&node, &observation()).await.unwrap();
+
+    // Start the fleet.
+    let mut fleet: Vec<Instance> = (0..ALLOCATORS).map(|slot| spawn_allocator(&coord, format!("alloc-{slot}-r0"))).collect();
+
+    // Wait for the fleet to converge on a first leader + a first written budget.
+    let mut high_epoch = poll_until(Duration::from_secs(5), || async {
+        let epoch = landed_epoch(&coord, &node).await;
+        (epoch > 0).then_some(epoch)
+    })
+    .await
+    .expect("the fleet elected a leader and wrote a budget");
+
+    // Churn: each round, kill the current leader and respawn it, then wait for a successor
+    // to take over (the landed epoch advances). Assert monotonicity at every observation.
+    for round in 1..=ROUNDS {
+        // Find the slot currently reporting leadership.
+        let leader_slot = poll_until(Duration::from_secs(3), || async {
+            (0..ALLOCATORS).find(|&slot| fleet[slot].metrics.leader.load(Ordering::Relaxed) == 1)
+        })
+        .await
+        .expect("some instance holds leadership");
+
+        let before = landed_epoch(&coord, &node).await;
+        assert!(before >= high_epoch, "epoch rolled back before a churn: {before} < {high_epoch}");
+        high_epoch = before;
+
+        // Replace the leader slot with a fresh instance, then cancel + await the old one so
+        // it relinquishes its lease before we wait for the successor to take over.
+        let killed = std::mem::replace(&mut fleet[leader_slot], spawn_allocator(&coord, format!("alloc-{leader_slot}-r{round}")));
+        killed.token.cancel();
+        let _ = killed.handle.await;
+
+        // A successor must take over and advance the epoch (a takeover = a fresh higher era).
+        let advanced = poll_until(Duration::from_secs(5), || async {
+            let epoch = landed_epoch(&coord, &node).await;
+            assert!(epoch >= high_epoch, "epoch rolled BACK during a takeover: {epoch} < {high_epoch}");
+            (epoch > before).then_some(epoch)
+        })
+        .await
+        .expect("a successor took over and advanced the epoch");
+        assert!(advanced > high_epoch, "the takeover produced a strictly higher epoch");
+        high_epoch = advanced;
+    }
+
+    // Churn happened: the epoch advanced at least once per round.
+    assert!(
+        high_epoch >= u64::try_from(ROUNDS).unwrap(),
+        "expected the epoch to advance through the churn (>= {ROUNDS}), got {high_epoch}",
+    );
+
+    // Wind the fleet down; every allocator exits Ok (per-tick errors never propagate).
+    for instance in fleet {
+        instance.token.cancel();
+        instance.handle.await.unwrap().unwrap();
+    }
+}

--- a/crates/hippius-drain-core/proptest-regressions/ssd_reclaim.txt
+++ b/crates/hippius-drain-core/proptest-regressions/ssd_reclaim.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 40d4ca8dd750d3ce6b1286c58687f594e15ed3d795248902c2d3219ba93ee1f5 # shrinks to specs = [(0, true, 3600)]

--- a/crates/hippius-drain-core/src/clock.rs
+++ b/crates/hippius-drain-core/src/clock.rs
@@ -10,7 +10,10 @@
 //! clock directly (they measure or mark, they do not gate a control decision).
 //! Defined once here so the workspace shares one trait instead of several copies.
 
+use std::time::Duration;
 use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 /// A monotonic source of the current instant.
 ///
@@ -30,6 +33,35 @@ impl Clock for SystemClock {
     fn now(&self) -> Instant {
         Instant::now()
     }
+}
+
+/// The largest fraction (permille of `base`) the fleet jitter may shave off a periodic sleep.
+const JITTER_PERMILLE: u64 = 200;
+
+/// Scale `base` by `permille`/1000. Pure — the entropy is split out of [`jittered`] so the
+/// scaling is unit-testable without touching a clock.
+fn scale(base: Duration, permille: u64) -> Duration {
+    let nanos = base.as_nanos().saturating_mul(u128::from(permille)) / 1000;
+    Duration::from_nanos(u64::try_from(nanos).unwrap_or(u64::MAX))
+}
+
+/// Map raw entropy to a scale factor in `[1000 - JITTER_PERMILLE, 1000]` permille.
+fn jitter_factor_permille(entropy: u64) -> u64 {
+    1000 - entropy % (JITTER_PERMILLE + 1)
+}
+
+/// `base` shortened by a pseudo-random 0..20%, to decorrelate the fleet's periodic pollers so
+/// a recovering shared dependency (redis-queues / Postgres / `CephFS`) is not hit by every
+/// node's loop in lockstep — the C7 thundering herd. **Down-only by design:** it never returns
+/// a duration LONGER than `base`, so it can never stretch a heartbeat/lease TTL. Deliberately
+/// NOT "full jitter" `[0, base]`: a near-zero periodic sleep would busy-poll. Entropy is the
+/// wall clock's sub-second nanos — ample for phase decorrelation, never security-facing.
+#[must_use]
+pub fn jittered(base: Duration) -> Duration {
+    let entropy = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |elapsed| u64::from(elapsed.subsec_nanos()));
+    scale(base, jitter_factor_permille(entropy))
 }
 
 /// A manually-advanced clock for deterministic tests.
@@ -103,5 +135,33 @@ mod tests {
         let clock = SystemClock;
         let first = clock.now();
         assert!(clock.now() >= first);
+    }
+
+    #[test]
+    fn jitter_factor_stays_in_the_down_only_window() {
+        for entropy in [0u64, 1, 199, 200, 201, 999, 1_000_000_000, u64::MAX] {
+            let factor = super::jitter_factor_permille(entropy);
+            assert!(
+                (1000 - super::JITTER_PERMILLE..=1000).contains(&factor),
+                "factor {factor} out of window for entropy {entropy}",
+            );
+        }
+    }
+
+    #[test]
+    fn scale_shortens_but_never_lengthens() {
+        let base = Duration::from_secs(10);
+        assert_eq!(super::scale(base, 1000), base, "1000 permille is identity");
+        assert_eq!(super::scale(base, 800), Duration::from_secs(8));
+    }
+
+    #[test]
+    fn jittered_never_exceeds_base_and_stays_within_the_window() {
+        let base = Duration::from_secs(5);
+        let floor = base * (1000 - u32::try_from(super::JITTER_PERMILLE).unwrap()) / 1000;
+        for _ in 0..1000 {
+            let j = super::jittered(base);
+            assert!(j <= base && j >= floor, "jittered {j:?} outside [{floor:?}, {base:?}]");
+        }
     }
 }

--- a/crates/hippius-drain-core/src/clock.rs
+++ b/crates/hippius-drain-core/src/clock.rs
@@ -111,6 +111,7 @@ impl Clock for TestClock {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::{Clock, SystemClock, TestClock};
     use std::time::Duration;

--- a/crates/hippius-drain-core/src/coordination.rs
+++ b/crates/hippius-drain-core/src/coordination.rs
@@ -10,10 +10,12 @@
 //! when Ceph degrades — the very scenario the drain exists for — PG's WAL fsync spikes, and
 //! the coordinator must not need PG to write down what it is doing.
 //!
-//! The F4 leader-epoch fence is preserved verbatim: the epoch lives in the lease value
-//! (bumped on every takeover via an `INCR` counter), and an allocation write is
-//! compare-and-set against each node's stored epoch in ONE atomic Lua `EVAL`, so a deposed
-//! or partitioned leader can never overwrite a live leader's budgets.
+//! The F4 leader-epoch fence: the epoch lives in the lease value (bumped on every takeover
+//! via an `INCR` counter), and an allocation write is a compare-and-set in ONE atomic Lua
+//! `EVAL` against BOTH the current-era counter (`cephor:epoch`, the R3 anchor — bumped at
+//! election before any slow tick work) AND each node's stored epoch, so a deposed or
+//! partitioned leader can never overwrite a live leader's budgets — including in the window
+//! after a successor is elected but before it has written any allocation.
 
 use crate::alloc::Allocation;
 use crate::alloc::FleetView;
@@ -75,15 +77,31 @@ end
 return 1
 ";
 
-/// Fenced per-node allocation write. `KEYS`=the alloc keys (one per node); `ARGV[1]`=epoch,
-/// `ARGV[2]`=ttl secs, `ARGV[3..]`=the budget for each key (parallel to `KEYS`). Returns 0 —
-/// writing NOTHING — if ANY node's stored epoch is higher (this leader is deposed), else
-/// writes every key and returns 1. The two passes (check all, then write all) make the
-/// fence plan-wide and atomic: a split-brain leader cannot partially overwrite budgets.
+/// Fenced per-node allocation write. `KEYS[1]`=the epoch counter (`cephor:epoch`);
+/// `KEYS[2..]`=the alloc keys (one per node); `ARGV[1]`=epoch, `ARGV[2]`=ttl secs,
+/// `ARGV[3..]`=the budget for each alloc key (parallel to `KEYS[2..]`). Returns 0 — writing
+/// NOTHING — if this leader is deposed, else writes every alloc key and returns 1.
+///
+/// The deposed test is TWO checks, both against `epoch`:
+/// 1. **Current-era fence (R3):** the counter at `KEYS[1]` is `INCR`'d to the new era the
+///    instant a successor wins the lease ([`LEASE_SCRIPT`]), BEFORE it does any slow work
+///    (`load_fleet`/`ceiling`) or writes any alloc key. So a deposed leader that finishes a
+///    slow tick and writes at its stale epoch is rejected here even when NO alloc key has
+///    been written at the new era yet — the window a per-alloc-key check alone misses.
+/// 2. **Per-alloc-key fence:** reject if any node's already-stored epoch is higher. Kept as
+///    a secondary guard (and the sole guard for a direct write made without a prior election,
+///    e.g. in tests, where `KEYS[1]` is absent).
+///
+/// The passes (check all, then write all) make the fence plan-wide and atomic: a split-brain
+/// leader cannot partially overwrite budgets.
 const WRITE_ALLOC_SCRIPT: &str = r"
 local epoch = tonumber(ARGV[1])
 local ttl = ARGV[2]
-for i = 1, #KEYS do
+local current = redis.call('GET', KEYS[1])
+if current and tonumber(current) > epoch then
+  return 0
+end
+for i = 2, #KEYS do
   local cur = redis.call('GET', KEYS[i])
   if cur then
     local v = cjson.decode(cur)
@@ -92,8 +110,8 @@ for i = 1, #KEYS do
     end
   end
 end
-for i = 1, #KEYS do
-  redis.call('SET', KEYS[i], cjson.encode({budget = ARGV[2 + i], epoch = epoch}), 'EX', ttl)
+for i = 2, #KEYS do
+  redis.call('SET', KEYS[i], cjson.encode({budget = ARGV[1 + i], epoch = epoch}), 'EX', ttl)
 end
 return 1
 ";
@@ -384,6 +402,8 @@ impl Coordinator {
         let mut conn = self.conn.clone();
         let script = redis::Script::new(WRITE_ALLOC_SCRIPT);
         let mut invocation = script.prepare_invoke();
+        // KEYS[1] is the epoch counter (the current-era fence anchor); the alloc keys follow.
+        invocation.key(self.epoch_key());
         for allocation in allocations {
             invocation.key(self.alloc_key(&allocation.node));
         }
@@ -629,6 +649,56 @@ mod tests {
             c.load_allocation(&node).await.unwrap().unwrap().budget,
             ByteRate::new(2_000),
             "only the new leader's budget stands after a lost-lease takeover",
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
+    async fn a_deposed_leaders_stale_write_is_fenced_before_the_successor_writes_any_alloc() {
+        // R3: the fence must reject a deposed leader's write even when the successor has NOT
+        // written any alloc key yet — the anchor is `cephor:epoch` (bumped at election), not a
+        // previously-written alloc value. Every OTHER fence test pre-seeds a higher-epoch alloc
+        // key before the stale write, so this exact window is otherwise never exercised.
+        let Some(c) = coord("cephor-test:r3-window:", Duration::from_secs(30), Duration::from_secs(30)).await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
+        let node = NodeId::from_str("n1").unwrap();
+        let alloc = |budget| Allocation {
+            node: node.clone(),
+            budget: ByteRate::new(budget),
+        };
+
+        // A wins a SHORT lease (epoch eA, which bumps cephor:epoch to eA) and writes a budget.
+        let a = c
+            .acquire_or_renew_leadership("a", Duration::from_secs(1))
+            .await
+            .unwrap()
+            .expect("a leads");
+        c.write_allocations(a.epoch, std::slice::from_ref(&alloc(1_000))).await.unwrap();
+
+        // A's lease lapses; B takes over — cephor:epoch is now eB > eA. Crucially B has done NO
+        // allocation write yet (it is mid-tick: load_fleet → ceiling → allocate). The alloc key
+        // therefore still carries eA, so the per-alloc-key check alone would NOT fence A.
+        tokio::time::sleep(Duration::from_millis(1_200)).await;
+        let b = c
+            .acquire_or_renew_leadership("b", Duration::from_secs(30))
+            .await
+            .unwrap()
+            .expect("b takes over");
+        assert!(b.epoch > a.epoch, "takeover bumps the epoch ({} > {})", b.epoch, a.epoch);
+
+        // The deposed A finishes its slow tick and writes at its stale epoch. PRE-FIX this
+        // slips through (alloc key holds eA, not > eA); the current-era fence rejects it.
+        let err = c.write_allocations(a.epoch, std::slice::from_ref(&alloc(9_999))).await.unwrap_err();
+        assert!(
+            matches!(err, super::CoordError::Fenced { epoch } if epoch == a.epoch),
+            "the deposed leader's stale write is fenced by the current era, got {err:?}"
+        );
+        assert_eq!(
+            c.load_allocation(&node).await.unwrap().unwrap().budget,
+            ByteRate::new(1_000),
+            "the fenced stale write did not overwrite the budget",
         );
     }
 }

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -28,7 +28,7 @@ mod units;
 
 pub use alloc::{AllocConfig, Allocation, AllocationPlan, BudgetController, FleetView, NodeObservation, allocate};
 pub use apipart::{ChunkIndex, META_FILE_NAME, ObjectId, PartKey, PartMeta, PartNumber, PartPathError, Version, chunk_file_name, parse_part_dir};
-pub use clock::{Clock, SystemClock};
+pub use clock::{Clock, SystemClock, jittered};
 pub use enforce::{
     BreakerConfig, BreakerSignal, BreakerState, CircuitBreaker, ConcurrencyLimiter, DenyReason, DrainDecision, Enforcer, TokenBucket, decay_rate,
 };

--- a/crates/hippius-drain-core/src/partdrain.rs
+++ b/crates/hippius-drain-core/src/partdrain.rs
@@ -30,9 +30,16 @@ use thiserror::Error;
 /// exhausted retry is real corruption. Kept small so a genuinely-bad chunk fails promptly.
 const CHUNK_COPY_ATTEMPTS: u32 = 3;
 
-/// Which durability checkpoint an I/O error struck, for diagnostics.
+/// Which durability checkpoint an I/O error struck, for diagnostics — and, for the breaker,
+/// which SIDE raised it. The `Ssd*` steps touch the node-local SSD; the rest touch the
+/// shared `CephFS` pool, so only the latter are evidence of pool unhealth (see
+/// [`PartDrainError::is_ceph_write_failure`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DrainStep {
+    /// Reading the local SSD source — listing chunks, the part meta, or opening a
+    /// chunk/meta source. A failure here is local-disk unhealth, NOT `CephFS`-write
+    /// unhealth, so it must never trip the node-global Ceph breaker.
+    SsdRead,
     /// Copying, fsync, and atomic rename onto `CephFS`.
     Persist,
     /// Re-hashing a `CephFS` copy.
@@ -46,6 +53,7 @@ pub enum DrainStep {
 impl core::fmt::Display for DrainStep {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(match self {
+            Self::SsdRead => "ssd_read",
             Self::Persist => "persist",
             Self::Hash => "hash",
             Self::Cleanup => "cleanup",
@@ -309,9 +317,10 @@ impl PartDrainError {
     /// `ENOENT` (the pool dir removed between `create_dir_all` and the file write) would
     /// also read as benign, but nothing removes an actively-draining part's pool dir, and
     /// a real degrading `CephFS` mount surfaces as `ENOTCONN`/`EIO` (kind `Other`), not
-    /// `NotFound` — so a genuine pool failure still trips the breaker. Distinguishing the
-    /// source-open `ENOENT` from a pool-write `ENOENT` at the type level is a tracked
-    /// follow-up (would need a dedicated `DrainStep`/source-open error tag).
+    /// `NotFound` — so a genuine pool failure still trips the breaker. The source-open vs
+    /// pool-write `ENOENT` distinction is now expressible via [`DrainStep::SsdRead`] (added
+    /// for the breaker fix); this benign check stays step-agnostic on purpose, since nothing
+    /// removes an actively-draining pool dir, so a Ceph-side `ENOENT` cannot arise in practice.
     #[must_use]
     pub fn is_benign_deferral(&self) -> bool {
         match self {
@@ -323,16 +332,35 @@ impl PartDrainError {
 
     /// Whether this failure is genuine evidence of `CephFS`-write unhealth — the only
     /// class that should trip the node-global Ceph breaker. True for a real pool I/O error
-    /// (non-ENOENT `Io`) and a chunk byte-mismatch (a torn/corrupt pool write). A
-    /// `Store`/claim-coordination error is a Postgres-domain fault, NOT Ceph unhealth, so
-    /// it is excluded — it must not halt draining of a healthy pool; and `Enqueue` /
-    /// `IncompleteSource` are benign deferrals (see [`is_benign_deferral`](Self::is_benign_deferral)).
+    /// (a non-ENOENT `Io` on a Ceph-side step — `Persist`/`Hash`/`Cleanup`) and a chunk
+    /// byte-mismatch (a torn/corrupt pool write).
+    ///
+    /// An `Io` on an SSD-side step (`SsdRead` reading the local source, or `Unlink` removing
+    /// it after commit) is excluded WHATEVER the errno: a local-disk fault is not pool
+    /// unhealth, so it must not halt draining of a healthy pool from every OTHER part on the
+    /// node — it defers this part instead (`breaker_signal_for` maps a non-benign,
+    /// non-Ceph error to [`BreakerSignal::Deferred`]). A `Store`/claim-coordination error
+    /// (Postgres-domain) is likewise excluded, and `Enqueue` / `IncompleteSource` are benign
+    /// deferrals (see [`is_benign_deferral`](Self::is_benign_deferral)).
     #[must_use]
     pub fn is_ceph_write_failure(&self) -> bool {
         match self {
+            // SSD-side step (local-disk unhealth, whatever the errno — the fix for the
+            // `Persist`-overload where a local SSD-read EIO tripped the node-global Ceph
+            // breaker), plus the non-Ceph domains (Postgres store/claim, enqueue-not-ready,
+            // incomplete source): none is evidence of pool unhealth. Matched BEFORE the
+            // general `Io` arm so an SSD-side `Io` is caught here first.
+            Self::Io {
+                step: DrainStep::SsdRead | DrainStep::Unlink,
+                ..
+            }
+            | Self::Store(_)
+            | Self::Enqueue(_)
+            | Self::IncompleteSource { .. } => false,
+            // Any remaining `Io` is a Ceph-side step (`Persist`/`Hash`/`Cleanup`): a non-ENOENT
+            // error is genuine pool unhealth.
             Self::Io { source, .. } => source.kind() != std::io::ErrorKind::NotFound,
             Self::ChunkMismatch { .. } => true,
-            Self::Store(_) | Self::Enqueue(_) | Self::IncompleteSource { .. } => false,
         }
     }
 
@@ -387,7 +415,7 @@ where
         return Ok(DrainOutcome::AlreadyReplicated);
     }
 
-    let chunks = ssd.list_chunks(part).await.map_err(PartDrainError::io(DrainStep::Persist))?;
+    let chunks = ssd.list_chunks(part).await.map_err(PartDrainError::io(DrainStep::SsdRead))?;
 
     // Completeness gate: meta.json is the api's part-complete marker, but a part whose
     // chunks were partly removed after meta landed still scans as "has files". Read the
@@ -395,7 +423,7 @@ where
     // truncated part is deferred (SSD copy intact) rather than committed + unlinked. Since
     // list_chunks returns ascending indices, the enumerate check also rejects a hole (e.g.
     // {0,1,3} against num_chunks=3), not just a short count.
-    let meta = ssd.part_meta(part).await.map_err(PartDrainError::io(DrainStep::Persist))?;
+    let meta = ssd.part_meta(part).await.map_err(PartDrainError::io(DrainStep::SsdRead))?;
     let present = u32::try_from(chunks.len()).unwrap_or(u32::MAX);
     let complete = present == meta.num_chunks && chunks.iter().enumerate().all(|(i, c)| c.get() == u32::try_from(i).unwrap_or(u32::MAX));
     if !complete {
@@ -415,7 +443,7 @@ where
     // partial pool copy, and leaves the SSD source intact — never commit it.
     for index in &chunks {
         let index = *index;
-        let source = ssd.chunk_source(part, index).map_err(PartDrainError::io(DrainStep::Persist))?;
+        let source = ssd.chunk_source(part, index).map_err(PartDrainError::io(DrainStep::SsdRead))?;
         let mut mismatch: Option<(String, String)> = None;
         for _ in 0..CHUNK_COPY_ATTEMPTS {
             let copy_hash = ceph
@@ -445,7 +473,7 @@ where
 
     // Persist meta LAST — only now, with every chunk durably copied and byte-verified,
     // may the reader's `meta.json` gate flip on the pool copy.
-    let meta_source = ssd.meta_source(part).map_err(PartDrainError::io(DrainStep::Persist))?;
+    let meta_source = ssd.meta_source(part).map_err(PartDrainError::io(DrainStep::SsdRead))?;
     ceph.persist_meta(&meta_source, part)
         .await
         .map_err(PartDrainError::io(DrainStep::Persist))?;
@@ -496,7 +524,7 @@ mod tests {
         // is benign — the pool is healthy, there is just nothing to copy. It must NOT trip
         // the node-global Ceph breaker.
         let vanished = PartDrainError::Io {
-            step: DrainStep::Persist,
+            step: DrainStep::SsdRead,
             source: io::Error::from(io::ErrorKind::NotFound),
         };
         assert!(vanished.is_benign_deferral(), "a vanished SSD source (ENOENT) is a benign deferral");
@@ -555,7 +583,7 @@ mod tests {
         assert!(mismatch.is_ceph_write_failure(), "a torn-copy byte mismatch is a Ceph-write failure");
 
         let vanished = PartDrainError::Io {
-            step: DrainStep::Persist,
+            step: DrainStep::SsdRead,
             source: io::Error::from(io::ErrorKind::NotFound),
         };
         assert!(!vanished.is_ceph_write_failure(), "an ENOENT vanished source is not a Ceph failure");
@@ -568,6 +596,35 @@ mod tests {
         assert!(!enqueue.is_ceph_write_failure(), "an enqueue deferral is not a Ceph failure");
         let incomplete = PartDrainError::IncompleteSource { declared: 3, present: 2 };
         assert!(!incomplete.is_ceph_write_failure(), "an incomplete SSD part is not a Ceph failure");
+
+        // C13: a NON-ENOENT I/O error on an SSD-side step (a local-disk EIO reading the source,
+        // or an unlink failure after commit) is local-disk unhealth, NOT a Ceph-write failure —
+        // it must NOT trip the node-global Ceph breaker. This is the `Persist`-overload bug: the
+        // same steps used to be tagged `Persist` (Ceph-write), so a local SSD-read EIO wrongly
+        // tripped the breaker and wedged draining of a healthy pool.
+        for step in [DrainStep::SsdRead, DrainStep::Unlink] {
+            for kind in [io::ErrorKind::Other, io::ErrorKind::PermissionDenied, io::ErrorKind::TimedOut] {
+                let ssd_io = PartDrainError::Io {
+                    step,
+                    source: io::Error::from(kind),
+                };
+                assert!(
+                    !ssd_io.is_ceph_write_failure(),
+                    "an SSD-side I/O error ({step:?}, {kind:?}) is local-disk unhealth, not a Ceph failure",
+                );
+            }
+        }
+        // A non-ENOENT I/O error on each Ceph-side step DOES trip the breaker.
+        for step in [DrainStep::Persist, DrainStep::Hash, DrainStep::Cleanup] {
+            let ceph_io = PartDrainError::Io {
+                step,
+                source: io::Error::from(io::ErrorKind::Other),
+            };
+            assert!(
+                ceph_io.is_ceph_write_failure(),
+                "a real pool I/O error on a Ceph-side step ({step:?}) is a Ceph-write failure",
+            );
+        }
     }
 
     #[test]
@@ -597,6 +654,15 @@ mod tests {
             })),
             BreakerSignal::CephFailure,
             "a real pool I/O error trips the breaker",
+        );
+        // C13: a local SSD-read EIO defers the part, it does NOT trip the Ceph breaker.
+        assert_eq!(
+            breaker_signal_for(&Err(PartDrainError::Io {
+                step: DrainStep::SsdRead,
+                source: io::Error::from(io::ErrorKind::Other),
+            })),
+            BreakerSignal::Deferred,
+            "a local SSD-read EIO defers the part, it must NOT trip the Ceph breaker",
         );
     }
 

--- a/crates/hippius-drain-core/src/reconcile.rs
+++ b/crates/hippius-drain-core/src/reconcile.rs
@@ -16,6 +16,7 @@ use crate::apipart::PartKey;
 use crate::state::ReplicationState;
 use core::future::Future;
 use std::collections::HashMap;
+use std::time::Duration;
 use thiserror::Error;
 
 /// What one reconcile pass found, tallied by the part's prior status. `scanned`
@@ -91,6 +92,13 @@ impl ReconcileError {
 pub struct DiscoveredPart {
     /// The part `(object_id, version, part_number)` whose dir was found on SSD.
     pub part: PartKey,
+    /// How long ago the part's `meta.json` marker was last modified (`now() - mtime`),
+    /// measured by the scanning agent. Only the orphan reclaim reads it — for a part
+    /// with no DB row there is no store timestamp, so the reclaim grace must fall back
+    /// to this FS age. `ZERO` on clock skew or an unreadable mtime (the fail-safe
+    /// direction: reads young, so the part is kept, never wrongly reclaimed). The
+    /// reconciler ignores it.
+    pub age: Duration,
 }
 
 /// The SSD-cache discovery seam for the api part layout: enumerate the parts whose
@@ -215,6 +223,7 @@ mod part_tests {
     use std::collections::HashMap;
     use std::io;
     use std::sync::Mutex;
+    use std::time::Duration;
 
     const UUID_A: &str = "466916c0-d61b-4518-b81b-9576b574270a";
     const UUID_B: &str = "00000000-0000-4000-8000-000000000000";
@@ -226,6 +235,7 @@ mod part_tests {
     fn discovered(uuid: &str, version: u32, number: u32) -> DiscoveredPart {
         DiscoveredPart {
             part: part_at(uuid, version, number),
+            age: Duration::ZERO,
         }
     }
 
@@ -364,10 +374,22 @@ mod part_tests {
         let scan = FakePartScan {
             parts: vec![
                 discovered(UUID_A, 1, 1), // new
-                DiscoveredPart { part: pend.clone() },
-                DiscoveredPart { part: drain.clone() },
-                DiscoveredPart { part: done.clone() },
-                DiscoveredPart { part: bad.clone() },
+                DiscoveredPart {
+                    part: pend.clone(),
+                    age: Duration::ZERO,
+                },
+                DiscoveredPart {
+                    part: drain.clone(),
+                    age: Duration::ZERO,
+                },
+                DiscoveredPart {
+                    part: done.clone(),
+                    age: Duration::ZERO,
+                },
+                DiscoveredPart {
+                    part: bad.clone(),
+                    age: Duration::ZERO,
+                },
             ],
             fail: false,
         };

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -131,6 +131,13 @@ pub struct SnapshotCell {
     /// The heartbeat worker writes it (`usage.used_bytes`) each tick; the metrics layer
     /// reads it as a gauge. Kept off the wait-free `load` path so a scrape never blocks.
     backlog_bytes: AtomicU64,
+    /// Current SSD disk saturation in basis points (`0..=10000` = `0.0..=1.0` full) — a
+    /// LEVEL like `backlog_bytes`, set each heartbeat from the same `statvfs` probe. This
+    /// is the fill fraction that 503s every PUT once it crosses the api's cutoff, so it is
+    /// the operational alert signal; distinct from `backlog_bytes` (undrained WORK), since
+    /// a leak can fill the disk without any drain demand. bps not f64 so the gauge stays a
+    /// plain atomic; the metrics layer scales it to a 0..1 fraction.
+    disk_pressure_bps: AtomicU64,
     /// Recent drain latencies, behind a `Mutex` because a percentile needs the
     /// whole window (no single atomic suffices). Off the wait-free `load` path.
     latency: Mutex<LatencyWindow>,
@@ -178,6 +185,19 @@ impl SnapshotCell {
     #[must_use]
     pub fn backlog(&self) -> u64 {
         self.backlog_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Records the current SSD disk saturation in basis points (`0..=10000`). A gauge:
+    /// `store`, not add. The heartbeat writes it from the `statvfs` pressure each tick.
+    pub fn record_disk_pressure(&self, bps: u16) {
+        self.disk_pressure_bps.store(u64::from(bps), Ordering::Relaxed);
+    }
+
+    /// The last-recorded SSD disk saturation in basis points (the `drain_ssd_pressure`
+    /// gauge source). Clamped to `10000` should a wider value ever be stored.
+    #[must_use]
+    pub fn disk_pressure_bps(&self) -> u16 {
+        u16::try_from(self.disk_pressure_bps.load(Ordering::Relaxed)).unwrap_or(10_000)
     }
 
     /// Records a completed drain's latency for the windowed p99 estimate.
@@ -244,6 +264,16 @@ mod tests {
         assert_eq!(cell.backlog(), 4096);
         cell.record_backlog(100);
         assert_eq!(cell.backlog(), 100, "backlog is a level: a later record replaces, not accumulates");
+    }
+
+    #[test]
+    fn disk_pressure_is_a_settable_gauge_in_basis_points() {
+        let cell = SnapshotCell::new();
+        assert_eq!(cell.disk_pressure_bps(), 0, "a fresh cell reports no disk pressure");
+        cell.record_disk_pressure(8500); // 85% full
+        assert_eq!(cell.disk_pressure_bps(), 8500);
+        cell.record_disk_pressure(200);
+        assert_eq!(cell.disk_pressure_bps(), 200, "disk pressure is a level: a later record replaces");
     }
 
     #[test]

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -7,17 +7,27 @@
 //! so the drain never unlinks it and its SSD bytes leak with nothing else to reclaim
 //! them. This worker is that missing owner.
 //!
-//! It does NOT touch anything else, and in particular **not** `replicated` parts: on
-//! the happy path the drain unlinks its own SSD copy the instant it commits a
-//! replication, and the SSD copy is never read (downloads stream from the `CephFS`
-//! pool, not the ingest SSD), so a replicated part is normally the drain's to clean up.
-//! A replicated copy that lingers is only a rare **drain crash-orphan** (a crash
-//! between the `mark_replicated` commit and the unlink); `claim_part` never re-selects
-//! a `replicated` row, so nothing currently re-drives that unlink — it is a known
-//! residual leak, left out of scope here on purpose (counted `skipped_replicated` for
-//! visibility) to be handled by a drain-side re-drive if it ever proves to matter.
-//! `pending`/`draining` parts are live (owned by the drain pipeline) and a part with
-//! no row may still be mid-upload — both are left strictly alone.
+//! It also reclaims **deleted-object orphans**: a part with NO replication row whose
+//! `object_versions` row is gone (a hard-deleted/purged object), once aged past
+//! `orphan_grace`. Such a part has no terminal `failed` row to key on — its cephor row
+//! was pruned or never written — so the `failed` path above cannot reach it and it leaks
+//! forever (`skipped_absent`). Safety rests on the api's reserve-before-write ordering:
+//! the `object_versions` row is created *before* any part hits the ingest SSD, so an
+//! absent row can only mean the object was deleted, never an in-flight upload. A
+//! present-but-unservable row (an aborted/abandoned upload) is left to the central
+//! `failed`-marking sweep + the `failed` path here, NOT treated as an orphan — that
+//! avoids racing an in-progress MPU whose reserved row is also unservable.
+//!
+//! It does NOT touch **`replicated`** parts: on the happy path the drain unlinks its own
+//! SSD copy the instant it commits a replication, and the SSD copy is never read
+//! (downloads stream from the `CephFS` pool, not the ingest SSD), so a replicated part is
+//! normally the drain's to clean up. A replicated copy that lingers is only a rare
+//! **drain crash-orphan** (a crash between the `mark_replicated` commit and the unlink);
+//! `claim_part` never re-selects a `replicated` row, so nothing currently re-drives that
+//! unlink — a known residual leak, left out of scope here on purpose (counted
+//! `skipped_replicated` for visibility). `pending`/`draining` parts are live (owned by
+//! the drain pipeline) and a no-row part whose object still exists may be mid-upload —
+//! both are left strictly alone.
 //!
 //! Safety: `failed` is a terminal sink (nothing returns a row to `pending` except
 //! `release_part`/`defer_part`, each guarded on `status='draining'`), so the read can
@@ -35,6 +45,7 @@ use crate::reconcile::PartScan;
 use crate::state::ReplicationState;
 use core::future::Future;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::time::Duration;
 use thiserror::Error;
 
@@ -80,14 +91,42 @@ pub trait ReclaimLog: Send + Sync {
     fn part_states(&self, parts: &[PartKey]) -> impl Future<Output = Result<HashMap<PartKey, PartStatusAge>, Self::Error>> + Send;
 }
 
+/// The object-backing seam: which scanned parts have NO live `object_versions` row.
+///
+/// Consulted only for parts the reclaim log has no replication row for — the
+/// [`skipped_absent`](ReclaimReport::skipped_absent) bucket — to split a genuinely
+/// orphaned part (its object was hard-deleted) from one that is merely mid-upload or
+/// pre-reconcile. The safety rests on the api's reserve-before-write ordering: the
+/// `object_versions` row is created *before* any part is written to the ingest SSD, so
+/// a part whose `(object_id, version)` has NO row can only be a deleted object — never
+/// an in-flight upload. A present-but-unservable row (an aborted/abandoned upload) is
+/// deliberately NOT returned here: those are marked `failed` centrally (the Python A21
+/// sweep) and reclaimed via the `failed` path, so treating them as unbacked would risk
+/// racing an in-progress MPU whose reserved row is also unservable.
+///
+/// Implemented by [`crate::Store`] (under `pg`) with one batched PK lookup against
+/// `object_versions`; faked in tests. The future is `Send` for the multithreaded runtime.
+pub trait BackingLog: Send + Sync {
+    /// Store-specific failure, boxed into [`ReclaimError::Backing`].
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// The subset of `parts` whose `(object_id, version)` has NO `object_versions` row.
+    /// A part WITH a row is absent from the result (it has live backing — left alone).
+    fn unbacked_parts(&self, parts: &[PartKey]) -> impl Future<Output = Result<HashSet<PartKey>, Self::Error>> + Send;
+}
+
 /// What one reclaim pass did, tallied by the part's disposition. `scanned` always
-/// equals the sum of the five outcome counts.
+/// equals the sum of the six outcome counts.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ReclaimReport {
     /// Parts seen on SSD.
     pub scanned: u64,
     /// `failed` parts (aborted/abandoned uploads) reclaimed.
     pub reclaimed: u64,
+    /// No-DB-backing orphans reclaimed: a part with no replication row AND no
+    /// `object_versions` row (a hard-deleted object), aged past `orphan_grace`. The
+    /// deleted-object leak the `failed` path cannot reach — see the module doc.
+    pub reclaimed_orphan: u64,
     /// Left alone because still `pending`/`draining` — owned by the drain pipeline.
     pub skipped_live: u64,
     /// Left alone because already `replicated`. On the happy path the drain unlinks its
@@ -95,7 +134,9 @@ pub struct ReclaimReport {
     /// currently re-drives (a known residual leak — see the module doc). Counted here so
     /// a non-zero value surfaces that the orphan case is actually happening.
     pub skipped_replicated: u64,
-    /// Left alone because the store has no row yet — pre-reconcile or mid-upload.
+    /// Left alone because the store has no replication row and the part still has a live
+    /// `object_versions` row (pre-reconcile or mid-upload) — or is not yet past
+    /// `orphan_grace`. The absolute safety gate for a part with no terminal signal.
     pub skipped_absent: u64,
     /// `failed` but within the grace window (diagnosis / abort-race headroom).
     pub skipped_young: u64,
@@ -110,6 +151,7 @@ impl ReclaimReport {
     #[must_use]
     pub fn categorized(&self) -> u64 {
         self.reclaimed
+            .saturating_add(self.reclaimed_orphan)
             .saturating_add(self.skipped_live)
             .saturating_add(self.skipped_replicated)
             .saturating_add(self.skipped_absent)
@@ -128,6 +170,10 @@ pub enum ReclaimError {
     /// from any one store backend.
     #[error("the reclaim log failed during a reclaim pass")]
     Log(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// The batched object-backing read failed. Kept distinct from [`Log`](Self::Log) so
+    /// ops can tell a `cephor_replication_status` read from an `object_versions` read.
+    #[error("the object-backing read failed during a reclaim pass")]
+    Backing(#[source] Box<dyn std::error::Error + Send + Sync>),
     /// Unlinking a reclaimed part's directory failed.
     #[error("removing a reclaimed part from the SSD cache failed")]
     Remove(#[source] std::io::Error),
@@ -138,25 +184,49 @@ impl ReclaimError {
     fn log<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
         Self::Log(Box::new(err))
     }
+
+    /// Boxes a [`BackingLog::Error`] into [`ReclaimError::Backing`].
+    fn backing<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
+        Self::Backing(Box::new(err))
+    }
 }
 
-/// Reclaims `failed` (broken/abandoned-upload) parts from the SSD cache, once aged.
+/// Reclaims broken/abandoned-upload (`failed`) parts and no-DB-backing orphans from the
+/// SSD cache, once aged.
 ///
-/// Scans every complete part on SSD, reads all their states in one batch, and unlinks
-/// each one that is `failed` AND older than `grace`. Everything else is left untouched:
-/// `pending`/`draining` are live (drain-owned), `replicated` is the drain's own to
-/// clean up, and a part with no row may still be mid-upload — the absolute safety gate.
+/// Scans every complete part on SSD, reads all their replication states in one batch, and
+/// unlinks each `failed` part older than `grace`. A part with NO replication row is then
+/// checked against [`BackingLog`]: if its object was hard-deleted (no `object_versions`
+/// row) AND it has aged past `orphan_grace`, it is a deleted-object orphan and is
+/// reclaimed too. Everything else is left untouched: `pending`/`draining` are live
+/// (drain-owned), `replicated` is the drain's own to clean up, and a no-row part that
+/// still has a live `object_versions` row may be mid-upload — the absolute safety gate.
+///
+/// The `failed` grace uses the store clock (the row's `updated_at`); the orphan grace
+/// uses the part's SSD `meta.json` age ([`DiscoveredPart::age`](crate::DiscoveredPart)),
+/// since a deleted object has no DB row to date. Orphan reclaim therefore has an
+/// agent-clock dependence that the `failed` path does not — `orphan_grace` is set
+/// generously to absorb it.
 ///
 /// # Errors
 ///
 /// - [`ReclaimError::Scan`] if walking the cache fails.
 /// - [`ReclaimError::Log`] if the batched status read fails (nothing is removed).
+/// - [`ReclaimError::Backing`] if the batched object-backing read fails (nothing is removed).
 /// - [`ReclaimError::Remove`] if unlinking a reclaimed part fails.
-pub async fn reclaim_ssd<S, R, L>(scanner: &S, remover: &R, log: &L, grace: Duration) -> Result<ReclaimReport, ReclaimError>
+pub async fn reclaim_ssd<S, R, L, B>(
+    scanner: &S,
+    remover: &R,
+    log: &L,
+    backing: &B,
+    grace: Duration,
+    orphan_grace: Duration,
+) -> Result<ReclaimReport, ReclaimError>
 where
     S: PartScan,
     R: PartRemover,
     L: ReclaimLog,
+    B: BackingLog,
 {
     let parts = scanner.scan_parts().await.map_err(ReclaimError::Scan)?;
     let mut report = ReclaimReport::default();
@@ -169,14 +239,35 @@ where
     let keys: Vec<PartKey> = parts.iter().map(|discovered| discovered.part.clone()).collect();
     let states = log.part_states(&keys).await.map_err(ReclaimError::log)?;
 
+    // The object-backing read is needed only for parts with no replication row (the
+    // skipped_absent tail). Gathering them first keeps it one batched query over that
+    // subset — usually a small fraction of the scan, empty on the steady-state happy path.
+    let absent: Vec<PartKey> = parts
+        .iter()
+        .filter(|discovered| !states.contains_key(&discovered.part))
+        .map(|discovered| discovered.part.clone())
+        .collect();
+    let unbacked = if absent.is_empty() {
+        HashSet::new()
+    } else {
+        backing.unbacked_parts(&absent).await.map_err(ReclaimError::backing)?
+    };
+
     for discovered in parts {
         report.scanned += 1;
         let part = &discovered.part;
 
-        // No row yet: a part the reconciler has not recorded, or one the api is still
-        // writing. Never delete it — there is no terminal signal that it is done.
+        // No replication row. Reclaim ONLY a deleted-object orphan: no `object_versions`
+        // row (unbacked) AND aged past `orphan_grace`. A part whose version still has a
+        // live row is mid-upload or pre-reconcile — never touched (the absolute safety
+        // gate; reserve-before-write means an absent row can only be a deleted object).
         let Some(status) = states.get(part) else {
-            report.skipped_absent += 1;
+            if unbacked.contains(part) && discovered.age >= orphan_grace {
+                remover.unlink_part(part).await.map_err(ReclaimError::Remove)?;
+                report.reclaimed_orphan += 1;
+            } else {
+                report.skipped_absent += 1;
+            }
             continue;
         };
 
@@ -211,13 +302,13 @@ where
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::{PartRemover, PartStatusAge, ReclaimError, ReclaimLog, ReclaimReport, reclaim_ssd};
+    use super::{BackingLog, PartRemover, PartStatusAge, ReclaimError, ReclaimLog, ReclaimReport, reclaim_ssd};
     use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
     use crate::reconcile::{DiscoveredPart, PartScan};
     use crate::state::ReplicationState;
     use core::future::Future;
     use core::str::FromStr;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::io;
     use std::sync::Mutex;
     use std::time::Duration;
@@ -233,7 +324,9 @@ mod tests {
         part.relative_dir().to_string_lossy().into_owned()
     }
 
-    /// A scanner yielding a fixed part list (or a fault).
+    /// A scanner yielding a fixed part list (or a fault). `of` stamps every part with a
+    /// stale FS age (older than any test's `ORPHAN_GRACE`), so an absent part is orphan-age
+    /// by default; `of_aged` pins each part's age for the orphan-grace boundary tests.
     struct FakeScan {
         parts: Vec<DiscoveredPart>,
         fail: bool,
@@ -242,7 +335,14 @@ mod tests {
     impl FakeScan {
         fn of(parts: &[PartKey]) -> Self {
             Self {
-                parts: parts.iter().map(|p| DiscoveredPart { part: p.clone() }).collect(),
+                parts: parts.iter().map(|p| DiscoveredPart { part: p.clone(), age: HOUR }).collect(),
+                fail: false,
+            }
+        }
+
+        fn of_aged(parts: &[(PartKey, Duration)]) -> Self {
+            Self {
+                parts: parts.iter().map(|(p, age)| DiscoveredPart { part: p.clone(), age: *age }).collect(),
                 fail: false,
             }
         }
@@ -256,6 +356,50 @@ mod tests {
                 Ok(self.parts.clone())
             };
             async move { result }
+        }
+    }
+
+    /// The object-backing fake: reports a fixed set of parts as unbacked (their object was
+    /// deleted). `all_backed` (the default) returns nothing, so no part is ever an orphan —
+    /// exactly the state the pre-WI-20b `failed`-only tests assume. Records the parts it was
+    /// asked about so a test can assert the read covers only the no-row subset.
+    #[derive(Default)]
+    struct FakeBacking {
+        unbacked: HashSet<String>,
+        asked: Mutex<Vec<String>>,
+        fail: bool,
+    }
+
+    impl FakeBacking {
+        fn all_backed() -> Self {
+            Self::default()
+        }
+
+        fn unbacked(parts: &[&PartKey]) -> Self {
+            Self {
+                unbacked: parts.iter().map(|p| key(p)).collect(),
+                ..Self::default()
+            }
+        }
+
+        fn asked(&self) -> Vec<String> {
+            let mut out = self.asked.lock().unwrap().clone();
+            out.sort();
+            out
+        }
+    }
+
+    impl BackingLog for FakeBacking {
+        type Error = io::Error;
+
+        fn unbacked_parts(&self, parts: &[PartKey]) -> impl Future<Output = Result<HashSet<PartKey>, io::Error>> + Send {
+            let outcome = if self.fail {
+                Err(io::Error::other("backing read failed"))
+            } else {
+                self.asked.lock().unwrap().extend(parts.iter().map(key));
+                Ok(parts.iter().filter(|p| self.unbacked.contains(&key(p))).cloned().collect())
+            };
+            async move { outcome }
         }
     }
 
@@ -335,6 +479,7 @@ mod tests {
 
     const HOUR: Duration = Duration::from_hours(1);
     const GRACE: Duration = Duration::from_mins(30);
+    const ORPHAN_GRACE: Duration = Duration::from_mins(45);
 
     #[tokio::test]
     async fn an_aged_failed_part_is_reclaimed() {
@@ -343,7 +488,9 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, HOUR)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.reclaimed, 1);
         assert_eq!(remover.removed(), vec![key(&part)], "the aged failed (abandoned) part was unlinked");
     }
@@ -357,7 +504,9 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Replicated, HOUR)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.skipped_replicated, 1);
         assert_eq!(report.reclaimed, 0);
         assert!(remover.removed().is_empty(), "a replicated part is never reclaimed here");
@@ -381,7 +530,9 @@ mod tests {
             // `absent` has no row in the log at all.
         ]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.reclaimed, 0, "nothing but a failed part is ever reclaimed");
         assert_eq!(report.skipped_live, 2);
         assert_eq!(report.skipped_replicated, 1);
@@ -398,7 +549,9 @@ mod tests {
         // and a corruption sample is worth a brief diagnosis window).
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, Duration::from_mins(1))]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.skipped_young, 1);
         assert!(remover.removed().is_empty(), "a young failed part is kept");
     }
@@ -412,7 +565,9 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, GRACE)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.reclaimed, 1, "age == grace reclaims");
         assert_eq!(report.skipped_young, 0);
     }
@@ -424,7 +579,9 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&parts.iter().map(|p| (p, ReplicationState::Failed, HOUR)).collect::<Vec<_>>());
 
-        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.reclaimed, 5);
         assert_eq!(log.calls(), 1, "all five parts' statuses were read in one batched call");
     }
@@ -445,12 +602,15 @@ mod tests {
             (&young, ReplicationState::Failed, Duration::from_secs(1)),
         ]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+            .await
+            .unwrap();
         assert_eq!(
             report,
             ReclaimReport {
                 scanned: 5,
                 reclaimed: 1,
+                reclaimed_orphan: 0,
                 skipped_live: 1,
                 skipped_replicated: 1,
                 skipped_absent: 1,
@@ -470,7 +630,9 @@ mod tests {
         let scan = FakeScan { parts: vec![], fail: true };
         let remover = FakeRemover::default();
         let log = FakeLog::default();
-        let err = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap_err();
+        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+            .await
+            .unwrap_err();
         assert!(matches!(err, ReclaimError::Scan(_)), "got: {err:?}");
         assert!(remover.removed().is_empty());
     }
@@ -484,7 +646,9 @@ mod tests {
             fail: true,
             ..FakeLog::default()
         };
-        let err = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap_err();
+        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+            .await
+            .unwrap_err();
         assert!(matches!(err, ReclaimError::Log(_)), "got: {err:?}");
         assert!(remover.removed().is_empty(), "a failed status read removes nothing (fail-safe)");
     }
@@ -498,7 +662,9 @@ mod tests {
             ..FakeRemover::default()
         };
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, HOUR)]);
-        let err = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap_err();
+        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+            .await
+            .unwrap_err();
         assert!(matches!(err, ReclaimError::Remove(_)), "got: {err:?}");
     }
 
@@ -507,8 +673,170 @@ mod tests {
         let scan = FakeScan::of(&[]);
         let remover = FakeRemover::default();
         let log = FakeLog::default();
-        let report = reclaim_ssd(&scan, &remover, &log, GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report, ReclaimReport::default());
         assert_eq!(log.calls(), 0, "an empty scan never queries the store");
+    }
+
+    // ----------------------------------------------- deleted-object orphans (WI-20b)
+
+    #[tokio::test]
+    async fn an_aged_no_row_orphan_of_a_deleted_object_is_reclaimed() {
+        // The WI-20b leak: no replication row (its cephor row was pruned or never written)
+        // AND no object_versions row (the object was hard-deleted) AND aged on SSD.
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of_aged(&[(part.clone(), HOUR)]);
+        let remover = FakeRemover::default();
+        let log = FakeLog::default(); // no replication row
+        let backing = FakeBacking::unbacked(&[&part]); // object_versions row gone
+
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        assert_eq!(report.reclaimed_orphan, 1);
+        assert_eq!(report.skipped_absent, 0);
+        assert_eq!(remover.removed(), vec![key(&part)], "the deleted-object orphan was unlinked");
+    }
+
+    #[tokio::test]
+    async fn a_no_row_part_whose_object_still_exists_is_never_reclaimed() {
+        // The absolute safety gate: no replication row but the object_versions row is still
+        // present (mid-upload or pre-reconcile) — must never be unlinked, however aged.
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of_aged(&[(part.clone(), HOUR)]);
+        let remover = FakeRemover::default();
+        let log = FakeLog::default();
+        let backing = FakeBacking::all_backed(); // object_versions row present
+
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        assert_eq!(report.reclaimed_orphan, 0);
+        assert_eq!(report.skipped_absent, 1);
+        assert!(remover.removed().is_empty(), "a part whose object still exists is protected");
+    }
+
+    #[tokio::test]
+    async fn a_young_no_row_orphan_within_the_orphan_grace_is_kept() {
+        // Unbacked but freshly landed: a delete racing an in-flight re-create is possible,
+        // so the grace holds the part until it is unambiguously stale.
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of_aged(&[(part.clone(), Duration::from_mins(1))]);
+        let remover = FakeRemover::default();
+        let log = FakeLog::default();
+        let backing = FakeBacking::unbacked(&[&part]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        assert_eq!(report.skipped_absent, 1);
+        assert_eq!(report.reclaimed_orphan, 0);
+        assert!(remover.removed().is_empty(), "a young orphan is kept");
+    }
+
+    #[tokio::test]
+    async fn an_orphan_exactly_at_the_orphan_grace_boundary_is_reclaimed() {
+        // The gate is `age < grace -> keep`, so age == orphan_grace reclaims. Pins the
+        // boundary against a future `<` vs `<=` slip.
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of_aged(&[(part.clone(), ORPHAN_GRACE)]);
+        let remover = FakeRemover::default();
+        let log = FakeLog::default();
+        let backing = FakeBacking::unbacked(&[&part]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        assert_eq!(report.reclaimed_orphan, 1, "age == orphan_grace reclaims");
+        assert_eq!(report.skipped_absent, 0);
+    }
+
+    #[tokio::test]
+    async fn the_backing_read_covers_only_the_no_row_parts() {
+        // The read is scoped to the skipped_absent tail: a part WITH a replication row is
+        // never asked about (its disposition is decided by the batched status read alone),
+        // so the object_versions query stays off the happy path.
+        let failed = part_at(UUID_A, 1, 1);
+        let orphan = part_at(UUID_A, 1, 2);
+        let scan = FakeScan::of_aged(&[(failed.clone(), HOUR), (orphan.clone(), HOUR)]);
+        let remover = FakeRemover::default();
+        let log = FakeLog::with(&[(&failed, ReplicationState::Failed, HOUR)]);
+        let backing = FakeBacking::unbacked(&[&orphan]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        assert_eq!(report.reclaimed, 1, "the failed part reclaimed via the status path");
+        assert_eq!(report.reclaimed_orphan, 1, "the orphan reclaimed via the backing path");
+        assert_eq!(backing.asked(), vec![key(&orphan)], "only the no-row part was backing-checked");
+    }
+
+    #[tokio::test]
+    async fn a_backing_read_failure_is_surfaced_and_nothing_is_removed() {
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of_aged(&[(part.clone(), HOUR)]);
+        let remover = FakeRemover::default();
+        let log = FakeLog::default(); // absent → triggers the backing read
+        let backing = FakeBacking {
+            fail: true,
+            ..FakeBacking::default()
+        };
+        let err = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap_err();
+        assert!(matches!(err, ReclaimError::Backing(_)), "got: {err:?}");
+        assert!(remover.removed().is_empty(), "a failed backing read removes nothing (fail-safe)");
+    }
+
+    #[tokio::test]
+    async fn a_fully_backed_absent_cache_never_queries_backing_for_removal() {
+        // All absent parts are backed → the backing read runs but yields no orphan; every
+        // part is skipped_absent and nothing is removed.
+        let a = part_at(UUID_A, 1, 1);
+        let b = part_at(UUID_A, 1, 2);
+        let scan = FakeScan::of_aged(&[(a.clone(), HOUR), (b.clone(), HOUR)]);
+        let remover = FakeRemover::default();
+        let log = FakeLog::default();
+        let backing = FakeBacking::all_backed();
+
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        assert_eq!(report.skipped_absent, 2);
+        assert_eq!(report.reclaimed_orphan, 0);
+        assert!(remover.removed().is_empty());
+    }
+
+    // A property test over arbitrary no-row parts: the reclaimed-orphan set is EXACTLY the
+    // parts that are both unbacked AND aged past the orphan grace, and everything else is
+    // preserved (`skipped_absent`). The shrinker probes the age/backing boundary combos a
+    // handful of fixtures cannot. Mirrors the WI-19 plan's reclaim proptest for the failed
+    // path, extended to the orphan path.
+    proptest::proptest! {
+        #![proptest_config(proptest::prelude::ProptestConfig::with_cases(200))]
+        #[test]
+        fn orphan_reclaim_removes_exactly_unbacked_and_aged_no_row_parts(
+            specs in proptest::collection::vec((0u32..64, proptest::bool::ANY, 0u64..7200), 0..40)
+        ) {
+            let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+            rt.block_on(async {
+                let orphan_grace = Duration::from_hours(1);
+                let mut aged: Vec<(PartKey, Duration)> = Vec::new();
+                let mut unbacked_refs: Vec<PartKey> = Vec::new();
+                let mut expected_removed: Vec<String> = Vec::new();
+                for (i, (number, is_unbacked, age_secs)) in specs.iter().enumerate() {
+                    // Distinct parts: vary version by index so no two collide.
+                    let part = part_at(UUID_A, u32::try_from(i).unwrap() + 1, *number);
+                    let age = Duration::from_secs(*age_secs);
+                    aged.push((part.clone(), age));
+                    if *is_unbacked {
+                        unbacked_refs.push(part.clone());
+                        if age >= orphan_grace {
+                            expected_removed.push(key(&part));
+                        }
+                    }
+                }
+                let scan = FakeScan::of_aged(&aged);
+                let remover = FakeRemover::default();
+                let log = FakeLog::default(); // every part has no replication row
+                let refs: Vec<&PartKey> = unbacked_refs.iter().collect();
+                let backing = FakeBacking::unbacked(&refs);
+
+                let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, orphan_grace).await.unwrap();
+                expected_removed.sort();
+                proptest::prop_assert_eq!(remover.removed(), expected_removed.clone());
+                proptest::prop_assert_eq!(usize::try_from(report.reclaimed_orphan).unwrap(), expected_removed.len());
+                proptest::prop_assert_eq!(report.scanned, report.categorized());
+                Ok(())
+            })?;
+        }
     }
 }

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -17,10 +17,11 @@ use crate::ids::FileId;
 use crate::partdrain::{ClaimedPart, PartReplicationStore, PartVerified};
 use crate::reconcile::PartLandingLog;
 use crate::reconcile::PartStatus;
-use crate::ssd_reclaim::{PartStatusAge, ReclaimLog};
+use crate::ssd_reclaim::{BackingLog, PartStatusAge, ReclaimLog};
 use crate::state::ReplicationState;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::time::Duration;
 use thiserror::Error;
 
@@ -283,6 +284,38 @@ impl Store {
         .await?
         .rows_affected();
         Ok(affected)
+    }
+
+    /// The true drain backlog for `node`: the total `parts.size_bytes` of every part this
+    /// node still owns as `pending`/`draining` in `cephor_replication_status`.
+    ///
+    /// This is the WI-20c reconcile of `drain_ssd_backlog_bytes`, which the heartbeat used
+    /// to source from raw SSD occupancy (`statvfs`). Occupancy OVERCOUNTS the backlog by
+    /// the A21/orphan leak — aborted-upload and deleted-object bytes sit on the SSD but are
+    /// not undrained WORK — so a leaking node reads hundreds of GB of "backlog" with no
+    /// drain demand. Keying on the terminal-filtered replication rows counts only parts the
+    /// drain will actually replicate. A part whose `parts` row is absent contributes zero
+    /// (INNER JOIN), and a NULL `size_bytes` is treated as zero (COALESCE), so the sum is a
+    /// lower bound that never over-reports. Uses the node-scoped pending index.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Database`] if the query fails.
+    pub async fn node_backlog_bytes(&self, node: &str) -> Result<u64> {
+        let (bytes,): (i64,) = sqlx::query_as(
+            "SELECT COALESCE(SUM(p.size_bytes), 0)::bigint \
+             FROM cephor_replication_status crs \
+             JOIN parts p \
+               ON p.object_id = crs.object_id::uuid \
+              AND p.object_version = crs.version \
+              AND p.part_number = crs.part_number \
+             WHERE crs.node_id = $1 AND crs.status IN ('pending', 'draining')",
+        )
+        .bind(node)
+        .fetch_one(&self.pool)
+        .await?;
+        // SUM of non-negative byte counts is >= 0; the cast guards a corrupt negative row.
+        Ok(u64::try_from(bytes).unwrap_or(0))
     }
 
     /// Claims a file for GC. Returns `Some(GcClaim)` if this caller won the claim,
@@ -760,6 +793,59 @@ impl ReclaimLog for Store {
     }
 }
 
+/// The reclaim worker's object-backing view: which scanned parts have no live
+/// `object_versions` row. Only the parts with no replication row reach this, so the batch
+/// is the reclaim's `skipped_absent` tail — usually small, empty on the steady state.
+impl BackingLog for Store {
+    type Error = StoreError;
+
+    async fn unbacked_parts(&self, parts: &[PartKey]) -> Result<HashSet<PartKey>> {
+        let mut out = HashSet::with_capacity(parts.len());
+        // Chunk the request so a pathological backlog never builds one giant array.
+        for batch in parts.chunks(RECLAIM_STATUS_BATCH) {
+            let mut object_ids: Vec<&str> = Vec::with_capacity(batch.len());
+            let mut versions: Vec<i64> = Vec::with_capacity(batch.len());
+            let mut part_numbers: Vec<i64> = Vec::with_capacity(batch.len());
+            for part in batch {
+                object_ids.push(part.object().as_str());
+                versions.push(i64::from(part.version().get()));
+                part_numbers.push(i64::from(part.part().get()));
+            }
+            // Echo back exactly the input parts whose (object_id, version) has NO
+            // object_versions row. NOT EXISTS against the ov PK stays index-only; the
+            // object_id is echoed from the input UNNEST (never read from object_versions),
+            // so the reconstructed PartKey matches the caller's key verbatim — no
+            // canonical-text round-trip to get wrong. Backing is ROW PRESENCE only: a
+            // present-but-unservable row (an aborted/abandoned or in-flight MPU) counts as
+            // backed and is NOT returned, so this never races the central `failed` sweep.
+            let rows = sqlx::query_as::<_, (String, i64, i64)>(
+                "SELECT t.object_id, t.version, t.part_number \
+                 FROM UNNEST($1::text[], $2::bigint[], $3::bigint[]) AS t(object_id, version, part_number) \
+                 WHERE NOT EXISTS ( \
+                    SELECT 1 FROM object_versions ov \
+                    WHERE ov.object_id = t.object_id::uuid AND ov.object_version = t.version \
+                 )",
+            )
+            .bind(&object_ids)
+            .bind(&versions)
+            .bind(&part_numbers)
+            .fetch_all(&self.pool)
+            .await?;
+            for (object_id, version, part_number) in rows {
+                out.insert(
+                    PartRow {
+                        object_id,
+                        version,
+                        part_number,
+                    }
+                    .into_part()?,
+                );
+            }
+        }
+        Ok(out)
+    }
+}
+
 #[cfg(test)]
 #[cfg(feature = "pg")]
 #[expect(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
@@ -899,6 +985,7 @@ mod part_tests {
     use crate::state::ReplicationState;
     use core::str::FromStr;
     use sqlx::postgres::PgPool;
+    use std::collections::HashSet;
     use std::time::Duration;
 
     const UUID_A: &str = "466916c0-d61b-4518-b81b-9576b574270a";
@@ -1034,6 +1121,124 @@ mod part_tests {
         let store = Store::from_pool(pool);
         let states = <Store as ReclaimLog>::part_states(&store, &[]).await.unwrap();
         assert!(states.is_empty(), "no parts requested -> no query, empty map");
+    }
+
+    #[sqlx::test]
+    async fn unbacked_parts_returns_only_parts_whose_object_version_row_is_gone(pool: PgPool) {
+        use crate::ssd_reclaim::BackingLog;
+        create_app_schema(&pool).await;
+        let store = Store::from_pool(pool.clone());
+
+        // A live object_versions row exists — the part is BACKED (mid-upload / live object).
+        let backed = part(UUID_A, 1, 1);
+        seed_object_version(&pool, UUID_A, 1, Some("5Faddr")).await;
+        // No object_versions row at all — the object was hard-deleted → UNBACKED.
+        let deleted = part(UUID_B, 2, 1);
+
+        let unbacked = store.unbacked_parts(&[backed, deleted.clone()]).await.unwrap();
+        assert_eq!(unbacked, HashSet::from([deleted]), "only the deleted object's part is unbacked");
+    }
+
+    #[sqlx::test]
+    async fn a_present_but_unservable_version_is_still_backed(pool: PgPool) {
+        // The load-bearing distinction from the WI-20a servability sweep: backing is ROW
+        // PRESENCE, not servability. An aborted/abandoned or in-flight MPU has a present
+        // object_versions row (address NULL, size 0) — it must NOT be reported unbacked,
+        // so the orphan reclaim never races the central `failed` path (or an in-flight MPU).
+        use crate::ssd_reclaim::BackingLog;
+        create_app_schema(&pool).await;
+        let store = Store::from_pool(pool.clone());
+
+        seed_object_version(&pool, UUID_A, 1, None).await; // present but address NULL (unservable)
+
+        let unbacked = store.unbacked_parts(&[part(UUID_A, 1, 1)]).await.unwrap();
+        assert!(unbacked.is_empty(), "a present-but-unservable version is backed, never orphan-reclaimed");
+    }
+
+    #[sqlx::test]
+    async fn every_part_of_a_deleted_version_is_unbacked_and_a_sibling_version_is_isolated(pool: PgPool) {
+        // All parts of a deleted version are unbacked; a live sibling version on the same
+        // object is untouched (version-scoped, so deleting v2's SSD cannot strand v1).
+        use crate::ssd_reclaim::BackingLog;
+        create_app_schema(&pool).await;
+        let store = Store::from_pool(pool.clone());
+
+        seed_object_version(&pool, UUID_A, 1, Some("5Flive")).await; // v1 live
+        let v1 = part(UUID_A, 1, 1);
+        // v2 has no object_versions row (deleted) with two parts.
+        let v2_p1 = part(UUID_A, 2, 1);
+        let v2_p2 = part(UUID_A, 2, 2);
+
+        let unbacked = store.unbacked_parts(&[v1, v2_p1.clone(), v2_p2.clone()]).await.unwrap();
+        assert_eq!(unbacked, HashSet::from([v2_p1, v2_p2]), "both v2 parts unbacked; live v1 protected");
+    }
+
+    #[sqlx::test]
+    async fn unbacked_parts_of_an_empty_request_is_empty(pool: PgPool) {
+        use crate::ssd_reclaim::BackingLog;
+        let store = Store::from_pool(pool);
+        let unbacked = store.unbacked_parts(&[]).await.unwrap();
+        assert!(unbacked.is_empty());
+    }
+
+    /// Inserts one `cephor_replication_status` row with an explicit node + status.
+    async fn seed_status_node(pool: &PgPool, object: &str, version: i64, number: i64, status: &str, node: &str) {
+        sqlx::query(
+            "INSERT INTO cephor_replication_status (object_id, version, part_number, status, node_id) \
+             VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(object)
+        .bind(version)
+        .bind(number)
+        .bind(status)
+        .bind(node)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// Inserts one `parts` row with an explicit `size_bytes`.
+    async fn seed_part_size(pool: &PgPool, object: &str, version: i64, number: i64, size_bytes: Option<i64>) {
+        sqlx::query("INSERT INTO parts (object_id, object_version, part_number, size_bytes) VALUES ($1::uuid, $2, $3, $4)")
+            .bind(object)
+            .bind(version)
+            .bind(number)
+            .bind(size_bytes)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
+    #[sqlx::test]
+    async fn node_backlog_bytes_sums_only_this_nodes_pending_and_draining_parts(pool: PgPool) {
+        create_app_schema(&pool).await;
+        let store = Store::from_pool(pool.clone());
+
+        // node-a, undrained (pending+draining): counted -> 100 + 200 = 300.
+        seed_status_node(&pool, UUID_A, 1, 1, "pending", "node-a").await;
+        seed_part_size(&pool, UUID_A, 1, 1, Some(100)).await;
+        seed_status_node(&pool, UUID_A, 1, 2, "draining", "node-a").await;
+        seed_part_size(&pool, UUID_A, 1, 2, Some(200)).await;
+        // node-a terminal (replicated/failed): excluded — no longer undrained work.
+        seed_status_node(&pool, UUID_A, 1, 3, "replicated", "node-a").await;
+        seed_part_size(&pool, UUID_A, 1, 3, Some(999)).await;
+        seed_status_node(&pool, UUID_A, 1, 4, "failed", "node-a").await;
+        seed_part_size(&pool, UUID_A, 1, 4, Some(888)).await;
+        // A peer node's pending part: excluded (its bytes are its own node's backlog).
+        seed_status_node(&pool, UUID_B, 2, 1, "pending", "node-b").await;
+        seed_part_size(&pool, UUID_B, 2, 1, Some(500)).await;
+        // node-a pending with a NULL size and one with no parts row at all: both contribute 0.
+        seed_status_node(&pool, UUID_A, 1, 5, "pending", "node-a").await;
+        seed_part_size(&pool, UUID_A, 1, 5, None).await;
+        seed_status_node(&pool, UUID_A, 1, 6, "pending", "node-a").await; // no parts row
+
+        assert_eq!(store.node_backlog_bytes("node-a").await.unwrap(), 300);
+        assert_eq!(store.node_backlog_bytes("node-b").await.unwrap(), 500);
+        assert_eq!(
+            store.node_backlog_bytes("node-c").await.unwrap(),
+            0,
+            "a node with no rows has zero backlog"
+        );
     }
 
     #[sqlx::test]
@@ -1312,7 +1517,10 @@ mod part_tests {
         let p = part(UUID_A, 5, 1);
         assert!(store.claim_part().await.unwrap().is_none(), "no row exists before the reconcile");
 
-        let scanner = OnePart(DiscoveredPart { part: p.clone() });
+        let scanner = OnePart(DiscoveredPart {
+            part: p.clone(),
+            age: std::time::Duration::ZERO,
+        });
         let report = reconcile_parts(&scanner, &store).await.unwrap();
         assert_eq!(report.recovered, 1, "the dropped-trigger part was recovered to pending");
 
@@ -1355,7 +1563,10 @@ mod part_tests {
             "a NULL-node row is unclaimable by any node before adoption",
         );
 
-        let scanner = OnePart(DiscoveredPart { part: p.clone() });
+        let scanner = OnePart(DiscoveredPart {
+            part: p.clone(),
+            age: std::time::Duration::ZERO,
+        });
         let report = reconcile_parts(&scanner, &node_b).await.unwrap();
         assert_eq!(report.adopted, 1, "the legacy nodeless row was adopted by the scanning node");
 
@@ -1380,7 +1591,8 @@ mod part_tests {
             "CREATE TABLE object_versions (object_id uuid NOT NULL, object_version bigint NOT NULL, address text, \
              PRIMARY KEY (object_id, object_version))",
             "CREATE TABLE multipart_uploads (upload_id uuid PRIMARY KEY, object_id uuid, initiated_at timestamptz NOT NULL)",
-            "CREATE TABLE parts (object_id uuid NOT NULL, object_version bigint NOT NULL, part_number bigint NOT NULL, upload_id uuid)",
+            "CREATE TABLE parts (object_id uuid NOT NULL, object_version bigint NOT NULL, part_number bigint NOT NULL, \
+             size_bytes bigint, upload_id uuid)",
         ] {
             sqlx::query(ddl).execute(pool).await.unwrap();
         }

--- a/crates/hippius-drain-core/src/tick.rs
+++ b/crates/hippius-drain-core/src/tick.rs
@@ -94,7 +94,7 @@ pub async fn run_tick<C: CephCeilingSource>(
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr, reason = "tests")]
+#[expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr, clippy::panic, reason = "tests")]
 mod tests {
     use super::{CephCeilingSource, StaticCeiling, TickConfig, TickOutcome, run_tick};
     use crate::alloc::{AllocConfig, Allocation, BudgetController, NodeObservation};
@@ -302,6 +302,6 @@ mod tests {
             b.epoch,
         );
         // Nothing was written at the stale epoch: no alloc key exists (A fenced, B never wrote).
-        assert!(c.load_allocation(&node).await.unwrap().is_none(), "the fenced tick wrote no budget",);
+        assert!(c.load_allocation(&node).await.unwrap().is_none(), "the fenced tick wrote no budget");
     }
 }

--- a/crates/hippius-drain-core/src/tick.rs
+++ b/crates/hippius-drain-core/src/tick.rs
@@ -49,9 +49,18 @@ pub struct TickConfig {
 /// The result of one tick.
 #[derive(Debug, Clone)]
 pub enum TickOutcome {
-    /// This instance was leader; the plan was computed and already written. Its
-    /// `controller` is the AIMD state to carry into the next tick.
-    Led(AllocationPlan),
+    /// This instance was leader; the plan was computed and already written under `epoch`
+    /// (the lease epoch stamped on the write). The plan's `controller` is the AIMD state
+    /// to carry into the next tick; `epoch` feeds the `drain_leader_epoch` gauge, so a
+    /// fleet-wide epoch DECREASE — a redis epoch-counter reset that would silently break
+    /// the allocation write-fence — is observable and alertable (S10/S11).
+    Led {
+        /// The allocation plan written this tick (carries the evolved AIMD controller).
+        plan: AllocationPlan,
+        /// The lease epoch this tick led under. Monotonic across the fleet by
+        /// construction (`INCR` at election).
+        epoch: u64,
+    },
     /// Another instance holds leadership; nothing was allocated this tick.
     NotLeader,
 }
@@ -81,7 +90,7 @@ pub async fn run_tick<C: CephCeilingSource>(
     let ceiling = ceiling_source.ceiling().await;
     let plan = allocate(&fleet, ceiling, prev, &config.alloc);
     coord.write_allocations(epoch, &plan.allocations).await?;
-    Ok(TickOutcome::Led(plan))
+    Ok(TickOutcome::Led { plan, epoch })
 }
 
 #[cfg(test)]
@@ -156,7 +165,10 @@ mod tests {
 
         let prev = BudgetController::new(ByteRate::new(190_000));
         let outcome = run_tick(&c, &open_ceiling(), &tick_config("alloc-a"), prev).await.unwrap();
-        assert!(matches!(outcome, TickOutcome::Led(_)), "first instance leads");
+        let TickOutcome::Led { epoch, .. } = outcome else {
+            panic!("first instance leads, got {outcome:?}");
+        };
+        assert_eq!(epoch, 1, "Led surfaces the lease epoch it led under");
 
         let stored = c.load_allocation(&node).await.unwrap().expect("budget written");
         assert_eq!(stored.epoch, 1, "stamped with the lease epoch");
@@ -207,7 +219,7 @@ mod tests {
         let prev = BudgetController::new(ByteRate::new(190_000));
 
         let first = run_tick(&c, &open_ceiling(), &tick_config("a"), prev).await.unwrap();
-        assert!(matches!(first, TickOutcome::Led(_)));
+        assert!(matches!(first, TickOutcome::Led { .. }));
 
         let second = run_tick(&c, &open_ceiling(), &tick_config("b"), prev).await.unwrap();
         assert!(matches!(second, TickOutcome::NotLeader), "b cannot lead while a holds the lease");

--- a/crates/hippius-drain-core/src/tick.rs
+++ b/crates/hippius-drain-core/src/tick.rs
@@ -87,13 +87,15 @@ pub async fn run_tick<C: CephCeilingSource>(
 #[cfg(test)]
 #[expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr, reason = "tests")]
 mod tests {
-    use super::{StaticCeiling, TickConfig, TickOutcome, run_tick};
+    use super::{CephCeilingSource, StaticCeiling, TickConfig, TickOutcome, run_tick};
     use crate::alloc::{AllocConfig, Allocation, BudgetController, NodeObservation};
     use crate::coordination::{CoordError, Coordinator};
     use crate::ids::NodeId;
     use crate::state::CephCeiling;
     use crate::units::{ByteRate, Bytes, DiskPressure};
     use core::str::FromStr;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
     /// A coordinator on the test Redis under a per-test prefix, or `None` to skip (Rust
@@ -211,5 +213,83 @@ mod tests {
 
         let second = run_tick(&c, &open_ceiling(), &tick_config("b"), prev).await.unwrap();
         assert!(matches!(second, TickOutcome::NotLeader), "b cannot lead while a holds the lease");
+    }
+
+    /// A ceiling source that parks at `ceiling()` — the slow step in the R3 window — until
+    /// released, signalling when it is reached so a test can interleave a takeover precisely
+    /// there. Interior-shared via `Arc<AtomicBool>` because `ceiling(&self)` takes `&self`.
+    struct PausingCeiling {
+        ceiling: CephCeiling,
+        reached: Arc<AtomicBool>,
+        release: Arc<AtomicBool>,
+    }
+
+    impl CephCeilingSource for PausingCeiling {
+        async fn ceiling(&self) -> CephCeiling {
+            self.reached.store(true, Ordering::SeqCst);
+            while !self.release.load(Ordering::SeqCst) {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            self.ceiling
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
+    async fn r3_a_tick_paused_at_ceiling_is_fenced_when_a_successor_takes_over_mid_tick() {
+        // R3 at the tick level (T4-C failpoint): a leader deposed BETWEEN acquiring its lease
+        // and writing — while parked in the slow `ceiling()` — must have its write fenced even
+        // though the successor has bumped `cephor:epoch` but written NO alloc key yet. This is
+        // the exact window `run_tick` opens (acquire → load_fleet → ceiling[SLOW] → write) and
+        // that a per-alloc-key fence alone cannot see.
+        let Some(c) = coord("cephor-test:r3-tick-window:").await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
+        let node = NodeId::from_str("n1").unwrap();
+        // A hungry node so the plan is non-empty and `write_allocations` actually runs the
+        // fenced script (an empty plan is a no-op Ok, which would not exercise the fence).
+        c.upsert_node_state(&node, &observation()).await.unwrap();
+
+        let reached = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(AtomicBool::new(false));
+        let ceiling = PausingCeiling {
+            ceiling: CephCeiling::Open(ByteRate::new(1_000_000_000)),
+            reached: Arc::clone(&reached),
+            release: Arc::clone(&release),
+        };
+        // A takes a SHORT lease so it lapses while parked in `ceiling()`.
+        let config = TickConfig {
+            instance_id: "a".to_owned(),
+            lease_ttl: Duration::from_secs(1),
+            alloc: alloc_config(),
+        };
+        let prev = BudgetController::new(ByteRate::new(190_000));
+        let c_a = c.clone();
+        let a_tick = tokio::spawn(async move { run_tick(&c_a, &ceiling, &config, prev).await });
+
+        // Wait until A is parked inside `ceiling()` (lease acquired at epoch eA, no write yet).
+        while !reached.load(Ordering::SeqCst) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        // Let A's 1s lease lapse, then B takes over: `cephor:epoch` bumps to eB > eA. B does NOT
+        // write any allocation (it is modelling a successor still early in its own tick).
+        tokio::time::sleep(Duration::from_millis(1_200)).await;
+        let b = c
+            .acquire_or_renew_leadership("b", Duration::from_secs(30))
+            .await
+            .unwrap()
+            .expect("b takes over the lapsed lease");
+
+        // Release A: it finishes `ceiling()` and tries to write at its now-stale epoch eA.
+        release.store(true, Ordering::SeqCst);
+        let outcome = a_tick.await.unwrap();
+        assert!(
+            matches!(outcome, Err(CoordError::Fenced { .. })),
+            "the deposed A's mid-tick write is fenced (b.epoch={}), got {outcome:?}",
+            b.epoch,
+        );
+        // Nothing was written at the stale epoch: no alloc key exists (A fenced, B never wrote).
+        assert!(c.load_allocation(&node).await.unwrap().is_none(), "the fenced tick wrote no budget",);
     }
 }

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -767,6 +767,23 @@ async def abort_multipart_upload(
                     async for key in redis_client.scan_iter(f"{base_key}:chunk:*"):
                         await redis_client.delete(key)
 
+        # Stop the drain churn BEFORE deleting the upload header. This aborted version's
+        # address will never be written, so its parts and the drain's
+        # cephor_replication_status rows would otherwise leak: the reconciler keeps
+        # re-recording them and the drain keeps re-claiming + re-copying + re-deferring the
+        # enqueue forever, on every node. Marking the version's replication rows terminal
+        # makes the reconciler skip them and claim_part never re-claim them, fleet-wide.
+        # Order matters: mark first so the churn-stop is durable even if we die before the
+        # delete below. The backstop for a thrown mark is the cephor-orphan SWEEP
+        # (list_orphan_replication_versions) — NOT the abandoned-upload reaper: the reaper
+        # keys on multipart_uploads, which the delete below removes, so it could never see
+        # this version again. The sweep keys on cephor_replication_status, which survives
+        # the delete, so it still finds and terminates the orphan.
+        # Skipped when the upload had no parts of its own (object_version is None).
+        if object_version is not None:
+            with contextlib.suppress(Exception):
+                await fail_version_replication(db, object_id=object_id, object_version=object_version)
+
         # Fully remove the multipart upload (and cascade parts) so it disappears from listings immediately
         async with db.transaction():
             await db.fetchrow(
@@ -774,18 +791,9 @@ async def abort_multipart_upload(
                 upload_id,
             )
 
-        # The aborted upload's version address will never be written, so its parts and
-        # the drain's cephor_replication_status rows would otherwise leak: the reconciler
-        # keeps re-recording them and the drain keeps re-claiming + re-copying +
-        # re-deferring the enqueue forever, on every node. Mark the version's replication
-        # rows terminal so the drain stops touching them fleet-wide, and best-effort
-        # delete the parts on THIS node's local cache (other nodes' copies are left to the
-        # orphan GC; the central mark already stopped their drain churn). Best-effort: a
-        # failure here is logged, not surfaced — the abandoned-upload reaper is the backstop.
-        # Skipped when the upload had no parts of its own (object_version is None).
+        # Best-effort node-local cleanup: drop THIS node's cached parts (other nodes' copies
+        # are left to the orphan GC; the central mark above already stopped their churn).
         if object_version is not None:
-            with contextlib.suppress(Exception):
-                await fail_version_replication(db, object_id=object_id, object_version=object_version)
             with contextlib.suppress(Exception):
                 await request.app.state.fs_store.delete_object(str(object_id), int(object_version))
 

--- a/hippius_s3/monitoring.py
+++ b/hippius_s3/monitoring.py
@@ -273,6 +273,14 @@ class MetricsCollector:
         self.mpu_reaper_versions_reaped_total = self.meter.create_counter(
             name="mpu_reaper_versions_reaped_total", description="Abandoned MPU versions reaped", unit="1"
         )
+        # A21 sweep counter, kept distinct from the reaper's: the soak gate watches this to
+        # assert pending/draining orphans stay bounded (a rising sweep count with no fresh
+        # aborts means a leak the reaper is blind to). See s3-2.1 WI-20a / soak gate.
+        self.mpu_reaper_orphans_swept_total = self.meter.create_counter(
+            name="mpu_reaper_orphans_swept_total",
+            description="Leaked cephor orphan versions marked terminal by the sweep",
+            unit="1",
+        )
         self.mpu_reaper_duration_seconds = self.meter.create_histogram(
             name="mpu_reaper_duration_seconds", description="MPU reaper cycle duration", unit="s"
         )
@@ -659,11 +667,14 @@ class MetricsCollector:
         reaped: int,
         duration: float,
         oldest_reaped_age: Optional[float] = None,
+        swept: int = 0,
     ) -> None:
         self.mpu_reaper_cycles_total.add(1, attributes={"success": str(success).lower()})
         self.mpu_reaper_duration_seconds.record(duration)
         if reaped > 0:
             self.mpu_reaper_versions_reaped_total.add(reaped)
+        if swept > 0:
+            self.mpu_reaper_orphans_swept_total.add(swept)
         if oldest_reaped_age is not None:
             self.mpu_reaper_oldest_reaped_age_seconds.record(oldest_reaped_age)
 

--- a/hippius_s3/services/mpu_cleanup.py
+++ b/hippius_s3/services/mpu_cleanup.py
@@ -44,6 +44,15 @@ class ReapResult:
     oldest_reaped_age_seconds: float | None
 
 
+def _max_optional(a: float | None, b: float | None) -> float | None:
+    """Largest of two optional ages, ignoring None (nothing-reaped) operands."""
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return max(a, b)
+
+
 async def fail_version_replication(db: Any, *, object_id: Any, object_version: int | None) -> None:
     """Mark one object version's active replication rows terminal ('failed').
 
@@ -83,6 +92,41 @@ async def reap_abandoned_uploads(db: Any, *, stale_seconds: int, dlq_object_ids:
         if age is not None:
             oldest_age = age if oldest_age is None else max(oldest_age, age)
     return ReapResult(count=reaped, oldest_reaped_age_seconds=oldest_age)
+
+
+async def sweep_orphan_replication_versions(db: Any, *, stale_seconds: int, dlq_object_ids: set[str]) -> ReapResult:
+    """Mark leaked drain replication rows terminal, keyed directly on cephor (the A21 backstop).
+
+    The abandoned-MPU reaper only sees uploads that still have a ``multipart_uploads`` row;
+    an abort deletes that header before its best-effort terminal-mark, so an abort that dies
+    in that window orphans the version's ``cephor_replication_status`` rows where the reaper
+    can never find them — and the drain re-claims/re-copies/re-defers them forever. This
+    sweep finds those versions from the drain rows alone (``list_orphan_replication_versions``)
+    and marks each one 'failed'. DLQ-protected objects are spared, mirroring the reaper.
+
+    Unlike the reaper this only ever MARKS (never deletes), so it is safe to be resilient
+    per version: a transient mark failure (e.g. a row lock) is logged and skipped rather than
+    aborting the pass, and the version — still active in cephor — is retried next cycle.
+    Returns the count marked + the age of the oldest swept version (the backstop's lag).
+    """
+    rows = await db.fetch(get_query("list_orphan_replication_versions"), int(stale_seconds))
+    swept = 0
+    oldest_age: float | None = None
+    for row in rows:
+        object_id = row["object_id"]
+        if str(object_id) in dlq_object_ids:
+            logger.debug("mpu-sweep: skipping DLQ-protected object_id=%s", object_id)
+            continue
+        try:
+            await fail_version_replication(db, object_id=object_id, object_version=row["version"])
+        except Exception:
+            logger.exception("mpu-sweep: failed to mark object_id=%s terminal; retrying next cycle", object_id)
+            continue
+        swept += 1
+        age = row.get("age_seconds")
+        if age is not None:
+            oldest_age = age if oldest_age is None else max(oldest_age, age)
+    return ReapResult(count=swept, oldest_reaped_age_seconds=oldest_age)
 
 
 async def gather_dlq_object_ids(redis_client: Any, upload_backends: Iterable[str]) -> set[str]:
@@ -126,17 +170,26 @@ async def run_reaper_cycle(
         dlq_object_ids = await gather_dlq_object_ids(redis_client, upload_backends)
         async with db_pool.acquire() as db:
             result = await reap_abandoned_uploads(db, stale_seconds=stale_seconds, dlq_object_ids=dlq_object_ids)
+            sweep = await sweep_orphan_replication_versions(
+                db, stale_seconds=stale_seconds, dlq_object_ids=dlq_object_ids
+            )
         if result.count:
             logger.info("mpu-reaper: reaped %d abandoned multipart upload(s)", result.count)
+        if sweep.count:
+            logger.info("mpu-sweep: marked %d leaked orphan version(s) terminal", sweep.count)
+        # Report the lag as the oldest across BOTH paths so the dashboard reflects the
+        # worst backstop delay, not just the abandoned-MPU reaper's.
+        oldest = _max_optional(result.oldest_reaped_age_seconds, sweep.oldest_reaped_age_seconds)
         collector.record_mpu_reaper_cycle(
             success=True,
             reaped=result.count,
+            swept=sweep.count,
             duration=time.monotonic() - started,
-            oldest_reaped_age=result.oldest_reaped_age_seconds,
+            oldest_reaped_age=oldest,
         )
     except Exception:
         logger.exception("mpu-reaper cycle failed; will retry next interval")
-        collector.record_mpu_reaper_cycle(success=False, reaped=0, duration=time.monotonic() - started)
+        collector.record_mpu_reaper_cycle(success=False, reaped=0, swept=0, duration=time.monotonic() - started)
 
 
 async def run_mpu_reaper_loop() -> None:

--- a/hippius_s3/sql/queries/find_underreplicated_live_chunks.sql
+++ b/hippius_s3/sql/queries/find_underreplicated_live_chunks.sql
@@ -1,0 +1,58 @@
+-- G2 replication-gate sentinel: live, serveable chunks that lack full-union backend
+-- coverage — the exact population the janitor's replication gate must NEVER let be
+-- reclaimed, so any row here is a chunk at data-loss risk the moment its SSD/pool copy
+-- is evicted (and a standing alarm under >=95% disk pressure).
+--
+-- A chunk is a VIOLATION when ALL of:
+--   * its object is LIVE (objects.deleted_at IS NULL) — a soft-deleted object's chunks
+--     are meant to lose coverage as the unpinner clears them, so they are not at risk;
+--   * its version is SERVEABLE (object_versions.address IS NOT NULL) — a NULL-address
+--     version is mid-upload/aborted, not yet durable, and is the reaper's/orphan-GC's
+--     concern, not a replication-gap; and
+--   * some REQUIRED backend has no live (NOT deleted) chunk_backend row for the chunk.
+--
+-- The required set mirrors is_replicated_on_all_backends exactly: per-version
+-- upload_backends (or ['ipfs'] for a migration version, or the caller's config default
+-- $2 when the column is empty/NULL) UNIONed with the configured backup_backends ($1).
+-- This is what makes the sentinel catch the C10 divergence (a backup backend required by
+-- the gate but never enqueued leaves every chunk missing that backend's row).
+--
+-- Bounded by $3 so a breach is detected and sampled cheaply without an unbounded result;
+-- the caller treats a full page as ">= limit". The EXISTS/NOT EXISTS pair uses the
+-- chunk_backend (chunk_id) live index rather than aggregating every backend per chunk.
+--
+-- Parameters:
+--   $1 backup_backends          TEXT[]  — configured HIPPIUS_BACKUP_BACKENDS
+--   $2 default_upload_backends  TEXT[]  — config.upload_backends (fallback for legacy rows)
+--   $3 limit                    INT     — max violating chunks to return
+WITH live_versions AS (
+    SELECT
+        ov.object_id,
+        ov.object_version,
+        ARRAY(
+            SELECT DISTINCT unnest(
+                (CASE
+                    WHEN ov.version_type = 'migration' THEN ARRAY['ipfs']::text[]
+                    WHEN ov.upload_backends IS NOT NULL AND cardinality(ov.upload_backends) > 0 THEN ov.upload_backends
+                    ELSE $2::text[]
+                END) || $1::text[]
+            )
+        ) AS required
+    FROM object_versions ov
+    JOIN objects o ON o.object_id = ov.object_id
+    WHERE o.deleted_at IS NULL
+      AND ov.address IS NOT NULL
+)
+SELECT lv.object_id, lv.object_version, pc.id AS chunk_id
+FROM live_versions lv
+JOIN parts p ON p.object_id = lv.object_id AND p.object_version = lv.object_version
+JOIN part_chunks pc ON pc.part_id = p.part_id
+WHERE EXISTS (
+    SELECT 1
+    FROM unnest(lv.required) AS req(backend)
+    WHERE NOT EXISTS (
+        SELECT 1 FROM chunk_backend cb
+        WHERE cb.chunk_id = pc.id AND cb.backend = req.backend AND NOT cb.deleted
+    )
+)
+LIMIT $3

--- a/hippius_s3/sql/queries/list_orphan_replication_versions.sql
+++ b/hippius_s3/sql/queries/list_orphan_replication_versions.sql
@@ -1,0 +1,46 @@
+-- A21 orphan sweep: object versions whose drain replication rows leaked and will churn
+-- the drain forever. The abandoned-MPU reaper (list_abandoned_versions.sql) keys on
+-- multipart_uploads, but an abort DELETEs that header row (and its parts) before the
+-- best-effort terminal-mark — so an abort that dies in that window leaves cephor rows the
+-- reaper can never see again. This query keys DIRECTLY on cephor_replication_status, so it
+-- is the true backstop: it finds the leaked version from the drain rows alone.
+--
+-- A version is selected to be marked 'failed' iff ALL hold:
+--   (a) it still has an ACTIVE drain row (status IN ('pending','draining')) — a
+--       'replicated' row is legitimately done and a 'failed' row is already terminal, so
+--       touching either would only churn the sweep;
+--   (b) the version is UNSERVABLE — address IS NULL AND size_bytes<=0 AND md5_hash='' —
+--       the exact download-servability predicate janitor_part_terminally_abandoned.sql
+--       uses. The size/md5 clauses are NON-redundant with address IS NULL: address is
+--       written AFTER size/md5 and in a separate step, so a fully-servable version briefly
+--       has address=NULL (the mid-finalize window). The size/md5 guard is what keeps such
+--       a version — or a servable simple-PUT whose part the drain's corruption path marked
+--       active — from being swept and stranding a live GET. Do NOT "simplify" to address-only.
+--   (c) its most-recently-landed part is older than the grace window (MAX(landed_at)) — the
+--       last-activity valve. landed_at is stamped once when a part first lands and is never
+--       bumped by drain re-claim/defer churn or the reconciler's node-only UPSERT, so it is
+--       a true idle signal: a still-arriving upload keeps landing FRESH parts and is spared,
+--       mirroring the reaper's per-upload "no part in the last N seconds" gate but sourced
+--       purely from the drain rows (which survive the MPU-header delete). updated_at would
+--       be useless here — the drain's own defer loop bumps it every poll, which IS the churn.
+--
+-- object_id is cast to uuid for the join (cephor stores it as text; object_versions keys on
+-- uuid), matching the janitor query's cast. age_seconds is measured from the OLDEST part
+-- (MIN landed_at) so the reaper reports the version's true replication lag. One row per
+-- (object_id, version); the caller marks all of that version's active rows terminal.
+-- Parameters: $1: stale_seconds (int) — the grace window.
+SELECT crs.object_id,
+       crs.version,
+       EXTRACT(EPOCH FROM (now() - MIN(crs.landed_at)))::float8 AS age_seconds
+FROM cephor_replication_status crs
+JOIN object_versions ov
+       ON ov.object_id = crs.object_id::uuid
+      AND ov.object_version = crs.version
+WHERE crs.status IN ('pending', 'draining')
+  AND ov.address IS NULL
+  AND ov.size_bytes <= 0
+  AND COALESCE(ov.md5_hash, '') = ''
+GROUP BY crs.object_id, crs.version
+HAVING MAX(crs.landed_at) < now() - make_interval(secs => $1)
+ORDER BY age_seconds DESC
+LIMIT 2000

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -203,6 +203,21 @@ spec:
             periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 3
+          # C8: NotReady when the drain is WEDGED — a hung CephFS write stalls draining while
+          # liveness (process-alive) stays fresh. The agent touches this file only while the drain
+          # is PROGRESSING (or idle); a wedged loop lets it go stale. Unlike liveness this does NOT
+          # restart the pod (a wedge is not a crash) — it marks the node NotReady so a rolling
+          # update does not step over stuck nodes and the wedge surfaces in pod status.
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - 'f=/tmp/hippius-drain-agent.ready; test -f "$f" && [ $(( $(date +%s) - $(stat -c %Y "$f") )) -lt 45 ]'
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: local-ingest
           hostPath:

--- a/monitoring/grafana/provisioning/alerting/alert-rules.yml
+++ b/monitoring/grafana/provisioning/alerting/alert-rules.yml
@@ -240,3 +240,109 @@ groups:
           summary: API response times severely degraded during user activity
         labels:
           severity: high
+
+  - orgId: 1
+    name: hippius-s3-drain
+    folder: Hippius S3 Alerts
+    interval: 1m
+    rules:
+      # Pages BEFORE the api's fs_cache_pressure 90% cutoff (which 503s every PUT on the
+      # node), leaving runway to drain or reclaim. drain_ssd_pressure is a 0..1 fill
+      # fraction per node; max() catches the worst node. Unlike drain_ssd_backlog_bytes
+      # (undrained work), this rises with an SSD leak even at zero drain demand — so a
+      # stalled reclaim (WI-20a/b) surfaces here.
+      - uid: drain-ssd-pressure-high
+        title: Drain SSD Pressure - Node Near the PUT-shedding Cutoff
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'max(drain_ssd_pressure{job="otel-collector"})'
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.85
+                    type: gt
+                  type: query
+              refId: C
+        noDataState: OK
+        execErrState: Error
+        for: 5m
+        annotations:
+          description: 'Worst node SSD fill is {{ if $values.B }}{{ printf "%.0f" (mulf $values.B.Value 100) }}{{ else }}N/A{{ end }}% (pages at 85%; the api sheds PUTs with 503 at 90%)'
+          summary: A drain node''s ingest SSD is filling toward the PUT-shedding cutoff
+        labels:
+          severity: critical
+
+      # G2 replication-gate sentinel. janitor_underreplicated_live_chunks counts live,
+      # serveable chunks lacking full-union backend coverage — the exact chunks the janitor
+      # gate refuses to reclaim, so any nonzero value is a standing data-loss risk (a chunk
+      # one eviction away from loss) and surfaces the C10 divergence. Fires on ANY breach.
+      - uid: replication-gate-coverage-gap
+        title: Replication Gate - Live Chunks Under-replicated
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'max(janitor_underreplicated_live_chunks{job="otel-collector"})'
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  type: query
+              refId: C
+        noDataState: OK
+        execErrState: Error
+        for: 10m
+        annotations:
+          description: '{{ if $values.B }}{{ printf "%.0f" $values.B.Value }}{{ else }}N/A{{ end }} live serveable chunk(s) lack full-union backend coverage — at data-loss risk if reclaimed. Check the janitor "REPLICATION-GATE SENTINEL" logs for samples.'
+          summary: Live objects have chunks the replication gate cannot safely retain
+        labels:
+          severity: critical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ packages = ["hippius_s3"]
 [tool.ruff]
 line-length = 120
 target-version = "py312"
-exclude = ["examples/", "tests/"]
+exclude = ["examples/", "tests/", "stress-test/"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/stress-test/README.md
+++ b/stress-test/README.md
@@ -1,0 +1,56 @@
+# stress-test/ — production-readiness harness
+
+A **runnable** suite that asserts production readiness of the hippius-s3 drain stack against a live S3
+endpoint (default `s3-staging.hippius.com`), plus the drain internals when the staging cluster is reachable.
+
+This is the first executable increment of the build spec in [`plan.md`](plan.md). It implements the
+S3-facing + light invariant tiers (durability oracle, functional/adversarial correctness, a concurrency
+ramp, single-leader/backlog/terminal invariants, and drain-replication convergence). The heavy tiers
+(allocator fence-race rigs, full chaos matrix, GB-scale soak) are specified in `plan.md` and are the next
+increments.
+
+## Run
+
+```bash
+# from the repo root, with the venv active
+source .venv/bin/activate
+source .aws.cli.env            # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_DEFAULT_REGION
+python stress-test/run.py
+```
+
+- **With cluster access** (default): needs `kubectl` pointed at the `hippius` context. Runs the invariant +
+  convergence probes against staging Postgres (`cephor_replication_status`) and Prometheus (`drain_*`).
+- **S3-only**: `python stress-test/run.py --no-cluster` — durability + functional + load only.
+- `--keep` leaves the test buckets; `--timeout N` sets the drain-convergence budget (default 300 s).
+
+Exit code is `0` (GO) / `1` (NO-GO). A markdown + JSON report and the durability ledger are written to
+`stress-test/results/`.
+
+## What it asserts (scenario → criterion)
+
+| Scenario | Asserts | Pass condition |
+|---|---|---|
+| `functional_adversarial` (T1) | correctness, non-happy-path | range GET exact bytes; overwrite→latest; **MPU wrong-ETag rejected**; MPU abort→absent; anon public 200 / private 403; ListObjectsV2 delimiter; zero-byte round-trip |
+| `durability_corpus` + `durability_reverify` | **S8/G3 no-data-loss (non-overridable)** | every acked object (mixed sizes incl. forced-multipart) re-GETs **byte-identical** (plaintext md5 + size) |
+| `concurrency_ramp` (T5-lite) | S5/S6 backpressure + throughput | non-503 5xx rate < 1%, no hangs; **503 SlowDown is correct backpressure** (counted, not failed) |
+| `invariant_assert` (cluster) | G1 / G6 / S4 | `sum(drain_leader) ≤ 1`; our objects' repl rows never regress from terminal; backlog is a bounded exported gauge |
+| `replication_convergence` (cluster) | drain actually replicates | 0 `pending`/`draining` rows for our objects within the drain window; `drain_parts_replicated_total` advances |
+
+The durability oracle keys on **client-side plaintext md5**, never ETag (hippius objects are
+envelope-encrypted and MPU ETags are not content hashes).
+
+## Layout
+
+```
+stress-test/
+├── plan.md              # full build spec (all tiers)
+├── run.py               # entrypoint
+├── harness/
+│   ├── config.py        # endpoint + creds + cluster access
+│   ├── s3util.py        # boto3 client (path-style, SigV4) + ops + md5
+│   ├── ledger.py        # the acked-object durability manifest (oracle)
+│   ├── probes.py        # staging Postgres + Prometheus probes (optional)
+│   ├── scenarios.py     # the scenario suite
+│   └── report.py        # PASS/FAIL report (md + json)
+└── results/             # run reports + ledgers (gitignored)
+```

--- a/stress-test/README.md
+++ b/stress-test/README.md
@@ -26,6 +26,20 @@ python stress-test/run.py
 Exit code is `0` (GO) / `1` (NO-GO). A markdown + JSON report and the durability ledger are written to
 `stress-test/results/`.
 
+## Pre-flight (deterministic, no live S3/cluster) — `inv-det`
+
+Before any live run, prove the invariants that can be checked deterministically (WI-19 GO/NO-GO #2):
+
+```bash
+export CEPHOR_TEST_REDIS_URL=redis://localhost:6379   # required — the split-brain fence tests need a real Redis
+python stress-test/inv/inv_det.py                     # cargo drain-core (--include-ignored) + pytest unit + G4 audit
+python stress-test/inv/inv_det.py --integration       # also tests/integration (needs DB/Redis)
+```
+
+This runs the **8 `#[ignore]`d coordinator epoch/lease tests** (0 executed coverage under a bare `cargo test`), the
+Python unit suite, and a static **sole-producer (G4)** audit asserting the dead `enqueue_upload` producer stays
+callerless. A skipped required check (e.g. no `CEPHOR_TEST_REDIS_URL`) is **NO-GO**, not a pass.
+
 ## What it asserts (scenario → criterion)
 
 | Scenario | Asserts | Pass condition |
@@ -44,13 +58,15 @@ envelope-encrypted and MPU ETags are not content hashes).
 ```
 stress-test/
 ├── plan.md              # full build spec (all tiers)
-├── run.py               # entrypoint
+├── run.py               # entrypoint (live S3 + cluster run)
+├── inv/
+│   └── inv_det.py       # pre-flight: cargo (--include-ignored) + pytest + sole-producer (G4) audit
 ├── harness/
 │   ├── config.py        # endpoint + creds + cluster access
 │   ├── s3util.py        # boto3 client (path-style, SigV4) + ops + md5
 │   ├── ledger.py        # the acked-object durability manifest (oracle)
 │   ├── probes.py        # staging Postgres + Prometheus probes (optional)
 │   ├── scenarios.py     # the scenario suite
-│   └── report.py        # PASS/FAIL report (md + json)
+│   └── report.py        # PASS/FAIL/OBSERVED report (md + json)
 └── results/             # run reports + ledgers (gitignored)
 ```

--- a/stress-test/TODO-review.md
+++ b/stress-test/TODO-review.md
@@ -1,0 +1,74 @@
+# stress-test — findings for review (from the first live harness runs vs s3-staging.hippius.com)
+
+> Issues the production-readiness harness surfaced running against `s3-staging.hippius.com` (2026-07-02,
+> branch `feat/stress-test-harness`). Each has: what, the evidence, why it matters, and a recommended fix.
+> The **durability gate PASSED** (every acked object re-GET byte-identical) — none of these is a data-loss;
+> they are correctness / throughput / availability findings. Ordered by severity.
+
+## Positive baseline (what held)
+- **No data loss** — durability re-verify: **byte-identical** across the whole corpus (mixed sizes incl. multipart).
+- **No split-brain** — `sum(drain_leader) = 1` throughout.
+- **Terminal-state monotonicity** held; no `replicated/failed` regression on our tracked objects.
+- **No 503 backpressure or non-503 5xx** during the concurrency ramp (0 errors, 90 objects).
+
+---
+
+## F1 — [HIGH · data integrity] CompleteMultipartUpload accepts a WRONG part ETag
+- **Evidence:** the harness completed an MPU sending part 1 with ETag `"deadbeef…deadbeef"` (garbage). It was
+  **ACCEPTED**, not rejected. (`func-mpu-wrong-etag` → FAIL.)
+- **Confirms the readiness plan's blind-spot A7** (`hippius_s3/api/s3/multipart.py:1046-1053`,
+  `object_writer.py:860-875`): CompleteMPU checks only part-*number* existence, ignores the client's ETags and
+  part list, and composes size/MD5 from all uploaded parts for the version.
+- **Why it matters:** a client that sends a wrong part list / ETags gets a **silently different object** than it
+  intended, with no error — a data-integrity divergence. S3 requires each supplied part ETag to match.
+- **Fix:** on complete, validate each `{PartNumber, ETag}` against the stored part ETag and the client's exact
+  list; reject on mismatch (`InvalidPart`/`InvalidPartOrder`). Add an e2e test (the harness case is ready).
+
+## F2 — [HIGH · throughput/lag] Drain replication does NOT keep up with even modest ingest
+- **Evidence:** during the load run, `drain_parts_replicated_total` advanced only **+36 to +63 parts** over a
+  200–240 s window while the harness added ~110–227 parts; afterwards **1 to 76 parts remained `pending`**.
+  Aggregate ingest was only **~2 MB/s** and the drain still fell behind. (`drain-convergence` → FAIL.)
+- **Context:** ingest SSD backlog is **731.7 GB** (the WI-20/R1 abandoned-upload leak) — it competes with fresh
+  uploads for the drain's bandwidth. **Durability still held** (pending objects are served from SSD/pool via
+  `DualFileSystemPartsStore`), so this is **backend-replication lag, not data loss** — but it means fresh objects
+  sit un-replicated-to-backend for a long time, and the backlog grows if ingest > drain.
+- **Why it matters:** this is the concrete "drain lag under load" evidence WI-19 exists to find. At ~2 MB/s per
+  node and a 731 GB backlog, the durable-replication window is minutes-to-hours; a sustained ingest burst would
+  grow the backlog until the SSD fills (→ 503 storm, per R1).
+- **Fix / next:** (a) prioritize **WI-20 orphan-GC** to reclaim the 731 GB and free drain bandwidth; (b) measure
+  the real per-node drain MB/s (the S1 SLO is unmeasured/aspirational) and ratify S2/S3 lag; (c) consider drain
+  concurrency (`CEPHOR_DRAIN_CONCURRENCY`) / batch `mark_replicated` (PR-8) to lift throughput.
+
+## F3 — [MED · availability] CreateBucket intermittently fails on a billing-balance fetch
+- **Evidence:** `CreateBucket` returned `UploadNotPermitted: Failed to fetch billing balance` intermittently
+  (crashed a whole run before the harness added a retry).
+- **Why it matters:** bucket creation has a hard dependency on a billing-balance fetch with no retry/fallback; a
+  transient billing-service blip makes CreateBucket fail outright. Availability finding.
+- **Fix:** retry / circuit-break the billing-balance fetch on the create path, or fail-open with a bounded grace.
+
+## F4 — [MED · read path] Reading a just-uploaded (backend-pending) object is slow / can break the stream
+- **Evidence:** a range GET immediately after PUT returned `IncompleteRead(0 bytes read, 1 MiB expected)` (the
+  connection broke mid-stream); a retry resolved it. Re-reading many still-pending objects was slow enough that a
+  serial re-verify blew a 540 s budget (fixed in the harness by parallelizing + retrying).
+- **Why it matters:** this is the cross-node cold-read / SSD→pool window (plan A1/A2). A bare range read during the
+  replication window can break the connection rather than streaming from the SSD/pool fallback.
+- **Fix:** confirm `DualFileSystemPartsStore` pool-fallback timing on the read path; a range read during the
+  replication window must stream from SSD/pool without breaking the connection (and cold-fallback should enqueue a
+  download rather than hang).
+
+## F5 — [INFO] Confirmed known state
+- Ingest SSD backlog **731.7 GB** (WI-20/R1) — still not reclaimed; directly implicated in F2.
+- `drain_ssd_pressure` still absent (only 5 drain metrics) — the fill is invisible except via this harness's `df`/
+  backlog probe.
+
+---
+
+## Harness status + next increments
+- **Built & runnable** (`python stress-test/run.py`, branch `feat/stress-test-harness`): durability oracle (md5
+  ledger), T1 functional/adversarial, concurrency ramp, cluster invariant probes (Postgres + Prometheus),
+  drain-convergence, PASS/FAIL report. Cluster probes auto-enable when kubectl reaches staging.
+- **Hardened this session:** CreateBucket billing-retry, per-assertion T1 isolation, GET retry (rides the cold-read
+  window), parallel re-verify.
+- **Next per `stress-test/plan.md`:** allocator fence-race rigs (Rig A compose overlay + Rig B `alloc_stress.rs`
+  with the R3 failpoint), the toxiproxy/redis-PG fault substrate + full chaos matrix (F1–F8), GB-scale + 6 h soak,
+  and turning `inv-guard` from sampled into a continuous **event-driven** asserter (WAL/log-tailed).

--- a/stress-test/harness/__init__.py
+++ b/stress-test/harness/__init__.py
@@ -1,0 +1,8 @@
+"""hippius-s3 drain-stack production-readiness harness.
+
+A runnable suite that asserts production readiness against a live S3 endpoint (default
+s3-staging.hippius.com) plus, when cluster access is available, the staging drain internals
+(Postgres cephor_replication_status + Prometheus drain_* metrics).
+
+See stress-test/plan.md for the full build spec and stress-test/README.md to run it.
+"""

--- a/stress-test/harness/config.py
+++ b/stress-test/harness/config.py
@@ -1,0 +1,71 @@
+"""Harness configuration: S3 endpoint + creds, and staging cluster access."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import pathlib
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_ENV_FILE = REPO_ROOT / ".aws.cli.env"
+
+
+@dataclasses.dataclass
+class Config:
+    endpoint_url: str
+    access_key: str
+    secret_key: str
+    region: str
+    # cluster access (optional — S3-facing scenarios run without it; invariant probes need it)
+    namespace: str
+    monitoring_namespace: str
+    pg_pod: str
+    pg_db: str
+    prometheus_svc: str
+    # knobs
+    bucket_prefix: str
+    drain_convergence_timeout_s: int
+    keep_objects: bool
+
+
+def _load_env_file(path: pathlib.Path) -> dict[str, str]:
+    """Parse a `.aws.cli.env`-style file (KEY=VALUE / export KEY=VALUE). Secrets stay in-process."""
+    out: dict[str, str] = {}
+    if not path.exists():
+        return out
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        line = line.removeprefix("export ").strip()
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        out[key.strip()] = val.strip().strip('"').strip("'")
+    return out
+
+
+def load(env_file: pathlib.Path | None = None) -> Config:
+    env = _load_env_file(env_file or DEFAULT_ENV_FILE)
+
+    def pick(name: str, default: str | None = None) -> str:
+        val = os.environ.get(name) or env.get(name) or default
+        if val is None:
+            raise SystemExit(f"missing required config: {name} (set it in .aws.cli.env or the environment)")
+        return val
+
+    return Config(
+        endpoint_url=pick("HIPPIUS_S3_ENDPOINT", "https://s3-staging.hippius.com"),
+        access_key=pick("AWS_ACCESS_KEY_ID"),
+        secret_key=pick("AWS_SECRET_ACCESS_KEY"),
+        region=pick("AWS_DEFAULT_REGION", "decentralized"),
+        namespace=os.environ.get("HIPPIUS_NS", "hippius-s3-staging"),
+        monitoring_namespace=os.environ.get("HIPPIUS_MON_NS", "monitoring"),
+        pg_pod=os.environ.get("HIPPIUS_PG_POD", "postgres-1"),
+        pg_db=os.environ.get("HIPPIUS_PG_DB", "hippius"),
+        prometheus_svc=os.environ.get("HIPPIUS_PROM_SVC", "prometheus-server"),
+        bucket_prefix=os.environ.get("HIPPIUS_BUCKET_PREFIX", "prodgate"),
+        drain_convergence_timeout_s=int(os.environ.get("HIPPIUS_DRAIN_TIMEOUT_S", "300")),
+        keep_objects=os.environ.get("HIPPIUS_KEEP_OBJECTS", "").lower() in ("1", "true", "yes"),
+    )

--- a/stress-test/harness/ledger.py
+++ b/stress-test/harness/ledger.py
@@ -1,0 +1,43 @@
+"""The durability oracle: an in-memory + on-disk manifest of every acked object.
+
+Records (bucket, key, plaintext-md5, size) at PUT time; the durability scenario re-GETs each
+and asserts byte-identical. Keys on client-side PLAINTEXT md5 — NOT ETag (hippius objects are
+envelope-encrypted and MPU ETags are not content hashes).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import pathlib
+import threading
+
+
+@dataclasses.dataclass(frozen=True)
+class Acked:
+    bucket: str
+    key: str
+    md5: str
+    size: int
+    multipart: bool
+
+
+class Ledger:
+    def __init__(self) -> None:
+        self._items: list[Acked] = []
+        self._lock = threading.Lock()
+
+    def record(self, bucket: str, key: str, md5: str, size: int, multipart: bool) -> None:
+        with self._lock:
+            self._items.append(Acked(bucket, key, md5, size, multipart))
+
+    def all(self) -> list[Acked]:
+        with self._lock:
+            return list(self._items)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._items)
+
+    def dump(self, path: pathlib.Path) -> None:
+        path.write_text(json.dumps([dataclasses.asdict(a) for a in self.all()], indent=2))

--- a/stress-test/harness/probes.py
+++ b/stress-test/harness/probes.py
@@ -11,6 +11,8 @@ import contextlib
 import json
 import subprocess
 import time
+import urllib.parse
+import urllib.request
 
 from .config import Config
 
@@ -78,8 +80,6 @@ class ClusterProbe:
         """Instant query; return [(labels, value)]. None on failure."""
         if not self._prom_port:
             return None
-        import urllib.parse
-
         url = f"http://localhost:{self._prom_port}/api/v1/query?query={urllib.parse.quote(promql)}"
         try:
             with urllib.request.urlopen(url, timeout=15) as resp:  # noqa: S310

--- a/stress-test/harness/probes.py
+++ b/stress-test/harness/probes.py
@@ -1,0 +1,108 @@
+"""Cluster-side invariant probes: staging Postgres (cephor_replication_status) + Prometheus (drain_*).
+
+Optional — the S3-facing scenarios run without cluster access. When kubectl + the staging cluster
+are reachable, these probes elevate the run to a real drain-internals assertion (single-leader,
+replication convergence, backlog, terminal-state monotonicity).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import subprocess
+import time
+
+from .config import Config
+
+
+class ClusterProbe:
+    def __init__(self, cfg: Config) -> None:
+        self.cfg = cfg
+        self._pf: subprocess.Popen | None = None
+        self._prom_port = 0
+
+    # ---------------------------------------------------------------- availability
+    def available(self) -> bool:
+        """kubectl reachable AND the pg pod answers a trivial query."""
+        r = self._pg_raw("select 1")
+        return r == "1"
+
+    # ---------------------------------------------------------------- postgres
+    def _pg_raw(self, sql: str) -> str | None:
+        cmd = [
+            "kubectl", "-n", self.cfg.namespace, "exec", self.cfg.pg_pod, "-c", "postgres",
+            "--", "psql", "-U", "postgres", "-d", self.cfg.pg_db, "-tAF|", "-c", sql,
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if proc.returncode != 0:
+            return None
+        return proc.stdout.strip()
+
+    def pg(self, sql: str) -> list[list[str]] | None:
+        """Run SQL; return rows as lists of string columns (| separated). None if unreachable."""
+        out = self._pg_raw(sql)
+        if out is None:
+            return None
+        if out == "":
+            return []
+        return [line.split("|") for line in out.splitlines()]
+
+    def pg_scalar(self, sql: str) -> str | None:
+        rows = self.pg(sql)
+        if not rows:
+            return None
+        return rows[0][0]
+
+    # ---------------------------------------------------------------- prometheus (port-forward)
+    def start_prometheus(self) -> bool:
+        """Start a port-forward to prometheus-server; returns True if it answers."""
+        for port in (9095, 9096, 9097):
+            self._pf = subprocess.Popen(  # noqa: S603
+                ["kubectl", "-n", self.cfg.monitoring_namespace, "port-forward",
+                 f"svc/{self.cfg.prometheus_svc}", f"{port}:80"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            self._prom_port = port
+            time.sleep(3)
+            if self.prom("vector(1)") is not None:
+                return True
+            self.stop_prometheus()
+        return False
+
+    def stop_prometheus(self) -> None:
+        if self._pf is not None:
+            self._pf.terminate()
+            self._pf = None
+
+    def prom(self, promql: str) -> list[tuple[dict, float]] | None:
+        """Instant query; return [(labels, value)]. None on failure."""
+        if not self._prom_port:
+            return None
+        import urllib.parse
+
+        url = f"http://localhost:{self._prom_port}/api/v1/query?query={urllib.parse.quote(promql)}"
+        try:
+            with urllib.request.urlopen(url, timeout=15) as resp:  # noqa: S310
+                data = json.load(resp)
+        except Exception:
+            return None
+        if data.get("status") != "success":
+            return None
+        out = []
+        for r in data["data"]["result"]:
+            out.append((r["metric"], float(r["value"][1])))
+        return out
+
+    def prom_scalar(self, promql: str) -> float | None:
+        r = self.prom(promql)
+        if not r:
+            return None
+        return r[0][1]
+
+    @contextlib.contextmanager
+    def prometheus(self):
+        ok = self.start_prometheus()
+        try:
+            yield ok
+        finally:
+            self.stop_prometheus()

--- a/stress-test/harness/report.py
+++ b/stress-test/harness/report.py
@@ -1,0 +1,69 @@
+"""Scenario results + a human/JSON PASS-FAIL report."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import pathlib
+import time
+
+
+@dataclasses.dataclass
+class Result:
+    name: str
+    invariant: str          # which G/S/criterion this asserts
+    passed: bool
+    detail: str             # one-line evidence (numbers, counts)
+    criteria: str           # the pass condition, in words
+    skipped: bool = False
+    metrics: dict = dataclasses.field(default_factory=dict)
+
+
+class Report:
+    def __init__(self, target: str) -> None:
+        self.target = target
+        self.results: list[Result] = []
+        self.started = time.time()
+
+    def add(self, r: Result) -> Result:
+        self.results.append(r)
+        tag = "SKIP" if r.skipped else ("PASS" if r.passed else "FAIL")
+        print(f"  [{tag}] {r.name} — {r.detail}")
+        return r
+
+    @property
+    def failed(self) -> list[Result]:
+        return [r for r in self.results if not r.passed and not r.skipped]
+
+    @property
+    def go(self) -> bool:
+        return len(self.failed) == 0
+
+    def summary_line(self) -> str:
+        p = sum(1 for r in self.results if r.passed and not r.skipped)
+        f = len(self.failed)
+        s = sum(1 for r in self.results if r.skipped)
+        return f"{p} pass, {f} fail, {s} skip"
+
+    def to_markdown(self) -> str:
+        lines = [
+            f"# Production-readiness harness run — {self.target}",
+            "",
+            f"**Verdict: {'🟢 GO' if self.go else '🔴 NO-GO'}** · {self.summary_line()} · "
+            f"{time.time() - self.started:.0f}s",
+            "",
+            "| Result | Scenario | Asserts | Evidence | Criteria |",
+            "|---|---|---|---|---|",
+        ]
+        for r in self.results:
+            tag = "⏭️ SKIP" if r.skipped else ("✅ PASS" if r.passed else "❌ FAIL")
+            lines.append(
+                f"| {tag} | {r.name} | {r.invariant} | {r.detail} | {r.criteria} |"
+            )
+        return "\n".join(lines) + "\n"
+
+    def dump(self, md_path: pathlib.Path, json_path: pathlib.Path) -> None:
+        md_path.write_text(self.to_markdown())
+        json_path.write_text(json.dumps(
+            {"target": self.target, "go": self.go, "summary": self.summary_line(),
+             "results": [dataclasses.asdict(r) for r in self.results]}, indent=2))

--- a/stress-test/harness/report.py
+++ b/stress-test/harness/report.py
@@ -16,6 +16,11 @@ class Result:
     detail: str             # one-line evidence (numbers, counts)
     criteria: str           # the pass condition, in words
     skipped: bool = False
+    # An OBSERVED result reports a measurement that has no ratified pass/fail threshold yet
+    # (e.g. the S4 backlog gauge) or that is verified elsewhere (corpus upload → durability-reverify).
+    # It is NOT a gate: it never flips the GO verdict and is counted apart from real passes, so a
+    # non-failing observer can't inflate the pass count into false confidence.
+    observed: bool = False
     metrics: dict = dataclasses.field(default_factory=dict)
 
 
@@ -27,23 +32,25 @@ class Report:
 
     def add(self, r: Result) -> Result:
         self.results.append(r)
-        tag = "SKIP" if r.skipped else ("PASS" if r.passed else "FAIL")
+        tag = "SKIP" if r.skipped else ("INFO" if r.observed else ("PASS" if r.passed else "FAIL"))
         print(f"  [{tag}] {r.name} — {r.detail}")
         return r
 
     @property
     def failed(self) -> list[Result]:
-        return [r for r in self.results if not r.passed and not r.skipped]
+        # Observers never fail the run — they carry no ratified threshold; only real gates gate.
+        return [r for r in self.results if not r.passed and not r.skipped and not r.observed]
 
     @property
     def go(self) -> bool:
         return len(self.failed) == 0
 
     def summary_line(self) -> str:
-        p = sum(1 for r in self.results if r.passed and not r.skipped)
+        p = sum(1 for r in self.results if r.passed and not r.skipped and not r.observed)
         f = len(self.failed)
         s = sum(1 for r in self.results if r.skipped)
-        return f"{p} pass, {f} fail, {s} skip"
+        o = sum(1 for r in self.results if r.observed and not r.skipped)
+        return f"{p} pass, {f} fail, {s} skip, {o} observed"
 
     def to_markdown(self) -> str:
         lines = [
@@ -56,7 +63,7 @@ class Report:
             "|---|---|---|---|---|",
         ]
         for r in self.results:
-            tag = "⏭️ SKIP" if r.skipped else ("✅ PASS" if r.passed else "❌ FAIL")
+            tag = "⏭️ SKIP" if r.skipped else ("ℹ️ OBSERVED" if r.observed else ("✅ PASS" if r.passed else "❌ FAIL"))
             lines.append(
                 f"| {tag} | {r.name} | {r.invariant} | {r.detail} | {r.criteria} |"
             )

--- a/stress-test/harness/s3util.py
+++ b/stress-test/harness/s3util.py
@@ -1,0 +1,141 @@
+"""boto3 client + S3 operations for the harness (path-style, SigV4, hippius endpoint)."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import io
+
+import boto3
+from boto3.s3.transfer import TransferConfig
+from botocore.config import Config as BotoConfig
+
+from .config import Config
+
+
+# 8 MiB threshold/chunk forces multipart on anything >= ~8 MiB (well under hippius' own 64 MiB CLI default,
+# so the harness deterministically exercises the MPU drain path on the "large" corpus objects).
+MPU_THRESHOLD = 8 * 1024 * 1024
+_TRANSFER = TransferConfig(multipart_threshold=MPU_THRESHOLD, multipart_chunksize=MPU_THRESHOLD, max_concurrency=4)
+
+
+def make_client(cfg: Config):
+    return boto3.client(
+        "s3",
+        endpoint_url=cfg.endpoint_url,
+        aws_access_key_id=cfg.access_key,
+        aws_secret_access_key=cfg.secret_key,
+        region_name=cfg.region,
+        config=BotoConfig(
+            signature_version="s3v4",
+            s3={"addressing_style": "path"},
+            retries={"max_attempts": 2, "mode": "standard"},
+            connect_timeout=15,
+            read_timeout=120,
+        ),
+    )
+
+
+def random_body(size: int, seed: bytes) -> bytes:
+    """Deterministic-per-seed pseudo-random bytes (so md5 is reproducible across a run)."""
+    out = bytearray()
+    counter = 0
+    while len(out) < size:
+        out += hashlib.sha256(seed + counter.to_bytes(8, "big")).digest()
+        counter += 1
+    return bytes(out[:size])
+
+
+def md5_hex(data: bytes) -> str:
+    return hashlib.md5(data).hexdigest()
+
+
+@dataclasses.dataclass
+class PutResult:
+    etag: str
+    elapsed_s: float
+    multipart: bool
+
+
+def put(client, bucket: str, key: str, body: bytes) -> str:
+    """Simple PUT; returns ETag."""
+    resp = client.put_object(Bucket=bucket, Key=key, Body=body)
+    return resp["ETag"].strip('"')
+
+
+def upload_forced_multipart(client, bucket: str, key: str, body: bytes) -> str:
+    """Upload via the transfer manager with an 8 MiB threshold so >=8 MiB bodies go multipart."""
+    client.upload_fileobj(io.BytesIO(body), bucket, key, Config=_TRANSFER)
+    return client.head_object(Bucket=bucket, Key=key)["ETag"].strip('"')
+
+
+def get_bytes(client, bucket: str, key: str, range_header: str | None = None, retries: int = 4) -> bytes:
+    """GET the body, retrying transient read failures (streaming breaks, 503/SlowDown, cross-node
+    cold-read gaps) the way a real client would. Raises the last error after `retries` attempts so a
+    *persistent* failure is still surfaced (not silently swallowed)."""
+    import time
+
+    import botocore.exceptions
+
+    kw = {"Bucket": bucket, "Key": key}
+    if range_header:
+        kw["Range"] = range_header
+    last: Exception | None = None
+    for attempt in range(retries):
+        try:
+            return client.get_object(**kw)["Body"].read()
+        except (botocore.exceptions.ResponseStreamingError, botocore.exceptions.ReadTimeoutError,
+                botocore.exceptions.ConnectionError) as e:
+            last = e
+        except botocore.exceptions.ClientError as e:
+            status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
+            if status not in (500, 503):
+                raise
+            last = e
+        time.sleep(1.0 * (attempt + 1))
+    raise last  # type: ignore[misc]
+
+
+def ensure_bucket(client, bucket: str, public: bool = False, retries: int = 4) -> None:
+    """CreateBucket, retrying the transient billing-balance-fetch failure hippius returns
+    (`UploadNotPermitted: Failed to fetch billing balance`) and 503s."""
+    import time
+
+    import botocore.exceptions
+
+    for attempt in range(retries):
+        try:
+            client.create_bucket(Bucket=bucket)
+            break
+        except botocore.exceptions.ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            msg = e.response.get("Error", {}).get("Message", "")
+            status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
+            transient = status == 503 or "billing balance" in msg or code in ("UploadNotPermitted", "SlowDown")
+            if not transient or attempt == retries - 1:
+                raise
+            time.sleep(2.0 * (attempt + 1))
+    if public:
+        client.put_bucket_acl(Bucket=bucket, ACL="public-read")
+
+
+def delete_bucket_recursive(client, bucket: str) -> None:
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket):
+        objs = [{"Key": o["Key"]} for o in page.get("Contents", [])]
+        if objs:
+            client.delete_objects(Bucket=bucket, Delete={"Objects": objs})
+    client.delete_bucket(Bucket=bucket)
+
+
+def anon_get_status(cfg: Config, bucket: str, key: str) -> int:
+    """Unauthenticated GET via plain HTTP — returns the status code (no creds)."""
+    import urllib.request
+
+    url = f"{cfg.endpoint_url.rstrip('/')}/{bucket}/{key}"
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted staging endpoint)
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code

--- a/stress-test/harness/scenarios.py
+++ b/stress-test/harness/scenarios.py
@@ -1,0 +1,347 @@
+"""The production-readiness scenario suite.
+
+Each scenario asserts one readiness criterion and appends a Result. S3-facing scenarios run
+against the endpoint; invariant/convergence scenarios additionally consult the staging cluster
+(Postgres cephor_replication_status + Prometheus drain_* metrics) when reachable.
+
+Mapping to the WI-19 gate (see ../s3-2.1-todo.md):
+  durability_corpus / durability_reverify -> S8 / G3 (no-data-loss)
+  functional_adversarial                  -> T1 (correctness, non-happy-path)
+  concurrency_ramp                        -> T5-lite (throughput / 503 backpressure / S5-S6)
+  invariant_assert                        -> G1 single-leader, G6 terminal monotonicity, S4 backlog
+  replication_convergence                 -> the drain actually replicates (lag via SQL)
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import time
+
+import botocore.exceptions
+
+from . import s3util
+from .config import Config
+from .ledger import Ledger
+from .probes import ClusterProbe
+from .report import Report
+from .report import Result
+
+
+def _bucket(cfg: Config, suffix: str) -> str:
+    return f"{cfg.bucket_prefix}-{suffix}-{int(time.time())}"
+
+
+def _check(report: Report, name: str, invariant: str, criteria: str, fn) -> None:
+    """Run one assertion; a crash becomes a recorded FAIL so sibling checks still run."""
+    try:
+        passed, detail = fn()
+    except Exception as e:  # noqa: BLE001 — per-assertion isolation is the point
+        passed, detail = False, f"{type(e).__name__}: {e}"
+    report.add(Result(name, invariant, passed=passed, detail=detail, criteria=criteria))
+
+
+def _upload_and_record(client, cfg: Config, ledger: Ledger, bucket: str, key: str, body: bytes,
+                       multipart: bool) -> None:
+    if multipart:
+        s3util.upload_forced_multipart(client, bucket, key, body)
+    else:
+        s3util.put(client, bucket, key, body)
+    ledger.record(bucket, key, s3util.md5_hex(body), len(body), multipart)
+
+
+# ---------------------------------------------------------------- 1. DURABILITY CORPUS (S8/G3)
+def durability_corpus(client, cfg: Config, ledger: Ledger, report: Report, buckets: dict) -> None:
+    b = _bucket(cfg, "durab")
+    s3util.ensure_bucket(client, b)
+    buckets["durability"] = b
+    corpus = (
+        [("small", 8 * 1024, False)] * 8
+        + [("medium", 1024 * 1024, False)] * 4
+        + [("large-mpu", 20 * 1024 * 1024, True)] * 2
+        + [("zerobyte", 0, False)]
+    )
+    t0 = time.time()
+    for i, (kind, size, mpu) in enumerate(corpus):
+        body = s3util.random_body(size, seed=f"{b}-{i}".encode())
+        _upload_and_record(client, cfg, ledger, b, f"{kind}/obj-{i}", body, mpu)
+    n = len(corpus)
+    mpu_n = sum(1 for _, _, m in corpus if m)
+    report.add(Result(
+        name="durability-corpus-upload",
+        invariant="S8/G3 setup",
+        passed=True,
+        detail=f"uploaded {n} objects ({mpu_n} multipart) in {time.time()-t0:.1f}s to {b}",
+        criteria="corpus PUTs succeed (verified for real in durability-reverify)",
+    ))
+
+
+# ---------------------------------------------------------------- 2. FUNCTIONAL / ADVERSARIAL (T1)
+def functional_adversarial(client, cfg: Config, ledger: Ledger, report: Report, buckets: dict) -> None:
+    b = _bucket(cfg, "func")
+    pub = _bucket(cfg, "pub")
+    s3util.ensure_bucket(client, b)
+    s3util.ensure_bucket(client, pub, public=True)
+    buckets["functional"] = b
+    buckets["public"] = pub
+
+    def range_get():
+        body = s3util.random_body(4 * 1024 * 1024, seed=b"range")
+        s3util.put(client, b, "range-target", body)
+        got = s3util.get_bytes(client, b, "range-target", range_header="bytes=0-1048575")
+        return got == body[:1024 * 1024], f"got {len(got)} B, match={s3util.md5_hex(got)==s3util.md5_hex(body[:1024*1024])}"
+    _check(report, "func-range-get", "T1 range", "Range bytes=0-1048575 returns exactly the first 1 MiB", range_get)
+
+    def overwrite():
+        s3util.put(client, b, "ow", s3util.random_body(1000, b"v1"))
+        v2 = s3util.random_body(1000, b"v2")
+        s3util.put(client, b, "ow", v2)
+        latest = s3util.get_bytes(client, b, "ow")
+        return latest == v2, f"GET-after-overwrite md5={s3util.md5_hex(latest)[:8]} want={s3util.md5_hex(v2)[:8]}"
+    _check(report, "func-overwrite-latest", "T1 overwrite", "GET after overwrite returns the latest bytes", overwrite)
+
+    def mpu_bad_etag():
+        up = client.create_multipart_upload(Bucket=b, Key="mpu-badetag")["UploadId"]
+        client.upload_part(Bucket=b, Key="mpu-badetag", PartNumber=1, UploadId=up,
+                           Body=s3util.random_body(6 * 1024 * 1024, b"part1"))
+        rejected = False
+        try:
+            client.complete_multipart_upload(
+                Bucket=b, Key="mpu-badetag", UploadId=up,
+                MultipartUpload={"Parts": [{"PartNumber": 1, "ETag": '"deadbeefdeadbeefdeadbeefdeadbeef"'}]})
+        except botocore.exceptions.ClientError:
+            rejected = True
+        if not rejected:
+            client.abort_multipart_upload(Bucket=b, Key="mpu-badetag", UploadId=up)
+        return rejected, f"wrong-ETag complete was {'rejected' if rejected else 'ACCEPTED (bug)'}"
+    _check(report, "func-mpu-wrong-etag", "T1 MPU integrity",
+           "CompleteMultipartUpload with a mismatched part ETag is rejected", mpu_bad_etag)
+
+    def mpu_abort():
+        up = client.create_multipart_upload(Bucket=b, Key="mpu-abort")["UploadId"]
+        client.upload_part(Bucket=b, Key="mpu-abort", PartNumber=1, UploadId=up,
+                           Body=s3util.random_body(6 * 1024 * 1024, b"a"))
+        client.abort_multipart_upload(Bucket=b, Key="mpu-abort", UploadId=up)
+        absent = False
+        try:
+            client.head_object(Bucket=b, Key="mpu-abort")
+        except botocore.exceptions.ClientError:
+            absent = True
+        return absent, f"aborted MPU object is {'absent' if absent else 'PRESENT (bug)'}"
+    _check(report, "func-mpu-abort", "T1 MPU abort", "An aborted MPU leaves no readable object", mpu_abort)
+
+    def acl_anon():
+        s3util.put(client, pub, "pubobj", s3util.random_body(1024, b"pub"))
+        client.put_object_acl(Bucket=pub, Key="pubobj", ACL="public-read")
+        pub_s = s3util.anon_get_status(cfg, pub, "pubobj")
+        priv_s = s3util.anon_get_status(cfg, b, "range-target")
+        return (pub_s == 200 and priv_s == 403), f"anon public={pub_s} (want 200), private={priv_s} (want 403)"
+    _check(report, "func-acl-anon", "T1 ACL", "Anon GET: public-read → 200, private → 403", acl_anon)
+
+    def listv2():
+        for k in ("a/1", "a/2", "c/1"):
+            s3util.put(client, b, k, b"x")
+        resp = client.list_objects_v2(Bucket=b, Delimiter="/")
+        prefixes = sorted(p["Prefix"] for p in resp.get("CommonPrefixes", []))
+        return ("a/" in prefixes and "c/" in prefixes), f"CommonPrefixes={prefixes}"
+    _check(report, "func-listv2-delimiter", "T1 ListObjectsV2", "delimiter '/' groups a/ and c/", listv2)
+
+    def zero_byte():
+        s3util.put(client, b, "empty", b"")
+        empty = s3util.get_bytes(client, b, "empty")
+        return empty == b"", f"zero-byte GET len={len(empty)}"
+    _check(report, "func-zero-byte", "T1 zero-byte", "A zero-byte object round-trips as empty", zero_byte)
+
+
+# ---------------------------------------------------------------- 3. CONCURRENCY RAMP (T5-lite / S5-S6)
+def _put_with_503_retry(client, bucket: str, key: str, body: bytes) -> tuple[str, float]:
+    """Returns (outcome, elapsed). outcome ∈ {ok, slowdown-then-ok, slowdown-fail, error:<code>}."""
+    t0 = time.time()
+    for attempt in range(2):
+        try:
+            client.put_object(Bucket=bucket, Key=key, Body=body)
+            return ("ok" if attempt == 0 else "slowdown-then-ok", time.time() - t0)
+        except botocore.exceptions.ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
+            if status == 503 or code in ("SlowDown", "ServiceUnavailable"):
+                time.sleep(1.5)
+                continue
+            return (f"error:{status or code}", time.time() - t0)
+    return ("slowdown-fail", time.time() - t0)
+
+
+def concurrency_ramp(client, cfg: Config, ledger: Ledger, report: Report, buckets: dict) -> None:
+    b = _bucket(cfg, "load")
+    s3util.ensure_bucket(client, b)
+    buckets["load"] = b
+    rungs = [5, 10, 20]
+    per_rung = 30
+    obj_size = 1024 * 1024  # 1 MiB
+    total_ok = total_slow = total_err = 0
+    total_bytes = 0
+    worst_5xx_rate = 0.0
+    for workers in rungs:
+        outcomes: list[str] = []
+        elapsed: list[float] = []
+        t0 = time.time()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as ex:
+            futs = []
+            for i in range(per_rung):
+                body = s3util.random_body(obj_size, seed=f"{b}-{workers}-{i}".encode())
+                key = f"load/w{workers}/obj-{i}"
+
+                def task(k=key, bd=body):
+                    outcome, el = _put_with_503_retry(client, b, k, bd)
+                    if outcome in ("ok", "slowdown-then-ok"):
+                        ledger.record(b, k, s3util.md5_hex(bd), len(bd), False)
+                    return outcome, el
+                futs.append(ex.submit(task))
+            for f in concurrent.futures.as_completed(futs):
+                o, el = f.result()
+                outcomes.append(o)
+                elapsed.append(el)
+        wall = time.time() - t0
+        ok = sum(1 for o in outcomes if o in ("ok", "slowdown-then-ok"))
+        slow = sum(1 for o in outcomes if o.startswith("slowdown"))
+        err = sum(1 for o in outcomes if o.startswith("error"))
+        total_ok += ok
+        total_slow += slow
+        total_err += err
+        total_bytes += ok * obj_size
+        rate_5xx = err / per_rung
+        worst_5xx_rate = max(worst_5xx_rate, rate_5xx)
+        thr = ok / wall if wall else 0
+        print(f"    rung workers={workers}: ok={ok} slowdown={slow} err={err} "
+              f"{thr:.1f} obj/s ({ok*obj_size/wall/1e6:.1f} MB/s)")
+
+    # 503 SlowDown is CORRECT backpressure, not a failure. Only non-503 5xx and hangs fail.
+    report.add(Result(
+        name="concurrency-ramp",
+        invariant="S5/S6 (backpressure) + throughput",
+        passed=(worst_5xx_rate < 0.01 and total_err == 0),
+        detail=f"{total_ok} ok, {total_slow} 503-backpressure(retried), {total_err} non-503-5xx; "
+               f"worst non-503 5xx rate={worst_5xx_rate:.1%}; {total_bytes/1e6:.0f} MB",
+        criteria="non-503 5xx rate < 1% and no hangs; 503 SlowDown is correct backpressure (informational)",
+        metrics={"ok": total_ok, "slowdown": total_slow, "non_503_5xx": total_err},
+    ))
+
+
+# ---------------------------------------------------------------- 4. INVARIANTS (cluster) G1/G6/S4
+def _our_repl_counts(probe: ClusterProbe, prefix: str) -> dict[str, int] | None:
+    rows = probe.pg(
+        "select crs.status, count(*) from cephor_replication_status crs "
+        "join objects o on o.object_id::text = crs.object_id::text "
+        "join buckets b on b.bucket_id = o.bucket_id "
+        f"where b.bucket_name like '{prefix}-%' group by crs.status")
+    if rows is None:
+        return None
+    return {r[0]: int(r[1]) for r in rows}
+
+
+def invariant_assert(probe: ClusterProbe, cfg: Config, report: Report, prom_ok: bool) -> None:
+    # G1 — single leader (Prometheus)
+    leaders = probe.prom_scalar('sum(drain_leader{service_namespace="hippius-s3-staging"})') if prom_ok else None
+    if leaders is None:
+        report.add(Result("inv-G1-single-leader", "G1", passed=True, skipped=True,
+                          detail="Prometheus not reachable — skipped", criteria="sum(drain_leader) ≤ 1"))
+    else:
+        report.add(Result("inv-G1-single-leader", "G1 single-leader", passed=(leaders <= 1.0),
+                          detail=f"sum(drain_leader)={leaders:g}",
+                          criteria="sum(drain_leader) ≤ 1 (no split-brain)"))
+
+    # G6 — terminal-state monotonicity: sample the whole table's replicated+failed count twice; it must not shrink
+    c1 = probe.pg_scalar("select count(*) from cephor_replication_status where status in ('replicated','failed')")
+    if c1 is None:
+        report.add(Result("inv-G6-terminal-monotonic", "G6", passed=True, skipped=True,
+                          detail="Postgres not reachable — skipped",
+                          criteria="no replicated/failed row regresses to a non-terminal state"))
+    else:
+        time.sleep(4)
+        c2 = probe.pg_scalar("select count(*) from cephor_replication_status where status in ('replicated','failed')")
+        # Terminal count may grow or stay; GC deletes rows entirely (fine). We assert no OUR object
+        # is stuck non-terminal, and report the global terminal delta for context.
+        our = _our_repl_counts(probe, cfg.bucket_prefix)
+        report.add(Result("inv-G6-terminal-monotonic", "G6 terminal monotonicity",
+                          passed=True,
+                          detail=f"global terminal rows {c1}→{c2}; our objects: {our}",
+                          criteria="observed replicated/failed rows never regress (our objects tracked)"))
+
+    # S4 — backlog is a finite gauge (bounded, not runaway) if exported
+    backlog = probe.prom_scalar(
+        'max(drain_ssd_backlog_bytes{service_namespace="hippius-s3-staging"})/1e9') if prom_ok else None
+    if backlog is None:
+        report.add(Result("inv-S4-backlog", "S4", passed=True, skipped=True,
+                          detail="drain_ssd_backlog_bytes not reachable — skipped",
+                          criteria="ingest SSD backlog is a bounded gauge"))
+    else:
+        report.add(Result("inv-S4-backlog", "S4 backlog gauge",
+                          passed=True,
+                          detail=f"max drain_ssd_backlog_bytes = {backlog:.1f} GB (informational)",
+                          criteria="backlog exported + bounded (absolute ceiling is a RATIFY item)"))
+
+
+# ---------------------------------------------------------------- 5. REPLICATION CONVERGENCE (cluster)
+def replication_convergence(probe: ClusterProbe, cfg: Config, report: Report, prom_ok: bool) -> None:
+    before = probe.prom_scalar(
+        'sum(drain_parts_replicated_total{service_namespace="hippius-s3-staging"})') if prom_ok else None
+    deadline = time.time() + cfg.drain_convergence_timeout_s
+    converged = False
+    last: dict[str, int] | None = None
+    while time.time() < deadline:
+        our = _our_repl_counts(probe, cfg.bucket_prefix)
+        if our is None:
+            report.add(Result("drain-convergence", "drain replicates", passed=True, skipped=True,
+                              detail="Postgres not reachable — skipped",
+                              criteria="all our parts reach a terminal state within the drain window"))
+            return
+        last = our
+        non_terminal = our.get("pending", 0) + our.get("draining", 0)
+        if non_terminal == 0:
+            converged = True
+            break
+        time.sleep(5)
+    elapsed = cfg.drain_convergence_timeout_s - max(0, deadline - time.time())
+    after = probe.prom_scalar(
+        'sum(drain_parts_replicated_total{service_namespace="hippius-s3-staging"})') if prom_ok else None
+    delta = (after - before) if (before is not None and after is not None) else None
+    report.add(Result(
+        name="drain-convergence",
+        invariant="drain actually replicates (lag proxy)",
+        passed=converged,
+        detail=f"our repl rows={last}; drain_parts_replicated Δ={delta}; "
+               f"{'converged' if converged else 'STILL non-terminal'} in ≤{elapsed:.0f}s",
+        criteria=f"0 pending/draining rows for our objects within {cfg.drain_convergence_timeout_s}s",
+    ))
+
+
+# ---------------------------------------------------------------- 6. DURABILITY RE-VERIFY (the gate)
+def durability_reverify(client, cfg: Config, ledger: Ledger, report: Report) -> None:
+    items = ledger.all()
+    mismatches: list[str] = []
+    missing: list[str] = []
+
+    def verify_one(a):
+        try:
+            data = s3util.get_bytes(client, a.bucket, a.key, retries=3)
+        except Exception as e:  # noqa: BLE001 — a persistent read failure is a data-availability finding
+            return ("missing", a.key, type(e).__name__)
+        if len(data) != a.size or s3util.md5_hex(data) != a.md5:
+            return ("corrupt", a.key, "")
+        return ("ok", a.key, "")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=12) as ex:
+        for kind, key, why in ex.map(verify_one, items):
+            if kind == "corrupt":
+                mismatches.append(key)
+            elif kind == "missing":
+                missing.append(f"{key}:{why}")
+    ok = len(items) - len(mismatches) - len(missing)
+    report.add(Result(
+        name="durability-reverify",
+        invariant="S8/G3 no-data-loss (NON-OVERRIDABLE)",
+        passed=(len(mismatches) == 0 and len(missing) == 0),
+        detail=f"{ok}/{len(items)} byte-identical; {len(mismatches)} corrupt, {len(missing)} missing"
+               + (f" — corrupt:{mismatches[:3]} missing:{missing[:3]}" if (mismatches or missing) else ""),
+        criteria="every acked object re-GETs byte-identical (plaintext md5 + size)",
+        metrics={"total": len(items), "ok": ok, "corrupt": len(mismatches), "missing": len(missing)},
+    ))

--- a/stress-test/harness/scenarios.py
+++ b/stress-test/harness/scenarios.py
@@ -15,6 +15,8 @@ Mapping to the WI-19 gate (see ../s3-2.1-todo.md):
 from __future__ import annotations
 
 import concurrent.futures
+import contextlib
+import re
 import time
 
 import botocore.exceptions
@@ -70,6 +72,7 @@ def durability_corpus(client, cfg: Config, ledger: Ledger, report: Report, bucke
         name="durability-corpus-upload",
         invariant="S8/G3 setup",
         passed=True,
+        observed=True,  # setup only — the real no-data-loss gate is durability-reverify
         detail=f"uploaded {n} objects ({mpu_n} multipart) in {time.time()-t0:.1f}s to {b}",
         criteria="corpus PUTs succeed (verified for real in durability-reverify)",
     ))
@@ -110,8 +113,13 @@ def functional_adversarial(client, cfg: Config, ledger: Ledger, report: Report, 
                 MultipartUpload={"Parts": [{"PartNumber": 1, "ETag": '"deadbeefdeadbeefdeadbeefdeadbeef"'}]})
         except botocore.exceptions.ClientError:
             rejected = True
-        if not rejected:
-            client.abort_multipart_upload(Bucket=b, Key="mpu-badetag", UploadId=up)
+        finally:
+            # On the CORRECT (rejected) path the upload is still open — abort it so the harness
+            # doesn't strand an in-progress MPU every run (the A21 orphan cephor-pending-row leak).
+            # On the ACCEPTED (bug) path complete already consumed the upload; NoSuchUpload is expected.
+            if rejected:
+                with contextlib.suppress(botocore.exceptions.ClientError):
+                    client.abort_multipart_upload(Bucket=b, Key="mpu-badetag", UploadId=up)
         return rejected, f"wrong-ETag complete was {'rejected' if rejected else 'ACCEPTED (bug)'}"
     _check(report, "func-mpu-wrong-etag", "T1 MPU integrity",
            "CompleteMultipartUpload with a mismatched part ETag is rejected", mpu_bad_etag)
@@ -227,15 +235,43 @@ def concurrency_ramp(client, cfg: Config, ledger: Ledger, report: Report, bucket
 
 
 # ---------------------------------------------------------------- 4. INVARIANTS (cluster) G1/G6/S4
+# cephor_replication_status PK is (object_id, version, part_number); replicated/failed are terminal sinks.
+_TERMINAL = frozenset({"replicated", "failed"})
+_NON_TERMINAL = frozenset({"pending", "draining"})
+_PREFIX_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+def _safe_prefix(prefix: str) -> str:
+    """Constrain the bucket prefix before it goes into a SQL LIKE — it's operator-set, but we build
+    raw SQL from it, so reject anything outside the S3 bucket-name charset rather than interpolate it."""
+    if not _PREFIX_RE.match(prefix):
+        raise ValueError(f"unsafe bucket prefix for SQL LIKE: {prefix!r}")
+    return prefix
+
+
 def _our_repl_counts(probe: ClusterProbe, prefix: str) -> dict[str, int] | None:
     rows = probe.pg(
         "select crs.status, count(*) from cephor_replication_status crs "
         "join objects o on o.object_id::text = crs.object_id::text "
         "join buckets b on b.bucket_id = o.bucket_id "
-        f"where b.bucket_name like '{prefix}-%' group by crs.status")
+        f"where b.bucket_name like '{_safe_prefix(prefix)}-%' group by crs.status")
     if rows is None:
         return None
     return {r[0]: int(r[1]) for r in rows}
+
+
+def _our_repl_rows(probe: ClusterProbe, prefix: str) -> dict[tuple[str, str, str], str] | None:
+    """Per-row status of our objects' replication rows, keyed by the PK (object_id, version, part_number).
+    The per-row view is what makes a real G6 monotonicity assertion possible — a count can't tell a
+    terminal row regressing apart from a new non-terminal row arriving."""
+    rows = probe.pg(
+        "select crs.object_id, crs.version, crs.part_number, crs.status from cephor_replication_status crs "
+        "join objects o on o.object_id::text = crs.object_id::text "
+        "join buckets b on b.bucket_id = o.bucket_id "
+        f"where b.bucket_name like '{_safe_prefix(prefix)}-%'")
+    if rows is None:
+        return None
+    return {(r[0], r[1], r[2]): r[3] for r in rows}
 
 
 def invariant_assert(probe: ClusterProbe, cfg: Config, report: Report, prom_ok: bool) -> None:
@@ -249,24 +285,31 @@ def invariant_assert(probe: ClusterProbe, cfg: Config, report: Report, prom_ok: 
                           detail=f"sum(drain_leader)={leaders:g}",
                           criteria="sum(drain_leader) ≤ 1 (no split-brain)"))
 
-    # G6 — terminal-state monotonicity: sample the whole table's replicated+failed count twice; it must not shrink
-    c1 = probe.pg_scalar("select count(*) from cephor_replication_status where status in ('replicated','failed')")
-    if c1 is None:
+    # G6 — terminal-state monotonicity (a REAL gate, per-row): snapshot our objects' rows keyed by
+    # (object_id, version, part_number), sleep, re-snapshot; FAIL if any row that was terminal
+    # (replicated/failed) is now non-terminal (pending/draining). A key vanishing between snapshots is
+    # GC deleting a terminal row — that is allowed, not a regression. This is still a sampled probe (the
+    # plan's end-state is a WAL-tailed event-driven guard, plan §4.2); a flap fully inside the sleep is
+    # invisible — but unlike the old count-only version it can now actually catch a regression.
+    snap1 = _our_repl_rows(probe, cfg.bucket_prefix)
+    if snap1 is None:
         report.add(Result("inv-G6-terminal-monotonic", "G6", passed=True, skipped=True,
                           detail="Postgres not reachable — skipped",
                           criteria="no replicated/failed row regresses to a non-terminal state"))
     else:
+        terminal_before = {k: s for k, s in snap1.items() if s in _TERMINAL}
         time.sleep(4)
-        c2 = probe.pg_scalar("select count(*) from cephor_replication_status where status in ('replicated','failed')")
-        # Terminal count may grow or stay; GC deletes rows entirely (fine). We assert no OUR object
-        # is stuck non-terminal, and report the global terminal delta for context.
-        our = _our_repl_counts(probe, cfg.bucket_prefix)
+        snap2 = _our_repl_rows(probe, cfg.bucket_prefix) or {}
+        regressed = {k: (terminal_before[k], snap2[k]) for k in terminal_before
+                     if snap2.get(k) in _NON_TERMINAL}
         report.add(Result("inv-G6-terminal-monotonic", "G6 terminal monotonicity",
-                          passed=True,
-                          detail=f"global terminal rows {c1}→{c2}; our objects: {our}",
-                          criteria="observed replicated/failed rows never regress (our objects tracked)"))
+                          passed=(len(regressed) == 0),
+                          detail=f"our terminal rows tracked={len(terminal_before)}, regressed={len(regressed)}"
+                                 + (f" — {list(regressed.items())[:3]}" if regressed else ""),
+                          criteria="no replicated/failed row of ours regresses to pending/draining"))
 
-    # S4 — backlog is a finite gauge (bounded, not runaway) if exported
+    # S4 — backlog gauge: reported, not gated. There is no ratified per-node ceiling yet
+    # (S4's absolute number is a RATIFY item, todo §SLO table), so this is an OBSERVED measurement.
     backlog = probe.prom_scalar(
         'max(drain_ssd_backlog_bytes{service_namespace="hippius-s3-staging"})/1e9') if prom_ok else None
     if backlog is None:
@@ -276,7 +319,8 @@ def invariant_assert(probe: ClusterProbe, cfg: Config, report: Report, prom_ok: 
     else:
         report.add(Result("inv-S4-backlog", "S4 backlog gauge",
                           passed=True,
-                          detail=f"max drain_ssd_backlog_bytes = {backlog:.1f} GB (informational)",
+                          observed=True,
+                          detail=f"max drain_ssd_backlog_bytes = {backlog:.1f} GB (no ratified ceiling yet)",
                           criteria="backlog exported + bounded (absolute ceiling is a RATIFY item)"))
 
 

--- a/stress-test/inv/__init__.py
+++ b/stress-test/inv/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic pre-deploy invariant proofs (WI-19 §4.1).
+
+`inv_det.py` is the pre-flight gate: it runs the checks that must be green before any dynamic
+staging run, with no live S3/cluster. See stress-test/plan.md §4.1.
+"""

--- a/stress-test/inv/guards.py
+++ b/stress-test/inv/guards.py
@@ -1,0 +1,209 @@
+"""Continuous invariant guards (WI-19 §4.2) — the predicates `inv_guard` polls every run.
+
+Each guard is a small stateful object with `.check(probe) -> GuardResult`, where `probe` is
+duck-typed on `harness.probes.ClusterProbe` (`pg`, `pg_scalar`, `prom_scalar`). Kept free of any
+cluster/harness import so the predicate logic is unit-testable with a fake probe. `inv_guard.py`
+is the thin runtime wrapper that wires a real `ClusterProbe` and streams the results to JSONL.
+
+Guard coverage here (the drain-internal invariants queryable from Postgres + Prometheus):
+  G1 single-leader + epoch-monotonicity · G2 replication-gate coverage · G3 stalled-drain (SQL
+  half; the byte-identical re-GET half is ledger/scenario-driven) · G4 sole-producer (runtime
+  uniqueness; the static half is inv-det) · G6 terminal-state monotonicity.
+G5/G7/G8 are inv-det / scenario-driven (at-least-once-no-dup, AEAD determinism, reaper safety) and
+report `skip` here so a run's guard table is explicit about what this asserter does NOT cover.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Protocol
+
+
+class Probe(Protocol):
+    """The subset of `harness.probes.ClusterProbe` the guards use (duck-typed for testing)."""
+
+    def pg(self, sql: str) -> list[list[str]] | None: ...
+    def pg_scalar(self, sql: str) -> str | None: ...
+    def prom_scalar(self, promql: str) -> float | None: ...
+
+
+@dataclasses.dataclass
+class GuardResult:
+    """One guard's verdict for one poll. `status` is `ok` | `breach` | `skip` (skip = could not
+    evaluate, e.g. the probe was unreachable — NOT a pass)."""
+
+    guard: str
+    status: str
+    detail: str
+    value: float | None = None
+
+
+class _Guard(Protocol):
+    name: str
+
+    def check(self, probe: Probe) -> GuardResult: ...
+
+
+class SingleLeaderEpoch:
+    """G1: at most one allocator leads, and the leadership epoch never decreases.
+
+    `sum(drain_leader) >= 2` is split-brain. A decrease in `max(drain_leader_epoch)` means the
+    redis `cephor:epoch` counter was reset (data loss / flush), which silently breaks the write
+    fence — so the guard carries the high-water epoch across polls and breaches on any drop.
+    """
+
+    name = "G1"
+
+    def __init__(self) -> None:
+        self._max_epoch: float | None = None
+
+    def check(self, probe: Probe) -> GuardResult:
+        leaders = probe.prom_scalar("sum(drain_leader)")
+        if leaders is None:
+            return GuardResult(self.name, "skip", "prometheus unreachable")
+        if leaders >= 2:
+            return GuardResult(self.name, "breach", f"{int(leaders)} concurrent leaders (split-brain)", leaders)
+        epoch = probe.prom_scalar("max(drain_leader_epoch)")
+        if epoch is not None:
+            if self._max_epoch is not None and epoch < self._max_epoch:
+                return GuardResult(self.name, "breach", f"epoch decreased {int(self._max_epoch)}->{int(epoch)} (counter reset)", epoch)
+            self._max_epoch = epoch if self._max_epoch is None else max(self._max_epoch, epoch)
+        return GuardResult(self.name, "ok", f"leaders={int(leaders)} epoch={int(epoch) if epoch is not None else 'n/a'}", leaders)
+
+
+class ReplicationGateCoverage:
+    """G2: no live, serveable chunk lacks full-union backend coverage.
+
+    Reads George's janitor replication-gate sentinel metric (WI-20 / #233): a nonzero count is a
+    live chunk at data-loss risk the gate must never reclaim. Absent metric → skip (sentinel not
+    deployed yet), so the guard never silently passes on a missing signal.
+    """
+
+    name = "G2"
+
+    def check(self, probe: Probe) -> GuardResult:
+        under = probe.prom_scalar("max(janitor_underreplicated_live_chunks)")
+        if under is None:
+            return GuardResult(self.name, "skip", "janitor_underreplicated_live_chunks absent (sentinel not deployed)")
+        if under > 0:
+            return GuardResult(self.name, "breach", f"{int(under)} under-replicated live chunk(s)", under)
+        return GuardResult(self.name, "ok", "no under-replicated live chunks", under)
+
+
+class StalledDrain:
+    """G3 (SQL half): no `pending`/`draining` part stuck past the lag SLO.
+
+    The byte-identical re-GET half of G3 is driven by the ledger (§4.3) in the scenario runner, not
+    here. This half catches a drain that has quietly stopped making progress on the backlog.
+    """
+
+    name = "G3"
+
+    def __init__(self, stall_secs: int = 120) -> None:
+        self._stall_secs = stall_secs
+
+    def check(self, probe: Probe) -> GuardResult:
+        stalled = probe.pg_scalar(
+            "SELECT count(*) FROM cephor_replication_status "
+            f"WHERE status IN ('pending','draining') AND landed_at < now() - interval '{self._stall_secs} seconds'"
+        )
+        if stalled is None:
+            return GuardResult(self.name, "skip", "postgres unreachable")
+        count = int(stalled)
+        if count > 0:
+            return GuardResult(self.name, "breach", f"{count} part(s) stalled > {self._stall_secs}s in pending/draining", float(count))
+        return GuardResult(self.name, "ok", f"no part stalled past {self._stall_secs}s", 0.0)
+
+
+class SoleProducer:
+    """G4 (runtime half): every `(chunk_id, backend)` is written at most once.
+
+    A duplicate means a second upload producer re-appeared (the drain must be the only one; the
+    static callerless-audit half is inv-det). Soft-deleted rows are excluded — a re-pin after an
+    unpin is legitimate.
+    """
+
+    name = "G4"
+
+    def check(self, probe: Probe) -> GuardResult:
+        rows = probe.pg(
+            "SELECT chunk_id, backend, count(*) FROM chunk_backend "
+            "WHERE deleted = false GROUP BY chunk_id, backend HAVING count(*) > 1 LIMIT 5"
+        )
+        if rows is None:
+            return GuardResult(self.name, "skip", "postgres unreachable")
+        if rows:
+            return GuardResult(self.name, "breach", f"duplicate (chunk_id, backend): {rows[:3]}")
+        return GuardResult(self.name, "ok", "no duplicate (chunk_id, backend)")
+
+
+class TerminalMonotonicity:
+    """G6: a terminal replication state (`replicated`/`failed`) is never left.
+
+    Samples every row's status each poll and compares to the previous sample; any
+    `replicated->*` or `failed->*` transition is a breach (a terminal row must be inert). First
+    poll only seeds the baseline.
+    """
+
+    name = "G6"
+    _TERMINAL = frozenset({"replicated", "failed"})
+
+    def __init__(self) -> None:
+        self._prev: dict[tuple[str, str, str], str] = {}
+
+    def check(self, probe: Probe) -> GuardResult:
+        rows = probe.pg("SELECT object_id, version, part_number, status FROM cephor_replication_status")
+        if rows is None:
+            return GuardResult(self.name, "skip", "postgres unreachable")
+        current = {(r[0], r[1], r[2]): r[3] for r in rows if len(r) >= 4}
+        breaches = [
+            f"{key}: {prev}->{current[key]}"
+            for key, prev in self._prev.items()
+            if prev in self._TERMINAL and key in current and current[key] != prev
+        ]
+        self._prev = current
+        if breaches:
+            return GuardResult(self.name, "breach", f"terminal-state regression: {breaches[:3]}")
+        return GuardResult(self.name, "ok", f"{len(current)} rows tracked, no terminal regression")
+
+
+class _InvDetGuard:
+    """G5/G7/G8: covered by inv-det or the scenario runner, not this periodic asserter — reported
+    as `skip` so the guard table is explicit rather than silently omitting them."""
+
+    def __init__(self, name: str, where: str) -> None:
+        self.name = name
+        self._where = where
+
+    def check(self, probe: Probe) -> GuardResult:
+        return GuardResult(self.name, "skip", f"covered by {self._where}, not the continuous asserter")
+
+
+def make_guard(name: str) -> _Guard:
+    """Instantiate a guard by its G-number. Raises KeyError on an unknown name."""
+    factories = {
+        "G1": SingleLeaderEpoch,
+        "G2": ReplicationGateCoverage,
+        "G3": StalledDrain,
+        "G4": SoleProducer,
+        "G5": lambda: _InvDetGuard("G5", "inv-det + scenario (at-least-once-no-dup)"),
+        "G6": TerminalMonotonicity,
+        "G7": lambda: _InvDetGuard("G7", "inv-det (AEAD determinism)"),
+        "G8": lambda: _InvDetGuard("G8", "inv-det + reaper scenario (reaper safety)"),
+    }
+    return factories[name]()
+
+
+def run_once(guards: list[_Guard], probe: Probe, emit) -> int:
+    """Poll every guard once, pass each result to `emit`, and return the number of BREACHES.
+
+    Pure orchestration: `probe` is duck-typed and `emit` is a callback, so a test drives this with a
+    fake probe and captures the emitted events without any cluster or file I/O.
+    """
+    breaches = 0
+    for guard in guards:
+        result = guard.check(probe)
+        emit(result)
+        if result.status == "breach":
+            breaches += 1
+    return breaches

--- a/stress-test/inv/inv_det.py
+++ b/stress-test/inv/inv_det.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""inv-det — deterministic pre-deploy invariant proof (WI-19 §4.1, GO/NO-GO item #2).
+
+The pre-flight gate. Runs the checks that must be green BEFORE any dynamic staging run, with no
+live S3/cluster:
+
+  1. Rust drain-core suite INCLUDING the #[ignore]d coordinator epoch/lease tests. Those 8 tests
+     are the split-brain core and have **0 executed coverage under a bare `cargo test`** — they
+     need `--include-ignored` AND a real Redis (`CEPHOR_TEST_REDIS_URL`). Without both, the fence
+     that defends G1 is unproven.
+  2. The Python unit suite (`tests/unit`), and optionally `tests/integration` (`--integration`,
+     needs a live DB/Redis via docker compose).
+  3. A static sole-producer audit (G4): the dead PUT-path producer `enqueue_upload`
+     (hippius_s3/writer/queue.py) must stay callerless — the drain is the only enqueuer. A new call
+     re-introduces a second producer, which the runtime `(chunk_id, backend)` uniqueness invariant
+     would only catch after the fact.
+
+Exit code is 0 (all gates green) / 1 (any hard-gate failure or a required check that could not run).
+See stress-test/plan.md §4.1 and s3-2.1-todo.md → PRODUCTION-READINESS GATE (WI-19).
+
+Usage:
+    export CEPHOR_TEST_REDIS_URL=redis://localhost:6379   # required for the split-brain tests
+    python stress-test/inv/inv_det.py
+    python stress-test/inv/inv_det.py --integration        # also run tests/integration
+    python stress-test/inv/inv_det.py --no-cargo           # python-only (skip the Rust suite)
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import os
+import pathlib
+import re
+import subprocess
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+# `\benqueue_upload(` matches a call to the dead producer but NOT enqueue_upload_to_backends( /
+# enqueue_upload_request( (those have `_` after the name, not `(`).
+_PRODUCER_CALL = re.compile(r"\benqueue_upload\(")
+
+
+@dataclasses.dataclass
+class Check:
+    name: str
+    gate: str
+    passed: bool
+    detail: str
+    skipped: bool = False
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=REPO_ROOT, text=True, capture_output=True)  # noqa: S603
+
+
+def _cargo_result_lines(out: str) -> str:
+    """The libtest `test result: ...` summary line(s) — the signal amid the noise."""
+    hits = [ln.strip() for ln in out.splitlines() if ln.strip().startswith("test result:")]
+    return " | ".join(hits) if hits else out.strip().splitlines()[-1][:200] if out.strip() else ""
+
+
+def check_cargo_coordinator(results: list[Check]) -> None:
+    redis_url = os.environ.get("CEPHOR_TEST_REDIS_URL")
+    if not redis_url:
+        # Skipped, but this is NOT a pass: without the real-Redis fence tests, G1 is unproven.
+        results.append(Check(
+            "cargo drain-core (--include-ignored)", "inv-det #2 / G1 split-brain",
+            passed=False, skipped=True,
+            detail="CEPHOR_TEST_REDIS_URL unset — the 8 #[ignore]d coordinator epoch/lease tests "
+                   "cannot run; export it (e.g. redis://localhost:6379) to close the coverage gap"))
+        return
+    proc = _run(["cargo", "test", "-p", "hippius-drain-core", "--", "--include-ignored"])
+    ok = proc.returncode == 0
+    results.append(Check(
+        "cargo drain-core (--include-ignored)", "inv-det #2 / G1 split-brain",
+        passed=ok,
+        detail=_cargo_result_lines(proc.stdout) if ok else _cargo_result_lines(proc.stdout + proc.stderr)))
+
+
+def check_pytest(results: list[Check], rel_path: str, required: bool) -> None:
+    pytest_bin = REPO_ROOT / ".venv" / "bin" / "pytest"
+    cmd = [str(pytest_bin) if pytest_bin.exists() else "pytest", rel_path, "-q"]
+    proc = _run(cmd)
+    ok = proc.returncode == 0
+    tail = (proc.stdout or proc.stderr).strip().splitlines()[-1:] or [""]
+    results.append(Check(
+        f"pytest {rel_path}", "inv-det #2",
+        passed=ok if required else True,
+        skipped=(not required and not ok),
+        detail=tail[0][:200]))
+
+
+def check_sole_producer(results: list[Check]) -> None:
+    """G4 static proof: the drain is the sole upload producer — `enqueue_upload` stays callerless."""
+    offenders: list[str] = []
+    for base in ("hippius_s3", "gateway"):
+        root = REPO_ROOT / base
+        if not root.exists():
+            continue
+        for py in root.rglob("*.py"):
+            for i, line in enumerate(py.read_text().splitlines(), 1):
+                if _PRODUCER_CALL.search(line) and "def enqueue_upload(" not in line:
+                    offenders.append(f"{py.relative_to(REPO_ROOT)}:{i}")
+    results.append(Check(
+        "sole-producer static audit", "G4",
+        passed=not offenders,
+        detail="enqueue_upload has no callers (drain is the sole producer)" if not offenders
+               else f"UNEXPECTED producer call site(s): {offenders[:5]}"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="inv-det — deterministic pre-deploy invariant proof")
+    ap.add_argument("--no-cargo", action="store_true", help="skip the Rust drain-core suite")
+    ap.add_argument("--integration", action="store_true", help="also run tests/integration (needs DB/Redis)")
+    args = ap.parse_args()
+
+    print("== inv-det: deterministic pre-deploy invariant proof ==\n")
+    results: list[Check] = []
+    check_sole_producer(results)
+    check_pytest(results, "tests/unit", required=True)
+    if args.integration:
+        check_pytest(results, "tests/integration", required=True)
+    if not args.no_cargo:
+        check_cargo_coordinator(results)
+
+    print(f"\n{'gate':<40} {'status':<8} detail")
+    print("-" * 100)
+    for r in results:
+        status = "SKIP" if r.skipped else ("PASS" if r.passed else "FAIL")
+        print(f"{r.name:<40} {status:<8} {r.detail}")
+
+    # A skipped required check (e.g. the fence tests with no Redis) is NOT a pass — it means the gate
+    # was not actually proven, so the run is NO-GO until it can run.
+    go = all(r.passed and not r.skipped for r in results)
+    print(f"\n{'🟢 inv-det GREEN' if go else '🔴 inv-det NOT PROVEN'}")
+    return 0 if go else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stress-test/inv/inv_guard.py
+++ b/stress-test/inv/inv_guard.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""inv-guard — the continuous background invariant asserter (WI-19 §4.2, the backbone).
+
+Every dynamic run (load, soak, chaos) runs under this: it polls the drain-internal invariants
+(single-leader+epoch, replication-gate coverage, stalled-drain, sole-producer, terminal
+monotonicity — see `guards.py`) against staging Postgres + Prometheus on an interval, streams one
+JSONL event per guard-check, and — with `--abort` — stops the moment any invariant BREACHES so the
+run fails fast instead of soaking on a broken cluster. The JSONL stream is the shared contract the
+chaos `gate.py` and the durability ledger consume.
+
+JSONL event shape (one per guard per poll):
+    {"run_id": str, "seq": int, "ts": float, "guard": "G1".."G8", "status": "ok"|"breach"|"skip",
+     "detail": str, "value": float|null}
+
+Usage (from the repo root):
+    python stress-test/inv/inv_guard.py --guards G1,G2,G3,G4,G6 --run-id run-XYZ --out run-XYZ.jsonl
+    python stress-test/inv/inv_guard.py --once            # one poll, print the guard table, exit
+    python stress-test/inv/inv_guard.py --abort           # exit non-zero on the first breach
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import pathlib
+import sys
+import time
+
+# allow `python stress-test/inv/inv_guard.py` from the repo root (mirrors run.py)
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from harness import config  # noqa: E402
+from harness.probes import ClusterProbe  # noqa: E402
+from inv.guards import GuardResult, make_guard, run_once  # noqa: E402
+
+DEFAULT_GUARDS = "G1,G2,G3,G4,G6"
+
+
+def _event(run_id: str, seq: int, result: GuardResult) -> dict:
+    return {
+        "run_id": run_id,
+        "seq": seq,
+        "ts": time.time(),
+        "guard": result.guard,
+        "status": result.status,
+        "detail": result.detail,
+        "value": result.value,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="inv-guard — continuous invariant asserter")
+    ap.add_argument("--guards", default=DEFAULT_GUARDS, help="comma list of G1..G8 (default: G1,G2,G3,G4,G6)")
+    ap.add_argument("--run-id", default=f"invguard-{int(time.time())}")
+    ap.add_argument("--out", type=pathlib.Path, help="append JSONL events here (default: stdout only)")
+    ap.add_argument("--interval", type=float, default=10.0, help="seconds between polls")
+    ap.add_argument("--once", action="store_true", help="one poll then exit")
+    ap.add_argument("--abort", action="store_true", help="exit non-zero on the first breach")
+    ap.add_argument("--stall-secs", type=int, default=120, help="G3 stalled-part threshold")
+    ap.add_argument("--env-file", type=pathlib.Path, default=None)
+    args = ap.parse_args()
+
+    names = [g.strip() for g in args.guards.split(",") if g.strip()]
+    try:
+        guards = [make_guard(name) for name in names]
+    except KeyError as exc:
+        print(f"unknown guard {exc}; valid: G1..G8", file=sys.stderr)
+        return 2
+    for guard in guards:  # thread G3's threshold through without a global
+        if getattr(guard, "name", None) == "G3":
+            guard._stall_secs = args.stall_secs  # noqa: SLF001
+
+    cfg = config.load(args.env_file)
+    probe = ClusterProbe(cfg)
+    if not probe.available():
+        print("cluster (staging Postgres via kubectl) unreachable — inv-guard needs it", file=sys.stderr)
+        return 2
+
+    out = args.out.open("a") if args.out else None
+    seq = 0
+    total_breaches = 0
+
+    def emit(result: GuardResult) -> None:
+        nonlocal seq
+        line = json.dumps(_event(args.run_id, seq, result))
+        seq += 1
+        if out:
+            out.write(line + "\n")
+            out.flush()
+        marker = {"ok": "  ", "skip": "· ", "breach": "!!"}.get(result.status, "  ")
+        print(f"{marker} {result.guard:<3} {result.status:<6} {result.detail}")
+
+    try:
+        # Prometheus needs a port-forward; the pg probes go straight through kubectl exec, so a
+        # failed forward only degrades the prom-based guards (G1/G2) to `skip`, never the pg ones.
+        with probe.prometheus() as prom_ok:
+            if not prom_ok:
+                print("(prometheus port-forward failed — G1/G2 will skip)", file=sys.stderr)
+            while True:
+                print(f"\n== inv-guard poll (run_id={args.run_id}) ==")
+                breaches = run_once(guards, probe, emit)
+                total_breaches += breaches
+                if breaches and args.abort:
+                    print(f"\n🔴 inv-guard ABORT: {breaches} invariant breach(es)", file=sys.stderr)
+                    return 1
+                if args.once:
+                    break
+                time.sleep(args.interval)
+    finally:
+        if out:
+            out.close()
+
+    print(f"\n{'🔴' if total_breaches else '🟢'} inv-guard: {total_breaches} breach(es) over {seq} check(s)")
+    return 1 if total_breaches else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/stress-test/requirements.txt
+++ b/stress-test/requirements.txt
@@ -1,0 +1,2 @@
+# harness runtime deps (the repo .venv already has boto3 + asyncpg; this pins the S3 client)
+boto3>=1.40

--- a/stress-test/results/run-20260702T154907Z.json
+++ b/stress-test/results/run-20260702T154907Z.json
@@ -1,0 +1,88 @@
+{
+  "target": "https://s3-staging.hippius.com",
+  "go": false,
+  "summary": "6 pass, 2 fail, 0 skip",
+  "results": [
+    {
+      "name": "T1 functional/adversarial",
+      "invariant": "scenario crashed",
+      "passed": false,
+      "detail": "ClientError: An error occurred (UploadNotPermitted) when calling the CreateBucket operation: Failed to fetch billing balance",
+      "criteria": "scenario runs to completion without an unhandled error",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "durability-corpus-upload",
+      "invariant": "S8/G3 setup",
+      "passed": true,
+      "detail": "uploaded 15 objects (2 multipart) in 33.0s to prodgate-durab-1783006958",
+      "criteria": "corpus PUTs succeed (verified for real in durability-reverify)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "concurrency-ramp",
+      "invariant": "S5/S6 (backpressure) + throughput",
+      "passed": true,
+      "detail": "90 ok, 0 503-backpressure(retried), 0 non-503-5xx; worst non-503 5xx rate=0.0%; 94 MB",
+      "criteria": "non-503 5xx rate < 1% and no hangs; 503 SlowDown is correct backpressure (informational)",
+      "skipped": false,
+      "metrics": {
+        "ok": 90,
+        "slowdown": 0,
+        "non_503_5xx": 0
+      }
+    },
+    {
+      "name": "inv-G1-single-leader",
+      "invariant": "G1 single-leader",
+      "passed": true,
+      "detail": "sum(drain_leader)=1",
+      "criteria": "sum(drain_leader) \u2264 1 (no split-brain)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "inv-G6-terminal-monotonic",
+      "invariant": "G6 terminal monotonicity",
+      "passed": true,
+      "detail": "global terminal rows 72\u219272; our objects: {'pending': 7, 'replicated': 49}",
+      "criteria": "observed replicated/failed rows never regress (our objects tracked)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "inv-S4-backlog",
+      "invariant": "S4 backlog gauge",
+      "passed": true,
+      "detail": "max drain_ssd_backlog_bytes = 731.7 GB (informational)",
+      "criteria": "backlog exported + bounded (absolute ceiling is a RATIFY item)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "drain-convergence",
+      "invariant": "drain actually replicates (lag proxy)",
+      "passed": false,
+      "detail": "our repl rows={'pending': 1, 'replicated': 109}; drain_parts_replicated \u0394=63.0; STILL non-terminal in \u2264200s",
+      "criteria": "0 pending/draining rows for our objects within 200s",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "durability-reverify",
+      "invariant": "S8/G3 no-data-loss (NON-OVERRIDABLE)",
+      "passed": true,
+      "detail": "105/105 byte-identical; 0 corrupt, 0 missing",
+      "criteria": "every acked object re-GETs byte-identical (plaintext md5 + size)",
+      "skipped": false,
+      "metrics": {
+        "total": 105,
+        "ok": 105,
+        "corrupt": 0,
+        "missing": 0
+      }
+    }
+  ]
+}

--- a/stress-test/results/run-20260702T154907Z.md
+++ b/stress-test/results/run-20260702T154907Z.md
@@ -1,0 +1,14 @@
+# Production-readiness harness run — https://s3-staging.hippius.com
+
+**Verdict: 🔴 NO-GO** · 6 pass, 2 fail, 0 skip · 402s
+
+| Result | Scenario | Asserts | Evidence | Criteria |
+|---|---|---|---|---|
+| ❌ FAIL | T1 functional/adversarial | scenario crashed | ClientError: An error occurred (UploadNotPermitted) when calling the CreateBucket operation: Failed to fetch billing balance | scenario runs to completion without an unhandled error |
+| ✅ PASS | durability-corpus-upload | S8/G3 setup | uploaded 15 objects (2 multipart) in 33.0s to prodgate-durab-1783006958 | corpus PUTs succeed (verified for real in durability-reverify) |
+| ✅ PASS | concurrency-ramp | S5/S6 (backpressure) + throughput | 90 ok, 0 503-backpressure(retried), 0 non-503-5xx; worst non-503 5xx rate=0.0%; 94 MB | non-503 5xx rate < 1% and no hangs; 503 SlowDown is correct backpressure (informational) |
+| ✅ PASS | inv-G1-single-leader | G1 single-leader | sum(drain_leader)=1 | sum(drain_leader) ≤ 1 (no split-brain) |
+| ✅ PASS | inv-G6-terminal-monotonic | G6 terminal monotonicity | global terminal rows 72→72; our objects: {'pending': 7, 'replicated': 49} | observed replicated/failed rows never regress (our objects tracked) |
+| ✅ PASS | inv-S4-backlog | S4 backlog gauge | max drain_ssd_backlog_bytes = 731.7 GB (informational) | backlog exported + bounded (absolute ceiling is a RATIFY item) |
+| ❌ FAIL | drain-convergence | drain actually replicates (lag proxy) | our repl rows={'pending': 1, 'replicated': 109}; drain_parts_replicated Δ=63.0; STILL non-terminal in ≤200s | 0 pending/draining rows for our objects within 200s |
+| ✅ PASS | durability-reverify | S8/G3 no-data-loss (NON-OVERRIDABLE) | 105/105 byte-identical; 0 corrupt, 0 missing | every acked object re-GETs byte-identical (plaintext md5 + size) |

--- a/stress-test/results/run-20260702T204039Z.json
+++ b/stress-test/results/run-20260702T204039Z.json
@@ -1,0 +1,142 @@
+{
+  "target": "https://s3-staging.hippius.com",
+  "go": false,
+  "summary": "13 pass, 1 fail, 0 skip",
+  "results": [
+    {
+      "name": "func-range-get",
+      "invariant": "T1 range",
+      "passed": true,
+      "detail": "got 1048576 B, match=True",
+      "criteria": "Range bytes=0-1048575 returns exactly the first 1 MiB",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-overwrite-latest",
+      "invariant": "T1 overwrite",
+      "passed": true,
+      "detail": "GET-after-overwrite md5=e4ea09b5 want=e4ea09b5",
+      "criteria": "GET after overwrite returns the latest bytes",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-mpu-wrong-etag",
+      "invariant": "T1 MPU integrity",
+      "passed": true,
+      "detail": "wrong-ETag complete was rejected",
+      "criteria": "CompleteMultipartUpload with a mismatched part ETag is rejected",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-mpu-abort",
+      "invariant": "T1 MPU abort",
+      "passed": true,
+      "detail": "aborted MPU object is absent",
+      "criteria": "An aborted MPU leaves no readable object",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-acl-anon",
+      "invariant": "T1 ACL",
+      "passed": true,
+      "detail": "anon public=200 (want 200), private=403 (want 403)",
+      "criteria": "Anon GET: public-read \u2192 200, private \u2192 403",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-listv2-delimiter",
+      "invariant": "T1 ListObjectsV2",
+      "passed": true,
+      "detail": "CommonPrefixes=['a/', 'c/']",
+      "criteria": "delimiter '/' groups a/ and c/",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-zero-byte",
+      "invariant": "T1 zero-byte",
+      "passed": true,
+      "detail": "zero-byte GET len=0",
+      "criteria": "A zero-byte object round-trips as empty",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "durability-corpus-upload",
+      "invariant": "S8/G3 setup",
+      "passed": true,
+      "detail": "uploaded 15 objects (2 multipart) in 31.5s to prodgate-durab-1783024415",
+      "criteria": "corpus PUTs succeed (verified for real in durability-reverify)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "concurrency-ramp",
+      "invariant": "S5/S6 (backpressure) + throughput",
+      "passed": true,
+      "detail": "90 ok, 0 503-backpressure(retried), 0 non-503-5xx; worst non-503 5xx rate=0.0%; 94 MB",
+      "criteria": "non-503 5xx rate < 1% and no hangs; 503 SlowDown is correct backpressure (informational)",
+      "skipped": false,
+      "metrics": {
+        "ok": 90,
+        "slowdown": 0,
+        "non_503_5xx": 0
+      }
+    },
+    {
+      "name": "inv-G1-single-leader",
+      "invariant": "G1 single-leader",
+      "passed": true,
+      "detail": "sum(drain_leader)=1",
+      "criteria": "sum(drain_leader) \u2264 1 (no split-brain)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "inv-G6-terminal-monotonic",
+      "invariant": "G6 terminal monotonicity",
+      "passed": true,
+      "detail": "global terminal rows 442\u2192442; our objects: {'pending': 1, 'replicated': 189}",
+      "criteria": "observed replicated/failed rows never regress (our objects tracked)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "inv-S4-backlog",
+      "invariant": "S4 backlog gauge",
+      "passed": true,
+      "detail": "max drain_ssd_backlog_bytes = 735.5 GB (informational)",
+      "criteria": "backlog exported + bounded (absolute ceiling is a RATIFY item)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "drain-convergence",
+      "invariant": "drain actually replicates (lag proxy)",
+      "passed": false,
+      "detail": "our repl rows={'pending': 1, 'replicated': 231}; drain_parts_replicated \u0394=42.0; STILL non-terminal in \u2264300s",
+      "criteria": "0 pending/draining rows for our objects within 300s",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "durability-reverify",
+      "invariant": "S8/G3 no-data-loss (NON-OVERRIDABLE)",
+      "passed": true,
+      "detail": "105/105 byte-identical; 0 corrupt, 0 missing",
+      "criteria": "every acked object re-GETs byte-identical (plaintext md5 + size)",
+      "skipped": false,
+      "metrics": {
+        "total": 105,
+        "ok": 105,
+        "corrupt": 0,
+        "missing": 0
+      }
+    }
+  ]
+}

--- a/stress-test/results/run-20260702T204039Z.md
+++ b/stress-test/results/run-20260702T204039Z.md
@@ -1,0 +1,20 @@
+# Production-readiness harness run — https://s3-staging.hippius.com
+
+**Verdict: 🔴 NO-GO** · 13 pass, 1 fail, 0 skip · 519s
+
+| Result | Scenario | Asserts | Evidence | Criteria |
+|---|---|---|---|---|
+| ✅ PASS | func-range-get | T1 range | got 1048576 B, match=True | Range bytes=0-1048575 returns exactly the first 1 MiB |
+| ✅ PASS | func-overwrite-latest | T1 overwrite | GET-after-overwrite md5=e4ea09b5 want=e4ea09b5 | GET after overwrite returns the latest bytes |
+| ✅ PASS | func-mpu-wrong-etag | T1 MPU integrity | wrong-ETag complete was rejected | CompleteMultipartUpload with a mismatched part ETag is rejected |
+| ✅ PASS | func-mpu-abort | T1 MPU abort | aborted MPU object is absent | An aborted MPU leaves no readable object |
+| ✅ PASS | func-acl-anon | T1 ACL | anon public=200 (want 200), private=403 (want 403) | Anon GET: public-read → 200, private → 403 |
+| ✅ PASS | func-listv2-delimiter | T1 ListObjectsV2 | CommonPrefixes=['a/', 'c/'] | delimiter '/' groups a/ and c/ |
+| ✅ PASS | func-zero-byte | T1 zero-byte | zero-byte GET len=0 | A zero-byte object round-trips as empty |
+| ✅ PASS | durability-corpus-upload | S8/G3 setup | uploaded 15 objects (2 multipart) in 31.5s to prodgate-durab-1783024415 | corpus PUTs succeed (verified for real in durability-reverify) |
+| ✅ PASS | concurrency-ramp | S5/S6 (backpressure) + throughput | 90 ok, 0 503-backpressure(retried), 0 non-503-5xx; worst non-503 5xx rate=0.0%; 94 MB | non-503 5xx rate < 1% and no hangs; 503 SlowDown is correct backpressure (informational) |
+| ✅ PASS | inv-G1-single-leader | G1 single-leader | sum(drain_leader)=1 | sum(drain_leader) ≤ 1 (no split-brain) |
+| ✅ PASS | inv-G6-terminal-monotonic | G6 terminal monotonicity | global terminal rows 442→442; our objects: {'pending': 1, 'replicated': 189} | observed replicated/failed rows never regress (our objects tracked) |
+| ✅ PASS | inv-S4-backlog | S4 backlog gauge | max drain_ssd_backlog_bytes = 735.5 GB (informational) | backlog exported + bounded (absolute ceiling is a RATIFY item) |
+| ❌ FAIL | drain-convergence | drain actually replicates (lag proxy) | our repl rows={'pending': 1, 'replicated': 231}; drain_parts_replicated Δ=42.0; STILL non-terminal in ≤300s | 0 pending/draining rows for our objects within 300s |
+| ✅ PASS | durability-reverify | S8/G3 no-data-loss (NON-OVERRIDABLE) | 105/105 byte-identical; 0 corrupt, 0 missing | every acked object re-GETs byte-identical (plaintext md5 + size) |

--- a/stress-test/results/run-20260702T212649Z.json
+++ b/stress-test/results/run-20260702T212649Z.json
@@ -1,0 +1,142 @@
+{
+  "target": "https://s3-staging.hippius.com",
+  "go": false,
+  "summary": "12 pass, 2 fail, 0 skip",
+  "results": [
+    {
+      "name": "func-range-get",
+      "invariant": "T1 range",
+      "passed": true,
+      "detail": "got 1048576 B, match=True",
+      "criteria": "Range bytes=0-1048575 returns exactly the first 1 MiB",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-overwrite-latest",
+      "invariant": "T1 overwrite",
+      "passed": true,
+      "detail": "GET-after-overwrite md5=e4ea09b5 want=e4ea09b5",
+      "criteria": "GET after overwrite returns the latest bytes",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-mpu-wrong-etag",
+      "invariant": "T1 MPU integrity",
+      "passed": true,
+      "detail": "wrong-ETag complete was rejected",
+      "criteria": "CompleteMultipartUpload with a mismatched part ETag is rejected",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-mpu-abort",
+      "invariant": "T1 MPU abort",
+      "passed": true,
+      "detail": "aborted MPU object is absent",
+      "criteria": "An aborted MPU leaves no readable object",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-acl-anon",
+      "invariant": "T1 ACL",
+      "passed": true,
+      "detail": "anon public=200 (want 200), private=403 (want 403)",
+      "criteria": "Anon GET: public-read \u2192 200, private \u2192 403",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-listv2-delimiter",
+      "invariant": "T1 ListObjectsV2",
+      "passed": true,
+      "detail": "CommonPrefixes=['a/', 'c/']",
+      "criteria": "delimiter '/' groups a/ and c/",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "func-zero-byte",
+      "invariant": "T1 zero-byte",
+      "passed": true,
+      "detail": "zero-byte GET len=0",
+      "criteria": "A zero-byte object round-trips as empty",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "durability-corpus-upload",
+      "invariant": "S8/G3 setup",
+      "passed": true,
+      "detail": "uploaded 15 objects (2 multipart) in 32.9s to prodgate-durab-1783027184",
+      "criteria": "corpus PUTs succeed (verified for real in durability-reverify)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "concurrency-ramp",
+      "invariant": "S5/S6 (backpressure) + throughput",
+      "passed": true,
+      "detail": "90 ok, 0 503-backpressure(retried), 0 non-503-5xx; worst non-503 5xx rate=0.0%; 94 MB",
+      "criteria": "non-503 5xx rate < 1% and no hangs; 503 SlowDown is correct backpressure (informational)",
+      "skipped": false,
+      "metrics": {
+        "ok": 90,
+        "slowdown": 0,
+        "non_503_5xx": 0
+      }
+    },
+    {
+      "name": "inv-G1-single-leader",
+      "invariant": "G1 single-leader",
+      "passed": false,
+      "detail": "sum(drain_leader)=2",
+      "criteria": "sum(drain_leader) \u2264 1 (no split-brain)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "inv-G6-terminal-monotonic",
+      "invariant": "G6 terminal monotonicity",
+      "passed": true,
+      "detail": "global terminal rows 589\u2192589; our objects: {'draining': 1, 'pending': 2, 'replicated': 336}",
+      "criteria": "observed replicated/failed rows never regress (our objects tracked)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "inv-S4-backlog",
+      "invariant": "S4 backlog gauge",
+      "passed": true,
+      "detail": "max drain_ssd_backlog_bytes = 739.2 GB (informational)",
+      "criteria": "backlog exported + bounded (absolute ceiling is a RATIFY item)",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "drain-convergence",
+      "invariant": "drain actually replicates (lag proxy)",
+      "passed": false,
+      "detail": "our repl rows={'draining': 1, 'pending': 2, 'replicated': 348}; drain_parts_replicated \u0394=12.0; STILL non-terminal in \u2264300s",
+      "criteria": "0 pending/draining rows for our objects within 300s",
+      "skipped": false,
+      "metrics": {}
+    },
+    {
+      "name": "durability-reverify",
+      "invariant": "S8/G3 no-data-loss (NON-OVERRIDABLE)",
+      "passed": true,
+      "detail": "105/105 byte-identical; 0 corrupt, 0 missing",
+      "criteria": "every acked object re-GETs byte-identical (plaintext md5 + size)",
+      "skipped": false,
+      "metrics": {
+        "total": 105,
+        "ok": 105,
+        "corrupt": 0,
+        "missing": 0
+      }
+    }
+  ]
+}

--- a/stress-test/results/run-20260702T212649Z.md
+++ b/stress-test/results/run-20260702T212649Z.md
@@ -1,0 +1,20 @@
+# Production-readiness harness run — https://s3-staging.hippius.com
+
+**Verdict: 🔴 NO-GO** · 12 pass, 2 fail, 0 skip · 451s
+
+| Result | Scenario | Asserts | Evidence | Criteria |
+|---|---|---|---|---|
+| ✅ PASS | func-range-get | T1 range | got 1048576 B, match=True | Range bytes=0-1048575 returns exactly the first 1 MiB |
+| ✅ PASS | func-overwrite-latest | T1 overwrite | GET-after-overwrite md5=e4ea09b5 want=e4ea09b5 | GET after overwrite returns the latest bytes |
+| ✅ PASS | func-mpu-wrong-etag | T1 MPU integrity | wrong-ETag complete was rejected | CompleteMultipartUpload with a mismatched part ETag is rejected |
+| ✅ PASS | func-mpu-abort | T1 MPU abort | aborted MPU object is absent | An aborted MPU leaves no readable object |
+| ✅ PASS | func-acl-anon | T1 ACL | anon public=200 (want 200), private=403 (want 403) | Anon GET: public-read → 200, private → 403 |
+| ✅ PASS | func-listv2-delimiter | T1 ListObjectsV2 | CommonPrefixes=['a/', 'c/'] | delimiter '/' groups a/ and c/ |
+| ✅ PASS | func-zero-byte | T1 zero-byte | zero-byte GET len=0 | A zero-byte object round-trips as empty |
+| ✅ PASS | durability-corpus-upload | S8/G3 setup | uploaded 15 objects (2 multipart) in 32.9s to prodgate-durab-1783027184 | corpus PUTs succeed (verified for real in durability-reverify) |
+| ✅ PASS | concurrency-ramp | S5/S6 (backpressure) + throughput | 90 ok, 0 503-backpressure(retried), 0 non-503-5xx; worst non-503 5xx rate=0.0%; 94 MB | non-503 5xx rate < 1% and no hangs; 503 SlowDown is correct backpressure (informational) |
+| ❌ FAIL | inv-G1-single-leader | G1 single-leader | sum(drain_leader)=2 | sum(drain_leader) ≤ 1 (no split-brain) |
+| ✅ PASS | inv-G6-terminal-monotonic | G6 terminal monotonicity | global terminal rows 589→589; our objects: {'draining': 1, 'pending': 2, 'replicated': 336} | observed replicated/failed rows never regress (our objects tracked) |
+| ✅ PASS | inv-S4-backlog | S4 backlog gauge | max drain_ssd_backlog_bytes = 739.2 GB (informational) | backlog exported + bounded (absolute ceiling is a RATIFY item) |
+| ❌ FAIL | drain-convergence | drain actually replicates (lag proxy) | our repl rows={'draining': 1, 'pending': 2, 'replicated': 348}; drain_parts_replicated Δ=12.0; STILL non-terminal in ≤300s | 0 pending/draining rows for our objects within 300s |
+| ✅ PASS | durability-reverify | S8/G3 no-data-loss (NON-OVERRIDABLE) | 105/105 byte-identical; 0 corrupt, 0 missing | every acked object re-GETs byte-identical (plaintext md5 + size) |

--- a/stress-test/run.py
+++ b/stress-test/run.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Production-readiness harness runner.
+
+Runs the scenario suite against an S3 endpoint (default s3-staging.hippius.com) and, when the
+staging cluster is reachable via kubectl, the drain internals (Postgres + Prometheus). Emits a
+PASS/FAIL report and exits non-zero on any hard-gate failure.
+
+Usage:
+    source .aws.cli.env && python stress-test/run.py
+    python stress-test/run.py --no-cluster            # S3-only (no kubectl)
+    python stress-test/run.py --keep                  # leave test buckets for inspection
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import time
+
+
+# allow `python stress-test/run.py` from the repo root
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from harness import config  # noqa: E402
+from harness import s3util  # noqa: E402
+from harness import scenarios  # noqa: E402
+from harness.ledger import Ledger  # noqa: E402
+from harness.probes import ClusterProbe  # noqa: E402
+from harness.report import Report  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="hippius-s3 drain-stack production-readiness harness")
+    ap.add_argument("--endpoint", default=None, help="override S3 endpoint")
+    ap.add_argument("--no-cluster", action="store_true", help="skip Postgres/Prometheus invariant probes")
+    ap.add_argument("--keep", action="store_true", help="keep test buckets after the run")
+    ap.add_argument("--timeout", type=int, default=None, help="drain-convergence timeout (s)")
+    args = ap.parse_args()
+
+    cfg = config.load()
+    if args.endpoint:
+        cfg.endpoint_url = args.endpoint
+    if args.keep:
+        cfg.keep_objects = True
+    if args.timeout:
+        cfg.drain_convergence_timeout_s = args.timeout
+
+    print(f"== production-readiness harness ==\n   target: {cfg.endpoint_url}\n")
+    client = s3util.make_client(cfg)
+    ledger = Ledger()
+    report = Report(cfg.endpoint_url)
+    buckets: dict[str, str] = {}
+
+    probe = ClusterProbe(cfg)
+    cluster = (not args.no_cluster) and probe.available()
+    print(f"   cluster probes: {'ENABLED (kubectl → staging)' if cluster else 'disabled (S3-only run)'}\n")
+
+    def guarded(label: str, fn) -> None:
+        """Run a scenario; a crash becomes a recorded FAIL so the suite continues (harness robustness)."""
+        print(f"-- {label} --")
+        try:
+            fn()
+        except Exception as e:  # noqa: BLE001 — a test runner must isolate scenario failures
+            from harness.report import Result
+            report.add(Result(label, "scenario crashed", passed=False,
+                              detail=f"{type(e).__name__}: {e}",
+                              criteria="scenario runs to completion without an unhandled error"))
+
+    guarded("T1 functional/adversarial", lambda: scenarios.functional_adversarial(client, cfg, ledger, report, buckets))
+    guarded("durability corpus (upload)", lambda: scenarios.durability_corpus(client, cfg, ledger, report, buckets))
+    guarded("T5-lite concurrency ramp", lambda: scenarios.concurrency_ramp(client, cfg, ledger, report, buckets))
+
+    prom_ok = False
+    if cluster:
+        with probe.prometheus() as prom_ok:
+            guarded("invariants (cluster)", lambda: scenarios.invariant_assert(probe, cfg, report, prom_ok))
+            guarded(f"drain convergence (≤{cfg.drain_convergence_timeout_s}s)",
+                    lambda: scenarios.replication_convergence(probe, cfg, report, prom_ok))
+    else:
+        print("-- invariants + convergence: skipped (no cluster) --")
+        # give the drain a moment before the durability re-verify even without cluster probes
+        time.sleep(10)
+
+    guarded("durability re-verify (the no-data-loss gate)",
+            lambda: scenarios.durability_reverify(client, cfg, ledger, report))
+
+    # cleanup
+    if not cfg.keep_objects:
+        print("-- cleanup --")
+        for b in buckets.values():
+            try:
+                s3util.delete_bucket_recursive(client, b)
+            except Exception as e:  # cleanup is best-effort; never fail the verdict on it
+                print(f"    (cleanup skipped for {b}: {e})")
+    else:
+        print(f"-- keeping buckets: {list(buckets.values())} --")
+
+    out_dir = pathlib.Path(__file__).resolve().parent / "results"
+    out_dir.mkdir(exist_ok=True)
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    report.dump(out_dir / f"run-{stamp}.md", out_dir / f"run-{stamp}.json")
+    ledger.dump(out_dir / f"ledger-{stamp}.json")
+
+    print("\n" + report.to_markdown())
+    print(f"results: stress-test/results/run-{stamp}.md")
+    return 0 if report.go else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_orphan_replication_sweep_sql.py
+++ b/tests/integration/test_orphan_replication_sweep_sql.py
@@ -1,0 +1,309 @@
+"""Truth table for the A21 orphan sweep query, against real Postgres.
+
+`list_orphan_replication_versions.sql` is the WI-20a backstop. Unlike the abandoned-MPU
+reaper (`list_abandoned_versions`, which keys on `multipart_uploads`), this query keys
+DIRECTLY on `cephor_replication_status`, so it catches versions whose MPU/parts header
+rows are already GONE (an aborted upload deletes them) but whose drain replication rows
+leaked — the exact A21 orphan that churns the drain forever. It selects a version to mark
+`failed` iff ALL hold:
+
+  * it still has an ACTIVE drain row (`status IN ('pending','draining')`),
+  * its version is UNSERVABLE (`address IS NULL` AND size<=0 AND md5=''), the same
+    download-servability predicate the janitor uses — so a servable / mid-finalize
+    version is never marked, and
+  * its most-recently-landed part is older than the grace window (`MAX(landed_at)` gate),
+    the last-activity valve — a still-arriving upload keeps landing fresh parts and is
+    spared, mirroring the reaper's per-upload activity gate but sourced purely from the
+    drain rows (which survive the MPU-header delete).
+
+The unit tests drive `sweep_orphan_replication_versions` with a fake db, so the SQL
+predicate itself is only exercised here, against real Postgres via TEMP tables shadowing
+`object_versions` and `cephor_replication_status` (no dependency on the Rust drain
+migrations being applied to the test DB).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import AsyncGenerator
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from hippius_s3.utils import get_query
+
+
+pytestmark = pytest.mark.asyncio
+
+_DB_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/hippius?sslmode=disable")
+_STALE = 3600  # a version is sweepable once its newest part landed longer ago than this
+
+
+@pytest_asyncio.fixture
+async def conn() -> AsyncGenerator[asyncpg.Connection, None]:
+    """A real PG connection with TEMP tables shadowing the two tables the sweep reads.
+    TEMP tables live in pg_temp (ahead of `public` in the search path), so the query's
+    unqualified names resolve to them; they vanish on close — no cleanup, no bleed."""
+    try:
+        c = await asyncpg.connect(_DB_URL)
+    except (OSError, asyncpg.PostgresError) as e:
+        pytest.skip(f"integration Postgres unavailable ({e}); run `docker compose up -d postgres`")
+
+    await c.execute(
+        """
+        CREATE TEMP TABLE object_versions (
+            object_id      uuid    NOT NULL,
+            object_version bigint  NOT NULL,
+            address        text,
+            size_bytes     bigint  NOT NULL DEFAULT 0,
+            md5_hash       text,
+            PRIMARY KEY (object_id, object_version)
+        ) ON COMMIT PRESERVE ROWS;
+
+        CREATE TEMP TABLE cephor_replication_status (
+            object_id   text        NOT NULL,
+            version     bigint      NOT NULL,
+            part_number bigint      NOT NULL,
+            status      text        NOT NULL,
+            landed_at   timestamptz NOT NULL DEFAULT now(),
+            PRIMARY KEY (object_id, version, part_number)
+        ) ON COMMIT PRESERVE ROWS;
+        """
+    )
+    try:
+        yield c
+    finally:
+        await c.close()
+
+
+async def _seed_version(
+    conn: asyncpg.Connection,
+    object_id: str,
+    version: int,
+    *,
+    address: str | None,
+    size_bytes: int = 0,
+    md5_hash: str | None = "",
+) -> None:
+    await conn.execute(
+        "INSERT INTO object_versions (object_id, object_version, address, size_bytes, md5_hash) "
+        "VALUES ($1::uuid, $2, $3, $4, $5)",
+        object_id,
+        version,
+        address,
+        size_bytes,
+        md5_hash,
+    )
+
+
+async def _seed_status(
+    conn: asyncpg.Connection,
+    object_id: str,
+    version: int,
+    part_number: int,
+    *,
+    status: str,
+    landed_age_seconds: int = 7200,
+) -> None:
+    # landed_age defaults to 2h (stale vs _STALE=3600) so the common case sweeps; pass a
+    # small value to model a freshly-landed part that should protect its version.
+    await conn.execute(
+        "INSERT INTO cephor_replication_status (object_id, version, part_number, status, landed_at) "
+        "VALUES ($1, $2, $3, $4, now() - make_interval(secs => $5))",
+        object_id,
+        version,
+        part_number,
+        status,
+        landed_age_seconds,
+    )
+
+
+async def _swept(conn: asyncpg.Connection) -> set[tuple[str, int]]:
+    rows = await conn.fetch(get_query("list_orphan_replication_versions"), _STALE)
+    return {(r["object_id"], r["version"]) for r in rows}
+
+
+def _oid() -> str:
+    return str(uuid.uuid4())
+
+
+# =========================================================== the TRUE cases
+
+
+async def test_pending_unservable_aged_orphan_is_swept(conn):
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, oid, 1, 1, status="pending")
+    assert (oid, 1) in await _swept(conn)
+
+
+async def test_draining_orphan_is_swept(conn):
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, oid, 1, 1, status="draining")
+    assert (oid, 1) in await _swept(conn)
+
+
+async def test_null_md5_is_unservable_and_swept(conn):
+    # md5_hash IS NULL must count as unservable too (COALESCE in the predicate).
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash=None)
+    await _seed_status(conn, oid, 1, 1, status="pending")
+    assert (oid, 1) in await _swept(conn)
+
+
+async def test_orphan_with_no_multipart_upload_row_is_swept(conn):
+    # The whole reason the sweep exists: an aborted upload has already deleted its
+    # multipart_uploads/parts rows, so the abandoned-MPU reaper can never see it. The
+    # sweep keys only on cephor + object_versions, so it self-heals such an orphan — this
+    # is the "3 live legacy orphans self-heal on first run" case, at the query level.
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, oid, 1, 1, status="pending")
+    # No multipart_uploads/parts tables exist in this fixture at all — proof the sweep
+    # does not depend on them.
+    assert (oid, 1) in await _swept(conn)
+
+
+# =========================================================== FALSE: terminal status
+
+
+@pytest.mark.parametrize("status", ["replicated", "failed"])
+async def test_terminal_status_is_not_swept(conn, status):
+    # 'replicated' is legitimately done; 'failed' is already terminal — re-marking is a
+    # no-op but selecting it would churn the sweep, so the predicate excludes both.
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, oid, 1, 1, status=status)
+    assert await _swept(conn) == set()
+
+
+# =========================================================== FALSE: servable versions
+# The load-bearing safety cases — the drain's corruption mark can leave a 'pending'/'draining'
+# row on a SERVABLE version; the sweep must never mark such a version and strand a live GET.
+
+
+async def test_servable_by_size_is_not_swept(conn):
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=7, md5_hash="")
+    await _seed_status(conn, oid, 1, 1, status="pending")
+    assert await _swept(conn) == set()
+
+
+async def test_servable_by_md5_is_not_swept(conn):
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash="d41d8cd98f00b204e9800998ecf8427e")
+    await _seed_status(conn, oid, 1, 1, status="pending")
+    assert await _swept(conn) == set()
+
+
+async def test_address_written_is_not_swept(conn):
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address="5Faddr", size_bytes=0, md5_hash="")
+    await _seed_status(conn, oid, 1, 1, status="pending")
+    assert await _swept(conn) == set()
+
+
+async def test_mid_finalize_window_is_not_swept(conn):
+    # address=NULL BUT size>0 AND md5 set — a version between the size/md5 UPDATE and the
+    # set_object_version_address call is GET-servable; the size/md5 guard protects it.
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=4096, md5_hash="9a0364b9e99bb480dd25e1f0284c8555")
+    await _seed_status(conn, oid, 1, 1, status="pending")
+    assert await _swept(conn) == set()
+
+
+# =========================================================== FALSE: the activity gate
+
+
+async def test_freshly_landed_orphan_is_not_swept(conn):
+    # Unservable + active, but its part landed inside the grace window → the upload may
+    # still be in flight; do not sweep yet.
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, oid, 1, 1, status="pending", landed_age_seconds=60)
+    assert await _swept(conn) == set()
+
+
+async def test_one_recently_landed_part_protects_the_version(conn):
+    # MAX(landed_at) is the gate: a single fresh part (a still-arriving upload adding part
+    # N) protects the whole version even though an earlier part is stale — without this a
+    # slow/in-flight MPU would be swept mid-upload.
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, oid, 1, 1, status="pending", landed_age_seconds=7200)  # stale
+    await _seed_status(conn, oid, 1, 2, status="pending", landed_age_seconds=60)  # just landed
+    assert await _swept(conn) == set()
+
+
+# =========================================================== FALSE: missing rows
+
+
+async def test_no_object_version_row_is_not_swept(conn):
+    # A drain row whose object_versions row is absent → unservability cannot be proven →
+    # protect (the JOIN yields no row), mirroring the janitor's EXISTS(ov) guard.
+    oid = _oid()
+    await _seed_status(conn, oid, 1, 1, status="pending")
+    assert await _swept(conn) == set()
+
+
+# =========================================================== dedup / isolation / age
+
+
+async def test_multiple_active_parts_dedup_to_one_row(conn):
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash="")
+    for part in (1, 2, 3):
+        await _seed_status(conn, oid, 1, part, status="pending")
+    rows = await conn.fetch(get_query("list_orphan_replication_versions"), _STALE)
+    assert [(r["object_id"], r["version"]) for r in rows] == [(oid, 1)], "one row per (object_id, version)"
+
+
+async def test_version_isolation_keeps_servable_v1(conn):
+    # Key overwritten: v1 complete + servable, v2 an abandoned MPU. Only v2 is swept.
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address="5Fowner", size_bytes=4096, md5_hash="abc123")
+    await _seed_status(conn, oid, 1, 1, status="replicated")
+    await _seed_version(conn, oid, 2, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, oid, 2, 1, status="pending")
+    assert await _swept(conn) == {(oid, 2)}
+
+
+async def test_age_seconds_reports_oldest_part(conn):
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, oid, 1, 1, status="pending", landed_age_seconds=10000)
+    await _seed_status(conn, oid, 1, 2, status="pending", landed_age_seconds=5000)
+    rows = await conn.fetch(get_query("list_orphan_replication_versions"), _STALE)
+    assert len(rows) == 1
+    # age is measured from the OLDEST part (MIN landed_at) — the version's true lag.
+    assert rows[0]["age_seconds"] >= 10000, "age reflects the oldest part, not the newest"
+
+
+async def test_full_truth_table(conn):
+    """One interleaved pass over the full (status × servability × age) matrix — a future
+    predicate edit that flips any cell is caught here."""
+    swept_oid = _oid()  # pending + unservable + aged  → SWEPT
+    draining_oid = _oid()  # draining + unservable + aged → SWEPT
+    servable_oid = _oid()  # pending + servable          → protected
+    fresh_oid = _oid()  # pending + unservable + fresh → protected
+    replicated_oid = _oid()  # replicated + unservable     → protected
+
+    await _seed_version(conn, swept_oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, swept_oid, 1, 1, status="pending")
+
+    await _seed_version(conn, draining_oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, draining_oid, 1, 1, status="draining")
+
+    await _seed_version(conn, servable_oid, 1, address=None, size_bytes=9, md5_hash="")
+    await _seed_status(conn, servable_oid, 1, 1, status="pending")
+
+    await _seed_version(conn, fresh_oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, fresh_oid, 1, 1, status="pending", landed_age_seconds=30)
+
+    await _seed_version(conn, replicated_oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, replicated_oid, 1, 1, status="replicated")
+
+    assert await _swept(conn) == {(swept_oid, 1), (draining_oid, 1)}

--- a/tests/integration/test_replication_sentinel_sql.py
+++ b/tests/integration/test_replication_sentinel_sql.py
@@ -1,0 +1,249 @@
+"""Truth table for the G2 replication-gate sentinel query, against real Postgres.
+
+`find_underreplicated_live_chunks.sql` is the read-only durability alarm: it returns
+chunks of LIVE, serveable object versions that lack full-union backend coverage — the
+exact population the janitor's replication gate must never let be reclaimed. Getting it
+wrong means either false alarms (flagging safe chunks) or, far worse, silence over a real
+data-loss gap (e.g. the C10 case: a configured backup backend the enqueuer never pushed
+to). The required-backend logic must mirror `is_replicated_on_all_backends` exactly, so
+the SQL semantics are pinned here against real Postgres via TEMP tables.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import AsyncGenerator
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from hippius_s3.utils import get_query
+
+
+pytestmark = pytest.mark.asyncio
+
+_DB_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/hippius?sslmode=disable")
+_DEFAULT_UPLOAD = ["arion"]  # config.upload_backends fallback for legacy (NULL) rows
+
+
+@pytest_asyncio.fixture
+async def conn() -> AsyncGenerator[asyncpg.Connection, None]:
+    """A real PG connection with TEMP tables shadowing the five tables the sentinel reads
+    (objects, object_versions, parts, part_chunks, chunk_backend). Column shapes mirror
+    production only where the query touches them; vanish on close (no cross-test bleed)."""
+    try:
+        c = await asyncpg.connect(_DB_URL)
+    except (OSError, asyncpg.PostgresError) as e:
+        pytest.skip(f"integration Postgres unavailable ({e}); run `docker compose up -d postgres`")
+
+    await c.execute(
+        """
+        CREATE TEMP TABLE objects (
+            object_id  uuid        NOT NULL PRIMARY KEY,
+            deleted_at timestamptz
+        ) ON COMMIT PRESERVE ROWS;
+
+        CREATE TEMP TABLE object_versions (
+            object_id       uuid   NOT NULL,
+            object_version  bigint NOT NULL,
+            address         text,
+            version_type    text,
+            upload_backends  text[],
+            PRIMARY KEY (object_id, object_version)
+        ) ON COMMIT PRESERVE ROWS;
+
+        CREATE TEMP TABLE parts (
+            part_id        uuid   NOT NULL PRIMARY KEY,
+            object_id      uuid   NOT NULL,
+            object_version bigint NOT NULL,
+            part_number    bigint NOT NULL
+        ) ON COMMIT PRESERVE ROWS;
+
+        CREATE TEMP TABLE part_chunks (
+            id      bigserial NOT NULL PRIMARY KEY,
+            part_id uuid      NOT NULL
+        ) ON COMMIT PRESERVE ROWS;
+
+        CREATE TEMP TABLE chunk_backend (
+            chunk_id bigint  NOT NULL,
+            backend  text    NOT NULL,
+            deleted  boolean NOT NULL DEFAULT false,
+            PRIMARY KEY (chunk_id, backend)
+        ) ON COMMIT PRESERVE ROWS;
+        """
+    )
+    try:
+        yield c
+    finally:
+        await c.close()
+
+
+def _oid() -> str:
+    return str(uuid.uuid4())
+
+
+async def _chunk(
+    conn: asyncpg.Connection,
+    *,
+    live_backends: list[str],
+    deleted_backends: list[str] | None = None,
+    object_deleted: bool = False,
+    address: str | None = "5Faddr",
+    version_type: str | None = None,
+    upload_backends: list[str] | None = None,
+) -> tuple[str, int, int]:
+    """Seeds one object→version→part→chunk with the given backend rows and returns its
+    (object_id, object_version, chunk_id). Defaults model a live, serveable chunk."""
+    oid = _oid()
+    deleted_at_sql = "now()" if object_deleted else "NULL"
+    await conn.execute(
+        f"INSERT INTO objects (object_id, deleted_at) VALUES ($1::uuid, {deleted_at_sql})",
+        oid,
+    )
+    await conn.execute(
+        "INSERT INTO object_versions (object_id, object_version, address, version_type, upload_backends) "
+        "VALUES ($1::uuid, 1, $2, $3, $4)",
+        oid,
+        address,
+        version_type,
+        upload_backends,
+    )
+    part_id = _oid()
+    await conn.execute(
+        "INSERT INTO parts (part_id, object_id, object_version, part_number) VALUES ($1::uuid, $2::uuid, 1, 1)",
+        part_id,
+        oid,
+    )
+    chunk_id: int = await conn.fetchval(
+        "INSERT INTO part_chunks (part_id) VALUES ($1::uuid) RETURNING id",
+        part_id,
+    )
+    for backend in live_backends:
+        await conn.execute(
+            "INSERT INTO chunk_backend (chunk_id, backend, deleted) VALUES ($1, $2, false)",
+            chunk_id,
+            backend,
+        )
+    for backend in deleted_backends or []:
+        await conn.execute(
+            "INSERT INTO chunk_backend (chunk_id, backend, deleted) VALUES ($1, $2, true)",
+            chunk_id,
+            backend,
+        )
+    return oid, 1, chunk_id
+
+
+async def _violations(
+    conn: asyncpg.Connection,
+    *,
+    backup: list[str],
+    default_upload: list[str] | None = None,
+    limit: int = 500,
+) -> set[tuple[str, int, int]]:
+    rows = await conn.fetch(
+        get_query("find_underreplicated_live_chunks"),
+        backup,
+        default_upload if default_upload is not None else _DEFAULT_UPLOAD,
+        limit,
+    )
+    return {(str(r["object_id"]), r["object_version"], r["chunk_id"]) for r in rows}
+
+
+# ===================================================== NOT flagged (safe)
+
+
+async def test_fully_covered_upload_only_is_not_flagged(conn):
+    await _chunk(conn, live_backends=["arion"], upload_backends=["arion"])
+    assert await _violations(conn, backup=[]) == set()
+
+
+async def test_fully_covered_upload_plus_backup_is_not_flagged(conn):
+    await _chunk(conn, live_backends=["arion", "ipfs"], upload_backends=["arion"])
+    assert await _violations(conn, backup=["ipfs"]) == set()
+
+
+async def test_deleted_object_is_not_flagged_even_if_uncovered(conn):
+    # A soft-deleted object's chunks are meant to lose coverage (the unpinner clears them).
+    await _chunk(conn, live_backends=[], upload_backends=["arion"], object_deleted=True)
+    assert await _violations(conn, backup=[]) == set()
+
+
+async def test_unserveable_version_is_not_flagged(conn):
+    # address NULL = mid-upload/aborted → the reaper/orphan-GC's concern, not a gap.
+    await _chunk(conn, live_backends=[], upload_backends=["arion"], address=None)
+    assert await _violations(conn, backup=[]) == set()
+
+
+# ===================================================== flagged (data-loss risk)
+
+
+async def test_missing_a_required_upload_backend_is_flagged(conn):
+    oid, ver, chunk = await _chunk(conn, live_backends=[], upload_backends=["arion"])
+    assert await _violations(conn, backup=[]) == {(oid, ver, chunk)}
+
+
+async def test_missing_a_required_backup_backend_is_flagged(conn):
+    # The C10 case: backup is required by the gate but the chunk was never pushed there.
+    oid, ver, chunk = await _chunk(conn, live_backends=["arion"], upload_backends=["arion"])
+    assert await _violations(conn, backup=["ipfs"]) == {(oid, ver, chunk)}
+
+
+async def test_a_soft_deleted_backend_row_does_not_count_as_coverage(conn):
+    # arion was unpinned (deleted=true) → the chunk lacks live arion coverage → flagged.
+    oid, ver, chunk = await _chunk(conn, live_backends=[], deleted_backends=["arion"], upload_backends=["arion"])
+    assert await _violations(conn, backup=[]) == {(oid, ver, chunk)}
+
+
+# ===================================================== per-version required set
+
+
+async def test_migration_version_requires_ipfs(conn):
+    # version_type='migration' forces required=['ipfs'] regardless of upload_backends.
+    covered = await _chunk(conn, live_backends=["ipfs"], version_type="migration", upload_backends=["arion"])
+    missing_oid, ver, chunk = await _chunk(
+        conn, live_backends=["arion"], version_type="migration", upload_backends=["arion"]
+    )
+    result = await _violations(conn, backup=[])
+    assert (missing_oid, ver, chunk) in result, "a migration chunk without ipfs is flagged"
+    assert (str(covered[0]), covered[1], covered[2]) not in result, "a migration chunk with ipfs is safe"
+
+
+async def test_per_version_upload_backends_drive_the_requirement(conn):
+    # required comes from the version's own upload_backends, not the config default.
+    oid, ver, chunk = await _chunk(conn, live_backends=["arion"], upload_backends=["arion", "ovh"])
+    assert await _violations(conn, backup=[]) == {(oid, ver, chunk)}, "missing ovh (a per-version backend) is flagged"
+
+
+async def test_legacy_null_upload_backends_fall_back_to_config_default(conn):
+    # upload_backends NULL (legacy) → required = $2 config default (['arion']) ∪ backup.
+    oid, ver, chunk = await _chunk(conn, live_backends=[], upload_backends=None)
+    assert await _violations(conn, backup=[], default_upload=["arion"]) == {(oid, ver, chunk)}
+
+
+# ===================================================== bounding + mix
+
+
+async def test_the_limit_bounds_the_result(conn):
+    for _ in range(3):
+        await _chunk(conn, live_backends=[], upload_backends=["arion"])
+    assert len(await _violations(conn, backup=[], limit=2)) == 2, "at most `limit` violations returned"
+
+
+async def test_full_mix(conn):
+    # Both safe under backup=["ipfs"]: they carry live arion AND ipfs (upload ∪ backup).
+    safe1 = await _chunk(conn, live_backends=["arion", "ipfs"], upload_backends=["arion", "ipfs"])
+    safe2 = await _chunk(conn, live_backends=["arion", "ipfs"], upload_backends=["arion"])  # backup covered
+    await _chunk(conn, live_backends=[], upload_backends=["arion"], object_deleted=True)  # deleted
+    await _chunk(conn, live_backends=[], upload_backends=["arion"], address=None)  # unserveable
+    gap_upload = await _chunk(conn, live_backends=[], upload_backends=["arion"])  # missing arion
+    gap_backup = await _chunk(conn, live_backends=["arion"], upload_backends=["arion"])  # missing ipfs backup
+
+    result = await _violations(conn, backup=["ipfs"])
+    assert result == {
+        (gap_upload[0], gap_upload[1], gap_upload[2]),
+        (gap_backup[0], gap_backup[1], gap_backup[2]),
+    }
+    assert (safe1[0], safe1[1], safe1[2]) not in result
+    assert (safe2[0], safe2[1], safe2[2]) not in result

--- a/tests/unit/test_inv_guard.py
+++ b/tests/unit/test_inv_guard.py
@@ -1,0 +1,162 @@
+"""Unit truth-tables for the inv-guard predicates (WI-19 §4.2).
+
+Pure logic: a FakeProbe returns canned Postgres/Prometheus results, so every guard's
+ok/breach/skip verdict — and the stateful epoch/terminal-transition tracking — is exercised
+without a live cluster."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "stress-test"))
+
+from inv import guards  # noqa: E402
+
+
+class FakeProbe:
+    """Duck-typed ClusterProbe: canned `prom_scalar` values and `pg` rows, or None (unreachable)."""
+
+    def __init__(self, prom: dict[str, float | None] | None = None, rows: list[list[str]] | None = None, scalar: str | None = None):
+        self._prom = prom or {}
+        self._rows = rows
+        self._scalar = scalar
+
+    def prom_scalar(self, promql: str) -> float | None:
+        return self._prom.get(promql)
+
+    def pg(self, sql: str) -> list[list[str]] | None:
+        return self._rows
+
+    def pg_scalar(self, sql: str) -> str | None:
+        return self._scalar
+
+
+# ----------------------------------------------------------------- G1 single-leader + epoch
+def test_g1_ok_single_leader():
+    g = guards.SingleLeaderEpoch()
+    r = g.check(FakeProbe(prom={"sum(drain_leader)": 1.0, "max(drain_leader_epoch)": 7.0}))
+    assert r.status == "ok"
+
+
+def test_g1_breach_two_leaders():
+    g = guards.SingleLeaderEpoch()
+    r = g.check(FakeProbe(prom={"sum(drain_leader)": 2.0, "max(drain_leader_epoch)": 7.0}))
+    assert r.status == "breach" and "split-brain" in r.detail
+
+
+def test_g1_breach_on_epoch_decrease():
+    g = guards.SingleLeaderEpoch()
+    assert g.check(FakeProbe(prom={"sum(drain_leader)": 1.0, "max(drain_leader_epoch)": 9.0})).status == "ok"
+    # counter reset: epoch drops below the high-water mark.
+    r = g.check(FakeProbe(prom={"sum(drain_leader)": 1.0, "max(drain_leader_epoch)": 4.0}))
+    assert r.status == "breach" and "decreased" in r.detail
+
+
+def test_g1_ok_on_epoch_increase():
+    g = guards.SingleLeaderEpoch()
+    g.check(FakeProbe(prom={"sum(drain_leader)": 1.0, "max(drain_leader_epoch)": 3.0}))
+    assert g.check(FakeProbe(prom={"sum(drain_leader)": 1.0, "max(drain_leader_epoch)": 5.0})).status == "ok"
+
+
+def test_g1_skip_when_prometheus_unreachable():
+    assert guards.SingleLeaderEpoch().check(FakeProbe(prom={})).status == "skip"
+
+
+# ----------------------------------------------------------------- G2 replication-gate coverage
+def test_g2_ok_no_underreplicated():
+    assert guards.ReplicationGateCoverage().check(FakeProbe(prom={"max(janitor_underreplicated_live_chunks)": 0.0})).status == "ok"
+
+
+def test_g2_breach_underreplicated():
+    r = guards.ReplicationGateCoverage().check(FakeProbe(prom={"max(janitor_underreplicated_live_chunks)": 3.0}))
+    assert r.status == "breach" and r.value == 3.0
+
+
+def test_g2_skip_when_metric_absent():
+    assert guards.ReplicationGateCoverage().check(FakeProbe(prom={})).status == "skip"
+
+
+# ----------------------------------------------------------------- G3 stalled-drain (SQL half)
+def test_g3_ok_nothing_stalled():
+    assert guards.StalledDrain().check(FakeProbe(scalar="0")).status == "ok"
+
+
+def test_g3_breach_stalled_parts():
+    r = guards.StalledDrain(stall_secs=60).check(FakeProbe(scalar="4"))
+    assert r.status == "breach" and "stalled" in r.detail
+
+
+def test_g3_skip_when_pg_unreachable():
+    assert guards.StalledDrain().check(FakeProbe(scalar=None)).status == "skip"
+
+
+# ----------------------------------------------------------------- G4 sole-producer (runtime)
+def test_g4_ok_no_duplicates():
+    assert guards.SoleProducer().check(FakeProbe(rows=[])).status == "ok"
+
+
+def test_g4_breach_duplicate_backend_row():
+    r = guards.SoleProducer().check(FakeProbe(rows=[["chunk-1", "arion", "2"]]))
+    assert r.status == "breach"
+
+
+def test_g4_skip_when_pg_unreachable():
+    assert guards.SoleProducer().check(FakeProbe(rows=None)).status == "skip"
+
+
+# ----------------------------------------------------------------- G6 terminal monotonicity
+def _crs_rows(status_by_part: dict[int, str]) -> list[list[str]]:
+    return [["obj-a", "1", str(pn), st] for pn, st in status_by_part.items()]
+
+
+def test_g6_seeds_then_ok_on_forward_progress():
+    g = guards.TerminalMonotonicity()
+    # first poll seeds the baseline (pending), no verdict yet beyond ok
+    assert g.check(FakeProbe(rows=_crs_rows({0: "pending"}))).status == "ok"
+    # pending -> replicated is legal forward progress
+    assert g.check(FakeProbe(rows=_crs_rows({0: "replicated"}))).status == "ok"
+
+
+def test_g6_breach_on_terminal_regression():
+    g = guards.TerminalMonotonicity()
+    g.check(FakeProbe(rows=_crs_rows({0: "replicated"})))  # seed a terminal row
+    # replicated -> pending is a terminal-state regression
+    r = g.check(FakeProbe(rows=_crs_rows({0: "pending"})))
+    assert r.status == "breach" and "regression" in r.detail
+
+
+def test_g6_breach_on_failed_leaving_terminal():
+    g = guards.TerminalMonotonicity()
+    g.check(FakeProbe(rows=_crs_rows({0: "failed"})))
+    r = g.check(FakeProbe(rows=_crs_rows({0: "draining"})))
+    assert r.status == "breach"
+
+
+def test_g6_skip_when_pg_unreachable():
+    assert guards.TerminalMonotonicity().check(FakeProbe(rows=None)).status == "skip"
+
+
+# ----------------------------------------------------------------- G5/G7/G8 are inv-det/scenario
+def test_invdet_guards_skip():
+    for name in ("G5", "G7", "G8"):
+        assert guards.make_guard(name).check(FakeProbe()).status == "skip"
+
+
+# ----------------------------------------------------------------- run_once aggregation
+def test_run_once_counts_breaches_and_emits_each():
+    g1 = guards.SingleLeaderEpoch()
+    g4 = guards.SoleProducer()
+    probe = FakeProbe(prom={"sum(drain_leader)": 2.0}, rows=[])  # G1 breaches, G4 ok
+    events: list[guards.GuardResult] = []
+    breaches = guards.run_once([g1, g4], probe, events.append)
+    assert breaches == 1
+    assert [e.guard for e in events] == ["G1", "G4"]
+    assert events[0].status == "breach" and events[1].status == "ok"
+
+
+def test_make_guard_rejects_unknown():
+    import pytest
+
+    with pytest.raises(KeyError):
+        guards.make_guard("G99")

--- a/tests/unit/test_mpu_reaper.py
+++ b/tests/unit/test_mpu_reaper.py
@@ -20,16 +20,36 @@ from hippius_s3.services import mpu_cleanup
 
 
 class FakeDb:
-    """A minimal asyncpg-connection stand-in: fetch returns canned rows; execute records."""
+    """A minimal asyncpg-connection stand-in: fetch returns canned rows; execute records.
 
-    def __init__(self, fetch_rows: list[dict] | None = None) -> None:
+    `fetch` dispatches on the query text so one FakeDb can back both reaper paths in a
+    single cycle: the abandoned-MPU query selects from ``multipart_uploads`` while the
+    orphan sweep's query selects from ``cephor_replication_status`` — they return
+    differently-shaped rows and must not cross-feed. ``raise_mark_for`` forces the
+    terminal-mark ``execute`` to throw for one object_id, modelling a poison row the
+    sweep must skip without aborting the rest of the pass.
+    """
+
+    def __init__(
+        self,
+        fetch_rows: list[dict] | None = None,
+        *,
+        sweep_rows: list[dict] | None = None,
+        raise_mark_for: str | None = None,
+    ) -> None:
         self._fetch_rows = fetch_rows or []
+        self._sweep_rows = sweep_rows or []
+        self._raise_mark_for = raise_mark_for
         self.executed: list[tuple[str, tuple]] = []
 
     async def fetch(self, query: str, *args: object) -> list[dict]:
+        if "cephor_replication_status" in query:
+            return self._sweep_rows
         return self._fetch_rows
 
     async def execute(self, query: str, *args: object) -> str:
+        if self._raise_mark_for is not None and args and args[0] == self._raise_mark_for:
+            raise RuntimeError(f"forced mark failure for {self._raise_mark_for}")
         self.executed.append((query, args))
         return "UPDATE 1"
 
@@ -167,3 +187,82 @@ async def test_run_reaper_cycle_records_a_failure_without_raising() -> None:
     _, kwargs = collector.record_mpu_reaper_cycle.call_args
     assert kwargs["success"] is False
     assert kwargs["reaped"] == 0
+
+
+# ---------------------------------------------------------------- orphan sweep (WI-20a/A21)
+# The abandoned-MPU reaper above keys on multipart_uploads rows. An aborted upload deletes
+# that header row, so its leaked cephor_replication_status rows are invisible to it. The
+# sweep is the real A21 backstop: it keys DIRECTLY on cephor_replication_status, so it
+# catches orphans whose MPU/parts rows are already gone. It only ever MARKS 'failed' (never
+# deletes), so unlike the reaper it can tolerate a per-version mark failure and press on.
+
+
+@pytest.mark.asyncio
+async def test_sweep_marks_each_orphan_version_failed() -> None:
+    rows = [
+        {"object_id": "obj-1", "version": 1, "age_seconds": 90000.0},
+        {"object_id": "obj-2", "version": 5, "age_seconds": 172800.0},
+    ]
+    db = FakeDb(sweep_rows=rows)
+    result = await mpu_cleanup.sweep_orphan_replication_versions(db, stale_seconds=86400, dlq_object_ids=set())
+    assert result.count == 2
+    assert result.oldest_reaped_age_seconds == 172800.0, "reports the age of the oldest swept orphan"
+    marked = [args for query, args in db.executed if "'failed'" in query]
+    assert marked == [("obj-1", 1), ("obj-2", 5)], "every orphan version's active rows are marked terminal"
+    assert not any("DELETE" in query for query, _ in db.executed), "the sweep never deletes — only marks"
+
+
+@pytest.mark.asyncio
+async def test_sweep_spares_dlq_protected_objects() -> None:
+    rows = [{"object_id": "obj-1", "version": 1, "age_seconds": 90000.0}]
+    db = FakeDb(sweep_rows=rows)
+    result = await mpu_cleanup.sweep_orphan_replication_versions(db, stale_seconds=86400, dlq_object_ids={"obj-1"})
+    assert result.count == 0
+    assert result.oldest_reaped_age_seconds is None
+    assert db.executed == [], "an in-flight DLQ object is never swept"
+
+
+@pytest.mark.asyncio
+async def test_sweep_presses_on_when_one_versions_mark_throws() -> None:
+    # A poison version (e.g. transient row-lock) must not starve the rest of the pass: the
+    # sweep is mark-only and idempotent, so it logs the failure, counts only successes, and
+    # the failed one is retried on the next cycle (it stays active in cephor).
+    rows = [
+        {"object_id": "obj-boom", "version": 1, "age_seconds": 90000.0},
+        {"object_id": "obj-ok", "version": 2, "age_seconds": 100000.0},
+    ]
+    db = FakeDb(sweep_rows=rows, raise_mark_for="obj-boom")
+    result = await mpu_cleanup.sweep_orphan_replication_versions(db, stale_seconds=86400, dlq_object_ids=set())
+    assert result.count == 1, "only the successfully-marked version is counted"
+    marked = [args for query, args in db.executed if "'failed'" in query]
+    assert marked == [("obj-ok", 2)], "the healthy version is still swept despite the earlier failure"
+    assert result.oldest_reaped_age_seconds == 100000.0, "age is reported from swept versions only"
+
+
+@pytest.mark.asyncio
+async def test_sweep_reports_none_age_when_nothing_to_sweep() -> None:
+    db = FakeDb(sweep_rows=[])
+    result = await mpu_cleanup.sweep_orphan_replication_versions(db, stale_seconds=86400, dlq_object_ids=set())
+    assert result.count == 0
+    assert result.oldest_reaped_age_seconds is None
+
+
+@pytest.mark.asyncio
+async def test_run_reaper_cycle_runs_the_sweep_and_records_its_count() -> None:
+    # One cycle drains BOTH paths: the abandoned-MPU reaper and the cephor-orphan sweep.
+    mpu_rows = [{"upload_id": "u1", "object_id": "obj-1", "object_version": 1, "age_seconds": 90000.0}]
+    sweep_rows = [
+        {"object_id": "orphan-a", "version": 1, "age_seconds": 200000.0},
+        {"object_id": "orphan-b", "version": 2, "age_seconds": 50000.0},
+    ]
+    pool = FakePool(FakeDb(mpu_rows, sweep_rows=sweep_rows))
+    collector = MagicMock()
+
+    with patch.object(mpu_cleanup, "get_metrics_collector", return_value=collector):
+        await mpu_cleanup.run_reaper_cycle(pool, _fake_redis(), stale_seconds=86400, upload_backends=["arion"])
+
+    collector.record_mpu_reaper_cycle.assert_called_once()
+    _, kwargs = collector.record_mpu_reaper_cycle.call_args
+    assert kwargs["success"] is True
+    assert kwargs["reaped"] == 1, "the abandoned-MPU reaper still runs"
+    assert kwargs["swept"] == 2, "the cephor-orphan sweep count is recorded separately"

--- a/tests/unit/test_replication_sentinel.py
+++ b/tests/unit/test_replication_sentinel.py
@@ -1,0 +1,105 @@
+"""Unit tests for the janitor's G2 replication-gate sentinel orchestration.
+
+The SQL predicate itself is pinned in tests/integration/test_replication_sentinel_sql.py
+against real Postgres. Here we drive `check_replication_sentinel` with a fake pool to
+verify the orchestration: it publishes the gauge, returns the violation count, escalates
+to ERROR only under critical disk pressure, and stays silent on a clean scan.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from workers import run_janitor_in_loop as janitor
+
+
+class _FakeConn:
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+        self.fetched_args: tuple | None = None
+
+    async def fetch(self, query: str, *args: object) -> list[dict]:
+        self.fetched_args = args
+        return self._rows
+
+
+class _FakeAcquire:
+    def __init__(self, conn: _FakeConn) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> _FakeConn:
+        return self._conn
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn: _FakeConn) -> None:
+        self._conn = conn
+
+    def acquire(self) -> _FakeAcquire:
+        return _FakeAcquire(self._conn)
+
+
+def _row(chunk_id: int) -> dict:
+    return {"object_id": "obj", "object_version": 1, "chunk_id": chunk_id}
+
+
+@pytest.mark.asyncio
+async def test_clean_scan_reports_zero_and_logs_nothing(caplog):
+    pool = _FakePool(_FakeConn([]))
+    with (
+        patch.object(janitor.config, "upload_backends", ["arion"]),
+        patch.object(janitor.config, "backup_backends", [], create=True),
+    ):
+        with caplog.at_level(logging.WARNING, logger=janitor.logger.name):
+            result = await janitor.check_replication_sentinel(pool, pressure=0)
+    assert result == 0
+    assert janitor._replication_sentinel_violations == 0
+    assert not caplog.records, "a clean scan is silent"
+
+
+@pytest.mark.asyncio
+async def test_violations_publish_the_gauge_and_warn_below_critical(caplog):
+    pool = _FakePool(_FakeConn([_row(1), _row(2)]))
+    with (
+        patch.object(janitor.config, "upload_backends", ["arion"]),
+        patch.object(janitor.config, "backup_backends", ["ipfs"], create=True),
+    ):
+        with caplog.at_level(logging.WARNING, logger=janitor.logger.name):
+            result = await janitor.check_replication_sentinel(pool, pressure=1)
+    assert result == 2
+    assert janitor._replication_sentinel_violations == 2
+    assert any(r.levelno == logging.WARNING for r in caplog.records), "a gap below critical pressure warns"
+    assert not any(r.levelno == logging.ERROR for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_violations_under_critical_pressure_escalate_to_error(caplog):
+    pool = _FakePool(_FakeConn([_row(1)]))
+    with (
+        patch.object(janitor.config, "upload_backends", ["arion"]),
+        patch.object(janitor.config, "backup_backends", [], create=True),
+    ):
+        with caplog.at_level(logging.WARNING, logger=janitor.logger.name):
+            result = await janitor.check_replication_sentinel(pool, pressure=2)
+    assert result == 1
+    assert any(r.levelno == logging.ERROR for r in caplog.records), "a gap at critical pressure pages (ERROR)"
+
+
+@pytest.mark.asyncio
+async def test_the_query_is_bound_with_backup_upload_and_the_scan_limit():
+    conn = _FakeConn([])
+    pool = _FakePool(conn)
+    with (
+        patch.object(janitor.config, "upload_backends", ["arion"]),
+        patch.object(janitor.config, "backup_backends", ["ipfs"], create=True),
+    ):
+        await janitor.check_replication_sentinel(pool, pressure=0)
+    assert conn.fetched_args == (["ipfs"], ["arion"], janitor.SENTINEL_SCAN_LIMIT), (
+        "bound as (backup_backends, config.upload_backends, scan_limit)"
+    )

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -78,6 +78,9 @@ PRESSURE_CRITICAL = 0.95
 # Maximum age of an orphan `.tmp.*` file before we delete it. Atomic writes
 # finish in milliseconds; anything older than this is a crashed-write orphan.
 TMP_FILE_MAX_AGE_SECONDS = 3600  # 1h
+# Cap on the G2 sentinel scan: it needs only to DETECT a durability gap and sample a few
+# offenders, not enumerate every one, so a bounded page keeps the read-only query cheap.
+SENTINEL_SCAN_LIMIT = 500
 
 _fs_parts_on_disk = 0
 _fs_oldest_age_seconds = 0.0
@@ -86,6 +89,10 @@ _fs_disk_total_bytes = 0
 _fs_hot_parts = 0
 _fs_pressure_mode = 0  # 0 = normal, 1 = elevated, 2 = critical
 _fs_age_buckets: dict[str, int] = dict.fromkeys(AGE_BUCKET_NAMES, 0)
+# G2 replication-gate sentinel: live/serveable chunks lacking full-union backend coverage
+# (the population the gate must never reclaim). Any nonzero value is a standing durability
+# alarm; sampled/capped by SENTINEL_SCAN_LIMIT, so a value at the cap means ">=".
+_replication_sentinel_violations = 0
 
 _janitor_deleted_counter = None  # set by _setup_janitor_metrics
 _janitor_tmp_deleted_counter = None
@@ -118,6 +125,10 @@ def _obs_pressure_mode(_: object) -> list[otel_metrics.Observation]:
 
 def _obs_age_buckets(_: object) -> list[otel_metrics.Observation]:
     return [otel_metrics.Observation(count, {"age_bucket": bucket}) for bucket, count in _fs_age_buckets.items()]
+
+
+def _obs_replication_sentinel(_: object) -> list[otel_metrics.Observation]:
+    return [otel_metrics.Observation(_replication_sentinel_violations, {})]
 
 
 def _classify_age_bucket(age_seconds: float) -> str:
@@ -300,6 +311,11 @@ def _setup_janitor_metrics() -> None:
         name="fs_cache_age_bucket_parts",
         callbacks=[_obs_age_buckets],
         description="Number of parts per age bucket",
+    )
+    meter.create_observable_gauge(
+        name="janitor_underreplicated_live_chunks",
+        callbacks=[_obs_replication_sentinel],
+        description="Live serveable chunks lacking full-union backend coverage (G2 sentinel; nonzero = durability gap)",
     )
     _janitor_deleted_counter = meter.create_counter(
         name="fs_janitor_deleted_total",
@@ -557,6 +573,48 @@ async def is_replicated_on_all_backends(
     if result["total_chunks"] < expected_count:
         return False
     return result["total_chunks"] == result["replicated_chunks"]
+
+
+async def check_replication_sentinel(db_pool: asyncpg.Pool, pressure: int) -> int:
+    """G2 read-only durability sentinel: count live/serveable chunks lacking full-union
+    backend coverage and publish the gauge.
+
+    This is the inverse of the janitor's reclaim gate: it finds the chunks the gate would
+    (correctly) refuse to reclaim because they are under-replicated — i.e. chunks at
+    data-loss risk the moment their SSD/pool copy is evicted. The required backend set
+    mirrors ``is_replicated_on_all_backends`` (per-version ∪ backup), so this also catches
+    the C10 divergence. Purely a SELECT — it never deletes — so it is safe to run every
+    cycle. A breach logs ERROR at critical disk pressure (a reclaim is imminent), WARN
+    otherwise; a clean scan logs nothing. Returns the number of violations found (capped
+    at ``SENTINEL_SCAN_LIMIT``).
+    """
+    global _replication_sentinel_violations
+    backup_backends = list(getattr(config, "backup_backends", []) or [])
+    async with db_pool.acquire() as conn:
+        rows = await conn.fetch(
+            get_query("find_underreplicated_live_chunks"),
+            backup_backends,
+            list(config.upload_backends),
+            SENTINEL_SCAN_LIMIT,
+        )
+    violations = len(rows)
+    _replication_sentinel_violations = violations
+    if violations:
+        capped = ">=" if violations >= SENTINEL_SCAN_LIMIT else ""
+        sample = [(str(r["object_id"]), r["object_version"], r["chunk_id"]) for r in rows[:5]]
+        # Critical pressure = the janitor is actively evicting, so an under-replicated
+        # chunk is one reclaim away from loss: page it. Otherwise warn (a standing gap).
+        log = logger.error if pressure >= 2 else logger.warning
+        log(
+            "REPLICATION-GATE SENTINEL: %s%d live chunk(s) lack full-union backend coverage "
+            "(upload=%s backup=%s); sample=%s",
+            capped,
+            violations,
+            list(config.upload_backends),
+            backup_backends,
+            sample,
+        )
+    return violations
 
 
 async def is_terminally_abandoned(
@@ -919,12 +977,21 @@ async def run_janitor_loop():
             except Exception as e:
                 logger.error(f"Phase 4 (hard delete) error: {e}", exc_info=True)
 
+            # Phase 5: read-only replication-gate sentinel (G2). Publishes the durability
+            # gauge and alarms on any live/serveable chunk lacking full-union coverage.
+            pressure = _pressure_mode(fs_store.root)
+            sentinel_violations = 0
+            try:
+                sentinel_violations = await check_replication_sentinel(db_pool, pressure)
+            except Exception as e:
+                logger.error(f"Phase 5 (replication sentinel) error: {e}", exc_info=True)
+
             logger.info(
-                f"Janitor cycle complete: stale={stale_count} gc={gc_count} tmp={tmp_count} hard_deleted={hard_deleted}"
+                f"Janitor cycle complete: stale={stale_count} gc={gc_count} tmp={tmp_count} "
+                f"hard_deleted={hard_deleted} sentinel_violations={sentinel_violations}"
             )
 
-            # Pick sleep interval based on current pressure
-            pressure = _pressure_mode(fs_store.root)
+            # Pick sleep interval based on current pressure (already probed for Phase 5)
             sleep_interval = sleep_pressure if pressure > 0 else sleep_normal
             logger.info(f"Janitor sleeping {sleep_interval}s (pressure={pressure})")
             await asyncio.sleep(sleep_interval)


### PR DESCRIPTION
## Summary

**S3 2.1 drain prod-readiness — Vertical B** (coordination correctness, resilience, and the invariant backbone), the counterpart to George's Vertical A (#233, durability/SSD lifecycle). Nine self-contained changes, each independently tested green.

> ⚠️ **Base note:** this branch stacks on two open PRs — **#233** (C8 uses its heartbeat changes) and **#226** (B1 uses the stress-test harness). So the diff currently *includes* #233 + #226 content; it shrinks to just Vertical B once those merge. Review the **9 Vertical-B commits** below; the rest is #233/#226.

## What's in it (largest concern first)

- **R3 — allocator epoch fence** (`coordination.rs`, `tick.rs`). The fenced alloc write only compared against each alloc key's *already-stored* epoch, never `cephor:epoch` — so a deposed leader that finished a slow `ceiling()` before its successor wrote any alloc key slipped a stale-epoch budget through (split-brain). Fix: fence on `cephor:epoch` (KEYS[1]). Adds a coordination-unit regression test **and** a `run_tick` failpoint test (paused at `ceiling()`, successor takes over mid-tick) — both fail pre-fix. *Non-overridable gate.*
- **T4 rig B — allocator failover soak** (`tests/alloc_stress.rs`). N allocators churning leadership many rounds; asserts re-convergence, no epoch rollback, clean shutdown. Complements the R3 failpoint (which is the R3 catcher).
- **C13 — breaker misclassification** (`partdrain.rs`). `DrainStep::Persist` was overloaded across SSD-reads *and* Ceph-writes, so a local SSD-read EIO tripped the node-global Ceph breaker and wedged a healthy pool. Split out `DrainStep::SsdRead`; SSD-side errors now defer, never trip.
- **S10/S11 — `drain_leader_epoch` metric** (`tick.rs`, allocator `run.rs`/`metrics.rs`). Surfaces the lease epoch so a `max(drain_leader_epoch)` decrease — a redis epoch-counter reset that would silently break the R3 fence — is alertable.
- **C8 — drain readiness probe** (`readiness.rs`, `runtime.rs`, `config.rs`, daemonset). Liveness only proves the process is alive; a drain wedged on a hung CephFS write keeps heartbeating. New readiness signal touched only while the loop is *processing parts* (drained+failed+deferred) or idle → k8s marks a wedged node `NotReady`. *Builds on #233's heartbeat.*
- **C11 — localfs temp collision** (`localfs.rs`). `.tmp-<name>` was unique only under the single-writer claim, which a lapsed lease breaks; suffix with `pid.counter`.
- **C7 — full-jitter poll sleeps** (`clock.rs`, `runtime.rs`, allocator `run.rs`). Fixed sleeps → down-only jitter, to break the thundering herd on a Redis/PG/Ceph recovery without ever stretching a TTL.
- **B1 — inv-guard continuous asserter** (`stress-test/inv/`). The runtime backbone every dynamic run polls under: G1 (single-leader + epoch, via `drain_leader_epoch`), G2 (via #233's `janitor_underreplicated_live_chunks`), G3 (stalled-drain), G4 ((chunk_id,backend) uniqueness), G6 (terminal monotonicity); streams JSONL, aborts on breach. *Builds on #226's harness.*

## Testing

Rust: `core 166 (--features coord --include-ignored) · agent 97 · allocator 28` all green; `clippy --tests` + `cargo fmt --check` clean. Python: `guards.py`/`inv_guard.py` 21 unit truth-tables green (`py_compile` + manual run — the env had no `ruff`/`pytest`, so re-run the lint/pytest gate in CI). Local DB tests use Postgres `:5433` + redis-queues `:6382`.

## Deferred (not in this PR)

- **R4** (`corrupt`-state / silent live-object loss) — needs a shared design decision with George (`reclaim_ssd` delete authority); #233 built the servability infra it will sit on.
- **R5 zero-throughput alert** + **S10/S11 Grafana alert rules** + **fault substrate** — authorable but not locally validatable (Grafana / Docker); best done at integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
