### PR TITLE
fix(writer): retry object_versions_pkey conflict on all reserve paths

### DIFF
--- a/docs/issues/object-versions-pkey-race.md
+++ b/docs/issues/object-versions-pkey-race.md
@@ -48,7 +48,16 @@ regression. The migrator intentionally keeps create and swap separate. Rejected.
 Generalize PR #243's approach into one shared helper and apply it to all four reserve
 callers (no duplicated retry loops):
 
-`hippius_s3/writer/db.py::retry_on_object_version_conflict(reserve, *, attempts=3)`
+`hippius_s3/db_retry.py::retry_on_object_version_conflict(reserve, *, attempts=3)`
+
+> The helper lives in a **lightweight top-level `hippius_s3/db_retry.py`** (only imports
+> `asyncpg`), NOT in `hippius_s3/writer/db.py`. One caller — `repositories/objects.py` — is
+> imported by the **gateway** (via `repositories/__init__.py`, which eagerly
+> `from .objects import ObjectRepository`). `hippius_s3/writer/__init__.py` in turn eagerly
+> `from .object_writer import ObjectWriter`, which drags in `cache`, `crypto_service`, and KMS.
+> So importing anything from `writer/*` into `objects.py` would load the whole write/crypto/KMS
+> stack into the gateway process at startup and make its container unhealthy (caught in E2E).
+> Keeping the helper out of the `writer` package avoids that.
 - Runs `reserve()`; on `asyncpg.UniqueViolationError` **scoped to `object_versions_pkey`**,
   retries. Each `reserve()` runs in its own autocommit statement / fresh transaction, so the
   retry re-reads the committed `MAX` and converges (typically attempt 2).

--- a/docs/issues/object-versions-pkey-race.md
+++ b/docs/issues/object-versions-pkey-race.md
@@ -1,0 +1,77 @@
+# object_versions_pkey duplicate-key race on concurrent version reservation
+
+## Summary
+Concurrent writes to the same object can 500 the client with
+`duplicate key value violates unique constraint "object_versions_pkey"`. PR #243
+closed this for the simple/streaming PUT path only; three other version-reservation
+callers (multipart initiate, copy fast-path, `upsert_with_cid`) had no protection.
+
+## Impact
+- Client receives S3 `InternalError` (HTTP 500) for a write that should succeed —
+  the racing request is lost, not retried.
+- Data path only: no corruption. `server_errors=0` in prod health snapshots (the 500 is
+  logged as an app ERROR, not a gateway 5xx audit line), so it hides in the noise.
+- Low but non-zero frequency; observed intermittently in prod api logs (1–2×/window).
+
+## Root cause
+`object_versions` PK is composite `(object_id, object_version)` with **no sequence** —
+`object_version` is allocated in SQL as:
+
+```
+GREATEST(objects.current_object_version, MAX(object_versions.object_version)) + 1
+```
+
+inside `upsert_object_*.sql`'s `ON CONFLICT DO UPDATE`. The `objects.current_object_version`
+term is row-locked and re-read post-lock (EvalPlanQual), which serializes PUT-vs-PUT. But
+the `MAX(object_version)` term is a **snapshot-stale subquery under READ COMMITTED**.
+
+`create_migration_version.sql` (the v4→v5 migrator) inserts a new version **without**
+bumping `current_object_version` — it deliberately leaves the pointer behind and only
+advances it later via `swap_current_version_cas.sql` once the migrated data is ready.
+That leaves `current_object_version` behind `MAX(object_version)`, so a writer whose snapshot
+predates the migrator's commit computes `GREATEST(1, stale 1) + 1 = 2`, collides with the
+migration's version 2, and raises `object_versions_pkey`.
+
+PR #243 (commit `375c043`) added a bounded retry-in-a-fresh-transaction, but **only** in
+`put_simple_stream_full`. The identical allocation is used, unguarded, by:
+- `hippius_s3/api/s3/multipart.py` — multipart initiate (`upsert_object_multipart`)
+- `hippius_s3/services/copy_service_v5.py` — copy fast-path (`upsert_object_basic`)
+- `hippius_s3/repositories/objects.py::upsert_with_cid` (`upsert_object_with_cid`)
+
+## Why not "just bump the counter in the migrator"
+Making `create_migration_version` advance `current_object_version` would make the collision
+structurally impossible — but it would also expose a **half-migrated version as the current
+(served) version** in the window before the migrated data lands, which is a correctness
+regression. The migrator intentionally keeps create and swap separate. Rejected.
+
+## Fix
+Generalize PR #243's approach into one shared helper and apply it to all four reserve
+callers (no duplicated retry loops):
+
+`hippius_s3/writer/db.py::retry_on_object_version_conflict(reserve, *, attempts=3)`
+- Runs `reserve()`; on `asyncpg.UniqueViolationError` **scoped to `object_versions_pkey`**,
+  retries. Each `reserve()` runs in its own autocommit statement / fresh transaction, so the
+  retry re-reads the committed `MAX` and converges (typically attempt 2).
+- Bounded: a persistent collision re-raises (a real error, not masked).
+- Scoped to the one constraint: a unique violation on any **other** constraint surfaces
+  immediately rather than being retried and hidden.
+
+`put_simple_stream_full` was refactored to call the helper too (the inline retry is gone),
+so all four paths share one implementation.
+
+## Testing
+- `tests/unit/test_object_version_retry.py` (adversarial, no DB): first-try success does not
+  retry; retries on `object_versions_pkey` and converges; **exhaustion re-raises and stays
+  bounded** (no infinite loop); a **different constraint is not retried** (call count == 1);
+  unrelated exceptions are not swallowed.
+- `tests/integration/test_object_version_concurrency_sql.py` (live Postgres, runs in CI):
+  the existing raw-collision test is retained; a new test drives a real migrator-vs-write race
+  through the helper on the **multipart** reserve and asserts it resolves to v3 with no error —
+  proving the wiring on a previously-unguarded path.
+
+## Alternatives considered
+- Advisory lock in the upsert statements — fragile: the writer locks the *candidate* object_id
+  (a fresh UUID) on the conflict path, not the resolved existing object_id the migrator locks,
+  so they wouldn't serialize.
+- Split `current_object_version` into a separate next-version counter vs current pointer — the
+  truly correct structural fix, but a larger schema change; out of scope here.

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -28,13 +28,13 @@ from hippius_s3.api.s3.common import format_s3_timestamp
 from hippius_s3.api.s3.errors import s3_error_response
 from hippius_s3.cache import RedisObjectPartsCache
 from hippius_s3.config import get_config
