### PR TITLE
test(smoke): add plain-English assert messages for Mattermost alerts

### DIFF
--- a/tests/smoke/test_smoke_production.py
+++ b/tests/smoke/test_smoke_production.py
@@ -77,10 +77,12 @@ def test_02_upload_simple_file(production_s3_client, session_tracker, file_gener
         },
     )
 
-    assert "ETag" in response
-    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert "ETag" in response, "Simple 1 MB PUT did not return an ETag — the upload was not accepted/acknowledged by the gateway."
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200, (
+        f"Simple 1 MB PUT returned HTTP {response['ResponseMetadata']['HTTPStatusCode']} instead of 200 — object upload is failing."
+    )
     etag = response["ETag"].strip('"')
-    assert not etag.endswith("-")
+    assert not etag.endswith("-"), "Simple PUT returned a multipart-style ETag (ends with '-') — a single-part upload should have a plain MD5 ETag."
 
     session_tracker.add_file(key=key, file_type="simple", size=size, hash_md5=hash_md5, upload_time=upload_time)
 
@@ -109,7 +111,7 @@ def test_03_upload_multipart_file(production_s3_client, session_tracker, file_ge
         },
     )
 
-    assert "UploadId" in create_response
+    assert "UploadId" in create_response, "CreateMultipartUpload did not return an UploadId — multipart uploads cannot be started."
     upload_id = create_response["UploadId"]
 
     part_etags = []
