### PR TITLE
fix: index MPU cleanup on object DELETE (slow prod deletes) + bound delete acquire

### DIFF
--- a/hippius_s3/api/s3/objects/router.py
+++ b/hippius_s3/api/s3/objects/router.py
@@ -20,9 +20,12 @@ from hippius_s3.api.s3.objects.put_object_endpoint import handle_put_object
 from hippius_s3.api.s3.objects.tagging_endpoint import delete_object_tags as tags_delete_object_tags
 from hippius_s3.api.s3.objects.tagging_endpoint import get_object_tags as tags_get_object_tags
 from hippius_s3.api.s3.objects.tagging_endpoint import set_object_tags as tags_set_object_tags
+from hippius_s3.config import get_config
+from hippius_s3.db_pool import acquire_with_timeout
 
 
 router = APIRouter()
+config = get_config()
 
 
 @router.head("/{bucket_name}/{object_key:path}", status_code=200)
@@ -90,5 +93,9 @@ async def delete_object(
     if "tagging" in request.query_params:
         async with pool.acquire() as conn:
             return await tags_delete_object_tags(bucket_name, object_key, conn, request.state.account.main_account)
-    async with pool.acquire() as conn:
+    # Bound the acquire: the delete handler holds this connection across the
+    # multipart_uploads cleanup, which can be a multi-second scan on large buckets.
+    # A bare pool.acquire() would block indefinitely and pin a pool slot under load;
+    # a timeout surfaces PoolAcquireTimeout -> 503 SlowDown via the global handler.
+    async with acquire_with_timeout(pool, config.db_pool_acquire_timeout) as conn:
         return await handle_delete_object(bucket_name, object_key, request, conn, redis_client)

--- a/hippius_s3/sql/migrations/20260715000000_multipart_uploads_bucket_key_incomplete_index.sql
+++ b/hippius_s3/sql/migrations/20260715000000_multipart_uploads_bucket_key_incomplete_index.sql
@@ -1,0 +1,39 @@
+-- migrate:up
+
+-- Slow object DELETE fix. Every object DELETE runs the "cleanup provisional
+-- multipart uploads" query (delete_object_endpoint.py):
+--   DELETE FROM multipart_uploads WHERE bucket_id=$1 AND object_key=$2 AND is_completed=FALSE
+-- The only usable index is idx_multipart_uploads_bucket (bucket_id), so the plan
+-- is an Index Scan on bucket_id + Filter on object_key: it scans EVERY row for the
+-- bucket. On prod multipart_uploads is ~38 GB / ~124M rows (only ~953k incomplete;
+-- completed rows are never pruned), so on the largest buckets (hippius-juicefs-data,
+-- ~39M rows) each delete is a disk-bound scan measured live at ~3-14.6 s, with ~10
+-- concurrent copies stuck on IO/AioIoCompletion on the primary.
+--
+-- Regression origin: the table originally carried UNIQUE(bucket_id, object_key,
+-- upload_id) whose btree led with (bucket_id, object_key) and served this predicate
+-- as a seek. Migration 20260528120600 dropped it as "redundant" (true as a uniqueness
+-- constraint - upload_id is already PK) but it was the only prefix cover, so dropping
+-- it introduced the full-bucket scan.
+--
+-- This restores prefix coverage in a far smaller, targeted form: a PARTIAL index
+-- limited to is_completed = FALSE. Only ~953k of ~124M rows are incomplete (<1%), so
+-- the index is a few tens of MB (vs the ~7 GB full unique that was dropped), and its
+-- predicate matches the DELETE's `is_completed = FALSE` exactly, so the planner can
+-- use it and turn the per-delete scan into a rows=1 seek.
+--
+-- Built CONCURRENTLY out-of-band on prod via a k8s apply job (mirror
+-- k8s/cleanup-indexes-staging-apply.yaml / migrate-recent-uploads-index-apply.yaml);
+-- that job inserts the schema_migrations row before this file runs via dbmate, so
+-- dbmate sees it applied and skips it (no SHARE lock stalling PUT/DELETE on the 38 GB
+-- table during deploy). On a fresh DB (dbmate's path) the plain CREATE INDEX below is
+-- a no-op-cost build on an empty table. Keep the file body a plain CREATE INDEX (no
+-- CONCURRENTLY): dbmate wraps migrations in a transaction and CONCURRENTLY cannot run
+-- inside one — the concurrency happens in the out-of-band job, not here.
+CREATE INDEX IF NOT EXISTS idx_mpu_bucket_key_incomplete
+    ON multipart_uploads (bucket_id, object_key)
+    WHERE is_completed = FALSE;
+
+-- migrate:down
+
+DROP INDEX IF EXISTS idx_mpu_bucket_key_incomplete;


### PR DESCRIPTION
## Summary

Object `DELETE` on large buckets is disk-bound at **~3–14.6 s** on prod. Every delete runs a "cleanup provisional multipart uploads" query in `delete_object_endpoint.py` with predicate `(bucket_id, object_key, is_completed = FALSE)`. The only usable index is `idx_multipart_uploads_bucket` (bucket_id only), so the planner **Index-Scans `bucket_id` and Filters `object_key` in the executor — scanning every row for the bucket**.

`multipart_uploads` on prod is **38 GB / ~124M rows** (only ~953k incomplete; completed rows are never pruned). On the biggest buckets (`hippius-juicefs-data`, ~39M rows) each delete scans tens of millions of rows. Verified live on `postgres-nvme-1`: ~10 concurrent cleanup DELETEs stuck at ~12 s on `IO / AioIoCompletion`, gateway `DELETE` p50 ~14.6 s. This backs up JuiceFS's delete pipeline and degrades the shared registry storage.

### Regression origin
The table originally had `UNIQUE(bucket_id, object_key, upload_id)` — its btree **led with `(bucket_id, object_key)`** and served this predicate as a cheap seek. Migration `20260528120600_drop_multipart_uploads_redundant_unique.sql` dropped it as "redundant" — correct as a *uniqueness* constraint (`upload_id` is already PK), but it was the **only prefix cover** for `(bucket_id, object_key)`, so dropping it introduced the full-bucket scan.

## Changes (2 files)

- **New partial index** `idx_mpu_bucket_key_incomplete (bucket_id, object_key) WHERE is_completed = FALSE`. Matches the DELETE predicate exactly and covers only the ~953k incomplete rows (<1% of the table) → a few tens of MB vs the ~7 GB full unique that was dropped. Turns the per-delete scan into a `rows≈1` seek. Follows this repo's **out-of-band CONCURRENTLY apply convention** (plain `CREATE INDEX IF NOT EXISTS` in the migration file; prod builds it `CONCURRENTLY` via a k8s apply job that pre-inserts the `schema_migrations` row so dbmate skips the write-locking file — same pattern as `20260427170000_add_objects_bucket_created_index.sql`).
- **Bound the delete route's connection acquire** with `acquire_with_timeout(pool, config.db_pool_acquire_timeout)` (parity with the PUT path). The handler holds one pooled connection across the multi-second cleanup; a bare `pool.acquire()` blocks indefinitely and pins a slot under load. On timeout it surfaces `PoolAcquireTimeout` → **503 SlowDown** via the existing global handler (`main.py` → `errors.pool_saturation_response`).

## Verification
All claims checked read-only against prod `postgres-nvme-1` / DB `hippius`:
- `pg_total_relation_size = 38 GB`, `reltuples ≈ 124.2M`; indexes are exactly `pkey`, `idx_multipart_uploads_bucket`, `idx_multipart_uploads_object_id` (no `(bucket_id, object_key)`).
- `EXPLAIN` of the cleanup DELETE (no execute) → `Index Scan using idx_multipart_uploads_bucket … Filter: object_key`, est. cost 4.7M.
- `pg_stat_activity` → ~10 live cleanup DELETEs at ~12 s on `IO/AioIoCompletion`.
- `ruff`, `ruff format`, `ty` type-check pass. (`pip-audit` failure is pre-existing CVEs in `click`/`ecdsa`, unrelated.)

## Rollout
Apply the index CONCURRENTLY out-of-band on prod via a k8s job mirroring `k8s/cleanup-indexes-staging-apply.yaml`, pre-inserting the `schema_migrations` row (same as the existing index migrations). After it lands, confirm gateway `DELETE` p50 drops to ms and re-check the registry's 404/blob-unknown upload failures (the JuiceFS-backlog → upload-failure hop is plausible but not yet proven).

## Follow-ups (not in this PR)
- **Retention for completed `multipart_uploads`** (124M of 125M rows are dead weight). Must respect the `objects/CLAUDE.md:27` ordering constraint so pruning a completed row doesn't cascade `chunk_backend` before the drain finishes.
- `idx_multipart_uploads_initiated_at` (the reaper's partial index) appears **absent on prod** — worth verifying.

## Conclusion
Restores the `(bucket_id, object_key)` prefix seek that the May index-drop removed — in a far smaller, targeted form — and stops a slow delete from pinning a DB pool slot. Branched cleanly off `main` (2 files only); supersedes #251, which was accidentally opened from a staging-ahead branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
