### PR TITLE
perf(unpinner): reuse Arion client + bound DB pool for higher parallelism

### DIFF
--- a/docs/issues/unpinner-throughput.md
+++ b/docs/issues/unpinner-throughput.md
@@ -1,0 +1,104 @@
+# Arion unpinner throughput (~10x drain deficit)
+
+## Summary
+
+Live prod incident: the `arion_unpin_requests` queue is ~1.6M and growing. The unpinner drains
+~446/min across 3 pods while inflow is ~4400/min — a ~10x deficit. As `redis-queues` fills it slows
+down, which mirrors a prior incident where **1.29M** `arion_unpin_requests` made redis slow enough to
+cause prod GET `IncompleteRead`s (see the team memory note "redis-queues unpin overrun incident";
+cleared then with `UNLINK`). We need high parallelism to be both **safe** and **effective**.
+
+## Root cause
+
+Per-pod effective concurrency was pinned low by two things:
+
+1. **Per-request ArionClient re-handshake.** `process_unpin_request` opened
+   `async with backend_client_factory() as client:` for **every** request, i.e. a brand-new
+   `ArionClient` (new `httpx.AsyncClient` + TLS handshake) per request. In prod nearly every unpin
+   request is a single chunk, so the shared per-pod Arion-DELETE budget (`HIPPIUS_UNPINNER_PARALLELISM`)
+   was mostly dead — effective concurrency was really just `HIPPIUS_UNPINNER_MAX_INFLIGHT` (was 4),
+   each paying a full handshake. Raising inflight without fixing this would just multiply handshakes and
+   storm ephemeral ports. Contrast `run_arion_uploader_in_loop.py`, which builds one `ArionClient()` for
+   the whole loop and reuses it.
+
+2. **Inflight ceiling coupled to the DB pool.** Raising `MAX_INFLIGHT` grew the pool floor
+   (`delete_concurrency + max_inflight`) unboundedly. Per pod × replicas already runs close to Postgres
+   `max_connections`, so cranking inflight risked exhausting Postgres.
+
+## Fix (code — this PR)
+
+- **Reuse one client across the loop.** `run_unpinner_loop` now creates the backend client once
+  (`async with backend_client_factory() as client:` wrapping the dispatch loop, mirroring the uploader)
+  and passes that live client into `process_unpin_request`. `process_unpin_request` gained a
+  `client` param; when it is `None` (standalone callers / tests) it still builds one from
+  `backend_client_factory` for that request. The DELETE / soft-delete logic is unchanged. This removes
+  the per-DELETE TLS handshake and prevents a handshake / ephemeral-port storm at high concurrency.
+
+- **Bounded, deadlock-safe DB pool.** New config `HIPPIUS_UNPINNER_DB_POOL_MAX` is now an explicit
+  **cap** (not a floor) on the pool. The loop sizes the pool as:
+
+  ```
+  ideal_pool    = parallelism + max_inflight     # throughput-optimal peak conns
+  deadlock_floor = parallelism + 1               # one request's max concurrent soft-deletes + 1 fetch
+  pool_max = max(2, min(ideal_pool, HIPPIUS_UNPINNER_DB_POOL_MAX))
+  # if the cap is below deadlock_floor, honor the floor and log a warning
+  if min(ideal_pool, cap) < deadlock_floor: pool_max = deadlock_floor  (+ WARNING)
+  ```
+
+  So raising `MAX_INFLIGHT` can never balloon the pool past the cap, but the pool is never sized below
+  the deadlock-safe floor. This is safe against deadlock because nothing acquires a second pool
+  connection while holding one (the initial fetch conn is released before any DELETE; soft-delete conns
+  are taken one-at-a-time under the shared `delete_sem`), and asyncpg `acquire()` has no timeout — an
+  undersized pool merely throttles, it does not deadlock. The floor keeps liveness comfortable.
+
+- **Modest default bump.** `HIPPIUS_UNPINNER_MAX_INFLIGHT` default 4 → 8 and
+  `HIPPIUS_UNPINNER_DB_POOL_MAX` default 12 → 16 so non-prod benefits. Prod uses the env/secret values
+  below — the defaults are **not** aggressive.
+
+## Ops ramp (NOT code — ops levers)
+
+Ramp in steps and watch Arion 429s + Postgres connection count between each step.
+
+- **`HIPPIUS_UNPINNER_MAX_INFLIGHT` 4 → 32** via the `hippius-s3-secrets` secret (already wired as a
+  `secretKeyRef` on the `arion-unpinner` deployment). This is the primary throughput lever now that the
+  client is reused.
+- **Replicas 3 → 6** in `k8s/base/workers-deployments.yaml` (the `arion-unpinner` Deployment, currently
+  `replicas: 3`).
+- **`HIPPIUS_UNPINNER_PARALLELISM` → 4.** In prod almost every request is one chunk, so this shared
+  per-pod DELETE budget is mostly dead; keep it small. It only matters for fat multi-chunk requests.
+- **`HIPPIUS_UNPINNER_DB_POOL_MAX`** — set per the connection budget below. If left at the default 16
+  while `MAX_INFLIGHT=32`, the pool is capped at 16 (ideal would be 36); raise the cap to trade
+  Postgres connections for throughput.
+
+### Connection-budget math (why this can't exhaust Postgres)
+
+Per pod, peak connections ≈ `min(parallelism + max_inflight, HIPPIUS_UNPINNER_DB_POOL_MAX)`.
+
+| max_inflight | parallelism | ideal | db_pool_max cap | pool/pod | × 6 replicas |
+|---|---|---|---|---|---|
+| 32 | 4 | 36 | 16 (default) | 16 | 96 |
+| 32 | 4 | 36 | 24 | 24 | 144 |
+| 32 | 4 | 36 | 40 | 36 | 216 |
+
+The cap makes the per-pod pool independent of how high inflight is cranked, so total unpinner
+connections stay bounded and can be kept under Postgres `max_connections` alongside the API/other
+workers. Deadlock floor at these settings is `parallelism + 1 = 5`, far below any of the caps.
+
+## Testing
+
+Unit tests in `tests/unit/test_unpinner_loop.py`:
+
+- Client is constructed **once** for the loop and the **same** live client is passed to every request
+  (not one per request).
+- `process_unpin_request` uses a supplied `client` directly and never calls the factory; DELETE +
+  soft-delete still fire once per chunk.
+- Pool sizing: cap honored when below the ideal; ideal used when the cap is high; and when the cap is
+  below the deadlock floor the floor wins and a warning is logged.
+
+Existing dispatch/semaphore/shutdown/best-effort tests remain unchanged and green.
+
+## Risks
+
+- **Arion 429 at high concurrency.** Ramp `MAX_INFLIGHT` in steps; back off if Arion returns 429s.
+- **Postgres connections.** Bounded by `HIPPIUS_UNPINNER_DB_POOL_MAX` (the cap) — raise it deliberately,
+  watching `pg_stat_activity`, not implicitly via inflight.

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -173,13 +173,15 @@ class Config:
     # Unpinner configuration
     # How many unpin requests one unpinner pod processes concurrently (outer bounded-dispatch,
     # mirroring the uploader). The old loop was a serial consumer.
