### PR TITLE
fix(staging): make chaos-mesh install work + harden the chaos harness

### DIFF
--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -297,12 +297,30 @@ jobs:
         run: |
           helm repo add chaos-mesh https://charts.chaos-mesh.org
           helm repo update chaos-mesh
+          # NO --wait: chaos-daemon is a DaemonSet that legitimately can't schedule on a node already
+          # at pod capacity, so a partial roll must not fail the deploy (same rationale as the
+          # drain-agent handling below). helm returning after apply is sufficient; the patches below
+          # are idempotent and the controller reconciles asynchronously.
           helm upgrade --install chaos-mesh chaos-mesh/chaos-mesh \
             --namespace hippius-s3-staging --version 2.7.3 \
-            -f k8s/chaos-testing/chaos-mesh.values.yaml \
-            --wait --timeout 5m
-          # enableFilterNamespace gate: only this labelled namespace can be fault-injected.
-          kubectl label namespace hippius-s3-staging chaos-mesh.org/inject=enabled --overwrite
+            -f k8s/chaos-testing/chaos-mesh.values.yaml --timeout 5m
+          # The chaos matrix needs the apiserver to reach the webhook, and the namespaced-mode
+          # controller needs one cluster-scoped read grant to start. Both are idempotent.
+          kubectl apply -f k8s/chaos-testing/webhook-networkpolicy.yaml
+          kubectl apply -f k8s/chaos-testing/remotecluster-rbac.yaml
+          # chaos-mesh 2.7.3 namespaced mode has two quirks the chart's values do NOT fix (they are
+          # ignored by the templates), so patch the running controller:
+          #  - WEBHOOK_PORT 10250 -> 9443: 10250 is the kubelet port and is firewalled apiserver->pod
+          #    here; move the webhook to a reachable port (the Service targetPort is a named port, so
+          #    it follows the containerPort).
+          #  - ENABLE_FILTER_NAMESPACE=false: the namespace filter needs cluster-scoped namespace
+          #    list/watch (not granted in namespaced mode); targetNamespace already confines injection
+          #    to hippius-s3-staging, so the filter is redundant. Dropping it avoids that RBAC need.
+          kubectl -n hippius-s3-staging set env deploy/chaos-controller-manager \
+            WEBHOOK_PORT=9443 ENABLE_FILTER_NAMESPACE=false
+          kubectl -n hippius-s3-staging patch deploy chaos-controller-manager --type=json \
+            -p '[{"op":"replace","path":"/spec/template/spec/containers/0/ports/0/containerPort","value":9443}]'
+          kubectl -n hippius-s3-staging rollout status deploy/chaos-controller-manager --timeout=3m || true
           kubectl apply -f k8s/chaos-testing/toxiproxy.yaml
 
       - name: Wait for rollout

--- a/k8s/chaos-testing/README.md
+++ b/k8s/chaos-testing/README.md
@@ -19,27 +19,52 @@ Prod and staging share one cluster, so containment is the whole point:
 - Chaos Mesh is installed with `clusterScoped: false` + `controllerManager.targetNamespace:
   hippius-s3-staging` (see `chaos-mesh.values.yaml`). Its fault-injection permission is a
   **RoleBinding in `hippius-s3-staging`**, not a ClusterRole — a `PodChaos`/`NetworkChaos` aimed at
-  `hippius-s3-prod` is rejected by the controller.
-- `enableFilterNamespace: true` adds a second gate: only a namespace labelled
-  `chaos-mesh.org/inject=enabled` can be injected, and the workflow labels **only**
-  `hippius-s3-staging`.
+  `hippius-s3-prod` is rejected by the controller. **This is the guarantee.**
 - Nothing here is referenced by any prod overlay (`k8s/production`) or by
-  `.github/workflows/production-deploy.yaml`. Only the **staging** workflow installs it.
+  `.github/workflows/production-deploy.yaml`. Only the **staging** workflow installs it. The one
+  cluster-scoped object (`remotecluster-rbac.yaml`) is read-only on a chaos-mesh CRD type — no access
+  over prod app workloads.
 
