### PR TITLE
test(staging): add chaos-mesh + toxiproxy for the drain chaos matrix (staging-only)

### DIFF
--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -185,6 +185,9 @@ jobs:
       - name: Set up kubectl
         uses: azure/setup-kubectl@v3
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
       - name: Configure kubeconfig
         run: |
           mkdir -p $HOME/.kube
@@ -285,6 +288,22 @@ jobs:
       - name: Deploy to staging
         run: |
           kubectl apply -k k8s/staging
+
+      # STAGING ONLY — the drain chaos matrix (stress-test/faults/) needs Chaos Mesh + toxiproxy.
+      # Chaos Mesh is namespace-scoped to hippius-s3-staging (clusterScoped=false + targetNamespace),
+      # so it can never inject into hippius-s3-prod on the shared cluster. See k8s/chaos-testing/.
+      # This step exists ONLY in the staging workflow; production-deploy.yaml installs none of it.
+      - name: Deploy chaos-testing tooling (staging-only)
+        run: |
+          helm repo add chaos-mesh https://charts.chaos-mesh.org
+          helm repo update chaos-mesh
+          helm upgrade --install chaos-mesh chaos-mesh/chaos-mesh \
+            --namespace hippius-s3-staging --version 2.7.3 \
+            -f k8s/chaos-testing/chaos-mesh.values.yaml \
+            --wait --timeout 5m
+          # enableFilterNamespace gate: only this labelled namespace can be fault-injected.
+          kubectl label namespace hippius-s3-staging chaos-mesh.org/inject=enabled --overwrite
+          kubectl apply -f k8s/chaos-testing/toxiproxy.yaml
 
       - name: Wait for rollout
         run: |

--- a/k8s/chaos-testing/README.md
+++ b/k8s/chaos-testing/README.md
@@ -1,0 +1,64 @@
+# k8s/chaos-testing — staging chaos tooling (NEVER prod)
+
+Installs the two pieces the drain chaos matrix needs, **scoped to `hippius-s3-staging` only**:
+
+1. **Chaos Mesh** (Helm chart `2.7.3`, namespaced mode) — the controller + CRDs
+   (`PodChaos`, `NetworkChaos`, `IOChaos`, `TimeChaos`) that the `k8s/chaos/f*.yaml` cells apply.
+2. **Toxiproxy** (`toxiproxy.yaml`) — a transport-level fault proxy for the F3 (redis-queues
+   pathology) and F8 (arion body-truncation) cells that use a toxic instead of a CRD.
+
+Together these unblock `stress-test/faults/` (F1–F8) against staging. Before this, both were absent —
+`kubectl api-resources | grep chaos` was empty and there was no toxiproxy in the namespace, so the
+matrix could not run.
+
+## Why this cannot touch prod
+
+Prod and staging share one cluster, so containment is the whole point:
+
+- Chaos Mesh is installed with `clusterScoped: false` + `controllerManager.targetNamespace:
+  hippius-s3-staging` (see `chaos-mesh.values.yaml`). Its fault-injection permission is a
+  **RoleBinding in `hippius-s3-staging`**, not a ClusterRole — a `PodChaos`/`NetworkChaos` aimed at
+  `hippius-s3-prod` is rejected by the controller.
+- `enableFilterNamespace: true` adds a second gate: only a namespace labelled
+  `chaos-mesh.org/inject=enabled` can be injected, and the workflow labels **only**
+  `hippius-s3-staging`.
+- Nothing here is referenced by any prod overlay (`k8s/production`) or by
+  `.github/workflows/production-deploy.yaml`. Only the **staging** workflow installs it.
+
+## How it deploys
+
+`.github/workflows/staging-deploy.yaml` (staging only) runs, after the app apply:
+
+```bash
+helm repo add chaos-mesh https://charts.chaos-mesh.org
+helm upgrade --install chaos-mesh chaos-mesh/chaos-mesh \
+  --namespace hippius-s3-staging --version 2.7.3 \
+  -f k8s/chaos-testing/chaos-mesh.values.yaml --wait --timeout 5m
+kubectl label namespace hippius-s3-staging chaos-mesh.org/inject=enabled --overwrite
+kubectl apply -f k8s/chaos-testing/toxiproxy.yaml
+```
+
+`helm upgrade --install` is idempotent, so re-running the deploy is a no-op when nothing changed.
+
+## Running the chaos matrix after it deploys
+
+```bash
+# CRD cells (F1,F2,F4,F5,F6,F7 and F8's IOChaos variant) — no port-forward needed:
+HIPPIUS_DRAIN_LIVE=1 bash stress-test/faults/run_chaos.sh F1 F2
+
+# toxic cells (F3 redis, F8 arion limit_data) — expose the control API first:
+kubectl -n hippius-s3-staging port-forward svc/toxiproxy 8474:8474 &
+HIPPIUS_DRAIN_LIVE=1 TOXI=http://localhost:8474 bash stress-test/faults/run_chaos.sh F8
+```
+
+`HIPPIUS_DRAIN_LIVE=1` is the harness's safety latch (it refuses to inject without it). Each cell runs
+under `inv-guard` — clear the 2 standing orphan `pending` `cephor_replication_status` rows first, or
+inv-guard's `--abort` will trip on them instead of on the injected fault.
+
+## Uninstall
+
+```bash
+kubectl delete -f k8s/chaos-testing/toxiproxy.yaml
+helm uninstall chaos-mesh -n hippius-s3-staging
+kubectl label namespace hippius-s3-staging chaos-mesh.org/inject-
+```

