### PR TITLE
S3 2.1 drain remediation follow-ups (post-#235: Batch C/D + harness + NITs)

### DIFF
--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -18,8 +18,10 @@ use hippius_drain_core::{
 };
 use sha2::{Digest, Sha256};
 use std::ffi::OsStr;
+use std::hash::BuildHasher;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
 use tokio::fs;
@@ -258,15 +260,30 @@ async fn stream_copy_hash(source: &Path, dest: &Path) -> io::Result<String> {
     Ok(hex_lower(hasher.finalize().as_slice()))
 }
 
-/// A monotonic per-process counter that, with the pid, makes each write temp unique —
+/// A monotonic per-process counter that makes each write temp unique WITHIN a process —
 /// so two tasks persisting the SAME `name` concurrently never share a temp file (C11).
 static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
+/// A per-process random nonce that makes write temps unique ACROSS processes. `pid` alone
+/// is not enough: two agent pods overlapping on one SSD mount during a rolling update
+/// commonly both run as pid 1, so both would emit `.tmp-<name>.1.0` for their first write
+/// and tear each other's copy (the post-copy SHA re-verify catches the tear, but this makes
+/// it impossible). Sourced from `RandomState`, whose `new()` is "initialized with random
+/// keys" and whose two instances are documented "unlikely to produce the same result for the
+/// same values" — process-unique entropy with no added dependency. Computed once on first use.
+static TEMP_NONCE: LazyLock<u64> = LazyLock::new(|| std::collections::hash_map::RandomState::new().hash_one(0u8));
+
 /// The write-temp name for `name`: the agent's `.tmp-` prefix (recognized by
-/// [`is_temp_name`] and the orphan sweep) plus a per-writer `pid.counter` suffix, so
-/// two concurrent persists of the same part write to DISTINCT temps.
+/// [`is_temp_name`] and the orphan sweep) plus a `pid.nonce.counter` suffix — the
+/// per-process [`TEMP_NONCE`] separates overlapping pods and the [`TEMP_SEQ`] counter
+/// separates concurrent writers in one process, so no two persists share a temp path.
 fn temp_name(name: &str) -> String {
-    format!(".tmp-{name}.{}.{}", std::process::id(), TEMP_SEQ.fetch_add(1, Ordering::Relaxed))
+    format!(
+        ".tmp-{name}.{}.{:x}.{}",
+        std::process::id(),
+        *TEMP_NONCE,
+        TEMP_SEQ.fetch_add(1, Ordering::Relaxed)
+    )
 }
 
 /// Atomically place `source`'s bytes into `dir` as `name`, returning the lowercase-hex
@@ -585,7 +602,7 @@ impl PartRemover for LocalSsd {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::{LocalSsd, TmpGuard, hex_lower, is_temp_name, safe_component, temp_name};
+    use super::{LocalSsd, TEMP_NONCE, TmpGuard, hex_lower, is_temp_name, safe_component, temp_name};
     use core::str::FromStr;
     use hippius_drain_core::{FileId, SsdCache};
     use proptest::prelude::*;
@@ -609,6 +626,13 @@ mod tests {
             assert!(t.starts_with(".tmp-"), "keeps the agent temp prefix: {t}");
             assert!(is_temp_name(t), "the orphan sweep still recognizes it as a temp: {t}");
         }
+        // The process nonce is constant within a run (only the trailing counter advances), so
+        // the two names differ only in the final field — the cross-process separator is stable.
+        let nonce = format!(".{:x}.", *TEMP_NONCE);
+        assert!(
+            a.contains(&nonce) && b.contains(&nonce),
+            "both carry the stable per-process nonce: {a} {b}"
+        );
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-agent/src/metrics.rs
+++ b/crates/hippius-drain-agent/src/metrics.rs
@@ -114,6 +114,19 @@ pub fn init(service_name: &'static str, snapshot: &Arc<SnapshotCell>, enforcer: 
             .build(),
     ));
 
+    // Reclaim-disabled alarm: cycles the `failed`-part SSD GC aborted on an object-backing read
+    // error (`object_versions` missing on a deploy, or a transient PG error). On this path the
+    // reclaim reads nothing and removes NOTHING — it is silently disabled while failing safe, so
+    // without a metric the GC stops and SSD debris accrues invisibly until drain_ssd_pressure trips
+    // the critical PUT-shedding alert. A monotonic counter: a sustained increase pages.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_counter("drain_reclaim_backing_errors_total")
+            .with_callback(move |observer| observer.observe(snap.load().reclaim_backing_errors, &[]))
+            .build(),
+    ));
+
     // Durability alarm: parts held `corrupt` (a live object whose pool copy is corrupt, kept
     // alive by its SSD source — R4). A gauge, not a counter: it falls when a re-drive recovers
     // a part. Any nonzero value pages (the alert), distinct from the drain's routine failures.

--- a/crates/hippius-drain-agent/src/readiness.rs
+++ b/crates/hippius-drain-agent/src/readiness.rs
@@ -8,10 +8,14 @@
 //! gating a rolling update from marching over stuck nodes.
 //!
 //! [`ReadinessTracker`] is the pure verdict: it folds the cumulative `drained` counter (monotonic)
-//! and the current `backlog` level (undrained bytes) from the agent snapshot, and reports READY
-//! unless there is a backlog that has made no drained progress for longer than a stall window. The
-//! tracker stays Ready through a legitimately long-but-progressing drain (the counter keeps
-//! advancing) and through idle (no backlog), so it does not flap those healthy cases.
+//! and the current count of undrained replication rows from the agent snapshot, and reports READY
+//! unless there is undrained work that has made no drained progress for longer than a stall window.
+//! The tracker stays Ready through a legitimately long-but-progressing drain (the counter keeps
+//! advancing) and through idle (no undrained rows), so it does not flap those healthy cases.
+//!
+//! The "is there work" signal is the undrained-row COUNT, not the byte backlog: the byte sum joins
+//! `parts` and a missing/NULL-size row contributes zero, so a wedged node's byte-backlog can read 0
+//! while rows remain — which would falsely read idle -> Ready, the exact wedge C8 catches (#235 D1).
 
 use std::time::Duration;
 use std::time::Instant;