-    unpinner_max_inflight: int = env("HIPPIUS_UNPINNER_MAX_INFLIGHT:4", convert=int)
+    unpinner_max_inflight: int = env("HIPPIUS_UNPINNER_MAX_INFLIGHT:8", convert=int)
     # Single shared per-pod bound on concurrent Arion DELETEs across ALL in-flight requests — one
     # fat request expands to ~N chunk identifiers, so this is what actually unlocks delete throughput.
     unpinner_parallelism: int = env("HIPPIUS_UNPINNER_PARALLELISM:5", convert=int)
-    # Per-pod unpinner DB pool size (concurrent soft-deletes). Multiplied by replica count against
-    # Postgres max_connections — keep modest and raise alongside parallelism.
-    unpinner_db_pool_max: int = env("HIPPIUS_UNPINNER_DB_POOL_MAX:12", convert=int)
+    # Explicit CAP on the per-pod unpinner DB pool. The loop sizes the pool to the throughput-optimal
+    # `max_inflight + parallelism` but never above this cap, so raising max_inflight (an ops secret)
+    # can't balloon Postgres connections (per pod × replicas runs close to server max_connections).
+    # The cap is clamped up to the deadlock-safe floor (parallelism + 1); see run_unpinner_loop.
+    unpinner_db_pool_max: int = env("HIPPIUS_UNPINNER_DB_POOL_MAX:16", convert=int)
     unpinner_max_attempts: int = env("HIPPIUS_UNPINNER_MAX_ATTEMPTS:5", convert=int)
     unpinner_backoff_base_ms: int = env("HIPPIUS_UNPINNER_BACKOFF_BASE_MS:1000", convert=int)
     unpinner_backoff_max_ms: int = env("HIPPIUS_UNPINNER_BACKOFF_MAX_MS:60000", convert=int)