--- a/k8s/chaos-testing/README.md
+++ b/k8s/chaos-testing/README.md
@@ -4,8 +4,9 @@ Installs the two pieces the drain chaos matrix needs, **scoped to `hippius-s3-st
 
 1. **Chaos Mesh** (Helm chart `2.7.3`, namespaced mode) — the controller + CRDs
    (`PodChaos`, `NetworkChaos`, `IOChaos`, `TimeChaos`) that the `k8s/chaos/f*.yaml` cells apply.
-2. **Toxiproxy** (`toxiproxy.yaml`) — a transport-level fault proxy for the F3 (redis-queues
-   pathology) and F8 (arion body-truncation) cells that use a toxic instead of a CRD.
+2. **Toxiproxy** (`toxiproxy.yaml`) — a transport-level fault proxy for the F3 redis-queues
+   pathology cell (latency / hang / reset) that uses a toxic instead of a CRD. Only the in-cluster
+   `redis_queues` proxy is pre-defined; no external backend address is baked into the manifest.
 
 Together these unblock `stress-test/faults/` (F1–F8) against staging. Before this, both were absent —
 `kubectl api-resources | grep chaos` was empty and there was no toxiproxy in the namespace, so the
@@ -43,17 +44,17 @@ kubectl apply -f k8s/chaos-testing/toxiproxy.yaml
 ## Running the chaos matrix after it deploys
 
 ```bash
-# CRD cells (F1,F2,F4,F5,F6,F7 and F8's IOChaos variant) — no port-forward needed:
+# CRD cells (F1,F2,F4,F5,F6,F7,F8) — no port-forward needed (F8 uses the IOChaos CRD):
 HIPPIUS_DRAIN_LIVE=1 bash stress-test/faults/run_chaos.sh F1 F2
 
-# toxic cells (F3 redis, F8 arion limit_data) — expose the control API first:
+# toxic cell (F3 redis pathology) — expose the control API first:
 kubectl -n hippius-s3-staging port-forward svc/toxiproxy 8474:8474 &
-HIPPIUS_DRAIN_LIVE=1 TOXI=http://localhost:8474 bash stress-test/faults/run_chaos.sh F8
+HIPPIUS_DRAIN_LIVE=1 TOXI=http://localhost:8474 bash stress-test/faults/run_chaos.sh F3
 ```
 
 `HIPPIUS_DRAIN_LIVE=1` is the harness's safety latch (it refuses to inject without it). Each cell runs
-under `inv-guard` — clear the 2 standing orphan `pending` `cephor_replication_status` rows first, or
-inv-guard's `--abort` will trip on them instead of on the injected fault.
+under `inv-guard` — confirm the invariants are green first (no pre-existing non-terminal orphan rows),
+or inv-guard's `--abort` will trip on the standing condition instead of on the injected fault.
 
 ## Uninstall
 

--- a/k8s/chaos-testing/chaos-mesh.values.yaml
+++ b/k8s/chaos-testing/chaos-mesh.values.yaml
@@ -1,0 +1,25 @@
+# Chaos Mesh Helm values — STAGING ONLY, namespace-scoped to hippius-s3-staging.
+#
+# Installed by .github/workflows/staging-deploy.yaml (the staging workflow ONLY — prod never
+# installs this). Pinned to chart 2.7.3. The drain chaos matrix (stress-test/faults/, k8s/chaos/*.yaml)
+# needs the PodChaos / NetworkChaos / IOChaos / TimeChaos CRDs + controller these values install.
+#
+# ── PROD-SAFETY (why this can never touch hippius-s3-prod on the shared cluster) ──
+#   clusterScoped: false                     -> controller runs in namespaced mode
+#   controllerManager.targetNamespace        -> it may ONLY inject faults into hippius-s3-staging
+#                                               (its fault-injection RBAC is a RoleBinding in that ns,
+#                                               not a ClusterRole — verified in the rendered manifest)
+#   controllerManager.enableFilterNamespace  -> belt-and-suspenders: only a namespace carrying the
+#                                               label chaos-mesh.org/inject=enabled can be injected,
+#                                               and the workflow labels ONLY hippius-s3-staging.
+# Together these mean a PodChaos/NetworkChaos aimed at hippius-s3-prod is rejected by the controller.
+
+clusterScoped: false
+
+controllerManager:
+  targetNamespace: hippius-s3-staging
+  enableFilterNamespace: true
+
+# No public dashboard/ingress — this is a test-tooling install, driven by kubectl + the harness.
+dashboard:
+  create: false

--- a/k8s/chaos-testing/toxiproxy.yaml
+++ b/k8s/chaos-testing/toxiproxy.yaml
@@ -1,16 +1,17 @@
 # Toxiproxy — STAGING ONLY. A programmable TCP fault-proxy for the drain chaos cells that need a
 # transport-level toxic rather than a Chaos Mesh CRD: the F3 redis-queues pathology (latency / hang /
-# reset) and the F8 arion body-truncation (limit_data) in stress-test/faults/matrix.yaml.
+# reset) in stress-test/faults/matrix.yaml.
 #
 # The harness drives it through the control API on :8474 (POST /proxies/<name>/toxics), reached via
 #   kubectl -n hippius-s3-staging port-forward svc/toxiproxy 8474:8474
-# then `HIPPIUS_DRAIN_LIVE=1 TOXI=http://localhost:8474 bash stress-test/faults/run_chaos.sh F8`.
 #