@@ -29,8 +33,8 @@ pub struct ReadinessTracker {
 }
 
 impl ReadinessTracker {
-    /// A tracker seeded at `now` that reports `NotReady` once a backlog sits `stall`-long without
-    /// the drain loop processing a single part.
+    /// A tracker seeded at `now` that reports `NotReady` once undrained work sits `stall`-long
+    /// without the drain loop processing a single part.
     #[must_use]
     pub fn new(now: Instant, stall: Duration) -> Self {
         Self {
@@ -42,9 +46,10 @@ impl ReadinessTracker {
 
     /// Folds one heartbeat observation and returns whether the drain is READY.
     ///
-    /// READY iff the backlog is empty (idle is healthy) OR the `processed` counter has advanced
-    /// within `stall` (the loop is cycling). `NotReady` iff there is a backlog but `processed` has
-    /// not advanced for longer than `stall` — the loop is WEDGED (blocked on a hung `CephFS` op).
+    /// READY iff there are no undrained rows (idle is healthy) OR the `processed` counter has
+    /// advanced within `stall` (the loop is cycling). `NotReady` iff there is undrained work but
+    /// `processed` has not advanced for longer than `stall` — the loop is WEDGED (blocked on a hung
+    /// `CephFS` op).
     ///
     /// `processed` is the cumulative count of claims the drain loop CYCLED — committed
     /// (`drained`) + `failed` + `deferred` + `throttled` — NOT just committed, so a node
@@ -52,15 +57,19 @@ impl ReadinessTracker {
     /// backing off every claim under an open breaker (a pool-wide Ceph outage) still reads as
     /// cycling (its loop is alive); only a loop that has stopped handling claims at all reads as
     /// wedged. Including `throttled` is what stops a Ceph outage from flipping the whole
-    /// `DaemonSet` `NotReady` at once (which would wedge a rolling update). `backlog` is the
-    /// current undrained bytes.
-    pub fn observe(&mut self, processed: u64, backlog: u64, now: Instant) -> bool {
+    /// `DaemonSet` `NotReady` at once (which would wedge a rolling update).
+    ///
+    /// `undrained` is the COUNT of this node's undrained replication rows — NOT the byte backlog.
+    /// The byte sum joins `parts` and a missing/NULL-size row contributes zero, so it can read 0
+    /// for a wedged node that still owns undrained rows; keying idle on the row COUNT closes that
+    /// false-negative (PR #235 D1).
+    pub fn observe(&mut self, processed: u64, undrained: u64, now: Instant) -> bool {
         if processed > self.last_processed {
             self.last_processed = processed;
             self.last_progress = now;
         }
-        if backlog == 0 {
-            // Idle is healthy; refresh the clock so a later backlog gets a FULL stall window
+        if undrained == 0 {
+            // Idle is healthy; refresh the clock so later undrained work gets a FULL stall window
             // before it can read as wedged (rather than inheriting a stale idle gap).
             self.last_progress = now;
             return true;
@@ -85,8 +94,24 @@ mod tests {
     fn idle_is_always_ready() {
         let t0 = Instant::now();
         let mut r = ReadinessTracker::new(t0, STALL);
-        assert!(r.observe(0, 0, t0), "no backlog is ready");
+        assert!(r.observe(0, 0, t0), "no undrained rows is ready");
         assert!(r.observe(0, 0, at(t0, 300)), "still idle after a long gap is ready");
+    }
+
+    #[test]
+    fn a_wedged_node_with_undrained_rows_goes_not_ready_even_at_zero_backlog_bytes() {
+        // PR #235 D1: the wiring feeds observe the undrained-row COUNT, not the byte backlog. A
+        // wedged node whose parts rows are missing has 0 backlog bytes but a nonzero undrained
+        // count; feeding that count, the tracker must NOT read idle -> Ready but must go NotReady
+        // once the stall window elapses with no drained progress. (Feeding the 0-byte backlog
+        // instead would refresh the idle clock every tick and never flip NotReady — the bug.)
+        let t0 = Instant::now();
+        let mut r = ReadinessTracker::new(t0, STALL);
+        assert!(r.observe(0, 1, at(t0, 5)), "one undrained row, fresh window -> still ready");
+        assert!(
+            !r.observe(0, 1, at(t0, 120)),
+            "one undrained row, no progress past the window -> NotReady"
+        );
     }
 
     #[test]

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -207,6 +207,27 @@ async fn run_drain<E: UploadEnqueuer>(token: CancellationToken, period: Duration
 /// Probes SSD disk pressure off the async runtime (statvfs blocks) and upserts
 /// this node's heartbeat. Probe or upsert failures are logged and skipped — the
 /// next tick retries; a missed heartbeat only ages the node out of the fleet.
+/// Refreshes this node's two DB-sourced drain-demand gauges: the byte backlog
+/// (`drain_ssd_backlog_bytes`) and the undrained-row COUNT (the C8 readiness wedge signal).
+///
+/// The byte backlog is the TRUE undrained-bytes gauge — the DB sum of this node's
+/// pending/draining part bytes — NOT raw disk occupancy (`usage.used_bytes`), which the
+/// A21/orphan leak overcounts by hundreds of GB with no drain demand (WI-20c). The COUNT is the
+/// signal readiness gates on, because the byte SUM joins `parts` and a missing/NULL-size row
+/// contributes zero: a wedged node's byte-backlog can read 0 while undrained rows remain, which
+/// readiness would misread as idle. On a query error, KEEP the last-recorded value rather than
+/// zeroing it (a transient blip must not read as "drained"); the next tick refreshes it.
+async fn record_drain_signals(store: &Store, node: &NodeId, snapshot: &SnapshotCell) {
+    match store.node_backlog_bytes(node.as_str()).await {
+        Ok(bytes) => snapshot.record_backlog(bytes),
+        Err(err) => tracing::warn!(error = %err, "backlog query failed; keeping the last value"),
+    }
+    match store.node_undrained_count(node.as_str()).await {
+        Ok(count) => snapshot.record_undrained_count(count),
+        Err(err) => tracing::warn!(error = %err, "undrained-count query failed; keeping the last value"),
+    }
+}
+
 async fn heartbeat_once(ssd: &LocalSsd, store: &Store, coord: &Coordinator, node: &NodeId, max_drain_rate: ByteRate, snapshot: &SnapshotCell) {
     let root = ssd.root().to_path_buf();
     // statvfs is a blocking syscall — never run it on an executor thread (axiom
@@ -232,15 +253,7 @@ async fn heartbeat_once(ssd: &LocalSsd, store: &Store, coord: &Coordinator, node
     // off the exporter thread and must never run statvfs itself.
     snapshot.record_disk_pressure(usage.pressure.bps());
 
-    // The drain_ssd_backlog_bytes gauge is the TRUE undrained work — the DB sum of this
-    // node's pending/draining part bytes — NOT raw disk occupancy (usage.used_bytes), which
-    // the A21/orphan leak overcounts by hundreds of GB with no drain demand (WI-20c). On a
-    // query error, leave the last-recorded backlog rather than zeroing it (a transient blip
-    // must not read as "drained"); the next tick refreshes it.
-    match store.node_backlog_bytes(node.as_str()).await {
-        Ok(bytes) => snapshot.record_backlog(bytes),
-        Err(err) => tracing::warn!(error = %err, "backlog query failed; keeping the last value"),
-    }
+    record_drain_signals(store, node, snapshot).await;
 
     // The allocator observation keeps SSD occupancy as its demand weight (a leak-inflated
     // value is a conservative over-demand, not a safety issue; refining it is coordination
@@ -616,14 +629,17 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
                             touch_liveness(path);
                         }
                         heartbeat_once(&ssd, &store, &coord, &node, max_drain_rate, &snapshot).await;
-                        // C8 readiness: heartbeat_once just refreshed the backlog. The drain is
-                        // PROGRESSING iff it cycled any claim (committed + failed + deferred +
+                        // C8 readiness: heartbeat_once just refreshed the drain signals. The drain
+                        // is PROGRESSING iff it cycled any claim (committed + failed + deferred +
                         // throttled) since the last tick; touch readiness only when progressing or
                         // idle, so a wedged loop (hung Ceph) lets the file go stale -> NotReady.
                         // `throttled` is included so a pool-wide Ceph outage — which trips the
                         // breaker and denies EVERY claim — reads as a healthy back-off, not a wedge:
                         // otherwise the whole DaemonSet flips NotReady at once and a rolling update
-                        // can never make progress over the outage.
+                        // can never make progress over the outage. The "is there work" signal is the
+                        // undrained-row COUNT, NOT the byte backlog: the byte sum can undercount a
+                        // wedged node to 0 (missing/NULL-size parts rows), which would falsely read
+                        // idle -> Ready — the exact wedge C8 exists to catch (PR #235 D1).
                         if let Some(path) = readiness.as_deref() {
                             let snap = snapshot.load();
                             let processed = snap
@@ -633,7 +649,7 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
                                 .saturating_add(snap.throttled);
                             let ready = readiness_tracker.lock().unwrap_or_else(PoisonError::into_inner).observe(
                                 processed,
-                                snapshot.backlog(),
+                                snapshot.undrained_count(),
                                 Instant::now(),
                             );
                             if ready {
@@ -661,7 +677,7 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr, reason = "tests")]
 mod tests {
-    use super::{AgentRuntime, HeartbeatConfig, PullAction, RateControl, RuntimeConfig, default_enforcer, pull_action};
+    use super::{AgentRuntime, HeartbeatConfig, PullAction, RateControl, RuntimeConfig, default_enforcer, pull_action, record_drain_signals};
     use crate::localfs::{LocalFs, LocalSsd};
     use crate::supervisor::ShutdownTrigger;
     use core::str::FromStr;
@@ -721,6 +737,55 @@ mod tests {
         // WI-6: an Err (e.g. a sustained redis-queues outage) must decay toward the floor
         // like silence, NOT hold the last budget and keep hammering a degraded Ceph.
         assert_eq!(pull_action(&Err(CoordError::Invalid { field: "test" })), PullAction::Decay);
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn a_wedged_node_with_zero_backlog_bytes_still_reports_undrained_work_to_readiness(pool: PgPool) {
+        // PR #235 D1 end-to-end: a `draining` replication row whose `parts` row is ABSENT is real
+        // undrained work, but node_backlog_bytes (an INNER JOIN to parts) sums it to 0. If readiness
+        // keyed on those 0 bytes it would read idle -> Ready and never catch this wedge. The signal
+        // recording must yield undrained_count == 1 while backlog bytes stay 0, and a readiness
+        // tracker fed that COUNT must go NotReady once the stall elapses with no drained progress.
+        use crate::readiness::ReadinessTracker;
+        use std::time::Instant;
+
+        let store = Store::from_pool(pool.clone());
+        // node_backlog_bytes joins `parts`, which the cephor-only migrations do not create.
+        sqlx::query(
+            "CREATE TABLE parts (object_id uuid NOT NULL, object_version bigint NOT NULL, part_number bigint NOT NULL, \
+             size_bytes bigint, upload_id uuid)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        // A draining row for node-x with NO parts row: 0 backlog bytes, 1 undrained row.
+        sqlx::query(
+            "INSERT INTO cephor_replication_status (object_id, version, part_number, status, node_id) \
+             VALUES ($1, 1, 1, 'draining', 'node-x')",
+        )
+        .bind(UUID)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let node = NodeId::from_str("node-x").unwrap();
+        let snapshot = SnapshotCell::new();
+        record_drain_signals(&store, &node, &snapshot).await;
+        assert_eq!(snapshot.backlog(), 0, "the wedged node's byte-backlog undercounts to 0");
+        assert_eq!(snapshot.undrained_count(), 1, "but one replication row is still undrained");
+
+        // Drive the readiness verdict exactly as the runtime wiring does — on the undrained COUNT.
+        let stall = Duration::from_mins(1);
+        let t0 = Instant::now();
+        let mut tracker = ReadinessTracker::new(t0, stall);
+        assert!(
+            tracker.observe(0, snapshot.undrained_count(), t0 + Duration::from_secs(5)),
+            "fresh window -> ready"
+        );
+        assert!(
+            !tracker.observe(0, snapshot.undrained_count(), t0 + Duration::from_mins(2)),
+            "undrained rows + no progress past the stall -> NotReady (keying on the 0-byte backlog would stay Ready)"
+        );
     }
 
     fn part_at(version: u32, number: u32) -> PartKey {

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -23,7 +23,8 @@ use crate::supervisor::{RunReport, Supervisor, WorkerName};
 use crate::worker::drain_until_empty;
 use hippius_drain_core::{
     BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, CoordError, Coordinator, Enforcer, NodeId, NodeObservation,
-    SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket, UploadEnqueuer, decay_rate, jittered, reclaim_ssd, reconcile_parts,
+    ReclaimError, SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket, UploadEnqueuer, decay_rate, jittered, reclaim_ssd,
+    reconcile_parts,
 };
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -314,6 +315,16 @@ async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, gr
                     "corrupt-live SSD parts held (pool copy corrupt) — last good source preserved, awaiting re-drive (R4)"
                 );
             }
+        }
+        // A backing-read abort (`ReclaimError::Backing`: `object_versions` missing on a deploy, or
+        // a transient PG error) leaves the servability/orphan gate blind, so the `failed`-part GC
+        // ran and removed NOTHING — it is silently DISABLED, not merely retried. Count it (the
+        // drain_reclaim_backing_errors_total alert) and ERROR so a stuck reclaim pages instead of
+        // hiding in a warn; the pass is still fail-safe (nothing was unlinked). The other reclaim
+        // errors are transient-retryable — leave them at warn.
+        Err(ReclaimError::Backing(err)) => {
+            snapshot.record_reclaim_backing_error();
+            tracing::error!(error = %err, "ssd reclaim disabled: object-backing read failed; failed-part GC removed nothing");
         }
         Err(err) => tracing::warn!(error = ?err, "ssd reclaim cycle failed; will retry next poll"),
     }
@@ -1309,6 +1320,39 @@ mod tests {
             "a servable object's last good SSD copy is preserved even with a failed replication row",
         );
         assert_eq!(snapshot.load().reclaimed, 0, "the corrupt-live part is not counted as reclaimed");
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn reclaim_once_alerts_and_removes_nothing_when_the_backing_read_fails(pool: PgPool) {
+        // D4: the object-backing read (servability gate) fails because `object_versions` is missing
+        // — the exact "table absent on a deploy" case. The `failed`-part GC then runs but is
+        // silently DISABLED: it must remove NOTHING (fail-safe) and increment the backing-error
+        // counter so a log-blind operator still gets the drain_reclaim_backing_errors_total alert.
+        // No create_object_versions_table() here: that absence IS the fault under test.
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let store = Store::from_pool(pool.clone());
+        let snapshot = SnapshotCell::new();
+
+        // An aged `failed` part forces the servability read (over aged-failed parts) to run, which
+        // hits the missing table and surfaces ReclaimError::Backing before any unlink.
+        let failed = part_at(5, 1);
+        seed_ssd_dir(ssd_dir.path(), &failed);
+        store.record_landed_part(&failed).await.unwrap();
+        force_terminal_2h(&pool, &failed, "failed").await;
+
+        let ssd = LocalSsd::new(ssd_dir.path());
+        super::reclaim_once(&ssd, &store, &snapshot, Duration::from_secs(1), Duration::from_secs(1)).await;
+
+        assert!(
+            ssd_dir.path().join(failed.relative_dir()).exists(),
+            "a backing-read failure removes NOTHING — the reclaim fails safe",
+        );
+        assert_eq!(snapshot.load().reclaimed, 0, "nothing was reclaimed on the aborted cycle");
+        assert_eq!(
+            snapshot.load().reclaim_backing_errors,
+            1,
+            "the aborted cycle is counted so a disabled reclaim is alertable, not just logged",
+        );
     }
 
     /// Stands up the `object_versions` table the reclaim's backing/servability reads

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -303,16 +303,18 @@ async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, gr
                     "replicated parts still on SSD — drain crash-orphans nothing currently reclaims"
                 );
             }
-            // Parts held because their live object's pool copy is corrupt (R4): a `corrupt`
-            // row, or the defense-in-depth `failed`+servable case not yet promoted. Their SSD
-            // copy is the last good source. This is LIVE, not hypothetical — the drain's
-            // ChunkMismatch path marks a servable part `corrupt` today — so a nonzero value is a
-            // real durability incident, not GC. ERROR so a log-based alert pages (the
-            // drain_corrupt_parts gauge + alert is the metric path).
+            // Parts held this cycle because their live object's pool copy is corrupt (R4): a
+            // `corrupt` row, or the defense-in-depth `failed`+servable case. Their SSD copy is the
+            // last good source. Reclaim runs BEFORE the corrupt re-drive in the poll cycle, so a
+            // TRANSIENT ChunkMismatch is counted here and then reset to `pending` and recovered on
+            // the very next re-drive — paging on this single-cycle held count would fire on
+            // self-healing corruption. WARN, not page: the STANDING incident signal is the
+            // drain_corrupt_parts gauge remaining nonzero across cycles (the drain-corrupt-live-parts
+            // alert, for:15m), which only at-cap unrecoverable parts sustain — see redrive_corrupt_once.
             if report.skipped_corrupt > 0 {
-                tracing::error!(
+                tracing::warn!(
                     skipped_corrupt = report.skipped_corrupt,
-                    "corrupt-live SSD parts held (pool copy corrupt) — last good source preserved, awaiting re-drive (R4)"
+                    "corrupt-live SSD parts held this cycle (pool copy corrupt) — last good source preserved, awaiting re-drive (R4)"
                 );
             }
         }

--- a/crates/hippius-drain-allocator/src/run.rs
+++ b/crates/hippius-drain-allocator/src/run.rs
@@ -22,10 +22,30 @@ pub struct AllocatorMetrics {
     pub leader: AtomicU64,
     /// The fleet write-budget estimate in bytes/s from the last led tick (`drain_fleet_estimate_bps`).
     pub fleet_estimate_bps: AtomicU64,
-    /// The lease epoch this instance last LED under (`drain_leader_epoch`); left at its last
-    /// led value while not leading. `max()` across the fleet is monotonic by construction, so
-    /// a decrease flags a redis epoch-counter reset that would silently break the write-fence.
+    /// The lease epoch this instance last LED under (`drain_leader_epoch`), reset to 0 on lease
+    /// loss (`NotLeader`/`Fenced`). Because a deposed leader drops to 0, `max()` across the fleet
+    /// tracks only the *live* leader's epoch — so a redis epoch-counter reset shows up as the
+    /// monotonic decrease the fleet alert watches for. Leaving a stale ex-leader exporting its
+    /// old (higher) epoch would mask that decrease and the write-fence-break alert could never fire.
     pub leader_epoch: AtomicU64,
+}
+
+impl AllocatorMetrics {
+    /// Record a led tick: this instance held the lease and wrote budgets stamped with `epoch`.
+    fn record_led(&self, epoch: u64, estimate: u64) {
+        self.leader.store(1, Ordering::Relaxed);
+        self.fleet_estimate_bps.store(estimate, Ordering::Relaxed);
+        self.leader_epoch.store(epoch, Ordering::Relaxed);
+    }
+
+    /// Record a lost lease (`NotLeader` or `Fenced`): drop BOTH leadership and its epoch to 0.
+    /// Resetting `leader_epoch` (not just `leader`) is what keeps `max(drain_leader_epoch)` across
+    /// the fleet tracking only the live leader, so a redis epoch-counter reset produces the
+    /// monotonic decrease the write-fence-break alert watches for (see the field doc above).
+    fn record_not_leading(&self) {
+        self.leader.store(0, Ordering::Relaxed);
+        self.leader_epoch.store(0, Ordering::Relaxed);
+    }
 }
 
 /// Loop-level observability inputs, bundled so `run_allocator` stays under the argument
@@ -85,22 +105,20 @@ pub async fn run_allocator<C: CephCeilingSource>(
                     nodes = plan.allocations.len(),
                     "led allocation tick"
                 );
-                obs.metrics.leader.store(1, Ordering::Relaxed);
-                obs.metrics.fleet_estimate_bps.store(estimate, Ordering::Relaxed);
-                obs.metrics.leader_epoch.store(epoch, Ordering::Relaxed);
+                obs.metrics.record_led(epoch, estimate);
                 // Carry the evolved AIMD state into the next tick.
                 controller = plan.controller;
             }
             Ok(TickOutcome::NotLeader) => {
                 tracing::debug!("another instance holds leadership this tick");
-                obs.metrics.leader.store(0, Ordering::Relaxed);
+                obs.metrics.record_not_leading();
             }
             // The coordinator fenced this instance's stale-epoch write: a higher-epoch
             // leader exists, so this instance is deposed. Expected handoff, not an
             // alert. Keep the carried controller so a re-win resumes from a sane rate.
             Err(CoordError::Fenced { epoch }) => {
                 tracing::info!(epoch, "allocation fenced; leadership has moved on");
-                obs.metrics.leader.store(0, Ordering::Relaxed);
+                obs.metrics.record_not_leading();
             }
             Err(err) => tracing::warn!(error = %err, "allocation tick failed; retrying next tick"),
         }
@@ -171,6 +189,31 @@ mod tests {
 
     fn open_ceiling() -> StaticCeiling {
         StaticCeiling(CephCeiling::Open(ByteRate::new(1_000_000_000)))
+    }
+
+    /// Regression for PR #235 D2: on lease loss the `drain_leader_epoch` gauge must drop to 0,
+    /// not keep exporting the last-led epoch. Both the `NotLeader` and `Fenced` tick arms delegate
+    /// to `record_not_leading`, so testing that function covers both. Were the epoch left stale, a
+    /// deposed leader would keep exporting its old (higher) epoch and `max(drain_leader_epoch)`
+    /// across the fleet would never decrease after a redis epoch-counter reset — the alert that
+    /// exists to catch that fence-break could never fire.
+    #[test]
+    fn lease_loss_resets_the_leader_epoch_gauge() {
+        use std::sync::atomic::Ordering;
+
+        let metrics = AllocatorMetrics::default();
+        metrics.record_led(100, 190_000);
+        assert_eq!(metrics.leader.load(Ordering::Relaxed), 1, "led: leader gauge set");
+        assert_eq!(metrics.leader_epoch.load(Ordering::Relaxed), 100, "led: epoch stamped");
+
+        // Lease loss (the shared path for both NotLeader and Fenced).
+        metrics.record_not_leading();
+        assert_eq!(metrics.leader.load(Ordering::Relaxed), 0, "lease loss drops leadership");
+        assert_eq!(
+            metrics.leader_epoch.load(Ordering::Relaxed),
+            0,
+            "lease loss must reset the epoch so max(drain_leader_epoch) can decrease on a redis reset",
+        );
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-core/src/coordination.rs
+++ b/crates/hippius-drain-core/src/coordination.rs
@@ -387,22 +387,27 @@ impl Coordinator {
     }
 
     /// Writes per-node allocations stamped with `epoch`, fenced atomically so a lower epoch
-    /// cannot overwrite a higher one (the deposed-leader guard). An empty plan is a no-op —
-    /// a node dropped from the plan is conserved by its key's TTL expiring (no zeroing pass
-    /// needed, unlike the old PG path).
+    /// cannot overwrite a higher one (the deposed-leader guard). A node dropped from the plan
+    /// is conserved by its key's TTL expiring (no zeroing pass needed, unlike the old PG path).
+    ///
+    /// An empty plan writes nothing but is NOT a bare `Ok` short-circuit: it still runs the
+    /// current-era fence (the EVAL sees only `KEYS[1]` = `cephor:epoch`, so both of the
+    /// script's write loops — which start at `KEYS[2]` — are empty). This preserves the
+    /// split-brain invariant on the empty-plan path: a deposed leader whose tick allocated
+    /// nothing (no hungry nodes) still learns it lost via [`CoordError::Fenced`] rather than a
+    /// false `Ok` that `run_tick` would surface as a stale `Led`.
     ///
     /// # Errors
     ///
     /// [`CoordError::Fenced`] if a higher-epoch leader exists (nothing was written);
     /// [`CoordError::Redis`] on a command failure.
     pub async fn write_allocations(&self, epoch: u64, allocations: &[Allocation]) -> Result<()> {
-        if allocations.is_empty() {
-            return Ok(());
-        }
         let mut conn = self.conn.clone();
         let script = redis::Script::new(WRITE_ALLOC_SCRIPT);
         let mut invocation = script.prepare_invoke();
         // KEYS[1] is the epoch counter (the current-era fence anchor); the alloc keys follow.
+        // On an empty plan this is the only key, so the EVAL is a pure fence — reads
+        // `cephor:epoch`, mutates nothing, returns Fenced-or-ok.
         invocation.key(self.epoch_key());
         for allocation in allocations {
             invocation.key(self.alloc_key(&allocation.node));
@@ -699,6 +704,50 @@ mod tests {
             c.load_allocation(&node).await.unwrap().unwrap().budget,
             ByteRate::new(1_000),
             "the fenced stale write did not overwrite the budget",
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires CEPHOR_TEST_REDIS_URL"]
+    async fn a_deposed_leader_with_an_empty_plan_is_still_fenced() {
+        // D3: an empty allocation plan must STILL run the current-era fence. Pre-fix,
+        // write_allocations short-circuited `Ok(())` on an empty slice and never consulted
+        // `cephor:epoch`, so a leader deposed between acquiring its lease and a tick that
+        // happened to allocate nothing (no hungry nodes) got a false `Ok` — run_tick then
+        // reported a stale `Led` instead of surfacing the fence. This exercises the empty
+        // slice directly; every other fence test passes at least one node.
+        let Some(c) = coord("cephor-test:empty-plan-fence:", Duration::from_secs(30), Duration::from_secs(30)).await else {
+            eprintln!("skipping: CEPHOR_TEST_REDIS_URL unset");
+            return;
+        };
+
+        // A wins a SHORT lease (epoch eA, which bumps cephor:epoch to eA).
+        let a = c
+            .acquire_or_renew_leadership("a", Duration::from_secs(1))
+            .await
+            .unwrap()
+            .expect("a leads");
+        // The CURRENT leader's empty plan is not a false positive: its epoch equals the era,
+        // so the fence passes and nothing is written.
+        c.write_allocations(a.epoch, &[])
+            .await
+            .expect("current leader's empty plan is not fenced");
+
+        // A's lease lapses; B takes over — cephor:epoch is now eB > eA.
+        tokio::time::sleep(Duration::from_millis(1_200)).await;
+        let b = c
+            .acquire_or_renew_leadership("b", Duration::from_secs(30))
+            .await
+            .unwrap()
+            .expect("b takes over");
+        assert!(b.epoch > a.epoch, "takeover bumps the epoch ({} > {})", b.epoch, a.epoch);
+
+        // The deposed A finishes a tick with an EMPTY plan and writes at its stale epoch. The
+        // current-era fence must reject it rather than returning a false `Ok`.
+        let err = c.write_allocations(a.epoch, &[]).await.unwrap_err();
+        assert!(
+            matches!(err, super::CoordError::Fenced { epoch } if epoch == a.epoch),
+            "an empty-plan write by a deposed leader is fenced, got {err:?}"
         );
     }
 }

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -140,6 +140,13 @@ pub struct SnapshotCell {
     /// The heartbeat worker writes it (`usage.used_bytes`) each tick; the metrics layer
     /// reads it as a gauge. Kept off the wait-free `load` path so a scrape never blocks.
     backlog_bytes: AtomicU64,
+    /// Count of this node's undrained replication rows (`pending` + `draining`) — a LEVEL like
+    /// `backlog_bytes`, set each heartbeat from `Store::node_undrained_count`. This is the C8
+    /// wedge signal, kept SEPARATE from `backlog_bytes` on purpose: the byte sum joins `parts`
+    /// and a missing/NULL-size row contributes zero, so a wedged node's byte-backlog can read 0
+    /// while undrained rows remain — which readiness would misread as idle. The COUNT cannot be
+    /// zeroed that way, so readiness keys on it while the gauge keeps reporting bytes.
+    undrained_count: AtomicU64,
     /// Current SSD disk saturation in basis points (`0..=10000` = `0.0..=1.0` full) — a
     /// LEVEL like `backlog_bytes`, set each heartbeat from the same `statvfs` probe. This
     /// is the fill fraction that 503s every PUT once it crosses the api's cutoff, so it is
@@ -207,6 +214,19 @@ impl SnapshotCell {
     #[must_use]
     pub fn backlog(&self) -> u64 {
         self.backlog_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Records the current count of undrained replication rows (`pending` + `draining`). A gauge:
+    /// `store`, not add. The heartbeat writes it from `Store::node_undrained_count` each tick.
+    pub fn record_undrained_count(&self, count: u64) {
+        self.undrained_count.store(count, Ordering::Relaxed);
+    }
+
+    /// The last-recorded count of undrained replication rows — the C8 readiness wedge signal
+    /// (nonzero means real drain work remains, even when [`backlog`](Self::backlog) reads 0).
+    #[must_use]
+    pub fn undrained_count(&self) -> u64 {
+        self.undrained_count.load(Ordering::Relaxed)
     }
 
     /// Records the current SSD disk saturation in basis points (`0..=10000`). A gauge:
@@ -299,6 +319,18 @@ mod tests {
         assert_eq!(cell.backlog(), 4096);
         cell.record_backlog(100);
         assert_eq!(cell.backlog(), 100, "backlog is a level: a later record replaces, not accumulates");
+    }
+
+    #[test]
+    fn undrained_count_is_a_settable_gauge_not_a_counter() {
+        // The C8 wedge signal (PR #235 D1): a LEVEL sourced from a COUNT of undrained
+        // replication rows, so a later record replaces rather than accumulates — like backlog.
+        let cell = SnapshotCell::new();
+        assert_eq!(cell.undrained_count(), 0, "a fresh cell reports no undrained rows");
+        cell.record_undrained_count(4);
+        assert_eq!(cell.undrained_count(), 4);
+        cell.record_undrained_count(1);
+        assert_eq!(cell.undrained_count(), 1, "undrained count is a level: a later record replaces");
     }
 
     #[test]

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -256,10 +256,14 @@ impl SnapshotCell {
     }
 
     /// The last-recorded SSD disk saturation in basis points (the `drain_ssd_pressure`
-    /// gauge source). Clamped to `10000` should a wider value ever be stored.
+    /// gauge source). Clamped to `10000` on read so the value honors the `bps ∈ [0, 10000]`
+    /// contract even if a wider one was ever stored.
     #[must_use]
     pub fn disk_pressure_bps(&self) -> u16 {
-        u16::try_from(self.disk_pressure_bps.load(Ordering::Relaxed)).unwrap_or(10_000)
+        // Clamp on read: the setter widens u16 -> u64, so a stored bps in (10000, 65535]
+        // would otherwise round-trip un-clamped and break the [0, 10000] contract. The
+        // `.min` makes the value always fit u16, so the `try_from` fallback never fires.
+        u16::try_from(self.disk_pressure_bps.load(Ordering::Relaxed).min(10_000)).unwrap_or(10_000)
     }
 
     /// Records the current count of parts held `corrupt` on this node. A gauge: `store`, not
@@ -362,6 +366,12 @@ mod tests {
         assert_eq!(cell.disk_pressure_bps(), 8500);
         cell.record_disk_pressure(200);
         assert_eq!(cell.disk_pressure_bps(), 200, "disk pressure is a level: a later record replaces");
+        cell.record_disk_pressure(12_000); // a u16 wider than the bps ceiling
+        assert_eq!(
+            cell.disk_pressure_bps(),
+            10_000,
+            "a stored bps above 10000 reads back clamped to the ceiling"
+        );
     }
 
     #[test]

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -365,6 +365,25 @@ mod tests {
     }
 
     #[test]
+    fn corrupt_parts_is_a_settable_gauge_not_a_counter() {
+        // D5: the R4 standing durability signal (the drain_corrupt_parts alert source). A LEVEL
+        // set each cycle from Store::count_corrupt_parts, so a later record REPLACES rather than
+        // accumulates — the page fires on this gauge staying nonzero ACROSS cycles (only at-cap
+        // unrecoverable parts sustain it), NOT on a single reclaim cycle's held count, which is
+        // logged at WARN and self-heals on the next re-drive.
+        let cell = SnapshotCell::new();
+        assert_eq!(cell.corrupt_parts(), 0, "a fresh cell reports no corrupt parts");
+        cell.record_corrupt(3);
+        assert_eq!(cell.corrupt_parts(), 3);
+        cell.record_corrupt(1);
+        assert_eq!(
+            cell.corrupt_parts(),
+            1,
+            "corrupt parts is a level: a later record replaces, not accumulates"
+        );
+    }
+
+    #[test]
     fn records_accumulate_per_counter() {
         let cell = SnapshotCell::new();
         cell.record_drained(3);

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -92,6 +92,14 @@ pub struct AgentSnapshot {
     /// `failed` (broken/abandoned-upload) SSD parts the reclaim worker unlinked — the
     /// SSD-ingest tier's eviction throughput, distinct from the drain's `CephFS` work.
     pub reclaimed: u64,
+    /// Reclaim cycles that aborted on an object-backing read error (`ReclaimError::Backing`):
+    /// the servability/orphan gate could not read `object_versions` (a missing table on some
+    /// deploy, or a transient PG error). A monotonic COUNT of aborted cycles — each removes
+    /// NOTHING (fail-safe), so a sustained rise means the `failed`-part SSD GC is silently
+    /// DISABLED and debris accrues, invisible outside logs. Deliberately kept OUT of
+    /// [`error_bps`](Self::error_bps): a reclaim stall is not a Ceph-write failure, exactly
+    /// like `deferred`/`throttled`.
+    pub reclaim_backing_errors: u64,
     /// Claims handed back un-drained because the breaker/throttle `Denied` the tick (the
     /// pool is unhealthy or the write budget is spent). NOT a drain outcome — no part moved
     /// — but the loop DID cycle, so the readiness tracker folds it into `processed`: a
@@ -134,6 +142,11 @@ pub struct SnapshotCell {
     deferred: AtomicU64,
     reconciler_recovered: AtomicU64,
     reclaimed: AtomicU64,
+    /// Aborted-reclaim counter mirroring `reclaimed`: bumped once per reclaim cycle that failed
+    /// its object-backing read (`ReclaimError::Backing`). Monotonic, `Relaxed` — a stat counter
+    /// with no cross-counter ordering dependency (axiom `rust_quality_92`). See
+    /// [`AgentSnapshot::reclaim_backing_errors`] for why it stays out of `error_bps`.
+    reclaim_backing_errors: AtomicU64,
     throttled: AtomicU64,
     /// Current SSD backlog (undrained bytes) — a LEVEL, not a monotonic counter, so it
     /// has its own atomic (set, not accumulated) rather than living in [`AgentSnapshot`].
@@ -196,6 +209,13 @@ impl SnapshotCell {
     /// Adds `n` to the SSD-reclaim total (terminal parts the reclaim worker unlinked).
     pub fn record_reclaimed(&self, n: u64) {
         self.reclaimed.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Records one reclaim cycle aborted on an object-backing read error — a `failed`-part GC
+    /// pass that read nothing and removed nothing (the `drain_reclaim_backing_errors_total`
+    /// counter). One abort per cycle, so it bumps by one, not by a caller-supplied count.
+    pub fn record_reclaim_backing_error(&self) {
+        self.reclaim_backing_errors.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Records `n` claims handed back because the breaker/throttle denied the tick. Counts
@@ -279,6 +299,7 @@ impl SnapshotCell {
             deferred: self.deferred.load(Ordering::Relaxed),
             reconciler_recovered: self.reconciler_recovered.load(Ordering::Relaxed),
             reclaimed: self.reclaimed.load(Ordering::Relaxed),
+            reclaim_backing_errors: self.reclaim_backing_errors.load(Ordering::Relaxed),
             throttled: self.throttled.load(Ordering::Relaxed),
         }
     }
@@ -360,6 +381,7 @@ mod tests {
                 deferred: 0,
                 reconciler_recovered: 4,
                 reclaimed: 6,
+                reclaim_backing_errors: 0,
                 throttled: 9,
             },
         );
@@ -376,6 +398,21 @@ mod tests {
         let snap = cell.load();
         assert_eq!(snap.throttled, 40, "throttled ticks are counted for readiness/visibility");
         assert_eq!(snap.error_bps(), 3000, "throttled ticks stay out of the Ceph failure rate");
+    }
+
+    #[test]
+    fn reclaim_backing_errors_accumulate_without_polluting_error_bps() {
+        // D4: a backing-read abort disables the `failed`-part SSD GC (the servability gate cannot
+        // read `object_versions`) but is NOT a Ceph-write failure, so — like `deferred`/`throttled`
+        // — it is counted for the alert yet kept out of the Ceph error rate.
+        let cell = SnapshotCell::new();
+        cell.record_drained(7);
+        cell.record_failed(3);
+        cell.record_reclaim_backing_error();
+        cell.record_reclaim_backing_error();
+        let snap = cell.load();
+        assert_eq!(snap.reclaim_backing_errors, 2, "each aborted reclaim cycle is counted");
+        assert_eq!(snap.error_bps(), 3000, "backing-read aborts stay out of the Ceph failure rate");
     }
 
     #[test]
@@ -408,6 +445,7 @@ mod tests {
             deferred: 0,
             reconciler_recovered: 0,
             reclaimed: 0,
+            reclaim_backing_errors: 0,
             throttled: 0,
         };
         assert_eq!(snapshot.error_bps(), 10_000);
@@ -421,6 +459,7 @@ mod tests {
             deferred: 0,
             reconciler_recovered: 0,
             reclaimed: 0,
+            reclaim_backing_errors: 0,
             throttled: 0,
         };
         // 3 failed attempts of 10 total attempts = 30%, i.e. 3000 basis points.

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -131,12 +131,15 @@ pub trait BackingLog: Send + Sync {
     fn unbacked_parts(&self, parts: &[PartKey]) -> impl Future<Output = Result<HashSet<PartKey>, Self::Error>> + Send;
 
     /// The subset of `parts` whose `(object_id, version)` row EXISTS and is SERVABLE — the
-    /// exact inverse of `janitor_part_terminally_abandoned.sql`'s unservable predicate
-    /// (`address IS NULL AND size_bytes <= 0 AND COALESCE(md5_hash,'') = ''`), i.e. a row
-    /// with `address` set OR `size_bytes > 0` OR a non-empty `md5_hash`. A part with no row,
-    /// or with an unservable (abandoned-upload) row, is absent from the result — the
-    /// reclaim treats those as safe to delete. A returned part is the corrupt-live case the
-    /// `failed` reclaim must NOT delete.
+    /// inverse of `janitor_part_terminally_abandoned.sql`'s unservable predicate
+    /// (`address IS NULL AND size_bytes <= 0 AND COALESCE(md5_hash,'') = ''`) for the servable
+    /// disjuncts, i.e. a row with `address` set OR `size_bytes > 0` OR a non-empty `md5_hash`.
+    /// A part with no row, or with an unservable (abandoned-upload) row, is absent from the
+    /// result — the reclaim treats those as safe to delete. A returned part is the corrupt-live
+    /// case the `failed` reclaim must NOT delete. The two predicates are not bit-identical under
+    /// a NULL `size_bytes`: a bare all-NULL row is unservable here (so reclaimable) while the
+    /// janitor's `size_bytes <= 0` is NULL so it never sweeps it — both fail safe, since a
+    /// bare-NULL row can serve no GET.
     fn servable_parts(&self, parts: &[PartKey]) -> impl Future<Output = Result<HashSet<PartKey>, Self::Error>> + Send;
 }
 

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -746,12 +746,16 @@ impl PartReplicationStore for Store {
     }
 
     async fn is_version_servable(&self, part: &PartKey) -> Result<bool> {
-        // The exact inverse of janitor_part_terminally_abandoned.sql's unservable predicate and
-        // the reclaim gate's servable_parts: a version SERVES a GET if its address is set, OR it
-        // has a real size, OR an md5. address is written AFTER size/md5 in a separate step, so a
-        // fully-servable version briefly has address=NULL (the mid-finalize window); the size/md5
-        // disjuncts keep such a live version from reading as unservable. Do NOT reduce to
-        // address-only. A missing row (deleted object) is not servable.
+        // The inverse of janitor_part_terminally_abandoned.sql's unservable predicate for the
+        // servable disjuncts (address set / size>0 / md5 set), shared with the reclaim gate's
+        // servable_parts: a version SERVES a GET if its address is set, OR it has a real size,
+        // OR an md5. address is written AFTER size/md5 in a separate step, so a fully-servable
+        // version briefly has address=NULL (the mid-finalize window); the size/md5 disjuncts
+        // keep such a live version from reading as unservable. Do NOT reduce to address-only.
+        // A missing row (deleted object) is not servable. NB: not bit-identical to the janitor
+        // under a NULL size_bytes — a bare all-NULL row is unservable here (`size_bytes > 0` is
+        // NULL -> not servable) yet the janitor's `size_bytes <= 0` is also NULL so it does not
+        // sweep it; both are fail-safe (a bare-NULL row can serve no GET).
         let servable = sqlx::query_scalar::<_, bool>(
             "SELECT EXISTS ( \
                 SELECT 1 FROM object_versions ov \
@@ -968,15 +972,19 @@ impl BackingLog for Store {
                 part_numbers.push(i64::from(part.part().get()));
             }
             // Echo back exactly the input parts whose (object_id, version) row EXISTS and is
-            // SERVABLE — the exact inverse of janitor_part_terminally_abandoned.sql's
-            // unservable predicate. MUST stay in lockstep with that file (and the A21 sweep's
-            // list_orphan_replication_versions.sql): servable = address written, OR a real
-            // size, OR an md5 — the download filter `(size_bytes > 0 OR md5_hash <> '')` plus
-            // a set address. `address` is written AFTER size/md5 in a separate step, so a
-            // fully-servable version briefly has address=NULL (the mid-finalize window); the
-            // size/md5 disjuncts are what keep such a live version from being read as
-            // reclaimable. Do NOT "simplify" to address-only. The object_id is echoed from the
-            // input UNNEST so the reconstructed PartKey matches the caller's key verbatim.
+            // SERVABLE — the inverse of janitor_part_terminally_abandoned.sql's unservable
+            // predicate for the servable disjuncts. MUST stay in lockstep with that file (and
+            // the A21 sweep's list_orphan_replication_versions.sql): servable = address
+            // written, OR a real size, OR an md5 — the download filter `(size_bytes > 0 OR
+            // md5_hash <> '')` plus a set address. `address` is written AFTER size/md5 in a
+            // separate step, so a fully-servable version briefly has address=NULL (the
+            // mid-finalize window); the size/md5 disjuncts are what keep such a live version
+            // from being read as reclaimable. Do NOT "simplify" to address-only. The two
+            // predicates are NOT bit-identical under a NULL size_bytes: a bare all-NULL row is
+            // unservable here (so reclaimable) while the janitor's `size_bytes <= 0` is NULL so
+            // it never sweeps it — both fail safe, since a bare-NULL row can serve no GET. The
+            // object_id is echoed from the input UNNEST so the reconstructed PartKey matches
+            // the caller's key verbatim.
             let rows = sqlx::query_as::<_, (String, i64, i64)>(
                 "SELECT t.object_id, t.version, t.part_number \
                  FROM UNNEST($1::text[], $2::bigint[], $3::bigint[]) AS t(object_id, version, part_number) \
@@ -1360,7 +1368,11 @@ mod part_tests {
         seed_ov(&pool, UUID_A, 3, None, Some(0), Some("d41d8cd9")).await;
         // address NULL, size 0, md5 '' → UNSERVABLE (the abandoned-upload shape).
         seed_ov(&pool, UUID_A, 4, None, Some(0), Some("")).await;
-        // address NULL, size NULL, md5 NULL → UNSERVABLE (bare reserved row).
+        // address NULL, size NULL, md5 NULL → UNSERVABLE here, so RECLAIMABLE (bare reserved
+        // row). This is the one shape where reclaim and the janitor diverge: `size_bytes > 0`
+        // is NULL -> not servable -> reclaimable here, while the janitor's `size_bytes <= 0` is
+        // also NULL so it never sweeps it. Both fail safe (a bare-NULL row can serve no GET);
+        // this case pins that intentional, non-bit-identical behavior.
         seed_ov(&pool, UUID_A, 5, None, None, None).await;
         // no object_versions row at all (v6) → UNSERVABLE (deleted object).
 

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -319,6 +319,29 @@ impl Store {
         Ok(u64::try_from(bytes).unwrap_or(0))
     }
 
+    /// The count of `node`'s undrained replication rows (`pending` + `draining`) — the C8
+    /// readiness wedge signal. Unlike [`node_backlog_bytes`](Self::node_backlog_bytes) this does
+    /// NOT join `parts`: a row whose `parts` row is absent or carries a NULL/0 `size_bytes`
+    /// contributes zero bytes to that SUM but is still undrained WORK, so the byte-backlog of a
+    /// wedged node can read 0 while rows remain — which readiness would misread as idle. Counting
+    /// the replication rows directly cannot be zeroed that way, so it is the signal readiness gates
+    /// on. Uses the node-scoped pending index. Mirrors the params of `node_backlog_bytes`.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Database`] if the query fails.
+    pub async fn node_undrained_count(&self, node: &str) -> Result<u64> {
+        let (count,): (i64,) = sqlx::query_as(
+            "SELECT count(*)::bigint FROM cephor_replication_status \
+             WHERE node_id = $1 AND status IN ('pending', 'draining')",
+        )
+        .bind(node)
+        .fetch_one(&self.pool)
+        .await?;
+        // count(*) is >= 0; the cast guards against an impossible negative for total-ness.
+        Ok(u64::try_from(count).unwrap_or(0))
+    }
+
     /// R4 re-drive: reset this node's `corrupt` parts back to `pending` for a fresh SSD->pool
     /// copy (overwriting the corrupt pool copy from the intact SSD source), bounded by
     /// `max_attempts`. Only rows still under the cap are reset; each reset bumps
@@ -1473,6 +1496,39 @@ mod part_tests {
             0,
             "a node with no rows has zero backlog"
         );
+    }
+
+    #[sqlx::test]
+    async fn node_undrained_count_counts_every_undrained_row_even_when_backlog_bytes_is_zero(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        // C8 wedge signal (PR #235 D1): a draining row whose `parts` row is missing or has a
+        // NULL/0 size contributes ZERO bytes to node_backlog_bytes (INNER JOIN + COALESCE), so a
+        // wedged node's byte-backlog can read 0 while real undrained work remains. The COUNT does
+        // NOT join `parts`, so those exact rows still register — that is why readiness keys on it.
+        create_app_schema(&pool).await;
+        let store = Store::from_pool(pool.clone());
+
+        // node-a undrained rows that ALL contribute 0 bytes: a draining row with no parts row, a
+        // pending row with a NULL size, and a pending row with a 0 size. node_backlog_bytes == 0.
+        seed_status_node(&pool, UUID_A, 1, 1, "draining", "node-a").await; // no parts row
+        seed_status_node(&pool, UUID_A, 1, 2, "pending", "node-a").await;
+        seed_part_size(&pool, UUID_A, 1, 2, None).await; // NULL size
+        seed_status_node(&pool, UUID_A, 1, 3, "pending", "node-a").await;
+        seed_part_size(&pool, UUID_A, 1, 3, Some(0)).await; // zero size
+        // Terminal rows are drained work, excluded from the count.
+        seed_status_node(&pool, UUID_A, 1, 4, "replicated", "node-a").await;
+        seed_part_size(&pool, UUID_A, 1, 4, Some(999)).await;
+        // A peer node's pending row belongs to its own node's count.
+        seed_status_node(&pool, UUID_B, 2, 1, "pending", "node-b").await;
+
+        assert_eq!(store.node_backlog_bytes("node-a").await?, 0, "every undrained row contributes 0 bytes");
+        assert_eq!(
+            store.node_undrained_count("node-a").await?,
+            3,
+            "the wedged node's 3 undrained rows are counted despite the 0-byte backlog"
+        );
+        assert_eq!(store.node_undrained_count("node-b").await?, 1, "counts only this node's rows");
+        assert_eq!(store.node_undrained_count("node-c").await?, 0, "a node with no rows is idle");
+        Ok(())
     }
 
     #[sqlx::test]

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -314,6 +314,14 @@ class Config:
     # clear (otherwise the gauge reads non-zero forever). Defaults to mpu_stale_seconds so the
     # leak backstop can be tuned independently of the abandoned-MPU reaper's own window.
     mpu_sweep_grace_seconds: int = env("HIPPIUS_MPU_SWEEP_GRACE_SECONDS:172800", convert=int)  # 2 days
+    # Idle grace for the janitor's aged-pending-orphan GAUGE only — deliberately DECOUPLED from
+    # mpu_sweep_grace_seconds. The sweep grace above is the reaper's *eligibility* window (48h);
+    # this is a leak-VISIBILITY window and must be SMALL. The gauge exists so a short (e.g. 6h)
+    # soak can see a re-introduced A21 leak: an orphan aged only a couple hours must register, so
+    # the soak gate's slope≈0 assertion is meaningful. Fed the 48h reaper grace, a soak-fresh leak
+    # never ages past the window and the gate passes vacuously — the failure C3 fixes. 1h default:
+    # long enough to exclude a still-arriving upload, short enough to surface a leak within a soak.
+    aged_orphan_gauge_grace_seconds: int = env("HIPPIUS_AGED_ORPHAN_GAUGE_GRACE_SECONDS:3600", convert=int)  # 1h
     # How often the abandoned-multipart-upload reaper sweeps. The reaper auto-aborts
     # never-finalized uploads older than mpu_stale_seconds (address never written),
     # purging their SSD parts + drain replication rows so the drain stops re-deferring.

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -309,10 +309,10 @@ class Config:
     # exceed a realistic pause. 2 days gives leeway over a full-day pause + resume.
     mpu_stale_seconds: int = env("HIPPIUS_MPU_STALE_SECONDS:172800", convert=int)  # 2 days
     # Idle grace before an orphaned cephor_replication_status version (pending/draining,
-    # unservable) is swept to `failed` AND counted by the janitor's aged-pending-orphan gauge.
-    # MUST be the same value for both so the gauge counts EXACTLY the population the sweep can
-    # clear (otherwise the gauge reads non-zero forever). Defaults to mpu_stale_seconds so the
-    # leak backstop can be tuned independently of the abandoned-MPU reaper's own window.
+    # unservable) is swept to `failed` by the A21 reaper sweep — the reaper's *eligibility* window.
+    # The janitor's aged-pending-orphan GAUGE is now DECOUPLED onto aged_orphan_gauge_grace_seconds
+    # (below), so this can stay the long (48h) leak backstop without making the leak-VISIBILITY gauge
+    # read non-zero forever. Defaults to mpu_stale_seconds (tunable independently of it).
     mpu_sweep_grace_seconds: int = env("HIPPIUS_MPU_SWEEP_GRACE_SECONDS:172800", convert=int)  # 2 days
     # Idle grace for the janitor's aged-pending-orphan GAUGE only — deliberately DECOUPLED from
     # mpu_sweep_grace_seconds. The sweep grace above is the reaper's *eligibility* window (48h);

--- a/hippius_s3/sql/migrations/20260706000000_parts_upload_uploaded_at_index.sql
+++ b/hippius_s3/sql/migrations/20260706000000_parts_upload_uploaded_at_index.sql
@@ -14,11 +14,21 @@
 -- PUT for minutes. CONCURRENTLY builds without the write lock, but Postgres forbids it inside a
 -- transaction block — hence dbmate's `transaction:false` directive on the migrate:up line.
 --
--- Recovery caveat: a CONCURRENTLY build that fails midway (crash, deadlock, cancelled deploy)
--- leaves an INVALID index of this name behind. `IF NOT EXISTS` then SKIPS it on the next run — it
--- will NOT rebuild an existing-but-invalid index. If this migration errors, drop the leftover
--- (`DROP INDEX CONCURRENTLY idx_parts_upload_uploaded_at;`) or `REINDEX INDEX CONCURRENTLY
--- idx_parts_upload_uploaded_at;` before re-running.
+-- Self-heal a failed build: a CONCURRENTLY build that fails midway (crash, deadlock, cancelled
+-- deploy) leaves an INVALID index of this name behind, and dbmate does NOT record a failed
+-- migration — so on retry a bare `CREATE ... IF NOT EXISTS` would SKIP the invalid index, record
+-- the migration as applied, and leave the reaper seq-scanning ~94M rows with no error. The
+-- `DROP INDEX CONCURRENTLY IF EXISTS` first removes any leftover so the CREATE always rebuilds a
+-- fresh valid index on retry. On the normal first run the index does not exist, so the DROP is a
+-- no-op; the migration runs once, so it never drops a good index in steady state. Both statements
+-- need `transaction:false` (set above) — CONCURRENTLY cannot run inside a transaction block.
+--
+-- NOTE (staging): version 20260706000000 was first added by an earlier commit as a NON-concurrent
+-- index and is already recorded in `schema_migrations` on staging; dbmate keys on the version
+-- number, not file content, so this edited body will NOT re-run there (staging already has the
+-- index, built the write-locking way — a one-time cost already paid). A fresh apply (prod) runs
+-- this final form and gets the CONCURRENTLY build. The resulting index is identical either way.
+DROP INDEX CONCURRENTLY IF EXISTS idx_parts_upload_uploaded_at;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_parts_upload_uploaded_at
     ON parts (upload_id, uploaded_at);
 

--- a/hippius_s3/sql/migrations/20260706000000_parts_upload_uploaded_at_index.sql
+++ b/hippius_s3/sql/migrations/20260706000000_parts_upload_uploaded_at_index.sql
@@ -14,21 +14,21 @@
 -- PUT for minutes. CONCURRENTLY builds without the write lock, but Postgres forbids it inside a
 -- transaction block — hence dbmate's `transaction:false` directive on the migrate:up line.
 --
--- Self-heal a failed build: a CONCURRENTLY build that fails midway (crash, deadlock, cancelled
--- deploy) leaves an INVALID index of this name behind, and dbmate does NOT record a failed
--- migration — so on retry a bare `CREATE ... IF NOT EXISTS` would SKIP the invalid index, record
--- the migration as applied, and leave the reaper seq-scanning ~94M rows with no error. The
--- `DROP INDEX CONCURRENTLY IF EXISTS` first removes any leftover so the CREATE always rebuilds a
--- fresh valid index on retry. On the normal first run the index does not exist, so the DROP is a
--- no-op; the migration runs once, so it never drops a good index in steady state. Both statements
--- need `transaction:false` (set above) — CONCURRENTLY cannot run inside a transaction block.
+-- Recovery caveat: a CONCURRENTLY build that fails midway (crash, deadlock, cancelled deploy)
+-- leaves an INVALID index of this name behind. `IF NOT EXISTS` then SKIPS it on the next run — it
+-- will NOT rebuild an existing-but-invalid index. If this migration errors, drop the leftover
+-- (`DROP INDEX CONCURRENTLY idx_parts_upload_uploaded_at;`) or `REINDEX INDEX CONCURRENTLY
+-- idx_parts_upload_uploaded_at;` before re-running. This MUST stay a SINGLE statement: dbmate runs
+-- a `transaction:false` migration body as one multi-command simple query, and Postgres runs any
+-- multi-statement string in an IMPLICIT transaction — so adding a second statement (e.g. a
+-- DROP CONCURRENTLY self-heal) makes CREATE INDEX CONCURRENTLY fail with "cannot run inside a
+-- transaction block". The invalid-index recovery above stays a manual operator step.
 --
 -- NOTE (staging): version 20260706000000 was first added by an earlier commit as a NON-concurrent
 -- index and is already recorded in `schema_migrations` on staging; dbmate keys on the version
 -- number, not file content, so this edited body will NOT re-run there (staging already has the
 -- index, built the write-locking way — a one-time cost already paid). A fresh apply (prod) runs
 -- this final form and gets the CONCURRENTLY build. The resulting index is identical either way.
-DROP INDEX CONCURRENTLY IF EXISTS idx_parts_upload_uploaded_at;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_parts_upload_uploaded_at
     ON parts (upload_id, uploaded_at);
 

--- a/hippius_s3/sql/migrations/20260706000000_parts_upload_uploaded_at_index.sql
+++ b/hippius_s3/sql/migrations/20260706000000_parts_upload_uploaded_at_index.sql
@@ -1,4 +1,4 @@
--- migrate:up
+-- migrate:up transaction:false
 
 -- R2: the MPU reaper's activity-gate (list_abandoned_versions.sql) checks, per candidate
 -- upload, whether any of its parts has recent `uploaded_at` activity — a correlated
@@ -7,7 +7,19 @@
 -- read uploaded_at; at prod cardinality (~94M parts) that is the reaper's dominant buffer cost.
 -- A composite (upload_id, uploaded_at) index makes the activity check an index-only range scan
 -- per upload — the R2 gate before enabling the reaper at prod scale.
-CREATE INDEX IF NOT EXISTS idx_parts_upload_uploaded_at
+--
+-- CONCURRENTLY (+ `transaction:false` above) is mandatory here: a plain CREATE INDEX takes a
+-- SHARE lock that blocks every INSERT/UPDATE/DELETE on `parts` for the whole build. Migrations
+-- run before the API serves traffic on deploy, so a plain build at ~94M rows would stall every
+-- PUT for minutes. CONCURRENTLY builds without the write lock, but Postgres forbids it inside a
+-- transaction block — hence dbmate's `transaction:false` directive on the migrate:up line.
+--
+-- Recovery caveat: a CONCURRENTLY build that fails midway (crash, deadlock, cancelled deploy)
+-- leaves an INVALID index of this name behind. `IF NOT EXISTS` then SKIPS it on the next run — it
+-- will NOT rebuild an existing-but-invalid index. If this migration errors, drop the leftover
+-- (`DROP INDEX CONCURRENTLY idx_parts_upload_uploaded_at;`) or `REINDEX INDEX CONCURRENTLY
+-- idx_parts_upload_uploaded_at;` before re-running.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_parts_upload_uploaded_at
     ON parts (upload_id, uploaded_at);
 
 -- migrate:down

--- a/hippius_s3/sql/queries/count_aged_pending_orphans.sql
+++ b/hippius_s3/sql/queries/count_aged_pending_orphans.sql
@@ -9,21 +9,31 @@
 -- It counts the EXACT population list_orphan_replication_versions.sql sweeps — an object
 -- version that is (a) still ACTIVE on the drain (status IN ('pending','draining')),
 -- (b) UNSERVABLE (the abandoned/leaked shape: address IS NULL AND size_bytes <= 0 AND
--- md5_hash = ''), and (c) idle past the grace (its most-recently-landed part older than
+-- md5_hash = ''), (c) idle past the grace (its most-recently-landed part older than
 -- $1 seconds — landed_at is the true idle signal, never bumped by drain re-claim/defer
--- churn) — but returns a single count rather than a page to mark. The servability predicate
--- MUST stay in lockstep with janitor_part_terminally_abandoned.sql (and the Rust reclaim
--- gate's Store::servable_parts): all three encode the one definition of "servable".
+-- churn), and (d) NOT DLQ-protected — the sweep skips any object_id parked in an upload/unpin
+-- DLQ (`sweep_orphan_replication_versions`: `if str(object_id) in dlq_object_ids: continue`),
+-- so a DLQ-parked orphan is one the sweep will never clear. Without $2 the pure-SQL gauge
+-- would count it forever — a phantom backlog contradicting the "same population as the sweep"
+-- claim and tripping the aged-pending-orphan-backlog alert on data that is not a leak. The
+-- servability predicate MUST stay in lockstep with janitor_part_terminally_abandoned.sql (and
+-- the Rust reclaim gate's Store::servable_parts): all three encode the one definition of
+-- "servable". It returns a single count rather than a page to mark.
 --
 -- Purely a SELECT: safe to run every janitor cycle. One row per (object_id, version) inside
 -- the subquery, so the outer count is a version count (the unit the sweep and the leak alarm
 -- both reason in), not a part count.
 --
--- Parameter: $1 stale_seconds (int) — the idle grace window. This MUST be passed the SAME
--- value as list_orphan_replication_versions.sql's grace (both sourced from
--- config.mpu_sweep_grace_seconds). If the gauge grace were smaller than the sweep grace it
--- would count orphans the sweep cannot yet clear, reading non-zero forever on a healthy stack
--- and defeating the soak gate's bounded/slope≈0 assertion.
+-- Parameters:
+--   $1 stale_seconds (int) — the idle grace window. This is the gauge's LEAK-VISIBILITY window
+--     (config.aged_orphan_gauge_grace_seconds), deliberately DECOUPLED from — and smaller than —
+--     the reaper sweep's 48h eligibility grace so a leak re-introduced during a short soak
+--     registers instead of hiding below the reaper's window.
+--   $2 dlq_object_ids (text[]) — object_ids currently parked in any DLQ, built the SAME way the
+--     reaper builds its set (str(object_id) form). Matches crs.object_id (stored as text) so the
+--     exclusion is byte-for-byte the reaper's `str(object_id) in dlq_object_ids`. An empty array
+--     excludes nothing (ANY over an empty array is false), so a healthy stack with no DLQ entries
+--     counts the full leak population.
 SELECT count(*)::bigint AS aged_pending_orphans
 FROM (
     SELECT crs.object_id, crs.version
@@ -35,6 +45,7 @@ FROM (
       AND ov.address IS NULL
       AND ov.size_bytes <= 0
       AND COALESCE(ov.md5_hash, '') = ''
+      AND NOT (crs.object_id = ANY($2::text[]))
     GROUP BY crs.object_id, crs.version
     HAVING MAX(crs.landed_at) < now() - make_interval(secs => $1)
 ) AS aged

--- a/hippius_s3/sql/queries/count_aged_pending_orphans.sql
+++ b/hippius_s3/sql/queries/count_aged_pending_orphans.sql
@@ -6,7 +6,7 @@
 -- catch) would therefore be invisible to the gate. This counts the standing population of
 -- that leak so the soak gate can assert it is bounded and its slope is ~ 0.
 --
--- It counts the EXACT population list_orphan_replication_versions.sql sweeps — an object
+-- It counts the same population SHAPE list_orphan_replication_versions.sql sweeps — an object
 -- version that is (a) still ACTIVE on the drain (status IN ('pending','draining')),
 -- (b) UNSERVABLE (the abandoned/leaked shape: address IS NULL AND size_bytes <= 0 AND
 -- md5_hash = ''), (c) idle past the grace (its most-recently-landed part older than
@@ -14,8 +14,11 @@
 -- churn), and (d) NOT DLQ-protected — the sweep skips any object_id parked in an upload/unpin
 -- DLQ (`sweep_orphan_replication_versions`: `if str(object_id) in dlq_object_ids: continue`),
 -- so a DLQ-parked orphan is one the sweep will never clear. Without $2 the pure-SQL gauge
--- would count it forever — a phantom backlog contradicting the "same population as the sweep"
--- claim and tripping the aged-pending-orphan-backlog alert on data that is not a leak. The
+-- would count it forever — a phantom backlog tripping the aged-pending-orphan-backlog alert on
+-- data that is not a leak. NOTE on the grace: $1 is the gauge's short LEAK-VISIBILITY window
+-- (default 1h), deliberately SMALLER than the sweep's 48h eligibility grace, so at any instant
+-- this set is a strict SUPERSET of what the sweep is currently eligible to clear (it also counts
+-- fresh 1h–48h orphans the sweep hasn't reached yet) — same shape, tighter grace, by design. The
 -- servability predicate MUST stay in lockstep with janitor_part_terminally_abandoned.sql (and
 -- the Rust reclaim gate's Store::servable_parts): all three encode the one definition of
 -- "servable". It returns a single count rather than a page to mark.

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -864,7 +864,9 @@ class ObjectWriter:
         # set — rather than deleting the unlisted parts (unsafe: multi-node SSD + in-flight drain +
         # chunk_backend/Arion pin leak via cascade). `selected_parts=None` (or the full set) →
         # every part, unchanged behaviour.
-        selected = sorted({int(pn) for pn in selected_parts}) if selected_parts else None
+        # `[]` is an explicit empty subset (complete zero parts), distinct from `None` (= all parts);
+        # test `is not None` so a falsy-but-present empty list is not collapsed into the all-parts sentinel.
+        selected = sorted({int(pn) for pn in selected_parts}) if selected_parts is not None else None
 
         # Compute combined ETag from part etags for this version (client-selected subset only).
         parts = await self.pool.fetch(

--- a/k8s/chaos/f5-ssd-fill.yaml
+++ b/k8s/chaos/f5-ssd-fill.yaml
@@ -1,10 +1,16 @@
 # F5 — ingest-SSD fill (pressure -> critical).
 # Chaos Mesh has no first-class disk-fill, so this is a one-shot Job that fallocates a large file on
-# the ingest SSD hostPath the drain-agent + API share, driving fs_cache_pressure into elevated then
-# critical. Gate: PUTs get a CLEAN 503 SlowDown (not a 5xx), the replication gate stays ABSOLUTE
+# the ingest SSD hostPath the drain-agent + api-local share, driving fs_cache_pressure into elevated
+# then critical. Gate: PUTs get a CLEAN 503 SlowDown (not a 5xx), the replication gate stays ABSOLUTE
 # (no non-replicated part evicted even ≥95%), and 503s cease ≤2min after the fill file is removed.
 #
-# ADJUST FILL_GIB + the hostPath to your node's ingest SSD size. Remove the fill with:
+# The shared host dir is /var/lib/hippius/local_ingest_staging (see drain-agent-daemonset.yaml and
+# api-local-deployments-staging.yaml: both hostPath-mount it at container /var/lib/hippius/local_object_cache,
+# which is HIPPIUS_OBJECT_CACHE_DIR — the exact path fs_cache_pressure statvfs's and the drain drains).
+# `local_object_cache` is only the in-container mount NAME, so a Job (a separate pod) must fill the
+# HOST path here or DirectoryOrCreate would just make an empty phantom dir and never move the gauge.
+#
+# ADJUST FILL_GIB + the hostPath to your node's ingest SSD size (prod uses local_ingest_prod). Remove the fill with:
 #   kubectl -n hippius-s3-staging delete job f5-ssd-fill
 #   # then rm the file via a debug pod, or a companion cleanup Job.
 apiVersion: batch/v1
@@ -48,5 +54,7 @@ spec:
       volumes:
         - name: ingest
           hostPath:
-            path: /var/lib/hippius/local_object_cache
+            # The node-local ingest SSD dir api-local + drain-agent share (their container mount
+            # /var/lib/hippius/local_object_cache = HIPPIUS_OBJECT_CACHE_DIR resolves to THIS host path).
+            path: /var/lib/hippius/local_ingest_staging
             type: DirectoryOrCreate

--- a/monitoring/grafana/provisioning/alerting/alert-rules.yml
+++ b/monitoring/grafana/provisioning/alerting/alert-rules.yml
@@ -596,13 +596,19 @@ groups:
         labels:
           severity: critical
 
-      # Epoch-counter reset. drain_leader_epoch is the monotonic leadership era; max() over the
-      # fleet only ever climbs BY CONSTRUCTION, so any decrease means the redis cephor:epoch
-      # counter was rewound (AOF reload / FLUSHALL / replica failover) — which silently degrades
-      # the R3 allocation write-fence OPEN (a legit leader can be fenced by cached higher-epoch
-      # alloc keys, or a stale writer slips through). The expr yields (epoch 5m ago − epoch now):
-      # positive only on a regression. This is the sole failure mode of the write-fence, so it
-      # pages critical even though no split-brain has occurred YET.
+      # Epoch-counter reset. drain_leader_epoch is the leadership era; while a leader is LIVE the
+      # fleet max() only climbs, so a decrease means the redis cephor:epoch counter was rewound
+      # (AOF reload / FLUSHALL / replica failover) — which silently degrades the R3 allocation
+      # write-fence OPEN (a legit leader can be fenced by cached higher-epoch alloc keys, or a
+      # stale writer slips through). The expr yields (epoch 5m ago − epoch now), positive only on
+      # a regression. The `and max(...) > 0` guard is load-bearing: a deposed leader now resets its
+      # gauge to 0 on lease loss (so a real reset is actually detectable — see the allocator
+      # `record_not_leading`), which means during a leadership-handoff VACUUM the fleet max() dips
+      # to 0 for a scrape or two before the new leader publishes its (higher) epoch. Without the
+      # guard that transient 0 vs the 5m-ago nonzero would page a spurious critical on every
+      # deploy/lease-loss. A genuine counter reset leaves the LIVE new leader at a low-but-nonzero
+      # epoch, so `max > 0` holds and the alert still fires. This is the sole failure mode of the
+      # write-fence, so it pages critical even though no split-brain has occurred YET.
       - uid: drain-leader-epoch-decrease
         title: Drain Allocator - Leader Epoch Decreased (counter reset)
         condition: C
@@ -613,7 +619,7 @@ groups:
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: 'max(drain_leader_epoch{job="otel-collector"} offset 5m) - max(drain_leader_epoch{job="otel-collector"})'
+              expr: '(max(drain_leader_epoch{job="otel-collector"} offset 5m) - max(drain_leader_epoch{job="otel-collector"})) and (max(drain_leader_epoch{job="otel-collector"}) > 0)'
               refId: A
           - refId: B
             relativeTimeRange:
@@ -642,7 +648,9 @@ groups:
               refId: C
         noDataState: OK
         execErrState: Error
-        for: 0m
+        # 2m (well under the 5m offset): a genuine reset holds the decrease for ~5m, so 2m still
+        # pages promptly while absorbing any single-scrape handoff-vacuum blip the guard misses.
+        for: 2m
         annotations:
           description: 'The drain leader epoch decreased (counter reset in redis-queues) — the R3 allocation write-fence is degraded open and split-brain is now possible. Confirm redis-queues persistence (noeviction + AOF) and the cephor:epoch value.'
           summary: Drain leader epoch counter was reset (write-fence degraded)

--- a/monitoring/grafana/provisioning/alerting/alert-rules.yml
+++ b/monitoring/grafana/provisioning/alerting/alert-rules.yml
@@ -701,3 +701,57 @@ groups:
           summary: Live objects have a corrupt pool copy and only an SSD source (R4)
         labels:
           severity: critical
+
+      # Reclaim disabled-alarm (D4). drain_reclaim_backing_errors_total counts reclaim cycles that
+      # aborted on an object-backing read (ReclaimError::Backing: the object_versions table missing
+      # on a deploy, or a transient PG error). On this path the failed-part SSD GC reads nothing and
+      # removes NOTHING — it is silently DISABLED while failing safe, so SSD debris accrues invisibly
+      # until drain_ssd_pressure trips the critical PUT-shedding alert downstream. increase()>0 held
+      # for 15m means the failure is STANDING across the 1m reclaim cycles, not a single transient PG
+      # blip (whose lone increment ages out of the window). Warning, not critical: the reclaim fails
+      # safe (no data loss) and drain-ssd-pressure-high is the downstream hard page.
+      - uid: drain-reclaim-backing-errors
+        title: Drain Reclaim Disabled - Object-Backing Read Failing
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'sum(increase(drain_reclaim_backing_errors_total{job="otel-collector"}[15m]))'
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  type: query
+              refId: C
+        noDataState: OK
+        execErrState: Error
+        for: 15m
+        annotations:
+          description: '{{ if $values.B }}{{ printf "%.0f" $values.B.Value }}{{ else }}N/A{{ end }} reclaim cycle(s) in 15m aborted on an object-backing read — the failed-part SSD GC is disabled and removing nothing. Check for a missing object_versions table on the drain deploy or a PG error; SSD debris will accrue until the disk-pressure alert fires.'
+          summary: The drain failed-part SSD reclaim is disabled (object-backing read failing)
+        labels:
+          severity: warning

--- a/s3-2.1-todo.md
+++ b/s3-2.1-todo.md
@@ -105,9 +105,11 @@ Apply: `db-migrations` Job → API/gateway → workers → mpu-reaper. initConta
 redis-queues is a separate host). Just confirm the alert thresholds are set post-deploy.
 
 [*reaper] **Reaper indexes (R2).** Before enabling on prod: (1) run the `20260702000000`
-`multipart_uploads(initiated_at)` partial index (not on prod yet); (2) add a composite `parts(upload_id, uploaded_at)`
-index; (3) raise `HIPPIUS_MPU_REAPER_INTERVAL_SECONDS` off the 120 s drain-down value. The reaper query also reads
-`object_versions.address` — the whole drain stack is staging-only today.
+`multipart_uploads(initiated_at)` partial index (not on prod yet); (2) ~~add a composite
+`parts(upload_id, uploaded_at)` index~~ **built (`20260706000000`, `CREATE INDEX CONCURRENTLY` +
+self-heal on a failed build) — #241**; (3) raise `HIPPIUS_MPU_REAPER_INTERVAL_SECONDS` off the 120 s
+drain-down value. The reaper query also reads `object_versions.address` — the whole drain stack is
+staging-only today.
 
 [*gate] **Gate structure.** T1 functional/adversarial · T2 invariant continuous-assertion (`inv-det` + `inv-guard`,
 the backbone) · T3 chaos · T4 allocator-under-load · T5 throughput/scale/soak. Every dynamic run runs on top of T2. The
@@ -182,7 +184,11 @@ prerequisite for the §4.8 symlink-refused test. Drops off entirely if the trust
 not an enter/exit band). The janitor already has hysteresis (elevated 0.85/0.83, critical 0.95/0.93).
 
 [*r5] **R5.** Alerts that exist: `drain-split-brain-two-leaders`, `drain-leader-epoch-decrease`,
-`aged-pending-orphan-backlog`, SSD backlog/pressure. Missing: a stall alert on `throughput==0 ∧ backlog>0` derived from
+`aged-pending-orphan-backlog`, SSD backlog/pressure. **#241** hardened these: `drain_leader_epoch` now resets on lease
+loss so the epoch-decrease alert can actually fire, guarded (`and max(...) > 0` + `for: 2m`) so a normal
+leadership-handoff vacuum can't false-page; + a reclaim-disabled alert and a corrupt-parts standing gauge; and the
+wedge/readiness signal now keys on an **undrained-row COUNT** (not a byte SUM a missing `parts` row could zero) so a
+wedged node reads NotReady. **Still missing:** the dedicated stall alert on `throughput==0 ∧ backlog>0` derived from
 SQL/Redis, independent of the lag histogram (a stalled drain emits no lag samples). F4 / agent-kill exercises it.
 
 [*load] **Load driver.** Have: boto3 fixed corpus, hardcoded rungs (5/10/20), the durability ledger. Missing:
@@ -197,7 +203,9 @@ two-node same-part, C13 through real faults.
 
 [*soak] **Soak/knee.** Certify the per-node knee (S1) and hold each SLO for the ramp duration. 6h soak:
 RSS/FD/pool/redis slopes ≈ 0 (≤ +2%/h) AND `replicated`-still-on-SSD count bounded (C2/R1) AND aged-pending orphan
-count bounded (A21 — the replicated-only gate is blind to it).
+count bounded (A21 — the replicated-only gate is blind to it). **#241** makes the aged-pending-orphan **gauge** usable
+for this gate: decoupled onto a short 1 h visibility grace (`aged_orphan_gauge_grace_seconds`) so a soak-fresh leak
+registers within the run, and DLQ-protected versions excluded so the gauge counts the same population the sweep clears.
 
 [*invguard] **inv-guard upgrade.** Today it polls with ≥4× lookbehind + hysteresis; hard binary invariants want
 event-driven log/DB tailing so a fast violation between polls isn't missed. Fork: trigger+LISTEN/NOTIFY vs

--- a/s3-2.1-todo.md
+++ b/s3-2.1-todo.md
@@ -106,8 +106,9 @@ redis-queues is a separate host). Just confirm the alert thresholds are set post
 
 [*reaper] **Reaper indexes (R2).** Before enabling on prod: (1) run the `20260702000000`
 `multipart_uploads(initiated_at)` partial index (not on prod yet); (2) ~~add a composite
-`parts(upload_id, uploaded_at)` index~~ **built (`20260706000000`, `CREATE INDEX CONCURRENTLY` +
-self-heal on a failed build) — #241**; (3) raise `HIPPIUS_MPU_REAPER_INTERVAL_SECONDS` off the 120 s
+`parts(upload_id, uploaded_at)` index~~ **built (`20260706000000`, `CREATE INDEX CONCURRENTLY`) —
+#241** (a failed CONCURRENTLY build still needs a manual `REINDEX`/drop — a dbmate `transaction:false`
+migration must stay a single statement, so it can't self-heal); (3) raise `HIPPIUS_MPU_REAPER_INTERVAL_SECONDS` off the 120 s
 drain-down value. The reaper query also reads `object_versions.address` — the whole drain stack is
 staging-only today.
 

--- a/stress-test/alloc-stress/gate.py
+++ b/stress-test/alloc-stress/gate.py
@@ -39,12 +39,20 @@ def _samples(rows: list[dict]) -> list[dict]:
 
 def check_epoch_monotonic(rows: list[dict]) -> tuple[bool, str]:
     prev = 0
+    skipped = 0
     for r in rows:
         e = int(r.get("epoch", 0))
+        # cephor:epoch is a positive INCR counter; epoch<=0 means the sampler's GET returned None
+        # this tick (a transient redis blip / the key briefly absent), NOT a real regression to
+        # zero — skip it so a momentary None can't fail an otherwise-monotonic run.
+        if e <= 0:
+            skipped += 1
+            continue
         if e < prev:
             return False, f"epoch went backward: {prev} -> {e} at t={r.get('t')}"
         prev = max(prev, e)
-    return True, f"epoch monotonic (max {prev})"
+    note = f", {skipped} null-epoch tick(s) skipped" if skipped else ""
+    return True, f"epoch monotonic (max {prev}{note})"
 
 
 def check_epoch_bumps(rows: list[dict], max_bumps: int) -> tuple[bool, str]:
@@ -134,7 +142,7 @@ def evaluate(scenario: str, rows: list[dict], args: argparse.Namespace) -> list[
         results.append(("epoch-monotonic", *check_epoch_monotonic(s)))
         results.append(("leaderless-gap", *check_leaderless_gap(s, args.max_gap_s)))
         results.append(
-            ("epoch-progresses", (len({int(r.get("epoch", 0)) for r in s}) > 1, "leader churned ⇒ epoch advanced"))
+            ("epoch-progresses", len({int(r.get("epoch", 0)) for r in s}) > 1, "leader churned ⇒ epoch advanced")
         )
     elif scenario == "C":
         results.append(("stale-window", *check_stale_window(s, args.stale_window)))
@@ -144,14 +152,21 @@ def evaluate(scenario: str, rows: list[dict], args: argparse.Namespace) -> list[
         results.append(("epoch-monotonic", *check_epoch_monotonic(s)))
         results.append(("recovery", *check_recovery_after_gap(s, args.recovery_ticks, args.interval)))
         # noeviction-full must fail LOUDLY: the sampler surfaces Redis errors as {"error": ...}
-        # rather than a silent split — a run under noeviction that never errored under injected
-        # OOM is suspicious, but we only assert we did not observe an epoch regression here.
-        results.append(("redis-errors-visible", (True, f"{err_count} redis-error samples recorded (loud, not silent)")))
+        # rather than a silent split. A run under injected noeviction OOM that recorded ZERO error
+        # samples means the fault never actually fired — the scenario proved nothing — so require at
+        # least one visible error sample rather than hardcoding a pass. (epoch-monotonic above is a
+        # separate assertion; this one asserts the injected fault was real.)
+        results.append((
+            "redis-errors-visible",
+            err_count > 0,
+            f"{err_count} redis-error sample(s) recorded"
+            + (" (fault fired, loud not silent)" if err_count else " — NO error samples: fault never fired?"),
+        ))
     elif scenario == "E":
         results.append(("budget-ceiling", *check_budget_ceiling(s, args.ceiling)))
     elif scenario == "F":
         results.append(("epoch-monotonic", *check_epoch_monotonic(s)))
-        results.append(("leader-restored", (bool(s and s[-1].get("leader")), "a leader is held at end (post-restore)")))
+        results.append(("leader-restored", bool(s and s[-1].get("leader")), "a leader is held at end (post-restore)"))
     return results
 
 
@@ -159,7 +174,10 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("jsonl")
     ap.add_argument("--scenario", required=True, choices=sorted(SCENARIOS))
-    ap.add_argument("--ceiling", type=int, default=10_000_000_000, help="fleet write-budget ceiling (bytes/s)")
+    # No default: the fleet write-budget ceiling is a real, rig-specific number the sampler can't
+    # infer. A default (the old 10 GB/s) let the budget-ceiling scenarios (C, E) PASS vacuously
+    # against a made-up bound, so it is REQUIRED for those scenarios (enforced in main()).
+    ap.add_argument("--ceiling", type=int, default=None, help="fleet write-budget ceiling (bytes/s); REQUIRED for C & E")
     ap.add_argument("--stale-window", type=float, default=15.0, help="max stale-alloc persistence (alloc-TTL)")
     ap.add_argument("--max-epoch-bumps", type=int, default=3)
     ap.add_argument("--max-gap-s", type=float, default=10.0)
@@ -167,6 +185,13 @@ def main() -> int:
     ap.add_argument("--min-leader-fraction", type=float, default=0.95)
     ap.add_argument("--interval", type=float, default=0.25)
     args = ap.parse_args()
+
+    # Scenarios C and E gate on Σbudget <= ceiling; without a real ceiling that check is vacuous, so
+    # refuse to run rather than emit a hollow green.
+    if args.scenario in ("C", "E") and args.ceiling is None:
+        print(f"FAIL[{args.scenario}]: --ceiling is required for the budget-ceiling scenario "
+              "(a run without a real fleet ceiling passes vacuously)", file=sys.stderr)
+        return 2
 
     rows = _load(args.jsonl)
     if not rows:

--- a/stress-test/alloc-stress/run_scenario.sh
+++ b/stress-test/alloc-stress/run_scenario.sh
@@ -17,9 +17,19 @@ TOXI="${TOXI:-http://localhost:8475}"
 REDIS_CLI=(redis-cli -u "${REDIS_URL:-redis://localhost:6390}")
 PY="${PYTHON:-python3}"
 INTERVAL="${INTERVAL:-0.25}"
-CEILING="${CEILING:-10000000000}"
+# CEILING is deliberately NOT defaulted: scenarios C and E gate on Σbudget <= ceiling, and a
+# made-up ceiling passes vacuously (the whole point of A5 removing gate.py's 10 GB/s default).
+# require_ceiling fails loudly if it's unset when running C or E.
 
 ts() { date +%Y%m%d-%H%M%S; }
+
+require_ceiling() { # scenario — the budget-ceiling scenarios need a real, operator-set fleet ceiling
+  if [ -z "${CEILING:-}" ]; then
+    echo "FATAL[$1]: CEILING is unset — scenario $1 gates on the fleet write-budget ceiling, and a" >&2
+    echo "  default would pass vacuously. Set it in bytes/s, e.g. CEILING=1000000000 bash $0 $1" >&2
+    return 1
+  fi
+}
 
 # --- toxiproxy helpers (redis_queues proxy fronting the coordinator Redis) ---
 toxic_add() { # name type json-attrs
@@ -44,7 +54,9 @@ print(json.loads(raw).get("instance","") if raw else "")' 2>/dev/null || true)"
 }
 
 run_monitor() { # scenario duration -> echoes jsonl path
-  local s="$1" dur="$2" out="$RESULTS/alloc-$s-$(ts).jsonl"
+  local s="$1" dur="$2"
+  local out
+  out="$RESULTS/alloc-$s-$(ts).jsonl"
   "$PY" "$HERE/monitor.py" --redis "${REDIS_URL:-redis://localhost:6390}" \
     --out "$out" --interval "$INTERVAL" --duration "$dur" &
   MON_PID=$!
@@ -68,6 +80,7 @@ scenario_B() { # forced leader churn: kill the leader every ~30s for ~5min
 }
 
 scenario_C() { # R3 gap approximation: latency during handover (deterministic version = Rig B)
+  require_ceiling C || return 1
   local out; out="$(run_monitor C 120)"
   sleep 20; toxic_add slow_lat latency '{"latency":1200,"jitter":300}'
   sleep 20; local c; c="$(leader_container || true)"; [ -n "$c" ] && { docker kill "$c" >/dev/null 2>&1 || true; docker start "$c" >/dev/null 2>&1 || true; }
@@ -88,6 +101,7 @@ scenario_D() { # redis pathology: latency -> timeout(hang) -> reset_peer, then c
 }
 
 scenario_E() { # budget fairness/ceiling under steady contention
+  require_ceiling E || return 1
   local out; out="$(run_monitor E 60)"; sleep 62; wait "$MON_PID" || true
   "$PY" "$HERE/gate.py" --scenario E "$out" --ceiling "$CEILING"
 }

--- a/stress-test/harness/probes.py
+++ b/stress-test/harness/probes.py
@@ -16,6 +16,11 @@ import urllib.request
 
 from .config import Config
 
+# psql field separator: ASCII Unit Separator (0x1f), not '|'. A '|' in a cell value (a detail
+# string, a base64-ish identifier, a status message) would mis-split the row on a printable
+# delimiter; US never appears in our text columns, so splitting on it is unambiguous.
+_PSQL_FIELD_SEP = "\x1f"
+
 
 class ClusterProbe:
     def __init__(self, cfg: Config) -> None:
@@ -33,7 +38,7 @@ class ClusterProbe:
     def _pg_raw(self, sql: str) -> str | None:
         cmd = [
             "kubectl", "-n", self.cfg.namespace, "exec", self.cfg.pg_pod, "-c", "postgres",
-            "--", "psql", "-U", "postgres", "-d", self.cfg.pg_db, "-tAF|", "-c", sql,
+            "--", "psql", "-U", "postgres", "-d", self.cfg.pg_db, "-tAF" + _PSQL_FIELD_SEP, "-c", sql,
         ]
         proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
         if proc.returncode != 0:
@@ -41,13 +46,13 @@ class ClusterProbe:
         return proc.stdout.strip()
 
     def pg(self, sql: str) -> list[list[str]] | None:
-        """Run SQL; return rows as lists of string columns (| separated). None if unreachable."""
+        """Run SQL; return rows as lists of string columns (US-separated). None if unreachable."""
         out = self._pg_raw(sql)
         if out is None:
             return None
         if out == "":
             return []
-        return [line.split("|") for line in out.splitlines()]
+        return [line.split(_PSQL_FIELD_SEP) for line in out.splitlines()]
 
     def pg_scalar(self, sql: str) -> str | None:
         rows = self.pg(sql)

--- a/stress-test/inv/guards.py
+++ b/stress-test/inv/guards.py
@@ -150,6 +150,13 @@ class TerminalMonotonicity:
     `replicated->*` or `failed->*` transition is a breach (a terminal row must be inert). First
     poll only seeds the baseline.
 
+    CAVEAT (poll-sampled — parity with the note in scenarios.py `invariant_assert`): this only sees
+    state at each poll boundary (inv_guard --interval, default 2s), so a fast
+    `replicated->pending->replicated` round-trip that both leaves and re-enters the terminal state
+    inside ONE interval is invisible. The 2s cadence narrows that blind window but cannot close it;
+    the real fix is the WAL-tailed event-driven guard (plan §4.2) that sees every transition rather
+    than a sampled snapshot.
+
     NOTE: `corrupt` (R4) is deliberately NOT terminal — the bounded re-drive worker legitimately
     resets `corrupt->pending` to re-copy a live object's intact SSD source over its corrupt pool
     copy. Only `replicated`/`failed` are inert sinks, so `corrupt->pending` must not be flagged.

--- a/stress-test/inv/inv_guard.py
+++ b/stress-test/inv/inv_guard.py
@@ -36,6 +36,27 @@ from inv.guards import GuardResult, make_guard, run_once  # noqa: E402
 
 DEFAULT_GUARDS = "G1,G2,G3,G4,G6,G9"
 
+# The load-bearing safety invariants: G1 (single-leader / split-brain) and G2 (replication-gate
+# coverage). If either was REQUESTED but returned `skip` on every poll it never once asserted —
+# prometheus/sentinel was unreachable the whole run — so the invariant was never actually checked
+# and the run must NOT read green (a `skip` is "could not evaluate", not "passed"). Operators who
+# genuinely run without one drop it from --guards; only requested required guards are enforced.
+REQUIRED_GUARDS = frozenset({"G1", "G2"})
+
+
+def required_never_asserted(
+    names: list[str], guard_asserts: dict[str, int], guard_polls: dict[str, int]
+) -> list[str]:
+    """Requested required guards that polled at least once but never once asserted (100% skip).
+
+    Pure so the verdict is unit-testable without a live cluster: `guard_asserts[g]` counts polls
+    where guard `g` returned ok/breach (actually evaluated), `guard_polls[g]` counts all its polls.
+    A required guard with polls but zero asserts is the silent-green case this guards against.
+    """
+    return sorted(
+        g for g in names if g in REQUIRED_GUARDS and guard_polls.get(g, 0) > 0 and guard_asserts.get(g, 0) == 0
+    )
+
 
 def _event(run_id: str, seq: int, result: GuardResult) -> dict:
     return {
@@ -54,7 +75,11 @@ def main() -> int:
     ap.add_argument("--guards", default=DEFAULT_GUARDS, help="comma list of G1..G9 (default: G1,G2,G3,G4,G6,G9)")
     ap.add_argument("--run-id", default=f"invguard-{int(time.time())}")
     ap.add_argument("--out", type=pathlib.Path, help="append JSONL events here (default: stdout only)")
-    ap.add_argument("--interval", type=float, default=10.0, help="seconds between polls")
+    # 2s (was 10s): G6 terminal-monotonicity is poll-sampled, so a fast replicated->pending->
+    # replicated round-trip inside one interval is invisible; the tighter cadence narrows that blind
+    # window. The pg claim query is a partial-index lookup and G1/G2 are prom scalars, so 2s polling
+    # is cheap. (The real fix for G6 is the WAL-tailed event guard, plan §4.2 — see guards.py.)
+    ap.add_argument("--interval", type=float, default=2.0, help="seconds between polls")
     ap.add_argument("--once", action="store_true", help="one poll then exit")
     ap.add_argument("--abort", action="store_true", help="exit non-zero on the first breach")
     ap.add_argument("--stall-secs", type=int, default=120, help="G3 stalled-part threshold")
@@ -87,11 +112,16 @@ def main() -> int:
     out = args.out.open("a") if args.out else None
     seq = 0
     total_breaches = 0
+    guard_polls: dict[str, int] = {}  # per-guard: total polls
+    guard_asserts: dict[str, int] = {}  # per-guard: polls that actually evaluated (ok/breach, not skip)
 
     def emit(result: GuardResult) -> None:
         nonlocal seq
         line = json.dumps(_event(args.run_id, seq, result))
         seq += 1
+        guard_polls[result.guard] = guard_polls.get(result.guard, 0) + 1
+        if result.status != "skip":
+            guard_asserts[result.guard] = guard_asserts.get(result.guard, 0) + 1
         if out:
             out.write(line + "\n")
             out.flush()
@@ -117,6 +147,15 @@ def main() -> int:
     finally:
         if out:
             out.close()
+
+    stuck = required_never_asserted(names, guard_asserts, guard_polls)
+    if stuck:
+        print(
+            f"\n🔴 inv-guard: required guard(s) {stuck} skipped on 100% of polls — never once asserted "
+            "(prometheus/sentinel unreachable all run). A required invariant that never ran is NOT green.",
+            file=sys.stderr,
+        )
+        return 3
 
     print(f"\n{'🔴' if total_breaches else '🟢'} inv-guard: {total_breaches} breach(es) over {seq} check(s)")
     return 1 if total_breaches else 0

--- a/tests/e2e/mock_faults.py
+++ b/tests/e2e/mock_faults.py
@@ -17,7 +17,13 @@ Configuration, two ways (runtime wins over env):
     MOCK_FAULT_MODE / MOCK_FAULT_OP / MOCK_FAULT_STATUS / MOCK_FAULT_DELAY_S /
     MOCK_FAULT_AFTER_N / MOCK_FAULT_TRUNCATE_BYTES knobs for a single rule.
   * runtime — the control API this module mounts: POST /_fault {rule|[rules]},
-    GET /_fault, DELETE /_fault (clear). Tests drive faults through these.
+    GET /_fault, DELETE /_fault (clear), POST /_fault/reset (zero the per-op counters WITHOUT
+    changing rules). Tests drive faults through these.
+
+Per-op call counters (which drive `fail_after_n`) reset on EVERY POST /_fault and on DELETE, so a
+test that (re-)POSTs its rules always starts from a fresh countdown and cannot inherit a prior
+test's count. POST /_fault/reset re-arms the countdown while keeping the same rules — for a test
+that wants several `fail_after_n` cycles without re-POSTing.
 
 Modes (matched by `op`, or "all"):
   off           no-op
@@ -101,6 +107,15 @@ class FaultController:
         self._rules = []
         self._counts.clear()
 
+    def reset_counts(self) -> None:
+        """Zero the per-op call counters WITHOUT touching the active rules.
+
+        `fail_after_n` counts up in `self._counts` and only ever resets on set_rules/clear, so a
+        second test reusing the SAME rules (without re-POSTing) would inherit the first test's count
+        and trip the fault early. This lets a test re-arm the countdown between phases explicitly.
+        """
+        self._counts.clear()
+
     def _match(self, op: str) -> FaultRule | None:
         for r in self._rules:
             if r.mode != "off" and r.op in (op, "all"):
@@ -147,6 +162,12 @@ def install_fault_controller(app: FastAPI, service: str) -> FaultController:
     @app.delete("/_fault")
     async def _clear_fault() -> dict:
         ctl.clear()
+        return {"ok": True}
+
+    @app.post("/_fault/reset")
+    async def _reset_counts() -> dict:
+        # Re-arm fail_after_n countdowns without disturbing the active rules.
+        ctl.reset_counts()
         return {"ok": True}
 
     return ctl

--- a/tests/integration/test_aged_pending_orphan_count_sql.py
+++ b/tests/integration/test_aged_pending_orphan_count_sql.py
@@ -239,6 +239,30 @@ async def test_version_with_no_object_versions_row_is_not_counted(conn):
     assert await _count(conn) == 0
 
 
+async def test_gauge_grace_is_a_short_soak_window_not_the_48h_reaper_grace(conn):
+    # C3: the gauge grace ($1) is a leak-VISIBILITY window (config.aged_orphan_gauge_grace_seconds,
+    # default 1h), deliberately DECOUPLED from the reaper sweep's 48h eligibility grace. A ~2h-old
+    # orphan re-introduced during a 6h soak MUST register at the 1h gauge grace; fed the reaper's
+    # 48h grace instead, the same orphan hides (slope stays ~0, the soak gate passes vacuously).
+    # This pins both directions so the decoupling cannot silently regress back to 48h.
+    from hippius_s3.config import get_config
+
+    config = get_config()
+    assert config.aged_orphan_gauge_grace_seconds <= 3600  # soak-visibility window, not the reaper's
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, oid, 1, 1, status="pending", landed_age_seconds=7200)  # 2h idle
+
+    at_gauge_grace = await conn.fetchval(
+        get_query("count_aged_pending_orphans"), config.aged_orphan_gauge_grace_seconds, []
+    )
+    at_reaper_grace = await conn.fetchval(
+        get_query("count_aged_pending_orphans"), config.mpu_sweep_grace_seconds, []
+    )
+    assert int(at_gauge_grace or 0) == 1  # visible at the 1h gauge grace
+    assert int(at_reaper_grace or 0) == 0  # invisible at the 48h reaper grace — the blindness C3 removes
+
+
 async def test_mixed_population_counts_only_the_leak(conn):
     # An end-to-end tally: two genuine aged orphans among servable, fresh, terminal, and
     # deleted-object rows -> exactly 2.

--- a/tests/integration/test_aged_pending_orphan_count_sql.py
+++ b/tests/integration/test_aged_pending_orphan_count_sql.py
@@ -107,8 +107,18 @@ async def _seed_status(
     )
 
 
-async def _count(conn: asyncpg.Connection) -> int:
-    return int(await conn.fetchval(get_query("count_aged_pending_orphans"), _STALE) or 0)
+async def _count(conn: asyncpg.Connection, *, dlq_object_ids: list[str] | None = None) -> int:
+    # $2 is the DLQ-protection array the janitor passes (the same set the reaper skips). Default
+    # to an empty array — the healthy no-DLQ case — so every pre-existing case exercises "exclude
+    # nothing" and only the DLQ test opts into a non-empty set.
+    return int(
+        await conn.fetchval(
+            get_query("count_aged_pending_orphans"),
+            _STALE,
+            dlq_object_ids or [],
+        )
+        or 0
+    )
 
 
 def _oid() -> str:
@@ -197,6 +207,28 @@ async def test_a_fresh_part_keeps_a_stale_sibling_uncounted(conn):
     await _seed_status(conn, oid, 1, 1, status="pending", landed_age_seconds=7200)
     await _seed_status(conn, oid, 1, 2, status="pending", landed_age_seconds=1)
     assert await _count(conn) == 0
+
+
+async def test_dlq_protected_orphan_is_not_counted(conn):
+    # C2: a DLQ-parked orphan is one the sweep SKIPS (`if str(object_id) in dlq_object_ids:
+    # continue`), so it is not a leak the sweep can clear — counting it would be a phantom
+    # backlog that reads non-zero forever. The gauge must exclude the same set via $2.
+    oid = _oid()
+    await _seed_version(conn, oid, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, oid, 1, 1, status="pending")
+    assert await _count(conn) == 1  # without DLQ protection it is an ordinary aged orphan
+    assert await _count(conn, dlq_object_ids=[oid]) == 0  # in the DLQ set -> excluded
+
+
+async def test_dlq_set_only_excludes_its_own_members(conn):
+    # A DLQ entry for one object must not spare a different aged orphan: exclusion is per
+    # object_id, matching the reaper's membership test exactly.
+    parked, leaked = _oid(), _oid()
+    await _seed_version(conn, parked, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, parked, 1, 1, status="pending")
+    await _seed_version(conn, leaked, 1, address=None, size_bytes=0, md5_hash="")
+    await _seed_status(conn, leaked, 1, 1, status="pending")
+    assert await _count(conn, dlq_object_ids=[parked]) == 1  # only `leaked` remains
 
 
 async def test_version_with_no_object_versions_row_is_not_counted(conn):

--- a/tests/integration/test_aged_pending_orphan_count_sql.py
+++ b/tests/integration/test_aged_pending_orphan_count_sql.py
@@ -260,6 +260,8 @@ async def test_gauge_grace_is_a_short_soak_window_not_the_48h_reaper_grace(conn)
         get_query("count_aged_pending_orphans"), config.mpu_sweep_grace_seconds, []
     )
     assert int(at_gauge_grace or 0) == 1  # visible at the 1h gauge grace
+    # Assumes the shipped defaults: HIPPIUS_MPU_SWEEP_GRACE_SECONDS (172800s / 48h) ≫ the 7200s seed,
+    # so the same 2h orphan is still inside the reaper grace and therefore uncounted.
     assert int(at_reaper_grace or 0) == 0  # invisible at the 48h reaper grace — the blindness C3 removes
 
 

--- a/tests/unit/services/test_read_response_mid_stream_chunk_timeout.py
+++ b/tests/unit/services/test_read_response_mid_stream_chunk_timeout.py
@@ -1,0 +1,138 @@
+"""B2: the read path bounds EVERY chunk wait, not just the first.
+
+`test_read_response_first_chunk_timeout.py` already locks in the FIRST-chunk bound
+(`stream_first_chunk_timeout_seconds`). This is the sibling regression for a stall on a LATER chunk:
+after chunk 0 streams fine, chunk 1 never lands (no worker fills it, no pub/sub notification). The
+stream must abort at the per-chunk bound (`stream_chunk_timeout_seconds`, threaded into `stream_plan`
+as `chunk_timeout` and enforced deep in `ChunkNotifier.wait_for_chunk`) rather than hanging up to
+`cache_ttl_seconds` (~1h).
+
+The test drives the REAL bounding path end to end: the real `stream_plan` (which passes
+`timeout=chunk_timeout` per chunk) over the real `ChunkNotifier` (whose deadline loop raises
+`asyncio.TimeoutError`). Only `decrypt_chunk_if_needed` is stubbed — decryption is orthogonal to the
+timeout under test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+
+from hippius_s3.cache.notifier import ChunkNotifier
+from hippius_s3.reader import streamer
+from hippius_s3.reader.types import ChunkPlanItem
+
+
+OBJ = "11111111-2222-3333-4444-555555555555"
+
+
+class _BlockingPubSub:
+    """A pubsub whose listen() blocks forever — no chunk-ready message is ever delivered.
+
+    This is the mid-stream stall: the downloader never fills the chunk and never publishes, so the
+    notifier's wait must fall through to its own timeout deadline.
+    """
+
+    def __init__(self) -> None:
+        self._messages: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self.subscribe = AsyncMock()
+        self.unsubscribe = AsyncMock()
+        self.aclose = AsyncMock()
+
+    async def listen(self) -> Any:
+        while True:
+            msg = await self._messages.get()  # never resolves — nothing is injected
+            yield msg
+
+
+class _SilentRedis:
+    """Minimal Redis surface for ChunkNotifier: a pubsub that never notifies."""
+
+    def __init__(self) -> None:
+        self._ps = _BlockingPubSub()
+
+    def pubsub(self) -> _BlockingPubSub:
+        return self._ps
+
+    async def publish(self, channel: str, message: bytes | str) -> None:
+        return None
+
+
+class _CacheStallsAfterFirstChunk:
+    """obj_cache adapter mirroring RedisObjectPartsCache.wait_for_chunk: delegate to the real
+    ChunkNotifier with a fetch_fn that serves chunk 0 and permanently misses every later chunk."""
+
+    def __init__(self, notifier: ChunkNotifier, first_chunk: bytes) -> None:
+        self._notifier = notifier
+        self._first = first_chunk
+
+    async def _fetch(self, oid: str, v: int, pn: int, ci: int) -> bytes | None:
+        return self._first if int(ci) == 0 else None
+
+    async def wait_for_chunk(
+        self,
+        object_id: str,
+        object_version: int,
+        part_number: int,
+        chunk_index: int,
+        *,
+        timeout: float | None = None,  # noqa: ASYNC109 (mirrors RedisObjectPartsCache.wait_for_chunk)
+    ) -> bytes:
+        return await self._notifier.wait_for_chunk(
+            object_id,
+            int(object_version),
+            int(part_number),
+            int(chunk_index),
+            fetch_fn=self._fetch,
+            timeout=float(timeout),
+        )
+
+
+async def _identity_decrypt(c: bytes, **_kw: Any) -> bytes:
+    return c
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_chunk_stall_is_bounded_by_per_chunk_timeout() -> None:
+    """Chunk 0 streams; chunk 1 stalls → abort at the per-chunk bound, not a ~1h hang."""
+    obj_cache = _CacheStallsAfterFirstChunk(ChunkNotifier(_SilentRedis()), first_chunk=b"chunk-zero")
+
+    plan = [
+        ChunkPlanItem(part_number=1, chunk_index=0),
+        ChunkPlanItem(part_number=1, chunk_index=1),  # never lands
+    ]
+    per_chunk_bound = 0.2
+
+    with patch.object(streamer, "decrypt_chunk_if_needed", new=_identity_decrypt):
+        gen = streamer.stream_plan(
+            obj_cache=obj_cache,
+            object_id=OBJ,
+            object_version=1,
+            plan=plan,
+            storage_version=5,
+            key_bytes=None,
+            suite_id="hip-enc/aes256gcm",
+            bucket_id="bkt",
+            upload_id="",
+            prefetch_chunks=0,
+            chunk_timeout=per_chunk_bound,
+        )
+        try:
+            first = await gen.__anext__()
+            assert first == b"chunk-zero", "first chunk must stream before the mid-stream stall"
+
+            loop = asyncio.get_running_loop()
+            t0 = loop.time()
+            with pytest.raises(asyncio.TimeoutError):
+                # The outer wait_for is a SAFETY ceiling so a genuinely unbounded wait fails the test
+                # (loudly) instead of hanging the suite. The elapsed assertion below is what proves the
+                # abort came from the 0.2s per-chunk bound, not from this 10s ceiling.
+                await asyncio.wait_for(gen.__anext__(), timeout=10.0)
+            elapsed = loop.time() - t0
+            assert elapsed < 5.0, f"mid-stream chunk wait was not bounded by the per-chunk timeout (took {elapsed:.2f}s)"
+        finally:
+            await gen.aclose()

--- a/tests/unit/test_inv_guard.py
+++ b/tests/unit/test_inv_guard.py
@@ -207,3 +207,44 @@ def test_make_guard_rejects_unknown():
 
     with pytest.raises(KeyError):
         guards.make_guard("G99")
+
+
+# ----------------------------------------------------------------- inv_guard all-skip verdict (A4)
+# A run where a REQUIRED guard (G1/G2) skipped EVERY poll never actually asserted the invariant, so
+# it must NOT read green. `required_never_asserted` is the pure verdict helper main() gates on.
+from inv import inv_guard  # noqa: E402
+
+
+def test_required_guard_all_skip_is_flagged():
+    # G1 requested, polled 5x, never once asserted (prometheus down all run) -> flagged as not-green.
+    flagged = inv_guard.required_never_asserted(
+        names=["G1", "G3"], guard_asserts={"G3": 5}, guard_polls={"G1": 5, "G3": 5}
+    )
+    assert flagged == ["G1"]
+
+
+def test_required_guard_that_asserted_once_is_not_flagged():
+    # A single real evaluation (ok or breach) means the guard ran — not the silent-green case.
+    flagged = inv_guard.required_never_asserted(
+        names=["G1"], guard_asserts={"G1": 1}, guard_polls={"G1": 5}
+    )
+    assert flagged == []
+
+
+def test_non_required_guard_all_skip_is_not_flagged():
+    # G3 is not load-bearing; an all-skip G3 (pg unreachable) does not by itself fail the run.
+    flagged = inv_guard.required_never_asserted(names=["G3"], guard_asserts={}, guard_polls={"G3": 5})
+    assert flagged == []
+
+
+def test_unrequested_required_guard_is_not_flagged():
+    # G2 not in --guards -> never polled -> not enforced (the operator opted out of it).
+    flagged = inv_guard.required_never_asserted(names=["G1"], guard_asserts={"G1": 3}, guard_polls={"G1": 3})
+    assert flagged == []
+
+
+def test_both_required_guards_all_skip_are_both_flagged():
+    flagged = inv_guard.required_never_asserted(
+        names=["G1", "G2", "G4"], guard_asserts={"G4": 4}, guard_polls={"G1": 4, "G2": 4, "G4": 4}
+    )
+    assert flagged == ["G1", "G2"]

--- a/tests/unit/test_mpu_complete_selected_parts.py
+++ b/tests/unit/test_mpu_complete_selected_parts.py
@@ -1,0 +1,148 @@
+"""B3: `mpu_complete(selected_parts=...)` sentinel discipline.
+
+`selected_parts=None` means "the client didn't name a subset — complete every uploaded part".
+`selected_parts=[]` means "the client named an EMPTY subset". Those are different intents, and an
+empty list must NOT be collapsed into the full-set sentinel: a `[]` that silently becomes "all parts"
+would let a caller assemble the entire object while asking for none of it.
+
+These tests drive the real `ObjectWriter.mpu_complete` against a fake asyncpg pool so the ETag/size
+filtering and the persisted `completed_part_numbers` reflect exactly what the sentinel logic decides.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import pytest
+
+from hippius_s3.cache import FileSystemPartsStore
+from hippius_s3.utils import get_query
+from hippius_s3.writer.object_writer import ObjectWriter
+
+
+# Two uploaded parts. ETags are `<hex-md5>-<n>`; mpu_complete hashes the concatenated per-part
+# digests, so the hex prefixes must be valid even-length hex for bytes.fromhex.
+_ETAG_ROWS = [
+    {"etag": "aabbccdd-1", "part_number": 1},
+    {"etag": "11223344-1", "part_number": 2},
+]
+_SIZE_ROWS = [
+    {"size_bytes": 100, "part_number": 1},
+    {"size_bytes": 200, "part_number": 2},
+]
+_FULL_SIZE = 300  # 100 + 200: the size an accidental "all parts" completion would produce.
+
+
+class _FakeTxn:
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(self, *_exc: Any) -> bool:
+        return False
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        # Each entry is (query, args) so a test can inspect what got persisted.
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    def transaction(self) -> _FakeTxn:
+        return _FakeTxn()
+
+    async def execute(self, query: str, *args: Any) -> None:
+        self.executed.append((query, args))
+
+
+class _FakeAcquire:
+    def __init__(self, conn: _FakeConn) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> _FakeConn:
+        return self._conn
+
+    async def __aexit__(self, *_exc: Any) -> bool:
+        return False
+
+
+class _FakePool:
+    """Just enough asyncpg surface for mpu_complete: two `fetch` queries + a scoped `acquire`."""
+
+    def __init__(self) -> None:
+        self.conn = _FakeConn()
+
+    async def fetch(self, query: str, *_args: Any) -> list[dict[str, Any]]:
+        if query == get_query("get_parts_etags_for_version"):
+            return _ETAG_ROWS
+        if query == get_query("list_parts_for_version"):
+            return _SIZE_ROWS
+        raise AssertionError(f"unexpected query in mpu_complete: {query!r}")
+
+    def acquire(self) -> _FakeAcquire:
+        return _FakeAcquire(self.conn)
+
+
+def _writer(tmp_path: Any) -> tuple[ObjectWriter, _FakePool]:
+    pool = _FakePool()
+    # mpu_complete never touches fs_store, but the constructor requires a usable cache dir; point it
+    # at a tmp dir so it doesn't try to create the prod default (/var/lib/hippius).
+    fs_store = FileSystemPartsStore(str(tmp_path))
+    writer = ObjectWriter(pool=pool, redis_client=object(), fs_store=fs_store)  # type: ignore[arg-type]
+    return writer, pool
+
+
+async def _complete(writer: ObjectWriter, **overrides: Any) -> Any:
+    kwargs: dict[str, Any] = {
+        "bucket_name": "bkt",
+        "object_id": "11111111-2222-3333-4444-555555555555",
+        "object_key": "k",
+        "upload_id": "up-1",
+        "object_version": 1,
+        "address": "acct",
+    }
+    kwargs.update(overrides)
+    return await writer.mpu_complete(**kwargs)
+
+
+def _persisted_completed_part_numbers(pool: _FakePool) -> Any:
+    """The `completed_part_numbers` bound into the object_versions UPDATE (its 5th positional arg)."""
+    update = next(q for q in pool.conn.executed if "completed_part_numbers" in q[0])
+    return update[1][4]
+
+
+@pytest.mark.asyncio
+async def test_empty_selected_parts_is_empty_subset_not_full_object(tmp_path: Any) -> None:
+    """`selected_parts=[]` must complete as an EMPTY subset (0 parts), not silently assemble all."""
+    writer, pool = _writer(tmp_path)
+
+    res = await _complete(writer, selected_parts=[])
+
+    assert res.size_bytes == 0, "empty selection was silently treated as 'all parts' (full-set completion)"
+    assert res.etag == hashlib.md5(b"").hexdigest() + "-0"
+    # The empty subset is persisted explicitly ([] not NULL) so the reader serves zero parts.
+    assert _persisted_completed_part_numbers(pool) == []
+
+
+@pytest.mark.asyncio
+async def test_none_selected_parts_completes_full_object(tmp_path: Any) -> None:
+    """`selected_parts=None` (default) keeps the unchanged 'complete every part' behaviour."""
+    writer, pool = _writer(tmp_path)
+
+    res = await _complete(writer)  # selected_parts defaults to None
+
+    assert res.size_bytes == _FULL_SIZE
+    assert res.etag.endswith("-2")
+    # Full-set completion leaves the column NULL (no per-read filter stored).
+    assert _persisted_completed_part_numbers(pool) is None
+
+
+@pytest.mark.asyncio
+async def test_strict_subset_selects_only_named_parts(tmp_path: Any) -> None:
+    """A strict subset (part 1 only) reflects only that part's bytes/ETag and persists the filter."""
+    writer, pool = _writer(tmp_path)
+
+    res = await _complete(writer, selected_parts=[1])
+
+    assert res.size_bytes == 100
+    assert res.etag.endswith("-1")
+    assert _persisted_completed_part_numbers(pool) == [1]

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -672,15 +672,20 @@ async def check_replication_sentinel(db_pool: asyncpg.Pool, pressure: int) -> in
     return violations
 
 
-async def check_aged_pending_orphans(db_pool: asyncpg.Pool) -> int:
+async def check_aged_pending_orphans(db_pool: asyncpg.Pool, dlq_object_ids: set[str]) -> int:
     """A21 soak-gate feed: count the standing aged pending/draining unservable orphan
     versions and publish the gauge.
 
     The 6h-soak gate asserts only the `replicated`-on-SSD count, so it is blind to A21
     orphans (which never reach `replicated`). This publishes the population the sweep
-    (`list_orphan_replication_versions.sql`) exists to clear, so the soak gate can assert it
+    (`sweep_orphan_replication_versions`) exists to clear, so the soak gate can assert it
     is bounded and its slope is ~ 0 — a rising value means orphans accrue faster than the
     sweep drains them (a re-introduced leak). Purely a SELECT, safe every cycle.
+
+    ``dlq_object_ids`` MUST be excluded to keep the gauge in lockstep with the sweep: the sweep
+    skips any object_id parked in a DLQ, so a DLQ-parked orphan is one it will never clear —
+    counting it here would be a permanent phantom backlog. Passed as $2 (text[]); the SQL matches
+    ``crs.object_id`` byte-for-byte against the reaper's ``str(object_id)`` membership test.
 
     Unlike the G2 sentinel this does NOT log on a nonzero value: a transient backlog between
     a leak and the next sweep is normal, so alerting is left to the gauge's slope/sustained
@@ -692,6 +697,7 @@ async def check_aged_pending_orphans(db_pool: asyncpg.Pool) -> int:
         count = await conn.fetchval(
             get_query("count_aged_pending_orphans"),
             config.mpu_sweep_grace_seconds,
+            list(dlq_object_ids),
         )
     _aged_pending_orphans = int(count or 0)
     return _aged_pending_orphans
@@ -1080,10 +1086,15 @@ async def run_janitor_loop():
                 logger.error(f"Phase 5 (replication sentinel) error: {e}", exc_info=True)
 
             # Phase 6: read-only aged-pending orphan gauge (A21 soak-gate feed). Publishes the
-            # standing leak backlog the replicated-only soak gate cannot see.
+            # standing leak backlog the replicated-only soak gate cannot see. The DLQ set is
+            # gathered fresh (same fail-closed helper the reaps use) and excluded so the gauge
+            # counts EXACTLY the population the sweep clears — a DLQ-parked orphan the sweep skips
+            # must not read as a phantom leak. On a DLQ-read failure the whole phase is skipped
+            # (gauge holds its prior value) rather than over-counting against an empty set.
             aged_orphans = 0
             try:
-                aged_orphans = await check_aged_pending_orphans(db_pool)
+                gauge_dlq_object_ids = await get_all_dlq_object_ids(redis_client)
+                aged_orphans = await check_aged_pending_orphans(db_pool, gauge_dlq_object_ids)
             except Exception as e:
                 logger.error(f"Phase 6 (aged-pending orphan gauge) error: {e}", exc_info=True)
 

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -696,7 +696,7 @@ async def check_aged_pending_orphans(db_pool: asyncpg.Pool, dlq_object_ids: set[
     async with db_pool.acquire() as conn:
         count = await conn.fetchval(
             get_query("count_aged_pending_orphans"),
-            config.mpu_sweep_grace_seconds,
+            config.aged_orphan_gauge_grace_seconds,
             list(dlq_object_ids),
         )
     _aged_pending_orphans = int(count or 0)
@@ -1031,7 +1031,10 @@ async def run_janitor_loop():
     logger.info("Starting janitor service...")
     logger.info(f"FS store root: {config.object_cache_dir}")
     logger.info(f"MPU stale threshold: {config.mpu_stale_seconds}s")
-    logger.info(f"Aged-pending-orphan gauge grace: {config.mpu_sweep_grace_seconds}s (matches the reaper sweep)")
+    logger.info(
+        f"Aged-pending-orphan gauge grace: {config.aged_orphan_gauge_grace_seconds}s "
+        f"(soak-visibility window, decoupled from the {config.mpu_sweep_grace_seconds}s reaper sweep grace)"
+    )
     logger.info(f"FS GC max age: {config.fs_cache_gc_max_age_seconds}s")
     logger.info(f"FS hot retention: {getattr(config, 'fs_cache_hot_retention_seconds', 10800)}s")
     logger.info(f"Cleanup concurrency: {concurrency}")

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -1090,10 +1090,14 @@ async def run_janitor_loop():
 
             # Phase 6: read-only aged-pending orphan gauge (A21 soak-gate feed). Publishes the
             # standing leak backlog the replicated-only soak gate cannot see. The DLQ set is
-            # gathered fresh (same fail-closed helper the reaps use) and excluded so the gauge
-            # counts EXACTLY the population the sweep clears — a DLQ-parked orphan the sweep skips
-            # must not read as a phantom leak. On a DLQ-read failure the whole phase is skipped
-            # (gauge holds its prior value) rather than over-counting against an empty set.
+            # gathered fresh via the janitor's fail-closed get_all_dlq_object_ids and excluded so
+            # the gauge counts EXACTLY the population the sweep clears — a DLQ-parked orphan the
+            # sweep skips must not read as a phantom leak. On a DLQ-read failure the whole phase is
+            # skipped (gauge holds its prior value) rather than over-counting against an empty set.
+            # Note: the sweep's own DLQ set comes from mpu_cleanup.gather_dlq_object_ids, which is
+            # BEST-EFFORT (a Redis read failure logs and skips that key rather than aborting), so
+            # under a partial Redis failure the two briefly diverge — the sweep proceeds with a
+            # smaller set (clears more) while this gauge deliberately fails closed and stalls.
             aged_orphans = 0
             try:
                 gauge_dlq_object_ids = await get_all_dlq_object_ids(redis_client)


### PR DESCRIPTION
Follow-up to #235 (merged). #235 landed the **critical wave** (the drain review's P0 + 4 P1s) into staging, but the review's remediation continued after that merge — these **19 commits** (Batch C/D + harness hardening + NITs + a holistic-review fix) were never merged. Applies cleanly on current staging; every commit was TDD'd + independently spec-reviewed, and the full Rust+Python gate is green (clippy/fmt clean, core 212 / agent 101 / allocator 27; ruff clean, integration/unit suites pass).

## What's in it (by area)

**Janitor / SQL (P2)**
- G2 sentinel gets a replication-SLA grace so in-flight uploads stop paging (`replication_sla_seconds`).
- Aged-orphan gauge excludes DLQ-protected versions (matches the sweep) and gets its own decoupled 1h soak-visibility grace (was inert at the 48h reaper grace).
- `parts` index built `CONCURRENTLY` to avoid a deploy-time write lock on the ~94M-row table.

**Rust drain (P2)**
- Readiness "is there work?" now keys on an undrained-row COUNT, not a byte SUM that a missing `parts` row could zero (a wedged node no longer reads idle→Ready).
- Allocator `drain_leader_epoch` resets on lease loss so the epoch-reset alert can actually fire...
- ...**plus** the alert guard (`and max(...) > 0` + `for:2m`) so that reset can't spuriously page a critical on a normal leadership-handoff vacuum. *(This interaction was caught by a holistic cross-cutting review — the two changes must ship together, which is why they're both here.)*
- Empty-plan alloc write is now fenced (a deposed leader with no work still learns it lost — split-brain fence honesty).
- Reclaim: alert when a backing-read error silently disables SSD reclaim; corrupt-parts paging moved off a transient per-cycle ERROR onto the standing gauge.
- NITs: `disk_pressure_bps` read-clamp; `servable_parts` doc precision; localfs temp made unique across overlapping pods.

**Read/write path (NIT)**
- `mpu_complete([])` is now an explicit empty subset, not a silent full-set completion.
- Added the missing mid-stream (chunk ≥2) per-chunk timeout regression test.

**Test / chaos harness (P2/NIT)**
- inv-guard/gate verdicts hardened against silent-green (all-skip run now fails; gate asserts the fault actually fired; ceiling required for C/E).
- F5 fill repointed to the real ingest hostPath (was filling a phantom dir); probe delimiter, mock-fault counter reset, epoch-None guard.

Related follow-up issue filed: #240 (subset-CompleteMPU orphan-part GC — deferred).