### PR TITLE
fix(logging): downgrade OTLP exporter backpressure errors to WARNING

### DIFF
--- a/docs/issues/otel-exporter-log-noise.md
+++ b/docs/issues/otel-exporter-log-noise.md
@@ -1,0 +1,90 @@
+# OTLP exporter backpressure floods ERROR logs
+
+## Summary
+
+The OpenTelemetry OTLP/gRPC exporter's own internal logger
+(`opentelemetry.exporter.otlp.proto.grpc.exporter` and sibling modules under the parent logger
+`opentelemetry.exporter.otlp.proto.grpc`) emits `logger.error(...)` lines like:
+
+```
+Failed to export <signal> to <collector>, error code: StatusCode.UNAVAILABLE,
+error details: data refused due to high memory usage
+```
+
+whenever the prod otel-collector's `memory_limiter` processor sheds load. These are telemetry-only,
+transient backpressure events — not service errors — but they land at ERROR level and flood the
+ERROR dashboards/alerts across every pod (api, gateway, arion-*, workers).
+
+## Impact
+
+- `server_errors=0` — no user-facing request ever fails because of these lines.
+- Fleet-wide ERROR-dashboard and alert noise: every pod that exports traces/metrics emits them,
+  drowning out genuine ERRORs and inflating error-rate panels.
+- The app has no OTLP *log* exporter; app logs flow to Loki via `LokiLoggerHandler`, so these lines
+  are purely the SDK's own internal reporting of failed telemetry exports.
+
+## Root cause
+
+Two layers:
+
+1. **True upstream cause (infra):** the collector's `memory_limiter` processor in
+   [k8s/base/otel-collector.yaml](../../k8s/base/otel-collector.yaml) refuses data when it is over its
+   memory limit, returning `StatusCode.UNAVAILABLE` to exporters. Under load this is expected
+   backpressure, not an outage.
+2. **Symptom (app-side):** the OTLP SDK's internal exporter logger reports each refused export at
+   ERROR level. The app-side fix below only de-noises the ERROR stream; it does not change the
+   collector behavior.
+
+## Fix
+
+Add a `logging.Filter` (`OtelExporterBackpressureFilter`) in
+[hippius_s3/logging_config.py](../../hippius_s3/logging_config.py) that DOWNGRADES a record at ERROR
+level (or above) **whose logger name starts with `opentelemetry.exporter.otlp.proto.grpc`** to
+WARNING — mutating `record.levelno`/`record.levelname` — and always returns `True` (never drops it).
+
+It is attached inside `setup_loki_logging(...)` to the shared **handlers** (exactly like the existing
+`RayIDFilter`), NOT to a logger:
+
+```python
+otel_backpressure_filter = OtelExporterBackpressureFilter()
+for handler in handlers:
+    handler.addFilter(otel_backpressure_filter)
+```
+
+### Why handler-attached + name-scoped (the important subtlety)
+
+The noisy lines are emitted by the exporter's **child** loggers
+(`...grpc.trace_exporter`, `...grpc.metric_exporter`, `...grpc.exporter`). A `logging.Filter`
+attached to the *parent* logger `opentelemetry.exporter.otlp.proto.grpc` would **not** fire for them:
+when a child logger emits, Python applies only the child's own logger-level filters, then propagates
+the record to *ancestor handlers* via `callHandlers` — it never runs ancestor **logger** filters.
+So the filter has to live on the **handlers** (which every propagated record passes through). Because
+a handler sees every record from every logger, the filter is then **name-scoped** so it only touches
+the otel exporter lines and leaves genuine app ERRORs alone.
+
+The lines stay VISIBLE at WARNING — a persistent collector outage is still discoverable — but they no
+longer inflate ERROR counts/alerts.
+
+## Testing
+
+Unit tests in [tests/unit/test_logging_config.py](../../tests/unit/test_logging_config.py) exercise the
+real filter class and the real propagation path:
+
+- An ERROR (and a CRITICAL) record from an otel exporter **child** logger is downgraded to WARNING;
+  `filter()` returns `True`.
+- A record already at WARNING (and one at INFO) is left unchanged.
+- A NON-otel ERROR (e.g. `hippius_s3.api`) is left at ERROR — name scoping proven.
+- End-to-end regression: a real `...grpc.trace_exporter` logger emitting at ERROR through a
+  handler-attached filter is observed as WARNING, while a `hippius_s3.api.*` ERROR stays ERROR. This
+  is the exact case the (rejected) parent-logger attachment would have missed.
+- `setup_loki_logging` attaches the filter to the handlers, and NOT as a logger-level filter on the
+  exporter logger.
+- `filter()` never returns `False` for any level/name (never drops a record).
+
+## Alternatives considered
+
+- **Bump the collector memory / tune `memory_limiter`** — the correct real fix for the backpressure
+  itself, but a separate infra change with its own capacity trade-offs; does not belong in the app and
+  would still leave transient ERRORs during spikes.
+- **Fully silence the logger** (`setLevel(CRITICAL)` / drop the records) — rejected: it hides genuine,
+  persistent collector outages. Downgrading to WARNING keeps the signal while removing the false ERRORs.