+from hippius_s3.db_retry import retry_on_object_version_conflict
 from hippius_s3.monitoring import get_metrics_collector
 from hippius_s3.queue import Chunk
 from hippius_s3.queue import UploadChainRequest
 from hippius_s3.queue import enqueue_upload_request
 from hippius_s3.storage_version import require_supported_storage_version
 from hippius_s3.utils import get_query
-from hippius_s3.writer.db import retry_on_object_version_conflict
 from hippius_s3.writer.object_writer import ObjectWriter
 from hippius_s3.xml_helpers import add_subelement
 from hippius_s3.xml_helpers import create_element

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -34,6 +34,7 @@ from hippius_s3.queue import UploadChainRequest
 from hippius_s3.queue import enqueue_upload_request
 from hippius_s3.storage_version import require_supported_storage_version
 from hippius_s3.utils import get_query
+from hippius_s3.writer.db import retry_on_object_version_conflict
 from hippius_s3.writer.object_writer import ObjectWriter
 from hippius_s3.xml_helpers import add_subelement
 from hippius_s3.xml_helpers import create_element
@@ -261,19 +262,23 @@ async def initiate_multipart_upload(
                 status_code=400,
             )
 
-        # Create initial objects row for this multipart upload
-        upsert_result = await db.fetchrow(
-            get_query("upsert_object_multipart"),
-            object_id,
-            bucket["bucket_id"],
-            object_key,
-            content_type,
-            json.dumps(metadata),
-            "",  # initial md5_hash (will be updated on completion)
-            0,  # initial size_bytes (will be updated on completion)
-            initiated_at,  # created_at
-            config.target_storage_version,
-            config.upload_backends,
+        # Create initial objects row for this multipart upload. The version allocation can collide
+        # with a concurrent create_migration_version on object_versions_pkey; retry re-reads the
+        # committed MAX in a fresh autocommit statement (see writer/db.py).
+        upsert_result = await retry_on_object_version_conflict(
+            lambda: db.fetchrow(
+                get_query("upsert_object_multipart"),
+                object_id,
+                bucket["bucket_id"],
+                object_key,
+                content_type,
+                json.dumps(metadata),
+                "",  # initial md5_hash (will be updated on completion)
+                0,  # initial size_bytes (will be updated on completion)
+                initiated_at,  # created_at
+                config.target_storage_version,
+                config.upload_backends,
+            )
         )
 
         # Use the returned object_id (will be existing one if conflict occurred)

--- a/hippius_s3/db_retry.py
+++ b/hippius_s3/db_retry.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from collections.abc import Callable
+from typing import Any
+
+import asyncpg
+
+
+OBJECT_VERSION_PK_CONSTRAINT = "object_versions_pkey"
+
+
+async def retry_on_object_version_conflict(reserve: Callable[[], Awaitable[Any]], *, attempts: int = 3) -> Any:
+    # The upsert_object_* queries allocate the next version as
+    # GREATEST(objects.current_object_version, MAX(object_versions.object_version)) + 1. The
+    # row-locked counter closes the PUT-vs-PUT race, but the MAX() floor is snapshot-stale under
+    # READ COMMITTED, so a concurrent create_migration_version (which inserts a version WITHOUT
+    # bumping current_object_version) can hand back a colliding version and raise
+    # object_versions_pkey. Retrying re-reads the committed MAX and resolves it — but only if each
+    # reserve() runs in its own autocommit statement / fresh transaction (a fresh snapshot). Scoped
+    # to that one constraint so we never mask an unrelated unique violation, and bounded so a
+    # persistent collision is a real error and surfaces.
+    #
+    # Lives here (not in writer/db.py) so repositories/objects.py — imported by the gateway via
+    # repositories/__init__ — can use it without dragging the whole writer/crypto/KMS import stack
+    # into the gateway process.
+    for attempt in range(attempts):
+        try:
+            return await reserve()
+        except asyncpg.exceptions.UniqueViolationError as exc:
+            # asyncpg populates constraint_name dynamically from the error fields (not in the type
+            # stubs), so read it defensively — a missing/other constraint is not our race.
+            if getattr(exc, "constraint_name", None) != OBJECT_VERSION_PK_CONSTRAINT or attempt == attempts - 1:
+                raise
+    raise RuntimeError("retry_on_object_version_conflict exhausted without returning")

--- a/hippius_s3/repositories/objects.py
+++ b/hippius_s3/repositories/objects.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import Any
 from typing import Optional
 
+from hippius_s3.db_retry import retry_on_object_version_conflict
 from hippius_s3.utils import get_query
-from hippius_s3.writer.db import retry_on_object_version_conflict
 
 
 class ObjectRepository:

--- a/hippius_s3/repositories/objects.py
+++ b/hippius_s3/repositories/objects.py
@@ -4,6 +4,7 @@ from typing import Any
 from typing import Optional
 
 from hippius_s3.utils import get_query
+from hippius_s3.writer.db import retry_on_object_version_conflict
 
 
 class ObjectRepository:
@@ -47,17 +48,21 @@ class ObjectRepository:
         storage_version: int,
         upload_backends: list[str] | None = None,
     ) -> Any:
-        return await self._db.fetchrow(
-            get_query("upsert_object_with_cid"),
-            object_id,
-            bucket_id,
-            object_key,
-            cid_id,
-            size_bytes,
-            content_type,
-            created_at,
-            metadata_json,
-            md5_hash,
-            storage_version,
-            upload_backends,
+        # Version allocation can collide with a concurrent create_migration_version on
+        # object_versions_pkey; retry re-reads the committed MAX in a fresh autocommit statement.
+        return await retry_on_object_version_conflict(
+            lambda: self._db.fetchrow(
+                get_query("upsert_object_with_cid"),
+                object_id,
+                bucket_id,
+                object_key,
+                cid_id,
+                size_bytes,
+                content_type,
+                created_at,
+                metadata_json,
+                md5_hash,
+                storage_version,
+                upload_backends,
+            )
         )

--- a/hippius_s3/services/copy_service_v5.py
+++ b/hippius_s3/services/copy_service_v5.py
@@ -15,6 +15,7 @@ from hippius_s3.services.parts_service import upsert_part_placeholder
 from hippius_s3.storage_version import require_supported_storage_version
 from hippius_s3.utils import get_query
 from hippius_s3.writer.db import ensure_upload_row
+from hippius_s3.writer.db import retry_on_object_version_conflict
 from hippius_s3.writer.db import upsert_object_basic
 
 
@@ -90,17 +91,21 @@ async def create_destination_objects(
 ) -> int:
     src_storage_version = require_supported_storage_version(int(src_obj_row.get("storage_version")))
 
-    row = await upsert_object_basic(
-        db,
-        object_id=object_id,
-        bucket_id=str(dest_bucket["bucket_id"]),
-        object_key=object_key,
-        content_type=content_type,
-        metadata=metadata,
-        md5_hash=md5_hash,
-        size_bytes=size_bytes,
-        storage_version=src_storage_version,
-        upload_backends=config.upload_backends,
+    # Version allocation can collide with a concurrent create_migration_version on
+    # object_versions_pkey; retry re-reads the committed MAX in a fresh autocommit statement.
+    row = await retry_on_object_version_conflict(
+        lambda: upsert_object_basic(
+            db,
+            object_id=object_id,
+            bucket_id=str(dest_bucket["bucket_id"]),
+            object_key=object_key,
+            content_type=content_type,
+            metadata=metadata,
+            md5_hash=md5_hash,
+            size_bytes=size_bytes,
+            storage_version=src_storage_version,
+            upload_backends=config.upload_backends,
+        )
     )
     dest_object_version = int(row.get("current_object_version") or 1) if row else 1
 

--- a/hippius_s3/services/copy_service_v5.py
+++ b/hippius_s3/services/copy_service_v5.py
@@ -11,11 +11,11 @@ from hippius_s3.api.s3.copy_helpers import build_copy_success_response
 from hippius_s3.api.s3.copy_helpers import parse_object_metadata
 from hippius_s3.api.s3.copy_helpers import resolve_chunk_size
 from hippius_s3.config import Config
+from hippius_s3.db_retry import retry_on_object_version_conflict
 from hippius_s3.services.parts_service import upsert_part_placeholder
 from hippius_s3.storage_version import require_supported_storage_version
 from hippius_s3.utils import get_query
 from hippius_s3.writer.db import ensure_upload_row
-from hippius_s3.writer.db import retry_on_object_version_conflict
 from hippius_s3.writer.db import upsert_object_basic
 
 

--- a/hippius_s3/writer/db.py
+++ b/hippius_s3/writer/db.py
@@ -30,7 +30,9 @@ async def retry_on_object_version_conflict(reserve: Callable[[], Awaitable[Any]]
         try:
             return await reserve()
         except asyncpg.exceptions.UniqueViolationError as exc:
-            if exc.constraint_name != OBJECT_VERSION_PK_CONSTRAINT or attempt == attempts - 1:
+            # asyncpg populates constraint_name dynamically from the error fields (not in the type
+            # stubs), so read it defensively — a missing/other constraint is not our race.
+            if getattr(exc, "constraint_name", None) != OBJECT_VERSION_PK_CONSTRAINT or attempt == attempts - 1:
                 raise
     raise RuntimeError("retry_on_object_version_conflict exhausted without returning")
 

--- a/hippius_s3/writer/db.py
+++ b/hippius_s3/writer/db.py
@@ -2,39 +2,11 @@ from __future__ import annotations
 
 import json
 import uuid
-from collections.abc import Awaitable
-from collections.abc import Callable
 from datetime import datetime
 from datetime import timezone
 from typing import Any
 
-import asyncpg
-
 from hippius_s3.utils import get_query
-
-
-OBJECT_VERSION_PK_CONSTRAINT = "object_versions_pkey"
-
-
-async def retry_on_object_version_conflict(reserve: Callable[[], Awaitable[Any]], *, attempts: int = 3) -> Any:
-    # The upsert_object_* queries allocate the next version as
-    # GREATEST(objects.current_object_version, MAX(object_versions.object_version)) + 1. The
-    # row-locked counter closes the PUT-vs-PUT race, but the MAX() floor is snapshot-stale under
-    # READ COMMITTED, so a concurrent create_migration_version (which inserts a version WITHOUT
-    # bumping current_object_version) can hand back a colliding version and raise
-    # object_versions_pkey. Retrying re-reads the committed MAX and resolves it — but only if each
-    # reserve() runs in its own autocommit statement / fresh transaction (a fresh snapshot). Scoped
-    # to that one constraint so we never mask an unrelated unique violation, and bounded so a
-    # persistent collision is a real error and surfaces.
-    for attempt in range(attempts):
-        try:
-            return await reserve()
-        except asyncpg.exceptions.UniqueViolationError as exc:
-            # asyncpg populates constraint_name dynamically from the error fields (not in the type
-            # stubs), so read it defensively — a missing/other constraint is not our race.
-            if getattr(exc, "constraint_name", None) != OBJECT_VERSION_PK_CONSTRAINT or attempt == attempts - 1:
-                raise
-    raise RuntimeError("retry_on_object_version_conflict exhausted without returning")
 
 
 async def upsert_object_basic(

--- a/hippius_s3/writer/db.py
+++ b/hippius_s3/writer/db.py
@@ -2,11 +2,37 @@ from __future__ import annotations
 
 import json
 import uuid
+from collections.abc import Awaitable
+from collections.abc import Callable
 from datetime import datetime
 from datetime import timezone
 from typing import Any
 
+import asyncpg
+
 from hippius_s3.utils import get_query
+
+
+OBJECT_VERSION_PK_CONSTRAINT = "object_versions_pkey"
+
+
+async def retry_on_object_version_conflict(reserve: Callable[[], Awaitable[Any]], *, attempts: int = 3) -> Any:
+    # The upsert_object_* queries allocate the next version as
+    # GREATEST(objects.current_object_version, MAX(object_versions.object_version)) + 1. The
+    # row-locked counter closes the PUT-vs-PUT race, but the MAX() floor is snapshot-stale under
+    # READ COMMITTED, so a concurrent create_migration_version (which inserts a version WITHOUT
+    # bumping current_object_version) can hand back a colliding version and raise
+    # object_versions_pkey. Retrying re-reads the committed MAX and resolves it — but only if each
+    # reserve() runs in its own autocommit statement / fresh transaction (a fresh snapshot). Scoped
+    # to that one constraint so we never mask an unrelated unique violation, and bounded so a
+    # persistent collision is a real error and surfaces.
+    for attempt in range(attempts):
+        try:
+            return await reserve()
+        except asyncpg.exceptions.UniqueViolationError as exc:
+            if exc.constraint_name != OBJECT_VERSION_PK_CONSTRAINT or attempt == attempts - 1:
+                raise
+    raise RuntimeError("retry_on_object_version_conflict exhausted without returning")
 
 
 async def upsert_object_basic(

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -25,6 +25,7 @@ from hippius_s3.services.parts_service import upsert_part_placeholder
 from hippius_s3.storage_version import require_supported_storage_version
 from hippius_s3.utils import get_query
 from hippius_s3.writer.db import ensure_upload_row
+from hippius_s3.writer.db import retry_on_object_version_conflict
 from hippius_s3.writer.db import upsert_object_basic
 from hippius_s3.writer.types import AppendPreconditionFailed
 from hippius_s3.writer.types import CompleteResult
@@ -194,7 +195,6 @@ class ObjectWriter:
         resolved_storage_version = require_supported_storage_version(resolved_storage_version)
         suite_id: str | None = None
         kek_id = None
-        wrapped_dek = None
 
         part_number = 1
 
@@ -229,62 +229,60 @@ class ObjectWriter:
             # closes the concurrent PUT-vs-PUT race, but the MAX() floor is snapshot-stale under
             # READ COMMITTED, so a concurrent create_migration_version (which inserts a version
             # WITHOUT bumping current_object_version) can still hand us a colliding version and
-            # raise object_versions_pkey. Retry on that specific violation: a fresh transaction
-            # re-reads the committed MAX and resolves it. Bounded — a persistent collision is a
-            # real error and must surface.
-            for reserve_attempt in range(3):
-                try:
-                    async with (
-                        acquire_with_timeout(self.pool, self.config.db_pool_acquire_timeout) as conn,
-                        conn.transaction(),
-                    ):
-                        reserve_row = await upsert_object_basic(
-                            conn,
-                            object_id=candidate_object_id,
-                            bucket_id=bucket_id,
-                            object_key=object_key,
-                            content_type=content_type,
-                            metadata=metadata,
-                            md5_hash="",
-                            size_bytes=0,
-                            storage_version=resolved_storage_version,
-                            upload_backends=self.config.upload_backends,
-                        )
-                        # IMPORTANT: `object_id` is authoritative from DB. Under concurrent creates,
-                        # our candidate UUID may conflict with an existing (bucket_id, object_key).
-                        # We must use the DB-returned object_id for cache keys, crypto binding, and enqueue.
-                        if reserve_row and reserve_row.get("object_id") is None:
-                            raise RuntimeError("reserve_version_missing_object_id")
-                        object_id = (
-                            str(reserve_row.get("object_id") or candidate_object_id)
-                            if reserve_row
-                            else str(candidate_object_id)
-                        )
-                        object_version = int(reserve_row.get("current_object_version") or 1) if reserve_row else 1
+            # raise object_versions_pkey. retry_on_object_version_conflict re-runs this reserve in a
+            # fresh transaction — a fresh snapshot re-reads the committed MAX and resolves it.
+            # Bounded — a persistent collision is a real error and must surface.
+            async def _reserve_version() -> tuple[str, int]:
+                async with (
+                    acquire_with_timeout(self.pool, self.config.db_pool_acquire_timeout) as conn,
+                    conn.transaction(),
+                ):
+                    reserve_row = await upsert_object_basic(
+                        conn,
+                        object_id=candidate_object_id,
+                        bucket_id=bucket_id,
+                        object_key=object_key,
+                        content_type=content_type,
+                        metadata=metadata,
+                        md5_hash="",
+                        size_bytes=0,
+                        storage_version=resolved_storage_version,
+                        upload_backends=self.config.upload_backends,
+                    )
+                    # IMPORTANT: `object_id` is authoritative from DB. Under concurrent creates,
+                    # our candidate UUID may conflict with an existing (bucket_id, object_key).
+                    # We must use the DB-returned object_id for cache keys, crypto binding, and enqueue.
+                    if reserve_row and reserve_row.get("object_id") is None:
+                        raise RuntimeError("reserve_version_missing_object_id")
+                    resolved_object_id = (
+                        str(reserve_row.get("object_id") or candidate_object_id)
+                        if reserve_row
+                        else str(candidate_object_id)
+                    )
+                    resolved_version = int(reserve_row.get("current_object_version") or 1) if reserve_row else 1
 
-                        aad = f"hippius-dek:{bucket_id}:{object_id}:{int(object_version)}".encode("utf-8")
-                        wrapped_dek = wrap_dek(kek=kek_bytes, dek=dek, aad=aad)
-                        await conn.execute(
-                            """
-                            UPDATE object_versions
-                               SET encryption_version = 5,
-                                   enc_suite_id = $1,
-                                   enc_chunk_size_bytes = $2,
-                                   kek_id = $3,
-                                   wrapped_dek = $4
-                             WHERE object_id = $5 AND object_version = $6
-                            """,
-                            str(suite_id),
-                            int(chunk_size),
-                            kek_id,
-                            wrapped_dek,
-                            object_id,
-                            int(object_version),
-                        )
-                    break
-                except asyncpg.exceptions.UniqueViolationError:
-                    if reserve_attempt == 2:
-                        raise
+                    aad = f"hippius-dek:{bucket_id}:{resolved_object_id}:{int(resolved_version)}".encode("utf-8")
+                    wrapped_dek = wrap_dek(kek=kek_bytes, dek=dek, aad=aad)
+                    await conn.execute(
+                        """
+                        UPDATE object_versions
+                           SET encryption_version = 5,
+                               enc_suite_id = $1,
+                               enc_chunk_size_bytes = $2,
+                               kek_id = $3,
+                               wrapped_dek = $4
+                         WHERE object_id = $5 AND object_version = $6
+                        """,
+                        str(suite_id),
+                        int(chunk_size),
+                        kek_id,
+                        wrapped_dek,
+                        resolved_object_id,
+                        int(resolved_version),
+                    )
+                    return resolved_object_id, resolved_version
+
+            object_id, object_version = await retry_on_object_version_conflict(_reserve_version)
 
         hasher = hashlib.md5()
         total_size = 0

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -20,12 +20,12 @@ from hippius_s3.cache import RedisObjectPartsCache
 from hippius_s3.cache import create_fs_store
 from hippius_s3.config import get_config
 from hippius_s3.db_pool import acquire_with_timeout
+from hippius_s3.db_retry import retry_on_object_version_conflict
 from hippius_s3.services.crypto_service import CryptoService
 from hippius_s3.services.parts_service import upsert_part_placeholder
 from hippius_s3.storage_version import require_supported_storage_version
 from hippius_s3.utils import get_query
 from hippius_s3.writer.db import ensure_upload_row
-from hippius_s3.writer.db import retry_on_object_version_conflict
 from hippius_s3.writer.db import upsert_object_basic
 from hippius_s3.writer.types import AppendPreconditionFailed
 from hippius_s3.writer.types import CompleteResult

--- a/tests/integration/test_object_version_concurrency_sql.py
+++ b/tests/integration/test_object_version_concurrency_sql.py
@@ -26,12 +26,15 @@ import asyncio
 import json
 import os
 import uuid
+from datetime import datetime
+from datetime import timezone
 from typing import Any
 
 import asyncpg
 import pytest
 
 from hippius_s3.utils import get_query
+from hippius_s3.writer.db import retry_on_object_version_conflict
 from hippius_s3.writer.db import upsert_object_basic
 
 
@@ -191,6 +194,71 @@ async def test_migration_version_race_collides_and_retry_resolves_it() -> None:
         retried = await _upsert(conn_p, bucket_id, key)
         assert retried["current_object_version"] == 3
         assert retried["object_id"] == object_id
+    finally:
+        if task_p is not None and not task_p.done():
+            task_p.cancel()
+        if conn_m.is_in_transaction():
+            await tr_m.rollback()
+        await _cleanup(setup, bucket_id, acct)
+        await conn_m.close()
+        await conn_p.close()
+        await setup.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_race_resolved_by_retry_helper_on_multipart_reserve() -> None:
+    """End-to-end wiring: retry_on_object_version_conflict wraps the multipart reserve, so a
+    migration-version collision that raises object_versions_pkey is retried in a fresh statement
+    and succeeds with v3 — no 500 reaches the caller. Mirrors the raw-collision test above but
+    exercises the helper on the (previously unguarded) multipart path."""
+    setup = await _connect_or_skip()
+    conn_m = await _connect_or_skip()
+    conn_p = await _connect_or_skip()  # autocommit — each helper retry is a fresh snapshot
+    acct = f"5MPRACE{uuid.uuid4().hex[:12]}"
+    bucket_id = uuid.uuid4()
+    key = f"mprace-{uuid.uuid4()}"
+    tr_m = conn_m.transaction()
+    task_p: asyncio.Task | None = None
+
+    async def _reserve_multipart() -> Any:
+        return await conn_p.fetchrow(
+            get_query("upsert_object_multipart"),
+            str(uuid.uuid4()),
+            str(bucket_id),
+            key,
+            "application/octet-stream",
+            json.dumps({}),
+            "",
+            0,
+            datetime.now(timezone.utc),
+            5,
+            ["arion"],
+        )
+
+    try:
+        await _seed_bucket(setup, acct, bucket_id)
+        first = await _upsert(setup, bucket_id, key)
+        object_id = first["object_id"]
+        assert first["current_object_version"] == 1
+
+        # Migrator inserts v2 without bumping current_object_version, holding the objects row.
+        await tr_m.start()
+        migrated = await conn_m.fetchval(
+            get_query("create_migration_version"), str(object_id), "x", json.dumps({}), 5, ["arion"]
+        )
+        assert migrated == 2
+
+        # The helper-wrapped multipart reserve blocks on the migrator's row lock (pre-commit snapshot).
+        task_p = asyncio.create_task(retry_on_object_version_conflict(_reserve_multipart))
+        await asyncio.sleep(0.5)
+        assert not task_p.done()
+
+        # Migrator commits v2: attempt 1 collides on object_versions_pkey, the helper retries in a
+        # fresh statement that sees the committed MAX and takes v3 — the caller never sees the error.
+        await tr_m.commit()
+        row_p = await task_p
+        assert row_p["object_id"] == object_id
+        assert row_p["current_object_version"] == 3
     finally:
         if task_p is not None and not task_p.done():
             task_p.cancel()

--- a/tests/integration/test_object_version_concurrency_sql.py
+++ b/tests/integration/test_object_version_concurrency_sql.py
@@ -33,8 +33,8 @@ from typing import Any
 import asyncpg
 import pytest
 
+from hippius_s3.db_retry import retry_on_object_version_conflict
 from hippius_s3.utils import get_query
-from hippius_s3.writer.db import retry_on_object_version_conflict
 from hippius_s3.writer.db import upsert_object_basic
 
 

--- a/tests/unit/test_object_version_retry.py
+++ b/tests/unit/test_object_version_retry.py
@@ -1,0 +1,110 @@
+"""Adversarial unit tests for retry_on_object_version_conflict.
+
+The helper wraps the version-reservation of every object write path (simple PUT,
+multipart initiate, copy fast-path, upsert_with_cid) so a snapshot-stale
+object_versions_pkey collision with a concurrent create_migration_version is
+retried in a fresh statement. These pin the branch logic without a DB:
+- succeed on first try (no wasted retries),
+- retry on object_versions_pkey and converge,
+- stay bounded and re-raise on persistent collision (never loop forever),
+- NOT retry a unique violation on a different constraint (don't mask real bugs),
+- never swallow unrelated exceptions.
+"""
+
+import asyncpg
+import pytest
+
+from hippius_s3.writer.db import OBJECT_VERSION_PK_CONSTRAINT
+from hippius_s3.writer.db import retry_on_object_version_conflict
+
+
+def _unique_violation(constraint: str) -> asyncpg.exceptions.UniqueViolationError:
+    exc = asyncpg.exceptions.UniqueViolationError("duplicate key value violates unique constraint")
+    exc.constraint_name = constraint
+    return exc
+
+
+@pytest.mark.asyncio
+async def test_returns_first_result_without_retrying() -> None:
+    calls = 0
+
+    async def reserve() -> str:
+        nonlocal calls
+        calls += 1
+        return "row"
+
+    assert await retry_on_object_version_conflict(reserve) == "row"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_retries_on_object_versions_pkey_then_succeeds() -> None:
+    calls = 0
+
+    async def reserve() -> str:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise _unique_violation(OBJECT_VERSION_PK_CONSTRAINT)
+        return "row-3"
+
+    assert await retry_on_object_version_conflict(reserve, attempts=3) == "row-3"
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_reraises_after_exhausting_attempts_and_stays_bounded() -> None:
+    calls = 0
+
+    async def reserve() -> str:
+        nonlocal calls
+        calls += 1
+        raise _unique_violation(OBJECT_VERSION_PK_CONSTRAINT)
+
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await retry_on_object_version_conflict(reserve, attempts=3)
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_single_attempt_reraises_immediately() -> None:
+    calls = 0
+
+    async def reserve() -> str:
+        nonlocal calls
+        calls += 1
+        raise _unique_violation(OBJECT_VERSION_PK_CONSTRAINT)
+
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await retry_on_object_version_conflict(reserve, attempts=1)
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_a_different_constraint() -> None:
+    # A unique violation on any OTHER constraint (e.g. objects_pkey) is not the migration race —
+    # it must surface immediately instead of being retried and masked.
+    calls = 0
+
+    async def reserve() -> str:
+        nonlocal calls
+        calls += 1
+        raise _unique_violation("objects_pkey")
+
+    with pytest.raises(asyncpg.exceptions.UniqueViolationError):
+        await retry_on_object_version_conflict(reserve, attempts=3)
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_does_not_swallow_unrelated_errors() -> None:
+    calls = 0
+
+    async def reserve() -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await retry_on_object_version_conflict(reserve, attempts=3)
+    assert calls == 1

--- a/tests/unit/test_object_version_retry.py
+++ b/tests/unit/test_object_version_retry.py
@@ -14,8 +14,8 @@ retried in a fresh statement. These pin the branch logic without a DB:
 import asyncpg
 import pytest
 
-from hippius_s3.writer.db import OBJECT_VERSION_PK_CONSTRAINT
-from hippius_s3.writer.db import retry_on_object_version_conflict
+from hippius_s3.db_retry import OBJECT_VERSION_PK_CONSTRAINT
+from hippius_s3.db_retry import retry_on_object_version_conflict
 
 
 def _unique_violation(constraint: str) -> asyncpg.exceptions.UniqueViolationError:


### PR DESCRIPTION
## Summary
Concurrent writes to the same object can 500 the client with `duplicate key value violates unique constraint "object_versions_pkey"`. PR #243 closed this for the simple/streaming PUT path only; **multipart initiate, the copy fast-path, and `upsert_with_cid` had no protection.**

## Root cause
`object_version` is allocated in SQL as `GREATEST(objects.current_object_version, MAX(object_versions.object_version)) + 1`. The row-locked counter serializes PUT-vs-PUT, but the `MAX()` term is snapshot-stale under READ COMMITTED. `create_migration_version` (v4→v5 migrator) inserts a version **without** bumping `current_object_version` (it flips the pointer later via `swap_current_version_cas` once data is ready), so a writer racing the migrator computes a colliding version → `object_versions_pkey` → 500.

## Changes
- Add `retry_on_object_version_conflict(reserve, *, attempts=3)` in `hippius_s3/writer/db.py` — retries `reserve()` on a `UniqueViolationError` **scoped to `object_versions_pkey`**, each attempt in a fresh autocommit statement/transaction (fresh snapshot re-reads the committed `MAX`). Bounded; a persistent collision re-raises; a different constraint surfaces immediately.
- Apply it to all four reserve callers (simple PUT refactored to share it; multipart, copy_v5, upsert_with_cid newly guarded) — one implementation, no duplicated retry loops.

## Why not "bump the counter in the migrator"
That would make the collision impossible but expose a **half-migrated version as current** before its data lands — a correctness regression. Rejected.

## Testing
- `tests/unit/test_object_version_retry.py` (no DB): first-try no-retry; converge on `object_versions_pkey`; **exhaustion re-raises and stays bounded**; a **different constraint is not retried**; unrelated errors not swallowed.
- `tests/integration/test_object_version_concurrency_sql.py` (live PG, CI): existing raw-collision test retained; new test drives a real migrator-vs-write race **through the helper on the multipart path** and asserts it resolves to v3 with no error.

## Conclusion
Eliminates the intermittent 500 on all version-reservation paths; simple, in-pattern, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