@@ -125,15 +127,19 @@ def test_03_upload_multipart_file(production_s3_client, session_tracker, file_ge
         etag = part_response["ETag"]
         part_etags.append({"ETag": etag, "PartNumber": i + 1})
 
-    assert len(part_etags) == part_count
+    assert len(part_etags) == part_count, (
+        f"Only {len(part_etags)} of {part_count} multipart parts uploaded successfully — one or more UploadPart calls failed."
+    )
 
     complete_response = production_s3_client.complete_multipart_upload(
         Bucket=session_tracker.bucket, Key=key, UploadId=upload_id, MultipartUpload={"Parts": part_etags}
     )
 
-    assert "ETag" in complete_response
+    assert "ETag" in complete_response, "CompleteMultipartUpload did not return an ETag — the multipart upload failed to finalize."
     final_etag = complete_response["ETag"].strip('"')
-    assert final_etag.endswith(f"-{part_count}")
+    assert final_etag.endswith(f"-{part_count}"), (
+        f"Final multipart ETag {final_etag!r} does not end with '-{part_count}' — the completed object was not assembled from all {part_count} parts."
+    )
 
     session_tracker.add_file(
         key=key, file_type="multipart", size=total_size, hash_md5=hash_md5, upload_time=upload_time
@@ -144,7 +150,9 @@ def test_03_upload_multipart_file(production_s3_client, session_tracker, file_ge
 
 def test_04_download_current_session_files(production_s3_client, session_tracker):
     files = session_tracker.get_files()
-    assert len(files) == 2
+    assert len(files) == 2, (
+        f"Expected 2 files uploaded this session (simple + multipart), tracker has {len(files)} — an earlier upload test did not record its file."
+    )
 
     for file_info in files:
         key = file_info["key"]
@@ -153,13 +161,19 @@ def test_04_download_current_session_files(production_s3_client, session_tracker
 
         response = production_s3_client.get_object(Bucket=session_tracker.bucket, Key=key)
 
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200, (
+            f"GET of just-uploaded object {key} returned HTTP {response['ResponseMetadata']['HTTPStatusCode']} instead of 200 — download of a fresh object is failing."
+        )
 
         downloaded_data = response["Body"].read()
         downloaded_hash = hashlib.md5(downloaded_data).hexdigest()
 
-        assert downloaded_hash == expected_hash
-        assert len(downloaded_data) == expected_size
+        assert downloaded_hash == expected_hash, (
+            f"Downloaded content of {key} does not match what was uploaded (MD5 {downloaded_hash} != {expected_hash}) — data is being corrupted in the upload/download/decrypt path."
+        )
+        assert len(downloaded_data) == expected_size, (
+            f"Downloaded {key} is {len(downloaded_data)} bytes but {expected_size} were uploaded — the object is being truncated or padded."
+        )
 
         print(f"Downloaded and validated: {key} ({expected_size} bytes, hash={expected_hash[:8]}...)")
 
@@ -185,8 +199,12 @@ def test_05_download_historical_files(production_s3_client, session_tracker):
         response = production_s3_client.get_object(Bucket=session_tracker.bucket, Key=file_info["key"])
         data = response["Body"].read()
 
-        assert len(data) == file_info["size"]
-        assert hashlib.md5(data).hexdigest() == file_info["hash"]
+        assert len(data) == file_info["size"], (
+            f"Historical object {file_info['key']} is {len(data)} bytes but its manifest recorded {file_info['size']} — a previously-stored object came back the wrong size (data durability/retrieval regression)."
+        )
+        assert hashlib.md5(data).hexdigest() == file_info["hash"], (
+            f"Historical object {file_info['key']} failed MD5 check — an object uploaded in a past session no longer decrypts/reads back to its original content."
+        )
 
         print(
             f"Validated historical file: {file_info['key']} (session={manifest['session_id']}, hash={file_info['hash'][:8]}...)"
@@ -200,14 +218,20 @@ def test_06_write_session_manifest(production_s3_client, session_tracker):
 
     verify_response = production_s3_client.get_object(Bucket=session_tracker.bucket, Key=manifest_key)
 
-    assert verify_response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert verify_response["ResponseMetadata"]["HTTPStatusCode"] == 200, (
+        f"Reading back the session manifest {manifest_key} returned HTTP {verify_response['ResponseMetadata']['HTTPStatusCode']} instead of 200 — the manifest we just wrote is not retrievable."
+    )
 
     import json
 
     retrieved_manifest = json.loads(verify_response["Body"].read())
 
-    assert retrieved_manifest["session_id"] == session_tracker.session_id
-    assert len(retrieved_manifest["files"]) == 2
+    assert retrieved_manifest["session_id"] == session_tracker.session_id, (
+        f"Manifest read back has session_id {retrieved_manifest['session_id']!r} but we wrote {session_tracker.session_id!r} — the manifest content was not persisted correctly."
+    )
+    assert len(retrieved_manifest["files"]) == 2, (
+        f"Manifest read back lists {len(retrieved_manifest['files'])} files, expected 2 — the manifest we persisted is missing this session's uploads."
+    )
 
     print(f"Session manifest saved: {manifest_key}")
 
@@ -235,7 +259,9 @@ def test_07_presigned_url_roundtrip(production_s3_client, session_tracker, file_
 
     downloaded_hash = hashlib.md5(get_resp.content).hexdigest()
     assert downloaded_hash == expected_hash, f"hash mismatch: {downloaded_hash} != {expected_hash}"
-    assert len(get_resp.content) == size
+    assert len(get_resp.content) == size, (
+        f"Object fetched via presigned GET is {len(get_resp.content)} bytes but {size} were uploaded via presigned PUT — the presigned URL round-trip is truncating data."
+    )
 
     print(f"Presigned roundtrip validated: {key} ({size} bytes, hash={expected_hash[:8]}...)")
 
@@ -289,9 +315,15 @@ def test_09_cors_preflight_on_direct_path(session_tracker):
     )
 
     assert resp.status_code in (200, 204), f"preflight failed: status={resp.status_code} body={resp.text[:200]}"
-    assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+    assert resp.headers.get("Access-Control-Allow-Origin") == "*", (
+        f"CORS preflight on a direct bucket path did not return Access-Control-Allow-Origin: * (got {resp.headers.get('Access-Control-Allow-Origin')!r}) — browsers will block cross-origin requests to the API."
+    )
     allow_headers = resp.headers.get("Access-Control-Allow-Headers", "").lower()
-    assert "content-type" in allow_headers
-    assert "authorization" in allow_headers
+    assert "content-type" in allow_headers, (
+        f"CORS preflight did not allow the content-type header (got {allow_headers!r}) — browser uploads with a body will be blocked."
+    )
+    assert "authorization" in allow_headers, (
+        f"CORS preflight did not allow the authorization header (got {allow_headers!r}) — browser requests using SigV4/bearer auth will be blocked."
+    )
 
     print(f"CORS preflight on direct path OK: {direct_url}")

--- a/tests/smoke/test_smoke_regional.py
+++ b/tests/smoke/test_smoke_regional.py
@@ -18,8 +18,8 @@ from datetime import datetime
 from datetime import timezone
 
 import boto3
-import pytest
 import httpx
+import pytest
 from botocore.config import Config
 
 
@@ -62,13 +62,21 @@ def test_regional_upload_download_roundtrip(regional_s3_client, session_tracker,
     key = f"smoke-test/{session_tracker.session_id}/regional/{region}/{uuid.uuid4()}.bin"
 
     put_resp = regional_s3_client.put_object(Bucket=session_tracker.bucket, Key=key, Body=data)
-    assert put_resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert put_resp["ResponseMetadata"]["HTTPStatusCode"] == 200, (
+        f"[{region}] authenticated PUT returned HTTP {put_resp['ResponseMetadata']['HTTPStatusCode']} instead of 200 — the {region} regional cache is not accepting uploads."
+    )
 
     get_resp = regional_s3_client.get_object(Bucket=session_tracker.bucket, Key=key)
-    assert get_resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert get_resp["ResponseMetadata"]["HTTPStatusCode"] == 200, (
+        f"[{region}] authenticated GET returned HTTP {get_resp['ResponseMetadata']['HTTPStatusCode']} instead of 200 — the {region} regional cache is not serving reads."
+    )
     downloaded = get_resp["Body"].read()
-    assert hashlib.md5(downloaded).hexdigest() == expected_hash
-    assert len(downloaded) == size
+    assert hashlib.md5(downloaded).hexdigest() == expected_hash, (
+        f"[{region}] object read back from the regional cache does not match what was uploaded — data is corrupted through the {region} edge."
+    )
+    assert len(downloaded) == size, (
+        f"[{region}] object read back is {len(downloaded)} bytes but {size} were uploaded — the {region} regional cache is truncating objects."
+    )
 
     print(f"[{region}] upload/download roundtrip OK: {key}")
 
@@ -87,8 +95,12 @@ def test_regional_public_object_anonymous_download(regional_s3_client, session_t
     anon_url = f"{endpoint.rstrip('/')}/{session_tracker.bucket}/{key}"
     resp = httpx.get(anon_url, timeout=60)
     assert resp.status_code == 200, f"anonymous GET failed: status={resp.status_code} body={resp.text[:200]}"
-    assert hashlib.md5(resp.content).hexdigest() == expected_hash
-    assert len(resp.content) == size
+    assert hashlib.md5(resp.content).hexdigest() == expected_hash, (
+        f"[{region}] anonymously-downloaded public object does not match what was uploaded — public-read reads through the {region} edge are corrupting data."
+    )
+    assert len(resp.content) == size, (
+        f"[{region}] anonymous public download is {len(resp.content)} bytes but {size} were uploaded — the {region} edge is truncating public objects."
+    )
 
     cache_control = resp.headers.get("Cache-Control", "")
     assert "public" in cache_control.lower(), f"expected public Cache-Control, got: {cache_control!r}"
@@ -119,7 +131,9 @@ def test_regional_presigned_url_roundtrip(regional_s3_client, session_tracker, f
     )
     get_resp = httpx.get(get_url, timeout=60)
     assert get_resp.status_code == 200, f"[{region}] presigned GET failed: {get_resp.status_code} {get_resp.text[:200]}"
-    assert hashlib.md5(get_resp.content).hexdigest() == expected_hash
+    assert hashlib.md5(get_resp.content).hexdigest() == expected_hash, (
+        f"[{region}] object fetched via presigned URL does not match what was PUT via presigned URL — the {region} presigned round-trip is corrupting data."
+    )
 
     print(f"[{region}] presigned URL roundtrip OK: {key}")
 

--- a/tests/smoke/test_smoke_subtoken_scope.py
+++ b/tests/smoke/test_smoke_subtoken_scope.py
@@ -206,11 +206,15 @@ def test_default_deny_no_scope_installed(
 
     with pytest.raises(ClientError) as exc:
         sub_token_s3_client.get_object(Bucket=bucket_a, Key="missing.bin")
-    assert _http_status(exc.value) == 403
+    assert _http_status(exc.value) == 403, (
+        f"A sub-token with no scope installed was able to GET (got HTTP {_http_status(exc.value)}, expected 403) — default-deny is broken and unscoped tokens can read data."
+    )
 
     with pytest.raises(ClientError) as exc:
         sub_token_s3_client.put_object(Bucket=bucket_a, Key="x.bin", Body=data)
-    assert _http_status(exc.value) == 403
+    assert _http_status(exc.value) == 403, (
+        f"A sub-token with no scope installed was able to PUT (got HTTP {_http_status(exc.value)}, expected 403) — default-deny is broken and unscoped tokens can write data."
+    )
 
 
 def test_object_read_allows_get_denies_writes(
@@ -232,16 +236,22 @@ def test_object_read_allows_get_denies_writes(
     _install_scope(scope_http_client, access_key_id, hippius_master_account_ss58, "object_read", "specific", [bucket_a])
 
     got = sub_token_s3_client.get_object(Bucket=bucket_a, Key=key)
-    assert hashlib.md5(got["Body"].read()).hexdigest() == expected_md5
+    assert hashlib.md5(got["Body"].read()).hexdigest() == expected_md5, (
+        "An object_read sub-token read back the wrong content — a scoped read either served the wrong object or corrupted it."
+    )
 
     # DELETE first (no body) — body-bearing 403 corrupts boto3 keepalive on the next req.
     with pytest.raises(ClientError) as exc:
         sub_token_s3_client.delete_object(Bucket=bucket_a, Key=key)
-    assert _http_status(exc.value) == 403
+    assert _http_status(exc.value) == 403, (
+        f"An object_read (read-only) sub-token was allowed to DELETE (got HTTP {_http_status(exc.value)}, expected 403) — read-only scope is not blocking writes."
+    )
 
     with pytest.raises(ClientError) as exc:
         sub_token_s3_client.put_object(Bucket=bucket_a, Key="write.bin", Body=b"x")
-    assert _http_status(exc.value) == 403
+    assert _http_status(exc.value) == 403, (
+        f"An object_read (read-only) sub-token was allowed to PUT (got HTTP {_http_status(exc.value)}, expected 403) — read-only scope is not blocking writes."
+    )
 
 
 def test_object_read_write_full_object_crud(
@@ -264,7 +274,9 @@ def test_object_read_write_full_object_crud(
 
     sub_token_s3_client.put_object(Bucket=bucket_a, Key=key, Body=data)
     got = sub_token_s3_client.get_object(Bucket=bucket_a, Key=key)
-    assert hashlib.md5(got["Body"].read()).hexdigest() == expected_md5
+    assert hashlib.md5(got["Body"].read()).hexdigest() == expected_md5, (
+        "An object_read_write sub-token read back different content than it just wrote — the scoped write/read round-trip is corrupting data."
+    )
     sub_token_s3_client.delete_object(Bucket=bucket_a, Key=key)
 
 
@@ -287,11 +299,15 @@ def test_specific_bucket_scope_excludes_other_bucket(
 
     with pytest.raises(ClientError) as exc:
         sub_token_s3_client.get_object(Bucket=bucket_b, Key="other.bin")
-    assert _http_status(exc.value) == 403
+    assert _http_status(exc.value) == 403, (
+        f"A sub-token scoped only to bucket A was able to GET from bucket B (got HTTP {_http_status(exc.value)}, expected 403) — per-bucket scope isolation is broken, tokens can read buckets outside their scope."
+    )
 
     with pytest.raises(ClientError) as exc:
         sub_token_s3_client.put_object(Bucket=bucket_b, Key="x.bin", Body=b"y")
-    assert _http_status(exc.value) == 403
+    assert _http_status(exc.value) == 403, (
+        f"A sub-token scoped only to bucket A was able to PUT into bucket B (got HTTP {_http_status(exc.value)}, expected 403) — per-bucket scope isolation is broken, tokens can write buckets outside their scope."
+    )
 
 
 def test_scope_update_is_immediate(
@@ -311,7 +327,9 @@ def test_scope_update_is_immediate(
     _install_scope(scope_http_client, access_key_id, hippius_master_account_ss58, "object_read", "specific", [bucket_a])
     with pytest.raises(ClientError) as exc:
         sub_token_s3_client.delete_object(Bucket=bucket_a, Key="probe.bin")
-    assert _http_status(exc.value) == 403
+    assert _http_status(exc.value) == 403, (
+        f"Under a freshly-installed object_read scope, DELETE was allowed (got HTTP {_http_status(exc.value)}, expected 403) — read-only scope is not being enforced immediately after install."
+    )
 
     # Upgrade: subsequent PUT must succeed on the very next request.
     _install_scope(
@@ -337,11 +355,15 @@ def test_revoke_scope_resumes_default_deny(
     sub_token_s3_client.put_object(Bucket=bucket_a, Key="before-revoke.bin", Body=b"ok")
 
     delete_resp = scope_http_client.delete(access_key_id)
-    assert delete_resp.status_code == 204, delete_resp.text
+    assert delete_resp.status_code == 204, (
+        f"Deleting the sub-token's scope row returned HTTP {delete_resp.status_code}, expected 204 — the scope revocation endpoint is failing. Body: {delete_resp.text}"
+    )
 
     with pytest.raises(ClientError) as exc:
         sub_token_s3_client.put_object(Bucket=bucket_a, Key="after-revoke.bin", Body=b"no")
-    assert _http_status(exc.value) == 403
+    assert _http_status(exc.value) == 403, (
+        f"After the scope row was deleted, the sub-token could still PUT (got HTTP {_http_status(exc.value)}, expected 403) — revoking a scope does not take effect, so revoked tokens keep their access."
+    )
 
 
 def test_admin_read_allows_list_buckets(
@@ -355,7 +377,9 @@ def test_admin_read_allows_list_buckets(
     _install_scope(scope_http_client, access_key_id, hippius_master_account_ss58, "admin_read", "all", [])
 
     listing = sub_token_s3_client.list_buckets()
-    assert listing["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert listing["ResponseMetadata"]["HTTPStatusCode"] == 200, (
+        f"An admin_read sub-token was denied ListBuckets (got HTTP {listing['ResponseMetadata']['HTTPStatusCode']}, expected 200) — the admin_read tier is not granting account-wide bucket listing."
+    )
 
 
 def test_object_read_denies_list_buckets(
@@ -372,7 +396,9 @@ def test_object_read_denies_list_buckets(
 
     with pytest.raises(ClientError) as exc:
         sub_token_s3_client.list_buckets()
-    assert _http_status(exc.value) == 403
+    assert _http_status(exc.value) == 403, (
+        f"An object_read (object-tier) sub-token was allowed to ListBuckets (got HTTP {_http_status(exc.value)}, expected 403) — object-scoped tokens must not see the account's bucket list."
+    )
 
 
 def test_object_read_write_can_bulk_delete(
@@ -402,8 +428,12 @@ def test_object_read_write_can_bulk_delete(
         Bucket=bucket_a,
         Delete={"Objects": [{"Key": "bulk-1.bin"}, {"Key": "bulk-2.bin"}]},
     )
-    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
-    assert len(resp.get("Deleted", [])) == 2
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200, (
+        f"An object_read_write sub-token was denied bulk DeleteObjects (got HTTP {resp['ResponseMetadata']['HTTPStatusCode']}, expected 200) — POST /bucket?delete is mis-mapped to a bucket-meta permission instead of delete_object (resolver regression)."
+    )
+    assert len(resp.get("Deleted", [])) == 2, (
+        f"Bulk DeleteObjects reported {len(resp.get('Deleted', []))} deletions, expected 2 — not all objects in the batch were actually deleted."
+    )
 
 
 def test_copy_object_source_bucket_must_be_in_scope(
@@ -434,7 +464,9 @@ def test_copy_object_source_bucket_must_be_in_scope(
         sub_token_s3_client.copy_object(
             Bucket=bucket_b, Key="leaked.txt", CopySource={"Bucket": bucket_a, "Key": "secret.txt"}
         )
-    assert _http_status(exc.value) == 403
+    assert _http_status(exc.value) == 403, (
+        f"A sub-token scoped only to bucket B was able to CopyObject with a source in bucket A (got HTTP {_http_status(exc.value)}, expected 403) — CopyObject is not enforcing scope on the source bucket, so copy is a back-door to read out-of-scope buckets."
+    )
 
     # When scope covers BOTH buckets, the copy succeeds.
     _install_scope(
@@ -448,4 +480,6 @@ def test_copy_object_source_bucket_must_be_in_scope(
     resp = sub_token_s3_client.copy_object(
         Bucket=bucket_b, Key="legit.txt", CopySource={"Bucket": bucket_a, "Key": "secret.txt"}
     )
-    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200, (
+        f"A sub-token scoped to BOTH buckets was denied a cross-bucket CopyObject (got HTTP {resp['ResponseMetadata']['HTTPStatusCode']}, expected 200) — copy is over-restricting even when both source and destination are in scope."
+    )


### PR DESCRIPTION
## Summary

The hourly production smoke tests notify Mattermost on failure via `scripts/extract_failure_details.py`, which forwards the pytest error/traceback. Until now most assertions were bare (`assert x == y`), so the alert carried only a raw traceback — readable by the author, not by the team monitoring the channel.

This adds a one-line, plain-English message to **every** bare assertion in the three smoke suites, stating *what capability broke* (and interpolating the offending value where it helps triage). No behavior change — messages only fire on failure.

## Changes

- **`test_smoke_production.py`** — simple PUT (ETag/200/non-multipart), multipart (UploadId, all parts, final `-N` ETag), fresh-download + historical-object integrity (size + MD5), session-manifest round-trip, presigned truncation, and direct-path CORS header checks.
- **`test_smoke_regional.py`** — per-region PUT/GET status, content integrity, and truncation for authenticated / anonymous-public / presigned paths (region name embedded in each message).
- **`test_smoke_subtoken_scope.py`** — each scope-enforcement assertion names the security property that failed: default-deny, read-only blocks writes, per-bucket isolation, immediate scope apply/revoke, admin_read vs object_read ListBuckets, bulk-delete permission mapping, CopyObject source-scope back-door.
- Sorts the `test_smoke_regional.py` import block (ruff I001) to keep CI green.

## Verification

Validated the full alert path end-to-end against the real Mattermost webhook: fed a simulated failure report through `extract_failure_details.py` and confirmed the rendered message now leads with the plain-English diagnosis. Existing assertions that already had good messages were left untouched.

Test-only change; no runtime/product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)