### PR TITLE
fix(gateway): log client-driven auth rejections at WARNING not ERROR

### DIFF
--- a/docs/issues/gateway-auth-client-error-log-level.md
+++ b/docs/issues/gateway-auth-client-error-log-level.md
@@ -1,0 +1,92 @@
+# Gateway auth: client-driven rejections logged at ERROR
+
+## Summary
+
+The gateway logs client-driven authentication rejections (malformed credentials,
+bad signatures, missing/invalid signing headers, invalid presigned-URL query
+params) inconsistently — many at `logger.error`. These are expected 4xx client
+rejections, not server faults, yet they surface on ERROR-level logs and
+dashboards alongside genuine failures. This change normalizes those specific
+sites to `logger.warning`, matching the convention already applied elsewhere in
+the same files (e.g. invalid access-key format, signature mismatch, invalid/
+inactive key were already at WARNING).
+
+## Impact
+
+- Pure observability noise: ERROR dashboards / alerts are polluted by ordinary
+  bad-client traffic.
+- No data-path impact. Response codes, control flow, and message text are all
+  unchanged — only the log level of the rejection lines moves ERROR -> WARNING.
+- `server_errors=0` for these cases: they are 4xx rejections, not 5xx.
+
+## Root cause
+
+Inconsistent ERROR-vs-WARNING policy for client-driven auth rejections across
+`gateway/services/auth_orchestrator.py`, `gateway/middlewares/access_key_auth.py`,
+and `gateway/middlewares/sigv4.py`. Some rejections were already WARNING; the
+sites below were left at ERROR.
+
+Historical note: the specific "Bad seed phrase format / non-ASCII bytes" ERROR
+lines were already removed in commit `899867a` (seed-phrase auth deprecation),
+but the *class* of problem — client-driven rejections logged at ERROR — persisted
+at the sites listed under Fix.
+
+## Fix
+
+Downgraded `logger.error` -> `logger.warning` (message text unchanged) at the
+following unambiguously client-driven sites:
+
+`gateway/services/auth_orchestrator.py`
+- "Failed to extract credential" — `AuthParsingError` from a malformed client
+  `Authorization` header.
+
+`gateway/middlewares/access_key_auth.py` (`verify_access_key_signature`)
+- "Missing required auth headers for access key verification" — client omitted
+  `Authorization` / `x-amz-date`.
+
+`gateway/middlewares/access_key_auth.py` (`verify_access_key_presigned_url`)
+- "Missing required X-Amz-* query parameters for presigned URL verification"
+- "Unsupported X-Amz-Algorithm in presigned URL"
+- "Invalid X-Amz-Credential format"
+- "Presigned URL credential ID mismatch"
+- "X-Amz-Date ... and credential scope date ... mismatch in presigned URL"
+- "Invalid X-Amz-Expires value"
+- "X-Amz-Expires out of allowed range (1-604800)"
+- "Invalid X-Amz-Date format"
+- "Presigned URL missing required 'host' header in X-Amz-SignedHeaders"
+
+`gateway/middlewares/sigv4.py`
+- "FAIL: Missing x-amz-content-sha256 header" — client omitted the payload-hash
+  header on a non-presigned request.
+
+## Deliberately left at ERROR (not client-driven)
+
+- `sigv4.py` `canonical_path_from_scope`: "ASGI scope missing 'raw_path'" —
+  internal contract violation (raises `RuntimeError`), not client input.
+- `auth_orchestrator.py`: "Hippius API error during presigned URL auth" /
+  "Hippius API error during Bearer auth" / "Hippius API error during auth" —
+  upstream `HippiusAPIError`, returns 503.
+- `auth_orchestrator.py` / `access_key_auth.py`: "API returned empty
+  account_address" and "API returned valid token without crypto material" —
+  server-side / upstream data integrity problems.
+- `access_key_auth.py`: "Invalid account address format" and "Invalid token
+  type" (both in the header and presigned paths). **These were on the suggested
+  downgrade list but were intentionally left at ERROR:** the offending value
+  (`token_response.account_address` / `token_response.token_type`) comes from the
+  upstream auth API (`cached_auth`), not from client input. A malformed SS58
+  address or an unexpected token type from the API is an upstream data-integrity
+  anomaly in the same class as the "empty account_address" line that must stay
+  ERROR — a client cannot drive it.
+
+## Testing
+
+`tests/unit/gateway/test_auth_log_levels.py` — adversarial, failure-path only,
+asserts on `record.levelname` explicitly:
+
+1. Malformed client credential (`AuthParsingError` path via
+   `authenticate_request`) logs WARNING, not ERROR.
+2. Invalid presigned-URL credential format logs WARNING, not ERROR.
+3. Presigned-URL signature mismatch logs WARNING, not ERROR.
+4. Genuine upstream failure (`HippiusAPIError` from
+   `verify_access_key_signature`) STILL logs ERROR — proves no over-downgrade.
+5. Missing `x-amz-content-sha256` payload-hash header logs WARNING, not ERROR.