--- a/hippius_s3/logging_config.py
+++ b/hippius_s3/logging_config.py
@@ -37,6 +37,23 @@ class HealthCheckFilter(logging.Filter):
         return "/health" not in message
 
 
+class OtelExporterBackpressureFilter(logging.Filter):
+    """Downgrade OTLP exporter backpressure ERRORs to WARNING (keep visible, off ERROR dashboards)."""
+
+    _LOGGER_PREFIX = "opentelemetry.exporter.otlp.proto.grpc"
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # The OTLP gRPC exporter logs "Failed to export ... StatusCode.UNAVAILABLE" at ERROR when the
+        # collector's memory_limiter sheds load — transient backpressure, not a service error. Scoped
+        # by record name because this filter is attached to the shared handlers (below), not to the
+        # exporter logger: a logger-level filter would NOT see records propagated from the exporter's
+        # child loggers (...grpc.trace_exporter / .metric_exporter / .exporter).
+        if record.name.startswith(self._LOGGER_PREFIX) and record.levelno >= logging.ERROR:
+            record.levelno = logging.WARNING
+            record.levelname = "WARNING"
+        return True
+
+
 def setup_loki_logging(config: LoggingConfig, service_name: str, include_ray_id: bool = True) -> logging.Logger:
     """
     Configure logging with optional Loki handler and ray ID support.
@@ -73,6 +90,12 @@ def setup_loki_logging(config: LoggingConfig, service_name: str, include_ray_id:
         log_format = "%(asctime)s - [%(ray_id)s] - %(name)s - %(levelname)s - %(message)s"
     else:
         log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+    # Attached to the handlers (like RayIDFilter) so it also catches records propagated up from the
+    # OTLP exporter's child loggers — a logger-level filter would miss those.
+    otel_backpressure_filter = OtelExporterBackpressureFilter()
+    for handler in handlers:
+        handler.addFilter(otel_backpressure_filter)
 
     logging.basicConfig(
         level=log_level,

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -3,8 +3,24 @@ from unittest.mock import Mock
 
 import pytest
 
+from hippius_s3.logging_config import OtelExporterBackpressureFilter
 from hippius_s3.logging_config import RayIDFilter
 from hippius_s3.logging_config import setup_loki_logging
+
+
+OTEL_LOGGER_NAME = "opentelemetry.exporter.otlp.proto.grpc"
+
+
+def _make_record(name: str, level: int) -> logging.LogRecord:
+    return logging.LogRecord(
+        name=name,
+        level=level,
+        pathname="exporter.py",
+        lineno=42,
+        msg="Failed to export to collector, error code: StatusCode.UNAVAILABLE",
+        args=(),
+        exc_info=None,
+    )
 
 
 @pytest.fixture
@@ -145,3 +161,115 @@ def test_setup_loki_logging_without_loki(mock_config):
     assert isinstance(logger, logging.Logger)
     root_logger = logging.getLogger()
     assert len(root_logger.handlers) >= 1
+
+
+OTEL_CHILD_LOGGER_NAME = "opentelemetry.exporter.otlp.proto.grpc.trace_exporter"
+
+
+def test_otel_filter_downgrades_error_to_warning_for_child_logger():
+    otel_filter = OtelExporterBackpressureFilter()
+    record = _make_record(OTEL_CHILD_LOGGER_NAME, logging.ERROR)
+
+    result = otel_filter.filter(record)
+
+    assert result is True
+    assert record.levelno == logging.WARNING
+    assert record.levelname == "WARNING"
+
+
+def test_otel_filter_downgrades_critical_to_warning():
+    otel_filter = OtelExporterBackpressureFilter()
+    record = _make_record(OTEL_CHILD_LOGGER_NAME, logging.CRITICAL)
+
+    result = otel_filter.filter(record)
+
+    assert result is True
+    assert record.levelno == logging.WARNING
+    assert record.levelname == "WARNING"
+
+
+def test_otel_filter_leaves_warning_unchanged():
+    otel_filter = OtelExporterBackpressureFilter()
+    record = _make_record(OTEL_LOGGER_NAME, logging.WARNING)
+
+    result = otel_filter.filter(record)
+
+    assert result is True
+    assert record.levelno == logging.WARNING
+    assert record.levelname == "WARNING"
+
+
+def test_otel_filter_leaves_info_unchanged():
+    otel_filter = OtelExporterBackpressureFilter()
+    record = _make_record(OTEL_LOGGER_NAME, logging.INFO)
+
+    result = otel_filter.filter(record)
+
+    assert result is True
+    assert record.levelno == logging.INFO
+    assert record.levelname == "INFO"
+
+
+def test_otel_filter_leaves_non_otel_error_unchanged():
+    # Name-scoped: an ERROR from an app logger must NOT be downgraded (the filter runs on the shared
+    # handlers, so it sees every record and must only touch the otel exporter's own lines).
+    otel_filter = OtelExporterBackpressureFilter()
+    record = _make_record("hippius_s3.api", logging.ERROR)
+
+    result = otel_filter.filter(record)
+
+    assert result is True
+    assert record.levelno == logging.ERROR
+    assert record.levelname == "ERROR"
+
+
+def test_otel_filter_never_drops_records():
+    otel_filter = OtelExporterBackpressureFilter()
+    for name in (OTEL_CHILD_LOGGER_NAME, "hippius_s3.api"):
+        for level in (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL):
+            record = _make_record(name, level)
+            assert otel_filter.filter(record) is True
+
+
+def test_handler_attached_filter_downgrades_child_logger_via_propagation():
+    # The regression this whole fix turns on: the noisy lines are emitted by CHILD loggers
+    # (...grpc.trace_exporter). A filter on the parent logger would NOT see them (propagation skips
+    # ancestor logger filters). Attached to a HANDLER, it does — and only touches otel records.
+    captured: list[tuple[str, str]] = []
+
+    class RecordCapture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append((record.name, record.levelname))
+
+    handler = RecordCapture()
+    handler.addFilter(OtelExporterBackpressureFilter())
+    root = logging.getLogger()
+    prev_level = root.level
+    root.addHandler(handler)
+    root.setLevel(logging.DEBUG)
+    try:
+        logging.getLogger(OTEL_CHILD_LOGGER_NAME).error("Failed to export traces, StatusCode.UNAVAILABLE")
+        logging.getLogger("hippius_s3.api.put").error("genuine service error")
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(prev_level)
+
+    assert (OTEL_CHILD_LOGGER_NAME, "WARNING") in captured
+    assert ("hippius_s3.api.put", "ERROR") in captured
+
+
+def test_setup_loki_logging_attaches_otel_filter_to_handlers_not_logger(mock_config):
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    otel_logger = logging.getLogger(OTEL_LOGGER_NAME)
+    otel_logger.filters = [f for f in otel_logger.filters if not isinstance(f, OtelExporterBackpressureFilter)]
+    # Simulate a fresh process: basicConfig (which setup_loki_logging uses, like the RayIDFilter path)
+    # only installs the filter-bearing handlers when the root logger has none yet.
+    root.handlers = []
+    try:
+        setup_loki_logging(mock_config, "test_service")
+        assert any(isinstance(f, OtelExporterBackpressureFilter) for h in root.handlers for f in h.filters)
+        # Must NOT be a logger-level filter on the exporter logger — that would miss child records.
+        assert not any(isinstance(f, OtelExporterBackpressureFilter) for f in otel_logger.filters)
+    finally:
+        root.handlers = saved_handlers


### PR DESCRIPTION
## Summary
The OpenTelemetry OTLP/gRPC exporter's internal logger emits `Failed to export … StatusCode.UNAVAILABLE, error details: data refused due to high memory usage` at **ERROR** whenever the prod otel-collector's `memory_limiter` sheds load. These are transient telemetry backpressure events — **not** service errors (`server_errors=0`) — but they flood the ERROR dashboards/alerts across every pod.

## Changes
- Add `OtelExporterBackpressureFilter` in `hippius_s3/logging_config.py` that downgrades ERROR→WARNING for records whose logger name starts with `opentelemetry.exporter.otlp.proto.grpc` (kept visible, off ERROR panels; never drops a record).
- Attach it to the shared log **handlers** (like the existing `RayIDFilter`), not to a logger.
  - **Why handler-attached + name-scoped:** the noisy lines come from *child* loggers (`…grpc.trace_exporter`/`.metric_exporter`). A parent-logger filter never fires for them — propagation runs ancestor *handlers*, not ancestor logger filters. A handler sees every propagated record, so the filter is name-scoped to touch only the otel exporter lines.
- 16 unit tests incl. an end-to-end propagation regression (a real `…trace_exporter` ERROR routed through a handler-attached filter is observed as WARNING; a `hippius_s3.api` ERROR stays ERROR).
- `docs/issues/otel-exporter-log-noise.md`.

## Not in scope
The true upstream cause is collector `memory_limiter` backpressure (`k8s/base/otel-collector.yaml`) — a separate infra/capacity change. This PR only de-noises the ERROR stream; it does not hide persistent outages (they show at WARNING).

## Conclusion
Removes fleet-wide false-ERROR noise with zero data-path impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