-## How it deploys
+## How it deploys (chart 2.7.3 needs post-install patches)
 
-`.github/workflows/staging-deploy.yaml` (staging only) runs, after the app apply:
+chaos-mesh 2.7.3's namespaced mode is buggy — the chart **ignores several values** and the install
+does not work out of the box on this cluster. `.github/workflows/staging-deploy.yaml` (staging only)
+therefore does, after the helm install:
 
 ```bash
-helm repo add chaos-mesh https://charts.chaos-mesh.org
 helm upgrade --install chaos-mesh chaos-mesh/chaos-mesh \
   --namespace hippius-s3-staging --version 2.7.3 \
-  -f k8s/chaos-testing/chaos-mesh.values.yaml --wait --timeout 5m
-kubectl label namespace hippius-s3-staging chaos-mesh.org/inject=enabled --overwrite
+  -f k8s/chaos-testing/chaos-mesh.values.yaml --timeout 5m     # NO --wait (chaos-daemon is a DaemonSet)
+kubectl apply -f k8s/chaos-testing/webhook-networkpolicy.yaml  # apiserver -> webhook (allow-internal drops it)
+kubectl apply -f k8s/chaos-testing/remotecluster-rbac.yaml     # the one cluster-scoped read the controller needs
+kubectl -n hippius-s3-staging set env deploy/chaos-controller-manager \
+  WEBHOOK_PORT=9443 ENABLE_FILTER_NAMESPACE=false              # 10250 is firewalled; filter needs cluster ns-list
+kubectl -n hippius-s3-staging patch deploy chaos-controller-manager --type=json \
+  -p '[{"op":"replace","path":"/spec/template/spec/containers/0/ports/0/containerPort","value":9443}]'
 kubectl apply -f k8s/chaos-testing/toxiproxy.yaml
 ```
 
-`helm upgrade --install` is idempotent, so re-running the deploy is a no-op when nothing changed.
+Everything is idempotent. **Why each patch** (all discovered live — each failure was a silent
+`context deadline exceeded` / `Selected=False` / manager cache-sync abort):
+- **webhook-networkpolicy** — the `allow-internal` NetworkPolicy only allows the apiserver on :8080, so
+  webhook calls to the chaos controller were dropped and every chaos CRD create failed fail-closed.
+- **remotecluster-rbac** — namespaced mode doesn't grant the cluster-scoped `remoteclusters` read the
+  controller still requires; without it the manager aborts at startup and no reconcilers run.
+- **WEBHOOK_PORT=9443** — the chart serves the webhook on 10250 (the kubelet port), firewalled
+  apiserver→pod here; the Service targetPort is a named port so it follows the containerPort patch.
+- **ENABLE_FILTER_NAMESPACE=false** — the namespace filter needs cluster-scoped namespace list/watch;
+  `targetNamespace` already confines injection to staging, so the filter is redundant.
+
+## Known limitation on this cluster
+
+**Only controller-driven `PodChaos` (pod-kill / pod-failure) injects here.** Daemon-driven chaos —
+`NetworkChaos`, `TimeChaos`, `IOChaos`, `StressChaos` — is created but **never reaches
+`AllInjected=True`**: the chaos-daemon can't drive the node container-runtime to enter the target's
+namespaces (a CRI-socket / privilege gap on these nodes). So of the matrix, the pod-kill cells (F1
+agent-kill, F2 allocator-kill → the single-leader/epoch-fence headline) work; the network/time/io
+cells (F2 partition, F3, F4, F5, F8-IOChaos) need the chaos-daemon runtime wired up first. The
+hardened `inject.py` surfaces this correctly (it fails the cell on a non-injecting fault rather than
+holding through and reporting green).
 
 ## Running the chaos matrix after it deploys
 