--- a/gateway/middlewares/access_key_auth.py
+++ b/gateway/middlewares/access_key_auth.py
@@ -60,7 +60,7 @@ async def verify_access_key_signature(
     amz_date = request.headers.get("x-amz-date", "")
 
     if not auth_header or not amz_date:
-        logger.error("Missing required auth headers for access key verification")
+        logger.warning("Missing required auth headers for access key verification")
         raise AccessKeyAuthError("Missing required auth headers")
 
     provided_signature = extract_signature_from_auth_header(auth_header)
@@ -169,7 +169,7 @@ async def verify_access_key_presigned_url(
     provided_signature = query.get("X-Amz-Signature")
 
     if not all([algorithm, credential, amz_date, expires_str, signed_headers_str, provided_signature]):
-        logger.error("Missing required X-Amz-* query parameters for presigned URL verification")
+        logger.warning("Missing required X-Amz-* query parameters for presigned URL verification")
         raise AccessKeyAuthError("Missing required presigned URL parameters")
 
     assert credential is not None
@@ -177,13 +177,13 @@ async def verify_access_key_presigned_url(
     assert signed_headers_str is not None
 
     if algorithm != "AWS4-HMAC-SHA256":
-        logger.error(f"Unsupported X-Amz-Algorithm in presigned URL: {algorithm}")
+        logger.warning(f"Unsupported X-Amz-Algorithm in presigned URL: {algorithm}")
         raise AccessKeyAuthError("Unsupported signature algorithm")
 
     # Parse credential: <access_key>/<date>/<region>/<service>/aws4_request
     credential_parts = credential.split("/")
     if len(credential_parts) < 5:
-        logger.error(f"Invalid X-Amz-Credential format: {credential}")
+        logger.warning(f"Invalid X-Amz-Credential format: {credential}")
         raise AccessKeyAuthError("Invalid credential format")
 
     credential_id = credential_parts[0]
@@ -192,27 +192,29 @@ async def verify_access_key_presigned_url(
     service = credential_parts[3]
 
     if credential_id != access_key:
-        logger.error(f"Presigned URL credential ID mismatch: header={access_key[:8]}***, query={credential_id[:8]}***")
+        logger.warning(
+            f"Presigned URL credential ID mismatch: header={access_key[:8]}***, query={credential_id[:8]}***"
+        )
         raise AccessKeyAuthError("Credential does not match access key")
 
     if not amz_date or len(amz_date) < 8 or date_scope != amz_date[:8]:
-        logger.error(f"X-Amz-Date ({amz_date}) and credential scope date ({date_scope}) mismatch in presigned URL")
+        logger.warning(f"X-Amz-Date ({amz_date}) and credential scope date ({date_scope}) mismatch in presigned URL")
         raise AccessKeyAuthError("Invalid credential scope")
 
     try:
         expires = int(expires_str)
     except ValueError:
-        logger.error(f"Invalid X-Amz-Expires value: {expires_str}")
+        logger.warning(f"Invalid X-Amz-Expires value: {expires_str}")
         raise AccessKeyAuthError("Invalid expires value") from None
 
     if expires <= 0 or expires > 604800:
-        logger.error(f"X-Amz-Expires out of allowed range (1-604800): {expires}")
+        logger.warning(f"X-Amz-Expires out of allowed range (1-604800): {expires}")
         raise AccessKeyAuthError("Expires value out of range")
 
     try:
         signed_at = datetime.datetime.strptime(amz_date, "%Y%m%dT%H%M%SZ").replace(tzinfo=datetime.timezone.utc)
     except ValueError:
-        logger.error(f"Invalid X-Amz-Date format: {amz_date}")
+        logger.warning(f"Invalid X-Amz-Date format: {amz_date}")
         raise AccessKeyAuthError("Invalid date format") from None
 
     now = datetime.datetime.now(datetime.timezone.utc)
@@ -227,7 +229,7 @@ async def verify_access_key_presigned_url(
     signed_headers = signed_headers_str.split(";")
 
     if "host" not in signed_headers:
-        logger.error("Presigned URL missing required 'host' header in X-Amz-SignedHeaders")
+        logger.warning("Presigned URL missing required 'host' header in X-Amz-SignedHeaders")
         raise AccessKeyAuthError("Invalid signed headers")
 
     token_response = await cached_auth(access_key, redis_client)

--- a/gateway/middlewares/sigv4.py
+++ b/gateway/middlewares/sigv4.py
@@ -141,7 +141,7 @@ async def create_canonical_request(
             logger.debug("No payload hash header found; treating presigned request as UNSIGNED-PAYLOAD")
             payload_hash = "UNSIGNED-PAYLOAD"
         else:
-            logger.error("FAIL: Missing x-amz-content-sha256 header")
+            logger.warning("FAIL: Missing x-amz-content-sha256 header")
             raise AuthParsingError("Missing payload hash header")
     if payload_hash == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD":
         payload_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/gateway/services/auth_orchestrator.py
+++ b/gateway/services/auth_orchestrator.py
@@ -79,7 +79,7 @@ async def authenticate_request(request: Request) -> AuthResult:
     try:
         credential, _, _, _ = extract_credential_from_auth_header(auth_header)
     except AuthParsingError as e:
-        logger.error(f"Failed to extract credential: {e}")
+        logger.warning(f"Failed to extract credential: {e}")
         return AuthResult(
             error_response=s3_error_response(
                 code="InvalidAccessKeyId",

--- a/tests/unit/gateway/test_auth_log_levels.py
+++ b/tests/unit/gateway/test_auth_log_levels.py
@@ -1,0 +1,187 @@
+"""Log-level regression tests for client-driven auth rejections.
+
+Client-driven auth rejections (malformed credentials, bad/expired presigned
+params, missing signing headers) must log at WARNING so they don't pollute the
+ERROR dashboards — these are expected 4xx rejections, not server faults. Genuine
+upstream failures (HippiusAPIError) must STAY at ERROR. These tests assert on
+record.levelname explicitly and are deliberately failure-path only.
+"""
+
+import datetime
+import logging
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from urllib.parse import urlencode
+
+import pytest
+from fastapi import Request
+
+from gateway.middlewares.access_key_auth import AccessKeyAuthError
+from gateway.middlewares.access_key_auth import verify_access_key_presigned_url
+from gateway.middlewares.sigv4 import AuthParsingError
+from gateway.middlewares.sigv4 import create_canonical_request
+from gateway.services.auth_orchestrator import _authenticate_access_key_header
+from gateway.services.auth_orchestrator import authenticate_request
+from hippius_s3.services.hippius_api_service import HippiusAPIError
+
+
+def make_request(
+    method: str = "GET",
+    path: str = "/bucket/key",
+    query_params: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+) -> Request:
+    headers = headers or {}
+    query_params = query_params or {}
+    scope: dict[str, Any] = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "headers": [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers.items()],
+        "query_string": urlencode(query_params).encode("latin-1"),
+        "raw_path": path.encode("latin-1"),
+        "state": {},
+        "app": MagicMock(),
+    }
+    return Request(scope)
+
+
+def _records(caplog: pytest.LogCaptureFixture, needle: str) -> list[logging.LogRecord]:
+    return [r for r in caplog.records if needle in r.getMessage()]
+
+
+@pytest.mark.asyncio
+async def test_malformed_credential_logs_warning_not_error(caplog: pytest.LogCaptureFixture) -> None:
+    """A SigV4 header that fails credential extraction (client input) -> WARNING, never ERROR."""
+    caplog.set_level(logging.DEBUG, logger="gateway.services.auth_orchestrator")
+
+    # Well-formed enough to be treated as a SigV4 header, but no parseable Credential=.
+    request = make_request(
+        method="PUT",
+        headers={"authorization": "AWS4-HMAC-SHA256 this-is-not-a-valid-credential-line"},
+    )
+
+    result = await authenticate_request(request)
+
+    assert result.is_valid is False
+    matched = _records(caplog, "Failed to extract credential")
+    assert matched, "expected the credential-extraction failure to be logged"
+    assert all(r.levelname == "WARNING" for r in matched)
+    assert not any(r.levelname == "ERROR" for r in matched)
+
+
+@pytest.mark.asyncio
+async def test_presigned_invalid_credential_format_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A presigned URL with a malformed X-Amz-Credential (client input) -> WARNING, never ERROR."""
+    caplog.set_level(logging.DEBUG, logger="gateway.middlewares.access_key_auth")
+
+    access_key = "hip_presigned_key_12345"
+    query_params = {
+        "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+        "X-Amz-Credential": access_key,  # missing /date/region/service/aws4_request -> <5 parts
+        "X-Amz-Date": "20260101T000000Z",
+        "X-Amz-Expires": "3600",
+        "X-Amz-SignedHeaders": "host",
+        "X-Amz-Signature": "deadbeef",
+    }
+    request = make_request(query_params=query_params)
+
+    with pytest.raises(AccessKeyAuthError):
+        await verify_access_key_presigned_url(request, access_key, AsyncMock())
+
+    matched = _records(caplog, "Invalid X-Amz-Credential format")
+    assert matched, "expected the invalid-credential-format rejection to be logged"
+    assert all(r.levelname == "WARNING" for r in matched)
+    assert not any(r.levelname == "ERROR" for r in matched)
+
+
+@pytest.mark.asyncio
+async def test_presigned_expired_signature_mismatch_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A presigned URL whose signature doesn't match (client input) -> WARNING, never ERROR."""
+    caplog.set_level(logging.DEBUG, logger="gateway.middlewares.access_key_auth")
+
+    access_key = "hip_presigned_key_67890"
+    now = datetime.datetime.now(datetime.timezone.utc)
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    date_scope = amz_date[:8]
+    query_params = {
+        "X-Amz-Algorithm": "AWS4-HMAC-SHA256",
+        "X-Amz-Credential": f"{access_key}/{date_scope}/us-east-1/s3/aws4_request",
+        "X-Amz-Date": amz_date,
+        "X-Amz-Expires": "3600",
+        "X-Amz-SignedHeaders": "host",
+        "X-Amz-Signature": "clientprovidedsig",
+    }
+    request = make_request(query_params=query_params, headers={"host": "s3.hippius.com"})
+
+    token_response = AsyncMock()
+    token_response.valid = True
+    token_response.status = "active"
+    token_response.account_address = "5FH2aQUbix3nNatzST4mPM8iuebGvSMFerZLdwvDmAwRDFep"
+    token_response.token_type = "sub"
+    token_response.encrypted_secret = "enc"
+    token_response.nonce = "nonce"
+
+    with patch("gateway.middlewares.access_key_auth.cached_auth", new_callable=AsyncMock, return_value=token_response):
+        with patch("gateway.middlewares.access_key_auth.decrypt_secret", return_value="secret"):
+            with patch(
+                "gateway.middlewares.access_key_auth.create_canonical_request",
+                new_callable=AsyncMock,
+                return_value="canonical",
+            ):
+                with patch("gateway.middlewares.access_key_auth.calculate_signature", return_value="serversidesig"):
+                    with pytest.raises(AccessKeyAuthError):
+                        await verify_access_key_presigned_url(request, access_key, AsyncMock())
+
+    matched = _records(caplog, "Presigned URL signature mismatch")
+    assert matched, "expected the signature-mismatch rejection to be logged"
+    assert all(r.levelname == "WARNING" for r in matched)
+    assert not any(r.levelname == "ERROR" for r in matched)
+
+
+@pytest.mark.asyncio
+async def test_upstream_hippius_api_error_stays_error(caplog: pytest.LogCaptureFixture) -> None:
+    """A genuine upstream failure (HippiusAPIError) must STILL log at ERROR — not downgraded."""
+    caplog.set_level(logging.DEBUG, logger="gateway.services.auth_orchestrator")
+
+    request = make_request(method="PUT")
+    logger = logging.getLogger("gateway.services.auth_orchestrator")
+
+    with patch(
+        "gateway.services.auth_orchestrator.verify_access_key_signature",
+        new_callable=AsyncMock,
+        side_effect=HippiusAPIError("arion down"),
+    ):
+        result = await _authenticate_access_key_header(request, "hip_some_key_12345", logger)
+
+    assert result.is_valid is False
+    matched = _records(caplog, "Hippius API error during auth")
+    assert matched, "expected the upstream failure to be logged"
+    assert all(r.levelname == "ERROR" for r in matched)
+    assert not any(r.levelname == "WARNING" for r in matched)
+
+
+@pytest.mark.asyncio
+async def test_sigv4_missing_payload_hash_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """A non-presigned request missing x-amz-content-sha256 (client input) -> WARNING, never ERROR."""
+    caplog.set_level(logging.DEBUG, logger="gateway.middlewares.sigv4")
+
+    request = make_request(method="PUT", headers={"host": "s3.hippius.com", "x-amz-date": "20260101T000000Z"})
+
+    with pytest.raises(AuthParsingError):
+        await create_canonical_request(
+            request=request,
+            signed_headers=["host", "x-amz-date"],
+            method="PUT",
+            path="/bucket/key",
+            query_string="",
+        )
+
+    matched = _records(caplog, "Missing x-amz-content-sha256 header")
+    assert matched, "expected the missing-payload-hash rejection to be logged"
+    assert all(r.levelname == "WARNING" for r in matched)
+    assert not any(r.levelname == "ERROR" for r in matched)


### PR DESCRIPTION
## Summary
Client-driven gateway auth rejections (malformed credentials, bad presigned-URL params, missing headers, signature/date-scope mismatches) were logged at **ERROR**, flooding the ERROR dashboards even though these are expected 4xx client rejections (`server_errors=0`). The repo already logs most such rejections at WARNING; this normalizes the rest.

## Changes
Swap `logger.error` → `logger.warning` (message text unchanged) at 12 unambiguously client-input-driven sites:
- `gateway/services/auth_orchestrator.py` — `Failed to extract credential` (malformed `Authorization`).
- `gateway/middlewares/access_key_auth.py` — missing auth headers; the presigned-URL validation block (missing/invalid `X-Amz-*` params, credential-ID mismatch, date-scope mismatch, expiry range, date format, missing signed `host`).
- `gateway/middlewares/sigv4.py` — `Missing x-amz-content-sha256 header`.

**Left at ERROR (server/upstream, not client):** `HippiusAPIError`/Arion upstream (→503); the ASGI `raw_path` contract violation; and `Invalid account address format` / `Invalid token type` — these read the **upstream auth API's** response (`account_address`/`token_type`), not client input, so a client cannot drive them.

## Testing
`tests/unit/gateway/test_auth_log_levels.py` (adversarial, asserts `record.levelname`): malformed credential → WARNING; invalid presigned credential → WARNING; expired/mismatched signature → WARNING; missing payload hash → WARNING; and **an upstream `HippiusAPIError` still logs ERROR** (proves no over-downgrade). 5 new + 29 regression green.

## Note
The specific `Bad seed phrase format` / `non-ASCII bytes` lines from the prod snapshots were already removed in `899867a`, but the ERROR-vs-WARNING inconsistency class persisted at the sites above.

## Conclusion
Cleans ERROR-dashboard noise; no data-path or behavior change (levels only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
