### PR TITLE
DO NOT MERGE: verify e2e catches per-chunk connection churn

### DIFF
--- a/tests/e2e/mock_arion_api.py
+++ b/tests/e2e/mock_arion_api.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi import File
 from fastapi import Form
 from fastapi import HTTPException
+from fastapi import Request
 from fastapi import UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
@@ -15,6 +16,37 @@ app = FastAPI()
 
 # In-memory store keyed by upload_id -> {"bytes": bytes, "account_ss58": str, "file_id": str}
 _store: dict[str, dict] = {}
+
+# Distinct peers seen on /download. A new TCP connection always arrives from a new ephemeral
+# source port, so len(_download_peers) counts connections while _download_requests counts
+# requests. The gap between them is what proves the downloader reuses a keep-alive pool
+# rather than handshaking per chunk — see test_Downloader_ConnectionReuse.py. Toxiproxy sits
+# in front of us but relays 1:1, so a per-request downstream connection still shows up here
+# as a distinct peer.
+_download_peers: set[tuple[str, int]] = set()
+_download_requests = 0
+
+
+@app.middleware("http")
+async def _track_download_connections(request: Request, call_next):
+    global _download_requests
+    if request.url.path.startswith("/download/") and request.client is not None:
+        _download_peers.add((request.client.host, request.client.port))
+        _download_requests += 1
+    return await call_next(request)
+
+
+@app.get("/debug/download_stats")
+async def download_stats() -> dict:
+    return {"connections": len(_download_peers), "requests": _download_requests}
+
+
+@app.post("/debug/reset_download_stats")
+async def reset_download_stats() -> dict:
+    global _download_requests
+    _download_peers.clear()
+    _download_requests = 0
+    return {"status": "reset"}
 
 
 class UploadResult(BaseModel):
@@ -72,7 +104,7 @@ async def can_upload(body: CanUploadRequest) -> CanUploadResult:
 
 @app.delete("/delete/{user_id}/{identifier}")
 async def delete(user_id: str, identifier: str) -> DeleteResult:
-    entry = _store.pop(identifier, None)
+    _store.pop(identifier, None)
     return DeleteResult(Success={"status": "deleted", "file_id": identifier, "user_id": user_id})
 
 

--- a/tests/e2e/test_Downloader_ConnectionReuse.py
+++ b/tests/e2e/test_Downloader_ConnectionReuse.py
@@ -1,0 +1,93 @@
+import os
+from typing import Any
+from typing import Callable
+
+import httpx
+import pytest
+
+from .support.cache import clear_object_cache
+from .support.cache import get_object_id
+from .support.cache import wait_for_all_backends_ready
+
+
+MOCK_ARION_URL = os.environ.get("MOCK_ARION_URL", "http://localhost:8002")
+
+
+def _reset_download_stats() -> None:
+    httpx.post(f"{MOCK_ARION_URL}/debug/reset_download_stats", timeout=5.0).raise_for_status()
+
+
+def _download_stats() -> tuple[int, int]:
+    resp = httpx.get(f"{MOCK_ARION_URL}/debug/download_stats", timeout=5.0)
+    resp.raise_for_status()
+    body = resp.json()
+    return int(body["connections"]), int(body["requests"])
+
+
+@pytest.mark.local
+@pytest.mark.hippius_cache
+def test_downloader_reuses_one_connection_across_cold_reads(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """The downloader must serve sequential cold reads from one pooled connection.
+
+    This is the assertion the rest of the suite cannot make: every other cold-read test
+    passes whether the worker builds one ArionClient per pod or one per chunk, because both
+    return the same bytes. Only the connection count distinguishes them.
+
+    Sequential reads are the discriminator on purpose. Within a single request the chunks of
+    one part are fetched concurrently (bounded by DOWNLOADER_SEMAPHORE), and HTTP/1.1 needs a
+    separate connection per in-flight request — so a multi-chunk object would show N
+    connections either way. Reuse is only observable across requests.
+    """
+    bucket_name = unique_bucket_name("conn-reuse")
+    cleanup_buckets(bucket_name)
+    boto3_client.create_bucket(Bucket=bucket_name)
+
+    # Small single-chunk objects: one Arion fetch each, so requests == number of GETs and the
+    # per-request connection count isn't muddied by intra-part concurrency.
+    num_objects = 5
+    objects: list[tuple[str, bytes, str]] = []
+    for i in range(num_objects):
+        key = f"reuse-{i}.bin"
+        content = os.urandom(1024)
+        boto3_client.put_object(Bucket=bucket_name, Key=key, Body=content)
+        assert wait_for_all_backends_ready(bucket_name, key, min_count=1, timeout_seconds=30.0), (
+            f"{key} never got chunk_backend rows; the uploader did not finish"
+        )
+        objects.append((key, content, get_object_id(bucket_name, key)))
+
+    # Evict everything BEFORE measuring: clear_object_cache shells into the api container, and
+    # those seconds between GETs would otherwise outlast httpx's 5s default keepalive_expiry
+    # and retire the very connection under test.
+    for _key, _content, object_id in objects:
+        clear_object_cache(object_id)
+
+    _reset_download_stats()
+
+    for key, content, _object_id in objects:
+        resp = boto3_client.get_object(Bucket=bucket_name, Key=key)
+        assert resp["Body"].read() == content, f"cold read of {key} returned wrong bytes"
+
+    connections, requests = _download_stats()
+
+    assert requests >= num_objects, (
+        f"expected at least {num_objects} Arion downloads (one per cold object), saw {requests}; "
+        "the objects were probably still cached, so this test proved nothing"
+    )
+    # A client per fetch makes connections == requests exactly, so `<` fails closed on the old
+    # behaviour. Any unrelated traffic raises both counters equally and cannot mask a
+    # regression.
+    assert connections < requests, (
+        f"downloader opened {connections} connections for {requests} downloads — no reuse. "
+        "Each fetch is paying a fresh TCP+TLS handshake, i.e. ArionClient is being "
+        "constructed per fetch instead of once per pod."
+    )
+    assert connections <= 2, (
+        f"expected ~1 pooled connection for {requests} sequential downloads, saw {connections}. "
+        "Reuse is happening but the pool is churning more than expected — check whether "
+        "keepalive_expiry is shorter than the gap between reads."
+    )


### PR DESCRIPTION
Scratch PR. The new e2e connection-reuse test applied to main WITHOUT the fix from #261. Expectation: `test_downloader_reuses_one_connection_across_cold_reads` FAILS. Proves the test discriminates rather than passing vacuously. Will be closed once CI reports.