### PR TITLE
chore(k8s): set HIPPIUS_MPU_STALE_SECONDS to 1 day

### DIFF
--- a/k8s/base/configmap-defaults.yaml
+++ b/k8s/base/configmap-defaults.yaml
@@ -34,6 +34,12 @@ data:
   ORPHAN_CHECKER_LOOP_SLEEP: "7200"
   ORPHAN_CHECKER_BATCH_SIZE: "100"
   HIPPIUS_ORPHAN_WORKER_ACCOUNT_WHITELIST: ""
+  # Janitor stale-parts reap window and, where the mpu-reaper runs, the incomplete-MPU
+  # auto-abort window. Lowered from the 2-day code default to 1 day to reclaim NVMe cache
+  # faster (hard-deleted orphan residue dominates resident dirs). Do not shorten further
+  # without splitting the janitor knob from the MPU-abort knob: uploads open past this
+  # window get auto-aborted, and multi-GB backups can legitimately run for many hours.
+  HIPPIUS_MPU_STALE_SECONDS: "86400"
   HTTP_STREAM_INITIAL_TIMEOUT_SECONDS: "0.5"
   HIPPIUS_DLQ_DIR: "/tmp/hippius_dlq"
   HIPPIUS_DLQ_ARCHIVE_DIR: "/tmp/hippius_dlq_archive"


### PR DESCRIPTION
## Summary

Sets `HIPPIUS_MPU_STALE_SECONDS` to `86400` (1 day) in the base configmap, down from the 2-day code default. The goal is faster NVMe cache reclaim on prod, where the janitor's stale-parts pass is the mechanism that evicts hard-deleted-object residue.

Context: the prod cache node (`k8s-v3-node6-cache`, 42TB NVMe) sits at ~69% with **4.29M object dirs**, ~76% of which are orphans (hard-deleted in DB, data still resident) — mostly younger than 2 days, i.e. sitting inside the current stale-parts grace. Halving that grace to 1 day lets the janitor reap them sooner, cutting both space and inode/scan pressure.

## Why this is safe

`HIPPIUS_MPU_STALE_SECONDS` drives two things:
1. **Janitor** stale-parts reap window (`run_janitor_in_loop.py`) — cache reclaim.
2. **mpu-reaper** incomplete-MPU auto-abort window (`services/mpu_cleanup.py`).

The **mpu-reaper is only deployed on `staging`** — not on `main`/`k8s-production` — so on prod this change affects **only** janitor cache reclaim. On staging (a test env) a 1-day incomplete-MPU abort is acceptable.

## Changes

- `k8s/base/configmap-defaults.yaml`: add `HIPPIUS_MPU_STALE_SECONDS: "86400"` with a comment documenting the dual-purpose nature and warning against shortening further without splitting the two knobs.

## Follow-up (not in this PR)

If we later want to reclaim even more aggressively, decouple the janitor stale-parts window from the MPU-abort window (separate env var) so we don't risk auto-aborting legitimate multi-GB uploads that run for many hours.

## Conclusion

Low-risk config change; on prod it's purely a janitor-reclaim tuning knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)