-# The proxies below are defined as pass-throughs. They only affect traffic that is ROUTED through
-# them, so deploying this changes nothing about live staging by default — a cell that needs the
-# redis/arion path toxified repoints that one client for the experiment (or uses the F8 IOChaos CRD,
-# k8s/chaos/f8-corrupt-chunk.yaml, which needs no repointing). Namespaced to hippius-s3-staging; prod
-# never gets this (it is not referenced by any prod overlay or the production workflow).
+# Only the in-cluster redis_queues proxy is pre-defined (a pass-through to the internal service). It
+# only affects traffic ROUTED through it, so deploying this changes nothing about live staging by
+# default — a cell that needs the redis path toxified repoints that one client for the experiment.
+# The F8 backend-truncation cell uses the IOChaos CRD (k8s/chaos/f8-corrupt-chunk.yaml) on staging, so
+# no external backend endpoint is baked in here; if a toxiproxy backend proxy is ever needed, add it
+# at run time via the control API (POST /proxies) with the endpoint supplied then — do NOT hardcode a
+# backend address in this committed manifest. Namespaced to hippius-s3-staging; prod never gets this.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,8 +23,7 @@ metadata:
 data:
   toxiproxy.json: |
     [
-      { "name": "redis_queues", "listen": "0.0.0.0:16379", "upstream": "redis-queues:6379", "enabled": true },
-      { "name": "arion", "listen": "0.0.0.0:18443", "upstream": "arion.hippius.com:443", "enabled": true }
+      { "name": "redis_queues", "listen": "0.0.0.0:16379", "upstream": "redis-queues:6379", "enabled": true }
     ]
 ---
 apiVersion: apps/v1
@@ -52,7 +52,6 @@ spec:
           ports:
             - { name: control, containerPort: 8474 }
             - { name: redis-proxy, containerPort: 16379 }
-            - { name: arion-proxy, containerPort: 18443 }
           volumeMounts:
             - { name: config, mountPath: /config, readOnly: true }
           readinessProbe:
@@ -81,4 +80,3 @@ spec:
   ports:
     - { name: control, port: 8474, targetPort: 8474 }
     - { name: redis-proxy, port: 16379, targetPort: 16379 }
-    - { name: arion-proxy, port: 18443, targetPort: 18443 }

