### PR TITLE
fix(otel): stop embedding pid in service.instance.id (Prometheus cardinality blowup)

### DIFF
--- a/hippius_s3/otel_setup.py
+++ b/hippius_s3/otel_setup.py
@@ -43,10 +43,14 @@ def configure_otel(service_name: str) -> None:
     endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4317")
 
     # Resource.create() automatically merges OTEL_RESOURCE_ATTRIBUTES from env
+    # Keep service.instance.id at the (stable) pod hostname — never append os.getpid().
+    # The collector promotes this resource attr to the `instance` metric label, so a
+    # per-process value mints a fresh series set for every worker (re)spawn and blows
+    # up Prometheus head cardinality. Workers of one pod aggregate under one instance.
     resource = Resource.create(
         {
             "service.name": service_name,
-            "service.instance.id": f"{socket.gethostname()}-{os.getpid()}",
+            "service.instance.id": socket.gethostname(),
         }
     )
 


### PR DESCRIPTION
## Summary

Prod Grafana dashboards were timing out (`Post http://prometheus-server.../query_range: net/http: timeout awaiting response headers`). Root cause is metric-cardinality, not a Prometheus/network fault: the server was pegged at its 2-core CPU limit serving a **1.07M-series** head, and a single 6h p95 panel query took ~40s — past Grafana's 30s datasource timeout.

A third of all series traced to one label: `service.instance.id`, set in `otel_setup.py` to `"{hostname}-{pid}"`. The collector's `resource_to_telemetry_conversion` promotes that resource attribute to the `instance` metric label, so **every uvicorn worker (re)spawn minted a whole new series set**. With `metric_expiration: 180m` on the collector + 30d Prometheus retention, ghost workers accumulated to ~40k distinct instance ids (one live 6-day pod alone had 977).

The k8s manifests already set `OTEL_RESOURCE_ATTRIBUTES=...service.instance.id=$(POD_NAME)` to stabilize this, but the explicit per-process value in code was overriding it (explicit resource attrs win over the env-merged ones).

## Change

- `hippius_s3/otel_setup.py`: set `service.instance.id` to the stable pod hostname (`socket.gethostname()`), dropping `os.getpid()`. Workers of a pod now aggregate under one instance.

## Impact

- Collapses `instance` cardinality from ~40k -> ~pod-count, shrinking the biggest metrics (`http_request_duration_seconds_bucket` alone was 233k series) by ~50x.
- Existing ghost series drain out as they age past the collector's 3h window + 30d retention (or force sooner via Prometheus admin TSDB delete after this lands).

## Follow-ups (not in this PR)

- Collector/Prometheus relabel backstop (`labeldrop instance` / disable `resource_to_telemetry_conversion`) so a future regression can't blow up cardinality again.
- Separately investigating why gateway/api uvicorn workers respawn ~6x/hr with `UVICORN_MAX_REQUESTS=0` (no OOMKills at container level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)