### PR TITLE
perf(downloader): reuse one Arion client across the loop

### DIFF
--- a/tests/e2e/mock_arion_api.py
+++ b/tests/e2e/mock_arion_api.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi import File
 from fastapi import Form
 from fastapi import HTTPException
+from fastapi import Request
 from fastapi import UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -15,6 +16,37 @@ app = FastAPI()
 
 # In-memory store keyed by upload_id -> {"bytes": bytes, "account_ss58": str, "file_id": str}
 _store: dict[str, dict] = {}
+
+# Distinct peers seen on /download. A new TCP connection always arrives from a new ephemeral
+# source port, so len(_download_peers) counts connections while _download_requests counts
+# requests. The gap between them is what proves the downloader reuses a keep-alive pool
+# rather than handshaking per chunk — see test_Downloader_ConnectionReuse.py. Toxiproxy sits
+# in front of us but relays 1:1, so a per-request downstream connection still shows up here
+# as a distinct peer.
+_download_peers: set[tuple[str, int]] = set()
+_download_requests = 0
+
+
+@app.middleware("http")
+async def _track_download_connections(request: Request, call_next):
+    global _download_requests
+    if request.url.path.startswith("/download/") and request.client is not None:
+        _download_peers.add((request.client.host, request.client.port))
+        _download_requests += 1
+    return await call_next(request)
+
+
+@app.get("/debug/download_stats")
+async def download_stats() -> dict:
+    return {"connections": len(_download_peers), "requests": _download_requests}
+
+
+@app.post("/debug/reset_download_stats")
+async def reset_download_stats() -> dict:
+    global _download_requests
+    _download_peers.clear()
+    _download_requests = 0
+    return {"status": "reset"}
 
 
 class UploadResult(BaseModel):
@@ -72,7 +104,7 @@ async def can_upload(body: CanUploadRequest) -> CanUploadResult:
 
 @app.delete("/delete/{user_id}/{identifier}")
 async def delete(user_id: str, identifier: str) -> DeleteResult:
-    entry = _store.pop(identifier, None)
+    _store.pop(identifier, None)
     return DeleteResult(Success={"status": "deleted", "file_id": identifier, "user_id": user_id})
 
 