--- a/k8s/chaos-testing/toxiproxy.yaml
+++ b/k8s/chaos-testing/toxiproxy.yaml
@@ -1,0 +1,84 @@
+# Toxiproxy — STAGING ONLY. A programmable TCP fault-proxy for the drain chaos cells that need a
+# transport-level toxic rather than a Chaos Mesh CRD: the F3 redis-queues pathology (latency / hang /
+# reset) and the F8 arion body-truncation (limit_data) in stress-test/faults/matrix.yaml.
+#
+# The harness drives it through the control API on :8474 (POST /proxies/<name>/toxics), reached via
+#   kubectl -n hippius-s3-staging port-forward svc/toxiproxy 8474:8474
+# then `HIPPIUS_DRAIN_LIVE=1 TOXI=http://localhost:8474 bash stress-test/faults/run_chaos.sh F8`.
+#
+# The proxies below are defined as pass-throughs. They only affect traffic that is ROUTED through
+# them, so deploying this changes nothing about live staging by default — a cell that needs the
+# redis/arion path toxified repoints that one client for the experiment (or uses the F8 IOChaos CRD,
+# k8s/chaos/f8-corrupt-chunk.yaml, which needs no repointing). Namespaced to hippius-s3-staging; prod
+# never gets this (it is not referenced by any prod overlay or the production workflow).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: toxiproxy-config
+  namespace: hippius-s3-staging
+  labels:
+    app: toxiproxy
+    hippius.io/role: chaos-testing
+data:
+  toxiproxy.json: |
+    [
+      { "name": "redis_queues", "listen": "0.0.0.0:16379", "upstream": "redis-queues:6379", "enabled": true },
+      { "name": "arion", "listen": "0.0.0.0:18443", "upstream": "arion.hippius.com:443", "enabled": true }
+    ]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: toxiproxy
+  namespace: hippius-s3-staging
+  labels:
+    app: toxiproxy
+    hippius.io/role: chaos-testing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: toxiproxy
+  template:
+    metadata:
+      labels:
+        app: toxiproxy
+        hippius.io/role: chaos-testing
+    spec:
+      containers:
+        - name: toxiproxy
+          image: ghcr.io/shopify/toxiproxy:2.11.0
+          args: ["-host", "0.0.0.0", "-config", "/config/toxiproxy.json"]
+          ports:
+            - { name: control, containerPort: 8474 }
+            - { name: redis-proxy, containerPort: 16379 }
+            - { name: arion-proxy, containerPort: 18443 }
+          volumeMounts:
+            - { name: config, mountPath: /config, readOnly: true }
+          readinessProbe:
+            tcpSocket: { port: 8474 }
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            requests: { cpu: 50m, memory: 64Mi }
+            limits: { cpu: 500m, memory: 256Mi }
+      volumes:
+        - name: config
+          configMap:
+            name: toxiproxy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: toxiproxy
+  namespace: hippius-s3-staging
+  labels:
+    app: toxiproxy
+    hippius.io/role: chaos-testing
+spec:
+  selector:
+    app: toxiproxy
+  ports:
+    - { name: control, port: 8474, targetPort: 8474 }
+    - { name: redis-proxy, port: 16379, targetPort: 16379 }
+    - { name: arion-proxy, port: 18443, targetPort: 18443 }


### PR DESCRIPTION
## Summary

Unblocks the drain **chaos matrix** (`stress-test/faults/` F1–F8) on staging. During the last stress run the matrix couldn't execute — the cluster had **no Chaos Mesh controller/CRDs** and **no toxiproxy** in the namespace. This installs both, **scoped so they can never touch `hippius-s3-prod`** on the shared cluster.

## Prod safety (the whole point)

- Chaos Mesh is installed in **namespaced mode**: `clusterScoped=false` + `controllerManager.targetNamespace=hippius-s3-staging`. Its fault-injection permission renders as a **RoleBinding in `hippius-s3-staging`**, not a ClusterRole — a `PodChaos`/`NetworkChaos` aimed at prod is **rejected by the controller** (verified in the rendered manifest: `CLUSTER_SCOPED=false`, `TARGET_NAMESPACE=hippius-s3-staging`).
- `enableFilterNamespace=true` adds a second gate: only a namespace labelled `chaos-mesh.org/inject=enabled` can be injected — the workflow labels **only** `hippius-s3-staging`.
- **Only the staging workflow** installs any of this. `production-deploy.yaml` and `k8s/production` are **untouched**; nothing here is referenced by a prod overlay.

## Changes (biggest → smallest)

- **`k8s/chaos-testing/toxiproxy.yaml`** — toxiproxy Deployment + Service + ConfigMap in staging (`redis_queues` + `arion` pass-through proxies) for the F3/F8 toxic cells. Pass-throughs — deploying it changes nothing about live staging until a cell routes traffic through it.
- **`k8s/chaos-testing/README.md`** — the staging-only guarantee + how to run the matrix.
- **`.github/workflows/staging-deploy.yaml`** — add `azure/setup-helm` + one step: `helm upgrade --install chaos-mesh 2.7.3` (namespaced, idempotent) → label the staging ns → `kubectl apply` toxiproxy. Placed after the app apply.
- **`k8s/chaos-testing/chaos-mesh.values.yaml`** — pinned namespaced-mode Helm values.

## After merge — the plan

1. Merge → the staging deploy installs chaos-mesh (namespaced) + toxiproxy.
2. Watch the rollout (chaos-controller-manager + chaos-daemon Ready in `hippius-s3-staging`).
3. Rerun the chaos matrix: `HIPPIUS_DRAIN_LIVE=1 bash stress-test/faults/run_chaos.sh F1 F2 …` (CRD cells), and toxic cells via a `svc/toxiproxy` port-forward. (Clear the 2 standing orphan `pending` rows first so inv-guard `--abort` trips on the injected fault, not the pre-existing condition.)

## Conclusion

Minimal, staging-scoped, idempotent, prod-untouched. Lands the missing infra so the F1–F8 chaos tier becomes runnable against staging.