--- a/hippius_s3/workers/unpinner.py
+++ b/hippius_s3/workers/unpinner.py
@@ -50,7 +50,8 @@ async def process_unpin_request(
     request: UnpinChainRequest,
     *,
     backend_name: str,
-    backend_client_factory: Any,
+    client: UnpinBackendClient | None = None,
+    backend_client_factory: Any = None,
     worker_logger: logging.LoggerAdapter,
     dlq_manager: UnpinDLQManager,
     db_pool: asyncpg.Pool,
@@ -61,6 +62,10 @@ async def process_unpin_request(
     A request expands to N chunk identifiers; their backend DELETEs run concurrently bounded by the
     shared per-pod `sem` (passed by the loop so all in-flight requests share one Arion-DELETE budget).
     Falls back to a per-request semaphore when called standalone (e.g. tests).
+
+    The loop passes its long-lived `client` so every request reuses one Arion connection pool (no TLS
+    handshake per request, which at high concurrency would storm ephemeral ports). When `client` is
+    None (standalone callers/tests) one is constructed from `backend_client_factory` for this request.
     """
     config = get_config()
     if sem is None:
@@ -121,16 +126,16 @@ async def process_unpin_request(
 
             span.set_attribute("num_identifiers", len(rows))
 
-            async with backend_client_factory() as client:
-                # Unpin each identifier concurrently, bounded by the shared per-pod `sem`. Each
-                # identifier is best-effort (a failed DELETE/soft-delete logs a warning but must not
-                # fail the whole request), mirroring the original serial behavior.
+            # Unpin each identifier concurrently, bounded by the shared per-pod `sem`. Each
+            # identifier is best-effort (a failed DELETE/soft-delete logs a warning but must not
+            # fail the whole request), mirroring the original serial behavior.
+            async def _unpin_all(active_client: Any) -> None:
                 async def _unpin_one(row: Any) -> None:
                     identifier = row["backend_identifier"]
                     chunk_id = row["chunk_id"]
                     async with sem:
                         try:
-                            await client.unpin_file(identifier, account_ss58=request.address)
+                            await active_client.unpin_file(identifier, account_ss58=request.address)
                             worker_logger.info(f"Unpinned {backend_name} identifier={identifier}")
                         except Exception as unpin_err:
                             worker_logger.warning(
@@ -150,6 +155,14 @@ async def process_unpin_request(
                             )
 
                 await asyncio.gather(*[_unpin_one(row) for row in rows])
+
+            # Reuse the loop's live client when supplied; only build (and close) a per-request client
+            # for standalone callers/tests that don't hand one in.
+            if client is not None:
+                await _unpin_all(client)
+            else:
+                async with backend_client_factory() as owned_client:
+                    await _unpin_all(owned_client)
 
             get_metrics_collector().record_unpinner_operation(
                 main_account=request.address,
@@ -219,11 +232,27 @@ async def run_unpinner_loop(
 
     delete_concurrency = max(1, int(config.unpinner_parallelism))
     max_inflight = max(1, int(config.unpinner_max_inflight))
-    # Peak concurrent pool acquires = up to `delete_concurrency` soft-deletes (each held inside
-    # delete_sem) + up to `max_inflight` per-request initial fetches. Floor the pool to that sum so
-    # scaling the concurrency knobs can never starve acquire() and silently wedge the pod (asyncpg
-    # acquire blocks indefinitely with no timeout).
-    pool_max = max(2, int(config.unpinner_db_pool_max), delete_concurrency + max_inflight)
+    # DB connection budget. A dispatched request briefly holds one pool conn for its initial
+    # chunk-identifier fetch (released before any DELETE), then in its gather phase holds up to
+    # `delete_concurrency` conns for concurrent soft-deletes (bounded by the shared per-pod
+    # `delete_sem`). So the throughput-optimal per-pod pool is ~ `max_inflight` (fetch conns) +
+    # `delete_concurrency` (soft-delete conns). We CAP that at HIPPIUS_UNPINNER_DB_POOL_MAX so raising
+    # max_inflight (an ops secret) can't balloon Postgres connections — per pod × replicas already
+    # runs close to the server's max_connections. The cap may trade throughput for connection count
+    # but is clamped up to the deadlock-safe floor: one request can hold up to `delete_concurrency`
+    # soft-delete conns at once, +1 so the next request's fetch always makes progress. (Nothing
+    # acquires a second conn while holding one and asyncpg acquire() has no timeout, so an undersized
+    # pool throttles rather than deadlocks — the floor just keeps liveness comfortable.)
+    ideal_pool = delete_concurrency + max_inflight
+    deadlock_floor = delete_concurrency + 1
+    capped_pool = min(ideal_pool, int(config.unpinner_db_pool_max))
+    if capped_pool < deadlock_floor:
+        logger.warning(
+            f"HIPPIUS_UNPINNER_DB_POOL_MAX={config.unpinner_db_pool_max} is below the deadlock-safe "
+            f"floor {deadlock_floor} (parallelism+1); honoring the floor instead"
+        )
+        capped_pool = deadlock_floor
+    pool_max = max(2, capped_pool)
     db_pool = await asyncpg.create_pool(
         dsn=config.database_url,
         min_size=2,
@@ -245,7 +274,7 @@ async def run_unpinner_loop(
         f"delete_concurrency={delete_concurrency} db_pool_max={pool_max})"
     )
 
-    async def _handle_unpin(request: UnpinChainRequest) -> None:
+    async def _handle_unpin(request: UnpinChainRequest, client: Any) -> None:
         ray_id = request.ray_id or "no-ray-id"
         ray_id_context.set(ray_id)
         worker_logger = get_logger_with_ray_id(__name__, ray_id)
@@ -262,7 +291,7 @@ async def run_unpinner_loop(
             await process_unpin_request(
                 request,
                 backend_name=backend_name,
-                backend_client_factory=backend_client_factory,
+                client=client,
                 worker_logger=worker_logger,
                 dlq_manager=dlq_manager,
                 db_pool=db_pool,
@@ -292,38 +321,50 @@ async def run_unpinner_loop(
 
     mover_task = asyncio.create_task(_retry_mover())
     try:
-        while True:
-            _reap({t for t in inflight if t.done()})
+        # One backend client for the whole loop — every dispatched request reuses this connection
+        # pool instead of re-handshaking TLS per request (a handshake/ephemeral-port storm at high
+        # inflight). Mirrors run_arion_uploader_in_loop's single ArionClient().
+        async with backend_client_factory() as client:
+            try:
+                while True:
+                    _reap({t for t in inflight if t.done()})
 
-            # Capacity gate — keep at most max_inflight requests processing at once.
-            if len(inflight) >= max_inflight:
-                done_wait, _ = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
-                _reap(done_wait)
-                continue
+                    # Capacity gate — keep at most max_inflight requests processing at once.
+                    if len(inflight) >= max_inflight:
+                        done_wait, _ = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
+                        _reap(done_wait)
+                        continue
 
-            unpin_request, redis_queues_client = await with_redis_retry(
-                lambda rc: dequeue_unpin_request(queue_name),
-                redis_queues_client,
-                config.redis_queues_url,
-                f"dequeue {backend_name} unpin request",
-            )
+                    unpin_request, redis_queues_client = await with_redis_retry(
+                        lambda rc: dequeue_unpin_request(queue_name),
+                        redis_queues_client,
+                        config.redis_queues_url,
+                        f"dequeue {backend_name} unpin request",
+                    )
 
-            if not unpin_request:
-                if inflight:
-                    done_wait, _ = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED, timeout=0.5)
-                    _reap(done_wait)
-                else:
-                    await asyncio.sleep(0.1)
-                continue
+                    if not unpin_request:
+                        if inflight:
+                            done_wait, _ = await asyncio.wait(
+                                inflight, return_when=asyncio.FIRST_COMPLETED, timeout=0.5
+                            )
+                            _reap(done_wait)
+                        else:
+                            await asyncio.sleep(0.1)
+                        continue
 
-            inflight.add(asyncio.create_task(_handle_unpin(unpin_request)))
+                    inflight.add(asyncio.create_task(_handle_unpin(unpin_request, client)))
+            finally:
+                # Drain in-flight requests while the shared client is still open: they hold it for
+                # their Arion DELETEs, so the client must outlive them — closing it first (the
+                # `async with` __aexit__) would fail every in-flight unpin mid-request on shutdown.
+                for t in inflight:
+                    t.cancel()
+                await asyncio.gather(*inflight, return_exceptions=True)
     except (KeyboardInterrupt, asyncio.CancelledError):
         logger.info(f"{backend_name} unpinner stopping…")
     finally:
         mover_task.cancel()
-        for t in inflight:
-            t.cancel()
-        # gather (not suppress) so cancelled tasks' CancelledError is absorbed here.
-        await asyncio.gather(mover_task, *inflight, return_exceptions=True)
+        # gather (not suppress) so the cancelled mover's CancelledError is absorbed here.
+        await asyncio.gather(mover_task, return_exceptions=True)
         if db_pool:
             await db_pool.close()

--- a/tests/unit/test_unpinner_loop.py
+++ b/tests/unit/test_unpinner_loop.py
@@ -45,11 +45,41 @@ def _req(name: str) -> MagicMock:
     return r
 
 
+class _NoopAsyncClient:
+    """Async-CM client stub — the loop now enters `async with backend_client_factory()`."""
+
+    async def __aenter__(self) -> "_NoopAsyncClient":
+        return self
+
+    async def __aexit__(self, *a) -> bool:
+        return False
+
+    async def unpin_file(self, *a, **k) -> None:
+        return None
+
+
+class _CountingFactory:
+    """Callable factory that records how many clients it constructs (should be 1 per loop)."""
+
+    def __init__(self) -> None:
+        self.count = 0
+        self.instances: list = []
+
+    def __call__(self) -> _NoopAsyncClient:
+        self.count += 1
+        inst = _NoopAsyncClient()
+        self.instances.append(inst)
+        return inst
+
+
 class _Harness:
-    def __init__(self, *, max_inflight: int) -> None:
+    def __init__(self, *, max_inflight: int, factory=None) -> None:
         self.config = _make_config(max_inflight=max_inflight)
         self.dequeue_sequence: list = []
         self.process_calls: list = []
+        self.client_args: list = []  # `client` kwarg seen by each process_unpin_request call
+        self.pool_max = None  # max_size passed to asyncpg.create_pool
+        self.factory = factory if factory is not None else _CountingFactory()
         self.process_fn = None  # type: ignore[var-annotated]
 
     async def _dequeue(self, queue_name: str):
@@ -66,6 +96,7 @@ class _Harness:
 
     async def _process(self, request, **kwargs):
         self.process_calls.append(request)
+        self.client_args.append(kwargs.get("client"))
         assert self.process_fn is not None
         return await self.process_fn(request)
 
@@ -87,11 +118,16 @@ class _Harness:
         ):
             pool = MagicMock()
             pool.close = AsyncMock()
-            mock_asyncpg.create_pool = AsyncMock(return_value=pool)
+
+            async def _create_pool(*args, **kwargs):
+                self.pool_max = kwargs.get("max_size")
+                return pool
+
+            mock_asyncpg.create_pool = AsyncMock(side_effect=_create_pool)
             mock_async_redis.from_url = MagicMock(return_value=MagicMock())
             await un.run_unpinner_loop(
                 backend_name="arion",
-                backend_client_factory=MagicMock(),
+                backend_client_factory=self.factory,
                 queue_name="arion_unpin_requests",
             )
 
@@ -168,6 +204,42 @@ async def test_graceful_shutdown_cancels_inflight():
     await asyncio.wait_for(h.run(), timeout=5.0)
     assert len(h.process_calls) == 2
     assert cancelled["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_client_closed_only_after_inflight_drained_on_shutdown():
+    """Regression: the shared client must OUTLIVE in-flight requests. On shutdown the loop must
+    cancel + drain in-flight tasks BEFORE the client's __aexit__ closes its connection pool — closing
+    it first would fail every in-flight Arion DELETE mid-request. Guards the try/finally ordering."""
+    events: list[str] = []
+
+    class _OrderingClient:
+        async def __aenter__(self) -> "_OrderingClient":
+            return self
+
+        async def __aexit__(self, *a) -> bool:
+            events.append("client_closed")
+            return False
+
+        async def unpin_file(self, *a, **k) -> None:
+            return None
+
+    h = _Harness(max_inflight=4, factory=lambda: _OrderingClient())
+    h.dequeue_sequence = [_req("x"), _req("y")]  # then dequeue raises KeyboardInterrupt
+
+    async def _block(_req):
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            events.append("task_cancelled")
+            raise
+
+    h.process_fn = _block
+    await asyncio.wait_for(h.run(), timeout=5.0)
+
+    assert events.count("task_cancelled") == 2, f"both in-flight tasks must drain: {events}"
+    assert events.count("client_closed") == 1
+    assert events[-1] == "client_closed", f"client closed before in-flight tasks drained: {events}"
 
 
 # --------------------------------------------------------------------------- #
@@ -285,3 +357,124 @@ async def test_failing_identifier_does_not_fail_request():
         )
 
     assert len(tracker.calls) == 4, "all identifiers attempted despite one failing"
+
+
+# --------------------------------------------------------------------------- #
+# Client reuse: the loop constructs ONE backend client and hands it to every
+# request (kills the per-request TLS handshake that starved throughput).
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_backend_client_constructed_once_and_reused_across_requests():
+    """The Arion client must be built ONCE for the loop and the SAME live client passed to every
+    request — not re-created per request (the handshake storm we are fixing)."""
+    factory = _CountingFactory()
+    h = _Harness(max_inflight=4, factory=factory)
+    h.dequeue_sequence = [_req("a"), _req("b"), _req("c")]
+
+    async def _noop(_req):
+        return None
+
+    h.process_fn = _noop
+    await asyncio.wait_for(h.run(), timeout=5.0)
+
+    assert factory.count == 1, f"client constructed {factory.count}x, expected 1 (per-loop reuse)"
+    assert len(h.process_calls) == 3
+    assert len(h.client_args) == 3
+    assert all(c is factory.instances[0] for c in h.client_args), "every request must reuse the one live client"
+    assert all(c is not None for c in h.client_args), "loop must pass a live client, not None"
+
+
+class _ReuseClient:
+    """A client handed straight to process_unpin_request. Re-entering it as a context manager is a
+    bug (the loop already owns its lifecycle), so __aenter__ blows up to catch that regression."""
+
+    def __init__(self, tracker: _DeleteTracker) -> None:
+        self.tracker = tracker
+
+    async def __aenter__(self):
+        raise AssertionError("passed-in client must not be re-entered as a context manager")
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def unpin_file(self, identifier, **kw):
+        self.tracker.enter(identifier)
+        self.tracker.leave()
+
+
+@pytest.mark.asyncio
+async def test_process_uses_passed_client_and_never_calls_factory():
+    """When a live `client` is supplied, process_unpin_request must use it directly and never touch
+    backend_client_factory. DELETE + soft-delete still fire once per chunk."""
+    tracker = _DeleteTracker()
+    client = _ReuseClient(tracker)
+    factory = MagicMock(side_effect=AssertionError("factory must not be called when client is supplied"))
+
+    rows = [{"backend_identifier": f"id-{i}", "chunk_id": i} for i in range(3)]
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(return_value=rows)
+    conn.fetchval = AsyncMock(return_value=1)
+    pool = MagicMock()
+    pool.acquire = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(return_value=conn), __aexit__=AsyncMock()))
+
+    with (
+        patch.object(un, "get_config", return_value=_make_config(max_inflight=4, parallelism=4)),
+        patch.object(un, "get_query", return_value="SQL"),
+        patch.object(un, "get_metrics_collector", return_value=MagicMock()),
+    ):
+        await un.process_unpin_request(
+            _req("o"),
+            backend_name="arion",
+            client=client,
+            backend_client_factory=factory,
+            worker_logger=MagicMock(),
+            dlq_manager=MagicMock(),
+            db_pool=pool,
+            sem=asyncio.Semaphore(4),
+        )
+
+    factory.assert_not_called()
+    assert len(tracker.calls) == 3, "DELETE must run once per chunk on the reused client"
+    assert conn.fetchval.await_count == 3, "soft-delete must run once per chunk"
+
+
+# --------------------------------------------------------------------------- #
+# DB pool cap: raising max_inflight must not balloon Postgres connections, but
+# the pool is never sized below the deadlock-safe floor (parallelism + 1).
+# --------------------------------------------------------------------------- #
+
+
+async def _pool_max_for(*, max_inflight: int, parallelism: int, db_pool_max: int) -> int:
+    h = _Harness(max_inflight=max_inflight)
+    h.config.unpinner_parallelism = parallelism
+    h.config.unpinner_db_pool_max = db_pool_max
+    h.dequeue_sequence = []  # no work -> immediate KeyboardInterrupt after pool is created
+    await asyncio.wait_for(h.run(), timeout=5.0)
+    assert h.pool_max is not None
+    return h.pool_max
+
+
+@pytest.mark.asyncio
+async def test_pool_uses_ideal_when_cap_is_high():
+    # ideal = parallelism + max_inflight = 4 + 8 = 12; cap 50 -> min(12, 50) = 12
+    assert await _pool_max_for(max_inflight=8, parallelism=4, db_pool_max=50) == 12
+
+
+@pytest.mark.asyncio
+async def test_pool_cap_bounds_growth_below_ideal():
+    # ideal = 4 + 32 = 36 but cap 20 wins (>= deadlock floor 5) -> pool stays at 20, not 36.
+    assert await _pool_max_for(max_inflight=32, parallelism=4, db_pool_max=20) == 20
+
+
+@pytest.mark.asyncio
+async def test_pool_never_below_deadlock_floor(caplog):
+    # deadlock floor = parallelism + 1 = 8 + 1 = 9; a too-small cap (3) is clamped up to 9 + warns.
+    import logging as _logging
+
+    with caplog.at_level(_logging.WARNING, logger="hippius_s3.workers.unpinner"):
+        pool_max = await _pool_max_for(max_inflight=16, parallelism=8, db_pool_max=3)
+
+    assert pool_max == 9, "cap below the deadlock-safe floor must be overridden by the floor"
+    assert "below the deadlock-safe floor" in caplog.text


### PR DESCRIPTION
## Summary
The `arion-unpinner` can't keep up with the delete flood (juicefs bulk-deletes → `arion_unpin_requests` ~950k and growing; redis-queues climbing toward its `maxmemory` cap, the precursor to the 2026-06-01 IncompleteRead incident). This makes higher parallelism **safe and effective**; the concurrency knob and replica count are ops levers.

## Root cause of the throughput ceiling
- **Per-request Arion client:** `process_unpin_request` did `async with backend_client_factory() as client:` — a **new httpx client + TLS handshake per request**. That inflates per-op latency and would cause an ephemeral-port/handshake storm at high inflight.
- Effective per-pod concurrency was pinned at `MAX_INFLIGHT` (4), and the DB pool floor `parallelism + max_inflight` meant naively raising inflight would balloon Postgres connections.

## Changes (code — the enablers)
- **Reuse one Arion client for the whole loop**, passed to every request (mirrors `run_arion_uploader_in_loop`). Falls back to a per-request client for standalone callers/tests. On shutdown, in-flight tasks are cancelled+drained **before** the shared client closes (they hold it for their DELETEs).
- **Bound the DB pool** with `HIPPIUS_UNPINNER_DB_POOL_MAX` (explicit cap) + a deadlock-safe floor (`parallelism + 1`), so raising `MAX_INFLIGHT` (an ops secret) can't exhaust Postgres. `min(ideal, cap)`, clamped up to the floor with a warning if misconfigured.
- Default `MAX_INFLIGHT` 4→8.

## Ops ramp (NOT code — turn the knob to actually drain faster)
- `HIPPIUS_UNPINNER_MAX_INFLIGHT` 4→32 (secret `hippius-s3-secrets`) **and** raise `HIPPIUS_UNPINNER_DB_POOL_MAX` alongside it (else the pool cap throttles DB concurrency).
- `HIPPIUS_UNPINNER_PARALLELISM` → 4 (dead budget: prod objects are ~1 chunk/request).
- replicas 3→6 in `k8s/base/workers-deployments.yaml`.
- Connection-budget table in `docs/issues/unpinner-throughput.md`. Ramp in steps, watch Arion for 429s.

## Testing (`tests/unit/test_unpinner_loop.py`, adversarial)
- Client built **once** and the same live client passed to every request; passed-in client never re-entered as a CM; factory never called when a client is supplied.
- **Shutdown ordering regression:** client `__aexit__` runs only *after* in-flight tasks drain.
- DB pool: ideal when cap high; cap bounds growth below ideal; **cap below the deadlock floor is overridden by the floor + warns** (both directions).
- Existing dispatch / max-inflight / shared-DELETE-semaphore / best-effort tests retained. 12 passing.

## Conclusion
Makes it safe to scale unpin concurrency without a Postgres/handshake blowup; ops turns the knob for immediate drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