@@ -60,6 +85,7 @@ or inv-guard's `--abort` will trip on the standing condition instead of on the i
 
 ```bash
 kubectl delete -f k8s/chaos-testing/toxiproxy.yaml
+kubectl delete -f k8s/chaos-testing/webhook-networkpolicy.yaml
+kubectl delete -f k8s/chaos-testing/remotecluster-rbac.yaml
 helm uninstall chaos-mesh -n hippius-s3-staging
-kubectl label namespace hippius-s3-staging chaos-mesh.org/inject-
 ```

--- a/k8s/chaos-testing/chaos-mesh.values.yaml
+++ b/k8s/chaos-testing/chaos-mesh.values.yaml
@@ -5,20 +5,26 @@
 # needs the PodChaos / NetworkChaos / IOChaos / TimeChaos CRDs + controller these values install.
 #
 # ── PROD-SAFETY (why this can never touch hippius-s3-prod on the shared cluster) ──
-#   clusterScoped: false                     -> controller runs in namespaced mode
-#   controllerManager.targetNamespace        -> it may ONLY inject faults into hippius-s3-staging
-#                                               (its fault-injection RBAC is a RoleBinding in that ns,
-#                                               not a ClusterRole — verified in the rendered manifest)
-#   controllerManager.enableFilterNamespace  -> belt-and-suspenders: only a namespace carrying the
-#                                               label chaos-mesh.org/inject=enabled can be injected,
-#                                               and the workflow labels ONLY hippius-s3-staging.
-# Together these mean a PodChaos/NetworkChaos aimed at hippius-s3-prod is rejected by the controller.
+#   clusterScoped: false               -> controller runs in namespaced mode
+#   controllerManager.targetNamespace  -> it may ONLY inject faults into hippius-s3-staging (its
+#                                         fault-injection RBAC is a RoleBinding in that ns, not a
+#                                         ClusterRole — verified in the rendered manifest). This is the
+#                                         guarantee that a PodChaos aimed at hippius-s3-prod is rejected.
+#
+# NOTE (chart 2.7.3 quirks): this chart IGNORES several of these values in its templates, so the
+# staging workflow patches the running controller after install (see staging-deploy.yaml):
+#   - enableFilterNamespace is left FALSE — it would need cluster-scoped namespace list/watch that
+#     namespaced mode doesn't grant; targetNamespace already confines injection to staging, so the
+#     filter is redundant here.
+#   - the webhook port is moved off 10250 (the firewalled kubelet port) to 9443.
+# Two companion manifests complete the working install: webhook-networkpolicy.yaml (apiserver ->
+# webhook) and remotecluster-rbac.yaml (the one cluster-scoped read the controller needs to start).
 
 clusterScoped: false
 
 controllerManager:
   targetNamespace: hippius-s3-staging
-  enableFilterNamespace: true
+  enableFilterNamespace: false
 
 # No public dashboard/ingress — this is a test-tooling install, driven by kubectl + the harness.
 dashboard:

--- a/k8s/chaos-testing/remotecluster-rbac.yaml
+++ b/k8s/chaos-testing/remotecluster-rbac.yaml
@@ -1,0 +1,36 @@
+# STAGING chaos tooling — narrow cluster-scoped read grant for chaos-mesh's own RemoteCluster CRD.
+#
+# In namespaced mode (clusterScoped=false) the chaos-mesh chart does NOT grant the controller the
+# cluster-scoped access it still tries to use for its multi-cluster RemoteCluster controller. Without
+# it the controller-manager fails cache-sync at startup ("remoteclusters.chaos-mesh.org is forbidden
+# ... at the cluster scope") and aborts — so NO reconcilers run and no fault is ever injected.
+#
+# This is the ONE cluster-scoped object the working install needs. It is read-only (get/list/watch)
+# and scoped to a chaos-mesh CRD type that only chaos-mesh uses — it grants zero access over prod
+# application workloads. (Approved as the "narrow cluster RBAC grant" over switching to a fully
+# cluster-scoped chaos-mesh install.)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chaos-mesh-remotecluster-reader
+  labels:
+    hippius.io/role: chaos-testing
+rules:
+  - apiGroups: ["chaos-mesh.org"]
+    resources: ["remoteclusters", "remoteclusters/status"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chaos-mesh-remotecluster-reader
+  labels:
+    hippius.io/role: chaos-testing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chaos-mesh-remotecluster-reader
+subjects:
+  - kind: ServiceAccount
+    name: chaos-controller-manager
+    namespace: hippius-s3-staging

--- a/k8s/chaos-testing/webhook-networkpolicy.yaml
+++ b/k8s/chaos-testing/webhook-networkpolicy.yaml
@@ -1,0 +1,26 @@
+# STAGING ONLY. Allows the kube-apiserver to reach the chaos-mesh admission webhook.
+#
+# hippius-s3-staging has a default `allow-internal` NetworkPolicy (podSelector={}) that only permits
+# the apiserver's source on port 8080 — so admission-webhook calls to the chaos-controller-manager
+# pods (a new in-namespace webhook) are silently dropped and EVERY chaos CRD create fails fail-closed
+# with `context deadline exceeded`. This additive policy opens just the webhook port to the chaos
+# controller pods. Port 9443 is exclusively the chaos webhook (an authenticated TLS endpoint that only
+# validates chaos CRs), so allowing it from any source is low-risk; the apiserver's source IP on this
+# cluster is SNAT'd/proxied and not a fixed CIDR, hence 0.0.0.0/0.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-chaos-mesh-webhook
+  namespace: hippius-s3-staging
+  labels:
+    hippius.io/role: chaos-testing
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: chaos-mesh
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - ipBlock: { cidr: 0.0.0.0/0 }
+      ports:
+        - { port: 9443, protocol: TCP }

--- a/stress-test/faults/inject.py
+++ b/stress-test/faults/inject.py
@@ -1,8 +1,11 @@
 """WI-19 §4.5 fault injector — apply/clean one F-cell from matrix.yaml.
 
 Thin wrapper over kubectl (Chaos Mesh CRDs + the F5 fill Job) and the toxiproxy control API (F8
-limit_data body-truncation + the redis/PG toxics). Deliberately dumb: it applies a fault and returns; run_chaos.sh owns
-the timing, the inv-guard/ledger assertions, and cleanup ordering.
+limit_data body-truncation + the redis/PG toxics). `apply` blocks until the fault has actually landed
+(Chaos Mesh AllInjected=True) so run_chaos.sh never holds through — and reports GREEN on — a fault that
+never injected; `cleanup` force-clears a stuck finalizer so a wedged chaos object can't hang the run or
+leak into the next cell. Beyond that it stays dumb: run_chaos.sh still owns the hold window, the
+inv-guard/ledger assertions, and cleanup ordering.
 
   python inject.py apply   F2 [--repo-root .] [--toxi http://localhost:8474]
   python inject.py cleanup F2
@@ -17,10 +20,15 @@ import argparse
 import json
 import subprocess
 import sys
+import time
 import urllib.request
 from pathlib import Path
 
 import yaml
+
+
+# How long to wait for a Chaos Mesh CR to actually inject before treating the cell as a setup failure.
+INJECT_TIMEOUT_S = 90.0
 
 
 def _load_matrix(repo_root: Path) -> dict:
@@ -32,6 +40,66 @@ def _kubectl(args: list[str], ns: str) -> None:
     cmd = ["kubectl", "-n", ns, *args]
     print(f"+ {' '.join(cmd)}", file=sys.stderr)
     subprocess.run(cmd, check=True)
+
+
+def _kubectl_out(args: list[str], ns: str, timeout: float = 40.0) -> tuple[int, str]:
+    proc = subprocess.run(["kubectl", "-n", ns, *args], capture_output=True, text=True, timeout=timeout)
+    return proc.returncode, (proc.stdout or "").strip()
+
+
+def _chaos_objects(manifest: Path) -> list[tuple[str, str]]:
+    """(kind, name) of every Chaos Mesh object (+ Job) declared in a cell manifest, so `apply` can
+    wait for the fault to land and `cleanup` can force-clear a stuck finalizer per object."""
+    objs: list[tuple[str, str]] = []
+    with manifest.open() as fh:
+        for doc in yaml.safe_load_all(fh):
+            if not doc:
+                continue
+            kind = doc.get("kind", "")
+            name = (doc.get("metadata") or {}).get("name", "")
+            if kind and name and (kind.endswith("Chaos") or kind == "Job"):
+                objs.append((kind, name))
+    return objs
+
+
+def _wait_injected(kind: str, obj: str, ns: str, timeout_s: float = INJECT_TIMEOUT_S) -> None:
+    """Block until a Chaos Mesh object reports AllInjected=True.
+
+    A chaos CR that is created but never selects a target or never injects (webhook unreachable,
+    missing RBAC, a selector that matches nothing, a controller not reconciling) is a SETUP failure,
+    not a fault the cell can assert against. Without this wait, run_chaos.sh would hold through the
+    recovery window against a fault that never landed and report the cell GREEN — the exact
+    silent-no-op the harness is built to prevent. Surfacing it (non-zero exit) is the point."""
+    deadline = time.time() + timeout_s
+    last = "<no status yet>"
+    while time.time() < deadline:
+        rc, out = _kubectl_out(
+            ["get", kind, obj, "-o",
+             "jsonpath={range .status.conditions[?(@.type=='AllInjected')]}{.status}{end}"], ns)
+        if rc == 0 and out == "True":
+            print(f"  {kind}/{obj} AllInjected=True", file=sys.stderr)
+            return
+        last = out or last
+        time.sleep(2)
+    raise SystemExit(
+        f"{kind}/{obj} did not reach AllInjected=True within {timeout_s:.0f}s (last={last!r}) — the "
+        f"fault never landed; check the chaos-mesh controller (leader/reconciler ready?) and selector")
+
+
+def _force_delete(kind: str, obj: str, ns: str) -> None:
+    """Delete a Chaos Mesh object, stripping a stuck finalizer if the normal delete blocks.
+
+    Chaos Mesh objects carry a `chaos-mesh/records` finalizer the controller only clears after it has
+    recovered the fault; if the target was killed or the daemon/controller hit a transient error, the
+    delete hangs indefinitely. A bounded delete followed by a finalizer-strip makes per-cell cleanup
+    deterministic instead of leaving a wedged object that poisons the next cell."""
+    rc, _ = _kubectl_out(["delete", kind, obj, "--ignore-not-found", "--timeout=25s"], ns, timeout=35.0)
+    if rc == 0:
+        return
+    print(f"  {kind}/{obj} delete stalled — stripping finalizer", file=sys.stderr)
+    _kubectl_out(["patch", kind, obj, "--type=json",
+                  "-p", '[{"op":"remove","path":"/metadata/finalizers"}]'], ns)
+    _kubectl_out(["delete", kind, obj, "--ignore-not-found", "--timeout=15s"], ns, timeout=25.0)
 
 
 def _toxi(base: str, method: str, path: str, body: dict | None = None) -> None:
@@ -51,7 +119,14 @@ def apply_cell(name: str, cell: dict, ns: str, repo_root: Path, toxi: str) -> No
     mech = cell["mechanism"]
     kind = mech["kind"]
     if kind in ("chaos-crd", "job"):
-        _kubectl(["apply", "-f", str(repo_root / mech["manifest"])], ns)
+        manifest = repo_root / mech["manifest"]
+        _kubectl(["apply", "-f", str(manifest)], ns)
+        # Confirm the fault actually injected before returning — a created-but-not-injected chaos CR
+        # is a setup failure, not a fault to hold through (see _wait_injected). Jobs have no
+        # AllInjected condition, so only wait on the Chaos Mesh kinds.
+        for k, obj in _chaos_objects(manifest):
+            if k.endswith("Chaos"):
+                _wait_injected(k, obj, ns)
     elif kind == "toxiproxy":
         proxy = mech["proxy"]
         payload = {
@@ -71,7 +146,10 @@ def cleanup_cell(name: str, cell: dict, ns: str, repo_root: Path, toxi: str) -> 
     kind = mech["kind"]
     try:
         if kind in ("chaos-crd", "job"):
-            _kubectl(["delete", "--ignore-not-found", "-f", str(repo_root / mech["manifest"])], ns)
+            # Per-object bounded delete + finalizer-strip so a wedged chaos object can't hang cleanup
+            # or leak into the next cell (see _force_delete).
+            for k, obj in _chaos_objects(repo_root / mech["manifest"]):
+                _force_delete(k, obj, ns)
         elif kind == "toxiproxy":
             proxy = mech["proxy"]
             with urllib.request.urlopen(  # noqa: S310


### PR DESCRIPTION
## Why

PR #244 installed chaos-mesh + toxiproxy, but the **staging deploy failed** at the `Deploy chaos-testing tooling` step ([run 29244158843](https://github.com/thenervelab/hippius-s3/actions/runs/29244158843)) and, once installed, **no fault could be injected** — chaos-mesh 2.7.3's namespaced mode is buggy and needs several post-install patches on this cluster. Every fix here was diagnosed and **proven live on staging** (a real allocator pod-kill now produces a clean single-leader failover with epoch fence 36→37). Staging-only; prod overlays + `production-deploy.yaml` untouched.

## Changes (biggest → smallest)

- **`staging-deploy.yaml`** — drop `helm --wait` (the `chaos-daemon` DaemonSet legitimately can't schedule on a node at pod capacity, so a partial roll must not fail the deploy — same rationale as the drain-agent handling), and add the idempotent post-install patches below.
- **`inject.py`** — reliability hardening: `apply` blocks until `AllInjected=True` (a created-but-not-injected chaos CR is a **setup failure**, not a fault to hold through and report GREEN — the silent-no-op the harness exists to prevent); `cleanup` force-clears a stuck `chaos-mesh/records` finalizer so a wedged object can't hang the run or leak into the next cell.
- **`webhook-networkpolicy.yaml`** (new) — allow apiserver → chaos webhook. The `allow-internal` NetworkPolicy only permits the apiserver on :8080, so webhook calls were dropped → every chaos CRD create failed fail-closed (`context deadline exceeded`).
- **`remotecluster-rbac.yaml`** (new) — the one cluster-scoped **read-only** grant (`remoteclusters`) the namespaced controller needs to start; without it the manager aborts at cache-sync and no reconcilers run. Grants zero access over prod app workloads.
- **`WEBHOOK_PORT` 10250→9443** (10250 is the firewalled kubelet port) + **`ENABLE_FILTER_NAMESPACE=false`** (needs cluster ns-list; `targetNamespace` already confines injection to staging) — patched on the running controller because the chart ignores these values.

## Prod safety

Unchanged from #244: `clusterScoped=false` + `targetNamespace=hippius-s3-staging` means the controller's fault-injection RBAC is a **RoleBinding in staging** — a PodChaos aimed at prod is rejected. The lone cluster-scoped object added here is read-only on a chaos-mesh CRD type.

## Known limitation (documented in README)

Only controller-driven **PodChaos (pod-kill)** injects on this cluster — the pod-kill cells (F1 agent-kill, F2 allocator-kill / single-leader+epoch-fence headline) work. Daemon-driven **Network/Time/IO** chaos is created but never reaches `AllInjected=True` (chaos-daemon can't drive the node container-runtime); those cells need the chaos-daemon runtime wired up first. The hardened `inject.py` surfaces this correctly instead of false-greening.

## Conclusion

Turns the merged-but-broken chaos install into a working one, and makes the harness fail honestly on a non-injecting fault. Staging deploys stop failing at the chaos step.