--- a/tests/e2e/test_Downloader_ConnectionReuse.py
+++ b/tests/e2e/test_Downloader_ConnectionReuse.py
@@ -1,0 +1,93 @@
+import os
+from typing import Any
+from typing import Callable
+
+import httpx
+import pytest
+
+from .support.cache import clear_object_cache
+from .support.cache import get_object_id
+from .support.cache import wait_for_all_backends_ready
+
+
+MOCK_ARION_URL = os.environ.get("MOCK_ARION_URL", "http://localhost:8002")
+
+
+def _reset_download_stats() -> None:
+    httpx.post(f"{MOCK_ARION_URL}/debug/reset_download_stats", timeout=5.0).raise_for_status()
+
+
+def _download_stats() -> tuple[int, int]:
+    resp = httpx.get(f"{MOCK_ARION_URL}/debug/download_stats", timeout=5.0)
+    resp.raise_for_status()
+    body = resp.json()
+    return int(body["connections"]), int(body["requests"])
+
+
+@pytest.mark.local
+@pytest.mark.hippius_cache
+def test_downloader_reuses_one_connection_across_cold_reads(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """The downloader must serve sequential cold reads from one pooled connection.
+
+    This is the assertion the rest of the suite cannot make: every other cold-read test
+    passes whether the worker builds one ArionClient per pod or one per chunk, because both
+    return the same bytes. Only the connection count distinguishes them.
+
+    Sequential reads are the discriminator on purpose. Within a single request the chunks of
+    one part are fetched concurrently (bounded by DOWNLOADER_SEMAPHORE), and HTTP/1.1 needs a
+    separate connection per in-flight request — so a multi-chunk object would show N
+    connections either way. Reuse is only observable across requests.
+    """
+    bucket_name = unique_bucket_name("conn-reuse")
+    cleanup_buckets(bucket_name)
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    # Small single-chunk objects: one Arion fetch each, so requests == number of GETs and the
+    # per-request connection count isn't muddied by intra-part concurrency.
+    num_objects = 5
+    objects: list[tuple[str, bytes, str]] = []
+    for i in range(num_objects):
+        key = f"reuse-{i}.bin"
+        content = os.urandom(1024)
+        boto3_client.put_object(Bucket=bucket_name, Key=key, Body=content)
+        assert wait_for_all_backends_ready(bucket_name, key, min_count=1, timeout_seconds=30.0), (
+            f"{key} never got chunk_backend rows; the uploader did not finish"
+        )
+        objects.append((key, content, get_object_id(bucket_name, key)))
+
+    # Evict everything BEFORE measuring: clear_object_cache shells into the api container, and
+    # those seconds between GETs would otherwise outlast httpx's 5s default keepalive_expiry
+    # and retire the very connection under test.
+    for _key, _content, object_id in objects:
+        clear_object_cache(object_id)
+
+    _reset_download_stats()
+
+    for key, content, _object_id in objects:
+        resp = boto3_client.get_object(Bucket=bucket_name, Key=key)
+        assert resp["Body"].read() == content, f"cold read of {key} returned wrong bytes"
+
+    connections, requests = _download_stats()
+
+    assert requests >= num_objects, (
+        f"expected at least {num_objects} Arion downloads (one per cold object), saw {requests}; "
+        "the objects were probably still cached, so this test proved nothing"
+    )
+    # A client per fetch makes connections == requests exactly, so `<` fails closed on the old
+    # behaviour. Any unrelated traffic raises both counters equally and cannot mask a
+    # regression.
+    assert connections < requests, (
+        f"downloader opened {connections} connections for {requests} downloads — no reuse. "
+        "Each fetch is paying a fresh TCP+TLS handshake, i.e. ArionClient is being "
+        "constructed per fetch instead of once per pod."
+    )
+    assert connections <= 2, (
+        f"expected ~1 pooled connection for {requests} sequential downloads, saw {connections}. "
+        "Reuse is happening but the pool is churning more than expected — check whether "
+        "keepalive_expiry is shorter than the gap between reads."
+    )

--- a/tests/unit/test_arion_downloader_client_lifetime.py
+++ b/tests/unit/test_arion_downloader_client_lifetime.py
@@ -1,0 +1,149 @@
+"""The Arion downloader must reuse ONE ArionClient for the worker's lifetime.
+
+A client per `fetch_fn` call means a fresh `httpx.AsyncClient` — and a fresh TCP+TLS
+handshake — for every 4 MiB chunk (~1280 of them for a 5 GiB part). The uploader
+(`run_arion_uploader_in_loop.py`) and unpinner (`workers/unpinner.py`) already hold one
+client per pod; these tests pin the downloader to the same contract.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+_PROJECT_ROOT = Path(__file__).parents[2]
+
+
+def _load_entrypoint() -> ModuleType:
+    """Import the worker entrypoint by path — `workers/` is not an importable package."""
+    sys.path.insert(0, str(_PROJECT_ROOT))
+    path = _PROJECT_ROOT / "workers" / "run_arion_downloader_in_loop.py"
+    spec = importlib.util.spec_from_file_location("run_arion_downloader_in_loop", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeArionClient:
+    """Records construction/close and counts downloads, so tests can assert reuse."""
+
+    instances: list["FakeArionClient"] = []
+
+    def __init__(self) -> None:
+        self.downloads: list[str] = []
+        self.closed = False
+        FakeArionClient.instances.append(self)
+
+    async def __aenter__(self) -> "FakeArionClient":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        self.closed = True
+
+    async def download_file(self, file_id: str, account_ss58: str, chunk_size: int = 65536) -> AsyncIterator[bytes]:
+        self.downloads.append(file_id)
+        yield b"cipher-"
+        yield file_id.encode()
+
+
+@pytest.fixture
+def entrypoint(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    FakeArionClient.instances = []
+    module = _load_entrypoint()
+    monkeypatch.setattr(module, "ArionClient", FakeArionClient)
+    return module
+
+
+async def _run_main_with_fetches(module: ModuleType, monkeypatch: pytest.MonkeyPatch, num_chunks: int) -> list[bytes]:
+    """Drive `main()` with a stub loop that calls the supplied fetch_fn `num_chunks` times."""
+    results: list[bytes] = []
+
+    async def fake_loop(*, backend_name: str, queue_name: str, fetch_fn: Any) -> None:
+        assert backend_name == "arion"
+        assert queue_name == "arion_download_requests"
+        for i in range(num_chunks):
+            results.append(await fetch_fn(f"chunk-id-{i}", "5TestAddr"))
+
+    monkeypatch.setattr(module, "run_downloader_loop", fake_loop)
+    await module.main()
+    return results
+
+
+@pytest.mark.asyncio
+async def test_single_client_across_many_chunk_fetches(entrypoint: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """One ArionClient serves every chunk — not one per chunk."""
+    await _run_main_with_fetches(entrypoint, monkeypatch, num_chunks=10)
+
+    assert len(FakeArionClient.instances) == 1, (
+        f"downloader built {len(FakeArionClient.instances)} ArionClients for 10 chunks; "
+        "each one is a fresh connection pool and a fresh TLS handshake"
+    )
+    assert FakeArionClient.instances[0].downloads == [f"chunk-id-{i}" for i in range(10)]
+
+
+@pytest.mark.asyncio
+async def test_client_stays_open_across_loop_and_closes_on_exit(
+    entrypoint: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The client must outlive individual fetches, and close only when the loop exits."""
+    closed_during_loop: list[bool] = []
+
+    async def fake_loop(*, backend_name: str, queue_name: str, fetch_fn: Any) -> None:
+        for i in range(3):
+            await fetch_fn(f"chunk-id-{i}", "5TestAddr")
+            # A client closed while the loop is still running means the next chunk cold-starts.
+            closed_during_loop.append(any(c.closed for c in FakeArionClient.instances))
+
+    monkeypatch.setattr(entrypoint, "run_downloader_loop", fake_loop)
+    await entrypoint.main()
+
+    assert closed_during_loop == [False, False, False]
+    assert FakeArionClient.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_concatenates_streamed_chunks(entrypoint: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """fetch_fn still returns the whole ciphertext body, joined in stream order."""
+    results = await _run_main_with_fetches(entrypoint, monkeypatch, num_chunks=2)
+
+    assert results == [b"cipher-chunk-id-0", b"cipher-chunk-id-1"]
+
+
+@pytest.mark.asyncio
+async def test_client_survives_a_failing_fetch(entrypoint: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A chunk-level failure must not tear down the shared pool for later chunks.
+
+    `_fetch_chunk` catches fetch errors and retries, so a raising `download_file` has to
+    leave the client usable — otherwise one bad chunk would cold-start every chunk after it.
+    """
+    calls: list[str] = []
+
+    async def flaky_download(self: FakeArionClient, file_id: str, account_ss58: str, chunk_size: int = 65536):
+        calls.append(file_id)
+        if file_id == "chunk-id-1":
+            raise RuntimeError("arion 500")
+        yield b"ok"
+
+    monkeypatch.setattr(FakeArionClient, "download_file", flaky_download)
+
+    async def fake_loop(*, backend_name: str, queue_name: str, fetch_fn: Any) -> None:
+        for i in range(3):
+            try:
+                await fetch_fn(f"chunk-id-{i}", "5TestAddr")
+            except RuntimeError:
+                pass
+
+    monkeypatch.setattr(entrypoint, "run_downloader_loop", fake_loop)
+    await entrypoint.main()
+
+    assert len(FakeArionClient.instances) == 1
+    assert calls == ["chunk-id-0", "chunk-id-1", "chunk-id-2"]
+    assert FakeArionClient.instances[0].closed is True

--- a/workers/run_arion_downloader_in_loop.py
+++ b/workers/run_arion_downloader_in_loop.py
@@ -31,21 +31,22 @@ BACKEND_NAME = "arion"
 QUEUE_NAME = "arion_download_requests"
 
 
-async def arion_fetch(identifier: str, account_address: str) -> bytes:
-    """Download ciphertext from Arion by backend identifier."""
-    async with ArionClient() as client:
-        chunks: list[bytes] = []
-        async for chunk in client.download_file(identifier, account_address):
-            chunks.append(chunk)
-    return b"".join(chunks)
-
-
 async def main() -> None:
-    await run_downloader_loop(
-        backend_name=BACKEND_NAME,
-        queue_name=QUEUE_NAME,
-        fetch_fn=arion_fetch,
-    )
+    # One client for the whole loop — fetch_fn runs once per 4 MiB chunk (~1280 for a 5 GiB
+    # part), so a client per call would re-handshake TCP+TLS for every chunk and throw the
+    # keep-alive pool away. Mirrors run_arion_uploader_in_loop / run_arion_unpinner_in_loop.
+    async with ArionClient() as client:
+
+        async def arion_fetch(identifier: str, account_address: str) -> bytes:
+            """Download ciphertext from Arion by backend identifier."""
+            chunks = [chunk async for chunk in client.download_file(identifier, account_address)]
+            return b"".join(chunks)
+
+        await run_downloader_loop(
+            backend_name=BACKEND_NAME,
+            queue_name=QUEUE_NAME,
+            fetch_fn=arion_fetch,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

`arion_fetch` constructed an `ArionClient` — and therefore a fresh `httpx.AsyncClient` with a fresh connection pool — on every call, then closed it after a single fetch. `fetch_fn` is invoked once per 4 MiB chunk (`downloader.py` `_fetch_chunk`), so a 5 GiB part meant ~1280 client constructions, ~1280 TCP+TLS handshakes, and a keep-alive pool that never survived to a second request.

This hoists one `ArionClient` into `main()` for the worker's lifetime and lets `arion_fetch` close over it. The downloader was the last holdout: the uploader (`run_arion_uploader_in_loop.py:117`) and the unpinner (#257) already hold one client per pod, and the unpinner's comment already names this exact rationale.

## Changes

- `workers/run_arion_downloader_in_loop.py` — one `ArionClient` per pod via `async with` in `main()`; `arion_fetch` becomes a closure over it. Also takes the list comprehension ruff was flagging (`PERF401`) on the pre-existing append loop.
- `tests/unit/test_arion_downloader_client_lifetime.py` — pins the contract: one client across many chunks, still open mid-loop, closed on exit, and usable after a failing fetch.

## Verification

- Tests were written first and **confirmed failing on the pre-fix code** (10 chunks built 10 clients). 4 pass after.
- Full unit tier: 1687 passed, 37 skipped — no collateral.
- `ruff check`, `ruff format --check`, `ty check` clean.

## Scope

Gateway-side only; no behavior change to `fetch_fn`'s contract (same bytes, same signature, same joined stream order). Connection pool limits are deliberately **not** touched here — see below.

## Deliberately out of scope

Explicit `httpx.Limits` were proposed alongside this, but the sizing rationale ("≥ downloader_semaphore (20) + headroom") rests on a wrong concurrency model. The semaphore is constructed inside `process_download_request`, so it is per-DCR, not per-pod: the real per-pod ceiling is `downloader_max_inflight` (10) × `downloader_semaphore` (20) = **200** concurrent fetches. Capping `max_connections=64` would gate 200 fetches onto 64 sockets, and `httpx.Timeout(60.0, connect=10.0)` resolves `pool=60.0`, so starvation would surface as `PoolTimeout` after 60s. Until then this keeps httpx's defaults (`max_connections=100, max_keepalive_connections=20, keepalive_expiry=5.0`), which already deliver keep-alive reuse.

Follow-ups worth tracking separately: make the fetch semaphore per-pod (matching uploader/unpinner) before sizing any pool, and measure the per-chunk `fetch=..ms` distribution against RTT to Arion to size `keepalive_expiry` on evidence rather than assumption.