### PR TITLE
chore(prod): raise arion-uploader mem limit 3Gi→4Gi (trim janitor 4Gi→3Gi to offset)

### DIFF
--- a/k8s/production/resource-limits.yaml
+++ b/k8s/production/resource-limits.yaml
@@ -50,7 +50,7 @@ spec:
               memory: 2Gi
             limits:
               cpu: 2000m
-              memory: 3Gi
+              memory: 4Gi
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -119,7 +119,7 @@ spec:
               memory: 512Mi
             limits:
               cpu: 1000m
-              memory: 4Gi
+              memory: 3Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
## Summary

After the Jul-10 node6-cache right-sizing cut arion-uploader to a **2Gi** memory limit, all 10 uploaders OOMKilled once (07-11 02:49) then stabilized at the follow-up **3Gi** limit. A transient upload spike still pushes past 2Gi, so this gives real headroom without touching real memory — pods OOM at their **own cgroup limit**, not on requests, and steady-state usage is only **~350 MiB/pod**.

## Changes

- **arion-uploader**: memory limit **3Gi → 4Gi** (request stays 2Gi).
- **janitor**: memory limit **4Gi → 3Gi** (near-idle; trimmed to offset the uploader increase).

## Node-safety math (k8s-v3-node6-cache, where all 10 uploaders are pinned)

| metric | value |
|---|---|
| allocatable RAM | 188.5 GiB |
| **actual usage now** | ~16 GiB (**8%**) |
| limits before | 151 GiB (80%) |
| **limits after** (net +9 GiB: +10 uploader, −1 janitor) | **~160 GiB (85%)** |

Sum-of-limits stays under allocatable, so even a fully-correlated spike (all uploaders at 4Gi at once) cannot trigger node-level OOM. Node is only 8% used in reality — this is a ceiling change, not a real-memory change.

## Conclusion

Restores uploader headroom lost in the Jul-10 cut while keeping node6-cache limits-overcommit at a comfortable ~85%. No request changes, so scheduler reservations are unaffected. Deploys on merge to `k8s-production`.