### PR TITLE
build(deps): clear pip-audit findings (bump click, ignore ecdsa Minerva)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,9 +46,16 @@ repos:
       # Audit the project venv (which we control via uv.lock) — NOT pip-audit's
       # own tool env (which we don't). The `uv run` invocation ensures the
       # audited interpreter is `.venv/bin/python`.
+      #
+      # CVE-2024-23342 (Minerva timing attack on P-256 in python-ecdsa) has no
+      # fixed release — the maintainers consider side-channel resistance out of
+      # scope for the pure-Python implementation. ecdsa is a transitive dep of
+      # substrate-interface (Hippius chain), so we cannot drop it; we do not use
+      # it for local ECDSA signing over attacker-controlled timing, so we accept
+      # and pin-ignore this single advisory.
       - id: pip-audit
         name: pip-audit (dependency scan)
-        entry: uv run --extra dev pip-audit
+        entry: uv run --extra dev pip-audit --ignore-vuln CVE-2024-23342
         language: system
         stages: [pre-commit]
         pass_filenames: false

--- a/uv.lock
+++ b/uv.lock
@@ -423,14 +423,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.0"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -922,7 +922,6 @@ dependencies = [
     { name = "httpx" },
     { name = "loki-logger-handler" },
     { name = "lxml" },
-    { name = "mnemonic" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
@@ -993,7 +992,6 @@ requires-dist = [
     { name = "loki-logger-handler", specifier = ">=1.1.2" },
     { name = "lxml", specifier = ">=4.9.3" },
     { name = "minio", marker = "extra == 'dev'", specifier = ">=7.1.15" },
-    { name = "mnemonic", specifier = ">=0.20" },
     { name = "msgpack", marker = "extra == 'dev'", specifier = ">=1.2.1" },
     { name = "opentelemetry-api", specifier = ">=1.37.0" },
     { name = "opentelemetry-distro", specifier = ">=0.58b0" },
@@ -1321,15 +1319,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a0/33ea2e18d5169817950edc13eba58cd781cedefe9f6696cae26aa2d75882/minio-7.2.16.tar.gz", hash = "sha256:81e365c8494d591d8204a63ee7596bfdf8a7d06ad1b1507d6b9c1664a95f299a", size = 139149, upload-time = "2025-07-21T20:11:15.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/a3/00260f8df72b51afa1f182dd609533c77fa2407918c4c2813d87b4a56725/minio-7.2.16-py3-none-any.whl", hash = "sha256:9288ab988ca57c181eb59a4c96187b293131418e28c164392186c2b89026b223", size = 95750, upload-time = "2025-07-21T20:11:14.139Z" },
-]
-
-[[package]]
-name = "mnemonic"
-version = "0.20"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/8d/d4dc2b2bddfeb57cab4404a41749b577f578f71140ab754da9afa8f5c599/mnemonic-0.20.tar.gz", hash = "sha256:7c6fb5639d779388027a77944680aee4870f0fcd09b1e42a5525ee2ce4c625f6", size = 67596, upload-time = "2021-07-27T13:31:43.63Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/95/3e07c33ffb26f5823b45a1c30db8acea44763198c2bd393e07e884f3295f/mnemonic-0.20-py3-none-any.whl", hash = "sha256:acd2168872d0379e7a10873bb3e12bf6c91b35de758135c4fbd1015ef18fafc5", size = 62028, upload-time = "2021-07-27T13:31:41.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The `pip-audit` pre-commit hook is currently failing on `main`, which blocks every local commit (`git commit` aborts before it starts). Two advisories were flagged:

| Package | Advisory | Fix |
|---|---|---|
| `click` 8.3.0 | CVE-2026-7246 / PYSEC-2026-2132 | bump to **8.4.2** (fixed in 8.3.3) |
| `ecdsa` 0.19.2 | CVE-2024-23342 (Minerva P-256 timing attack) | **no fixed release** — pin-ignore |

## Changes

- **Bump `click` → 8.4.2** in `uv.lock`. Clears CVE-2026-7246. `click` is transitive via `uvicorn`; the bump resolves cleanly (145 packages re-resolved, no other version changes).
- **Pin-ignore CVE-2024-23342 for `ecdsa`** via `--ignore-vuln` on the pip-audit hook entry, with an inline comment explaining why: the Minerva timing attack has no upstream fix (maintainers consider side-channel resistance out of scope for the pure-Python implementation), `ecdsa` is a transitive dependency of `substrate-interface` (Hippius chain) and can't be dropped, and we don't use it for local ECDSA signing exposed to attacker-controlled timing.
- **Prunes orphaned `mnemonic` 0.20** from the lock as a side effect of regenerating it. `mnemonic` is not declared in `pyproject.toml` and is imported nowhere in the tree — `main`'s lockfile had drifted and any `uv lock` reconciles it. No runtime impact.

## Verification

Ran the hook exactly as pre-commit invokes it:

```
$ uv run --extra dev pip-audit --ignore-vuln CVE-2024-23342
No known vulnerabilities found, 1 ignored
```

Confirmed green through an actual `git commit` (the `pip-audit` hook reports **Passed**).

## Notes

The ecdsa ignore is scoped to the **single** CVE — any *new* advisory on ecdsa (or anything else) will still fail the audit. Revisit if `substrate-interface` ever moves off pure-Python ecdsa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)