### PR TITLE
feat(drain): decouple the Ceph-commit from the backend-upload enqueue

### DIFF
--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -18,6 +18,11 @@ use thiserror::Error;
 const DEFAULT_DRAIN_POLL: Duration = Duration::from_secs(5);
 /// Reconciler scan period when `CEPHOR_RECONCILE_POLL_SECS` is unset.
 const DEFAULT_RECONCILE_POLL: Duration = Duration::from_mins(1);
+/// Enqueue-sweep period when `CEPHOR_ENQUEUE_POLL_SECS` is unset. How often a `replicated`
+/// part whose address was not finalized at drain time (an in-flight MPU) is retried for its
+/// backend upload. Off the read path (the object serves from the pool), so a few seconds is
+/// ample; short enough that a completed MPU's parts publish promptly.
+const DEFAULT_ENQUEUE_POLL: Duration = Duration::from_secs(5);
 /// Shutdown grace when `CEPHOR_GRACE_SECS` is unset.
 const DEFAULT_GRACE: Duration = Duration::from_secs(30);
 /// Heartbeat period when `CEPHOR_HEARTBEAT_POLL_SECS` is unset.
@@ -89,6 +94,9 @@ pub struct Config {
     pub drain_poll: Duration,
     /// Reconciler scan period.
     pub reconcile_poll: Duration,
+    /// Enqueue-sweep period: how often a `replicated` part whose backend upload was not
+    /// enqueued at drain time (address not yet finalized) is retried.
+    pub enqueue_poll: Duration,
     /// Grace given to in-flight ticks on shutdown before a forced abort.
     pub grace: Duration,
     /// This node's identity in the fleet (the allocator keys heartbeats by it).
@@ -211,6 +219,7 @@ impl Config {
         RuntimeConfig {
             drain_poll: self.drain_poll,
             reconcile_poll: self.reconcile_poll,
+            enqueue_poll: self.enqueue_poll,
             reclaim_poll: self.reclaim_poll,
             reclaim_grace: self.reclaim_grace,
             orphan_reclaim_grace: self.orphan_reclaim_grace,
@@ -268,6 +277,7 @@ impl Config {
             ssd_root: required_path(&get, "CEPHOR_SSD_ROOT")?,
             drain_poll: duration_secs(&get, "CEPHOR_DRAIN_POLL_SECS", DEFAULT_DRAIN_POLL)?,
             reconcile_poll: duration_secs(&get, "CEPHOR_RECONCILE_POLL_SECS", DEFAULT_RECONCILE_POLL)?,
+            enqueue_poll: duration_secs(&get, "CEPHOR_ENQUEUE_POLL_SECS", DEFAULT_ENQUEUE_POLL)?,
             grace: duration_secs(&get, "CEPHOR_GRACE_SECS", DEFAULT_GRACE)?,
             node_id: required_node_id(&get, "CEPHOR_NODE_ID")?,
             heartbeat_poll: duration_secs(&get, "CEPHOR_HEARTBEAT_POLL_SECS", DEFAULT_HEARTBEAT_POLL)?,

--- a/crates/hippius-drain-agent/src/enqueue.rs
+++ b/crates/hippius-drain-agent/src/enqueue.rs
@@ -106,14 +106,16 @@ impl UploadEnqueuer for RedisEnqueuer {
 
     async fn enqueue(&self, part: &PartKey) -> Result<(), EnqueueError> {
         let Some(ctx) = self.store.load_upload_context(part).await.map_err(EnqueueError::Store)? else {
-            // Diagnostic: name the part so a stuck/abandoned not-ready loop is traceable
-            // (the upload context is missing because object_versions.address is NULL or
-            // the version row is absent for this exact object_id/version).
-            tracing::warn!(
+            // Not-ready is now an EXPECTED, common outcome, not an anomaly: the drain commits
+            // `replicated` and enqueues best-effort, so an in-flight MPU part (address NULL until
+            // CompleteMultipartUpload) hits this on the inline attempt AND on each enqueue-sweep
+            // pass until the address lands. debug, not warn, so it does not spam; a genuinely
+            // abandoned part is surfaced by the aged-orphan gauge + the reaper, not by this line.
+            tracing::debug!(
                 object_id = %part.object().as_str(),
                 version = part.version().get(),
                 part = part.part().get(),
-                "upload context not ready (address NULL or version row absent)",
+                "upload context not ready (address NULL or version row absent); enqueue sweep will retry",
             );
             return Err(EnqueueError::NotReady);
         };

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -801,6 +801,12 @@ mod part_tests {
             }
         }
 
+        async fn mark_upload_enqueued(&self, _part: &PartKey) -> Result<(), io::Error> {
+            // The localfs drain tests assert the SSD/pool copy + commit; the upload_enqueued_at
+            // stamp is exercised by the core partdrain tests + the store integration tests.
+            Ok(())
+        }
+
         fn mark_failed(&self, part: &ClaimedPart, _reason: &str) -> impl Future<Output = Result<(), io::Error>> + Send {
             let key = Self::key(part.part());
             async move {

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -23,8 +23,8 @@ use crate::supervisor::{RunReport, Supervisor, WorkerName};
 use crate::worker::drain_until_empty;
 use hippius_drain_core::{
     BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, CoordError, Coordinator, Enforcer, NodeId, NodeObservation,
-    ReclaimError, SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket, UploadEnqueuer, decay_rate, jittered, reclaim_ssd,
-    reconcile_parts,
+    PartReplicationStore, ReclaimError, SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket, UploadEnqueuer, decay_rate, jittered,
+    reclaim_ssd, reconcile_parts,
 };
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -87,6 +87,10 @@ pub struct RuntimeConfig {
     pub reconcile_poll: Duration,
     /// How often the reclaim worker scans the SSD for `failed` (abandoned-upload) parts.
     pub reclaim_poll: Duration,
+    /// How often the enqueue sweep publishes the backend upload for `replicated` parts whose
+    /// address was not finalized at drain time (an in-flight MPU). Short, since a completed
+    /// MPU's parts should publish promptly — but off the read path, so seconds is fine.
+    pub enqueue_poll: Duration,
     /// How long a `failed` part (and an orphan write-temp) is kept before the reclaim
     /// worker unlinks it — a diagnosis / abort-settle window.
     pub reclaim_grace: Duration,
@@ -359,6 +363,47 @@ async fn redrive_corrupt_once(store: &Store, snapshot: &SnapshotCell, max_attemp
     }
 }
 
+/// How many replicated-but-unenqueued parts one enqueue-sweep pass publishes. Bounded so a
+/// large post-CompleteMPU burst is drained over a few passes rather than one giant query +
+/// Redis fan-out; the partial index keeps each scan cheap, and the leftover is picked up on
+/// the next tick.
+const ENQUEUE_SWEEP_BATCH: u32 = 512;
+
+/// One enqueue-sweep pass: publish the backend `UploadChainRequest` for this node's
+/// `replicated` parts whose upload was not enqueued at drain time (an in-flight MPU part whose
+/// `object_versions.address` was still NULL). For each, attempt the enqueue; on success stamp
+/// `upload_enqueued_at` so the part drops off the worklist. This is the decoupled counterpart
+/// to the drain's inline best-effort enqueue: it re-drives the publish once `CompleteMPU` lands
+/// the address, so the Ceph-commit never has to wait on it. A not-ready enqueue (address still
+/// NULL) is left for the next pass; a genuinely abandoned part is swept to `failed` by the
+/// mpu-reaper's orphan sweep, not here. Errors log and retry next poll (fail-safe: an
+/// un-stamped part is simply re-attempted).
+async fn enqueue_sweep_once<E: UploadEnqueuer>(store: &Store, enqueuer: &E) {
+    let parts = match store.list_replicated_unenqueued_parts(ENQUEUE_SWEEP_BATCH).await {
+        Ok(parts) => parts,
+        Err(err) => {
+            tracing::warn!(error = %err, "enqueue-sweep worklist query failed; will retry next poll");
+            return;
+        }
+    };
+    let mut published = 0u64;
+    for part in &parts {
+        // A failed enqueue is the common not-ready case (address still NULL) or a transient
+        // Redis blip: skip it, the next pass retries. The concrete enqueuer logs the not-ready
+        // case at debug. Only stamp AFTER a successful publish, so a crash between the two just
+        // re-publishes (idempotent at the consumer) on the next pass.
+        if enqueuer.enqueue(part).await.is_ok() {
+            match store.mark_upload_enqueued(part).await {
+                Ok(()) => published += 1,
+                Err(err) => tracing::warn!(error = %err, "enqueue-sweep stamp failed; will re-publish next poll"),
+            }
+        }
+    }
+    if published > 0 {
+        tracing::info!(published, "enqueue sweep published backend uploads for replicated parts");
+    }
+}
+
 /// Sets the enforcer's rate under its lock. The op is synchronous, so the guard
 /// never crosses an `.await` (axiom `rust_quality_74`); a poisoned lock recovers
 /// via `into_inner` — the `Enforcer` is a small `Copy` value left consistent.
@@ -549,6 +594,10 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
 
     /// Spawns the workers under a supervisor and runs until `shutdown` resolves
     /// (or a worker faults), returning how every worker wound down.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one linear block of worker-spawn wiring (drain, reconcile, ssd_reclaim, enqueue_sweep, heartbeat, allocation); splitting it would just scatter the topology"
+    )]
     pub async fn run(self, shutdown: impl Future<Output = ()>) -> RunReport {
         let mut supervisor = Supervisor::new(self.config.grace);
 
@@ -600,6 +649,19 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
                     // node-local SSD lifecycle); errors log and retry next poll (fail-safe).
                     redrive_corrupt_once(&store, &snapshot, redrive_max_attempts).await;
                 }
+            })
+        });
+
+        // Enqueue-sweep worker: publish the backend upload for `replicated` parts whose
+        // address was NULL at drain time (an in-flight MPU) — the decoupled counterpart to the
+        // drain's inline best-effort enqueue. Uses only the Postgres store + the shared
+        // enqueuer, so it runs whenever the drain does (no coordinator needed).
+        let (store, enqueuer) = (Arc::clone(&self.store), Arc::clone(&self.enqueuer));
+        let enqueue_poll = self.config.enqueue_poll;
+        supervisor.spawn(WorkerName::new("enqueue_sweep"), move |token| {
+            run_periodic(token, enqueue_poll, move || {
+                let (store, enqueuer) = (Arc::clone(&store), Arc::clone(&enqueuer));
+                async move { enqueue_sweep_once(store.as_ref(), enqueuer.as_ref()).await }
             })
         });
 
@@ -883,6 +945,7 @@ mod tests {
             RuntimeConfig {
                 drain_poll: Duration::from_mins(1),
                 reconcile_poll: Duration::from_mins(1),
+                enqueue_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
@@ -956,6 +1019,7 @@ mod tests {
             RuntimeConfig {
                 drain_poll: Duration::from_mins(1),
                 reconcile_poll: Duration::from_mins(1),
+                enqueue_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
@@ -1047,6 +1111,7 @@ mod tests {
                 // Park drain/reconcile; this test exercises only the heartbeat.
                 drain_poll: Duration::from_mins(1),
                 reconcile_poll: Duration::from_mins(1),
+                enqueue_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
@@ -1111,6 +1176,7 @@ mod tests {
             RuntimeConfig {
                 drain_poll: Duration::from_millis(20),
                 reconcile_poll: Duration::from_millis(20),
+                enqueue_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
@@ -1158,6 +1224,7 @@ mod tests {
             RuntimeConfig {
                 drain_poll: Duration::from_millis(20),
                 reconcile_poll: Duration::from_millis(50),
+                enqueue_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -665,15 +665,14 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
-    async fn an_enqueue_deferral_counts_as_deferred_not_failed_and_spares_the_breaker(pool: PgPool) {
-        // P1a end-to-end through drain_next: a part whose Ceph copy + verify succeed
-        // but whose post-write enqueue defers (address not finalized / Redis down)
-        // must (1) count as `deferred`, not `failed`, so error_bps stays a clean
-        // Ceph-write signal; (2) be returned to `pending` for a later re-drain; and
-        // (3) NOT signal the breaker. The enforcer's breaker trips on a single Ceph
-        // failure, so a subsequently-admitted drain is the proof the deferral never
-        // reached it — which is what kept an in-progress large MPU from wedging the
-        // whole node's drain.
+    async fn a_not_ready_enqueue_commits_replicated_and_lands_on_the_sweep_worklist(pool: PgPool) {
+        // Tier-2 decoupled commit end-to-end through drain_next: a part whose Ceph copy + verify
+        // succeed but whose backend enqueue is not ready (an in-flight MPU whose address is NULL)
+        // now (1) COMMITS Replicated and frees the SSD copy — it does NOT defer + re-copy as
+        // before; (2) counts as `drained`, not `deferred`/`failed`; (3) is left unstamped
+        // (upload_enqueued_at NULL) on the enqueue-sweep worklist so the publish is re-driven once
+        // the address lands. The enforcer's breaker trips on a single Ceph failure, so a
+        // subsequently-admitted drain proves a successful commit never signalled it.
         let ssd_dir = tempfile::tempdir().unwrap();
         let pool_dir = tempfile::tempdir().unwrap();
         let ssd = LocalSsd::new(ssd_dir.path());
@@ -691,24 +690,30 @@ mod tests {
         let part = part_at(5, 1);
         seed_part(ssd_dir.path(), &store, &part, &[b"deferred part bytes"]).await;
 
-        let err = drain_next(&ceph, &ssd, &store, &DeferringEnqueuer, Some(&enforcer), Some(&snapshot))
+        let outcome = drain_next(&ceph, &ssd, &store, &DeferringEnqueuer, Some(&enforcer), Some(&snapshot))
             .await
-            .unwrap_err();
-        assert!(
-            matches!(err, super::DrainCycleError::Drain(_)),
-            "the deferral surfaces as a drain error, got {err:?}"
-        );
+            .unwrap();
+        assert_eq!(outcome, Some(DrainOutcome::Replicated), "a not-ready enqueue still commits Replicated");
 
         let counts = snapshot.load();
-        assert_eq!(counts.deferred, 1, "the enqueue deferral was counted as deferred");
-        assert_eq!(counts.failed, 0, "a deferral is not a Ceph-write failure");
-        assert_eq!(counts.drained, 0, "the part was not committed, so it is not drained");
-        assert_eq!(counts.error_bps(), 0, "deferrals stay out of the Ceph failure rate");
+        assert_eq!(counts.drained, 1, "the part was committed (Ceph-durable)");
+        assert_eq!(counts.deferred, 0, "a not-ready enqueue is no longer a deferral");
+        assert_eq!(counts.failed, 0, "and it is not a Ceph-write failure");
+        assert_eq!(counts.error_bps(), 0, "so it stays out of the Ceph failure rate");
 
         assert_eq!(
             status_of(&store, &part).await,
-            Some(ReplicationState::Pending),
-            "a deferred part is returned to pending for a later re-drain",
+            Some(ReplicationState::Replicated),
+            "the Ceph commit is decoupled from the address-gated enqueue",
+        );
+        assert!(
+            !ssd_dir.path().join(part.relative_dir()).exists(),
+            "the SSD copy is freed — the uploader reads the chunks from the shared pool",
+        );
+        let worklist = store.list_replicated_unenqueued_parts(10).await.unwrap();
+        assert!(
+            worklist.contains(&part),
+            "the un-enqueued replicated part is on the enqueue-sweep worklist",
         );
 
         // The breaker (threshold 1) never saw a failure, so a fresh drain is still
@@ -716,7 +721,7 @@ mod tests {
         assert_eq!(
             enforcer.lock().unwrap().try_drain(1, Instant::now()),
             DrainDecision::Allowed,
-            "the deferral neither tripped the breaker nor leaked the permit",
+            "a committed drain neither tripped the breaker nor leaked the permit",
         );
     }
 
@@ -758,13 +763,12 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
-    async fn a_deferred_part_does_not_starve_the_ready_parts_in_a_burst(pool: PgPool) {
-        // A not-ready part must not stop the burst: part 1 defers (backs off) but parts
-        // 2 and 3 are ready and must still replicate in the same run. concurrency=1
-        // forces serial claims so part 1 (the oldest) is reached first — without the
-        // skip-and-continue, its deferral would stop the burst before 2 and 3 drain.
-        // This is the starvation the e2e DLQ MPU hit: ready parts crowded out by
-        // not-ready ones (in-progress / abandoned MPUs).
+    async fn a_not_ready_enqueue_does_not_stall_the_burst_and_only_it_awaits_the_sweep(pool: PgPool) {
+        // Tier-2 decoupled commit: a not-ready enqueue no longer defers, so ALL three parts
+        // commit Replicated in one burst — part 1's backend enqueue is not ready (address NULL)
+        // but it still commits, and parts 2 and 3 enqueue inline. Only part 1 is left unstamped
+        // on the enqueue-sweep worklist; parts 2 and 3 are stamped and off it. concurrency=1
+        // forces serial claims so part 1 (the oldest) is reached first.
         let ssd_dir = tempfile::tempdir().unwrap();
         let pool_dir = tempfile::tempdir().unwrap();
         let ssd = LocalSsd::new(ssd_dir.path());
@@ -775,26 +779,23 @@ mod tests {
         }
 
         let token = CancellationToken::new();
-        // A burst of only deferrals + successes is not a cycle error, so this is Ok.
         let drained = drain_until_empty(&ceph, &ssd, &store, &DeferPartOneEnqueuer, None, None, &token, 1)
             .await
             .unwrap();
-        assert_eq!(drained, 2, "the two ready parts drained despite part 1 deferring");
+        assert_eq!(drained, 3, "all three parts committed (a not-ready enqueue no longer defers)");
 
+        for number in 1..=3_u32 {
+            assert_eq!(
+                status_of(&store, &part_at(5, number)).await,
+                Some(ReplicationState::Replicated),
+                "part {number} committed Replicated",
+            );
+        }
+        let worklist = store.list_replicated_unenqueued_parts(10).await.unwrap();
         assert_eq!(
-            status_of(&store, &part_at(5, 2)).await,
-            Some(ReplicationState::Replicated),
-            "ready part 2 drained"
-        );
-        assert_eq!(
-            status_of(&store, &part_at(5, 3)).await,
-            Some(ReplicationState::Replicated),
-            "ready part 3 drained"
-        );
-        assert_eq!(
-            status_of(&store, &part_at(5, 1)).await,
-            Some(ReplicationState::Pending),
-            "the deferred part is backed off (pending), not replicated and not starving the rest",
+            worklist,
+            vec![part_at(5, 1)],
+            "only the not-ready part 1 awaits the enqueue sweep; parts 2 & 3 enqueued inline",
         );
     }
 

--- a/crates/hippius-drain-core/migrations/0012_replication_upload_enqueued.sql
+++ b/crates/hippius-drain-core/migrations/0012_replication_upload_enqueued.sql
@@ -1,0 +1,27 @@
+-- Decouple the Ceph-commit from the backend-upload enqueue.
+--
+-- Before this, drain_part enqueued the backend UploadChainRequest (which needs
+-- object_versions.address) BEFORE committing 'replicated', so an in-flight MPU part
+-- (address NULL until CompleteMultipartUpload) deferred and RE-COPIED to the pool on
+-- every poll until the object completed. Now drain_part commits 'replicated' as soon as
+-- the verified copy is durable on the pool, and a separate enqueue sweep publishes the
+-- backend upload once the address lands. This column records that publish so the sweep
+-- knows what is still outstanding.
+--
+-- upload_enqueued_at:
+--   NULL      -> replicated on Ceph but the backend upload has NOT been enqueued yet
+--               (an in-flight/abandoned MPU whose address is not written, or a transient
+--               enqueue miss the sweep will retry).
+--   timestamp -> the backend UploadChainRequest was published to the {backend}_upload_requests
+--               queues; the sweep is done with this part.
+--
+-- Only meaningful for status='replicated'. Terminal 'failed'/'corrupt' and live
+-- 'pending'/'draining' rows leave it NULL.
+ALTER TABLE cephor_replication_status ADD COLUMN upload_enqueued_at TIMESTAMPTZ;
+
+-- The enqueue sweep's worklist: this node's replicated parts still awaiting a backend
+-- enqueue, oldest-committed first. A partial index keyed on the exact predicate keeps the
+-- sweep's scan proportional to the small outstanding set, never the full table.
+CREATE INDEX cephor_replication_unenqueued_idx
+    ON cephor_replication_status (node_id, updated_at)
+    WHERE status = 'replicated' AND upload_enqueued_at IS NULL;

--- a/crates/hippius-drain-core/src/partdrain.rs
+++ b/crates/hippius-drain-core/src/partdrain.rs
@@ -11,11 +11,19 @@
 //! # The ordering that must not change
 //!
 //! `persist every chunk (copy+fsync+rename) → byte-verify each copy → persist
-//! meta.json LAST → commit Replicated → unlink the SSD part`. `meta.json` is the
-//! reader's readiness gate, so writing it last means a reader never sees a
-//! half-copied part on `CephFS`; and the SSD copy — the only durable one until the
-//! pool copy is complete and committed — is unlinked only on the post-commit `Ok`
-//! path. [`PartVerified`] makes "commit before verify" a compile error.
+//! meta.json LAST → commit Replicated → (best-effort) enqueue the backend upload →
+//! unlink the SSD part`. `meta.json` is the reader's readiness gate, so writing it
+//! last means a reader never sees a half-copied part on `CephFS`; and the SSD copy —
+//! the only durable one until the pool copy is complete and committed — is unlinked
+//! only on the post-commit `Ok` path. [`PartVerified`] makes "commit before verify" a
+//! compile error.
+//!
+//! The commit is DECOUPLED from the backend enqueue: `mark_replicated` fires as soon as
+//! the verified copy is durable on the pool, and the address-gated
+//! [`UploadEnqueuer::enqueue`] runs afterward, best-effort. An in-flight MPU part (address
+//! NULL until `CompleteMultipartUpload`) therefore reaches `Replicated` on the first drain
+//! instead of deferring + re-copying every poll; the agent's enqueue sweep publishes its
+//! backend upload once the address lands.
 
 use crate::apipart::{ChunkIndex, PartKey, PartMeta};
 use crate::enforce::BreakerSignal;
@@ -216,6 +224,13 @@ pub trait PartReplicationStore: Send + Sync {
     /// copy was verified, so this cannot be called before verification.
     fn mark_replicated(&self, part: &ClaimedPart, proof: &PartVerified) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
+    /// Stamp that this part's backend `UploadChainRequest` has been published (sets
+    /// `upload_enqueued_at`). Called after a successful enqueue — inline in [`drain_part`]
+    /// for the common ready case, and by the agent's enqueue sweep for parts whose address
+    /// was not finalized at drain time. Keyed on `status = 'replicated'` and idempotent, so
+    /// a re-stamp (a re-drive or a sweep racing the inline enqueue) is a harmless no-op.
+    fn mark_upload_enqueued(&self, part: &PartKey) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
     /// Record that the part's drain failed (e.g. a byte-mismatch on copy).
     fn mark_failed(&self, part: &ClaimedPart, reason: &str) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
@@ -235,21 +250,28 @@ pub trait PartReplicationStore: Send + Sync {
 
 /// Publishes the per-part backend upload request once the part is durably on the pool.
 ///
-/// Called by [`drain_part`] **after** the verified copy + meta are persisted but
-/// **before** `mark_replicated` commits — so a crash between the enqueue and the commit
-/// leaves the part `draining`, which a later re-drain re-enqueues (a harmless duplicate;
-/// the backend uploader is idempotent). This is the at-least-once seam that lets the
-/// drain be the sole upload producer without a separate notify/sweep.
+/// Called by [`drain_part`] **after** `mark_replicated` commits (the Ceph copy is durable
+/// and the SSD source is about to be freed) — a **best-effort** publish that does NOT gate
+/// the commit. When the upload context is not ready yet (an in-progress MPU whose
+/// `object_versions.address` is still NULL) the impl returns an error and the part is left
+/// with `upload_enqueued_at` NULL; the agent's **enqueue sweep** re-publishes it once the
+/// address lands. Enqueue is idempotent at the consumer (the backend uploader dedups via
+/// `chunk_backend ON CONFLICT`), so the inline publish racing the sweep is harmless.
+///
+/// This decouples the Ceph-commit from the address-gated enqueue: an MPU part reaches
+/// `replicated` as soon as it is verified on the pool, instead of deferring + re-copying
+/// every poll until `CompleteMultipartUpload`.
 ///
 /// The trait is storage-generic (takes only a [`PartKey`]); the concrete impl lives in
 /// the agent, which loads the request fields from the store and pushes to Redis — so
 /// `hippius-drain-core` stays free of Redis and the app schema.
 pub trait UploadEnqueuer: Send + Sync {
-    /// Impl-specific failure, boxed into [`PartDrainError::Enqueue`].
+    /// Impl-specific failure. In [`drain_part`] it is logged and swallowed (the enqueue
+    /// sweep retries); it never fails the drain.
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Enqueue the part's backend upload request(s). Idempotent at the consumer, so a
-    /// retry after a transient failure (or a re-drain) is safe.
+    /// retry after a transient failure (or the sweep re-publishing) is safe.
     fn enqueue(&self, part: &PartKey) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
@@ -282,11 +304,6 @@ pub enum PartDrainError {
     /// The replication store rejected a state transition; nothing was unlinked.
     #[error("replication store rejected the drain")]
     Store(#[source] Box<dyn std::error::Error + Send + Sync>),
-    /// Enqueuing the backend upload request failed (e.g. Redis unavailable, or the
-    /// upload context isn't ready yet). The part is NOT committed, so it stays
-    /// `draining` and a later re-drain re-enqueues it — no upload is lost.
-    #[error("enqueuing the backend upload failed")]
-    Enqueue(#[source] Box<dyn std::error::Error + Send + Sync>),
     /// The SSD part's `meta.json` declares more (or different) chunks than are present on
     /// disk — the part is incomplete (its chunks were partly removed after meta landed, or
     /// an ingest crash left it torn). It is NOT committed and NOT unlinked; the SSD copy is
@@ -307,24 +324,22 @@ impl PartDrainError {
         Self::Store(Box::new(err))
     }
 
-    /// Box an enqueuer error into [`PartDrainError::Enqueue`].
-    fn enqueue<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
-        Self::Enqueue(Box::new(err))
-    }
-
     /// Whether this failure is a benign deferral rather than a Ceph-write failure — the
     /// part could not be drained *right now* for a reason that is NOT evidence of `CephFS`
     /// unhealth, so the caller must neither trip the node-global Ceph breaker nor count
     /// it as a failure; the part is backed off and a later re-drain retries it.
     ///
     /// Two cases:
-    /// - [`Enqueue`](Self::Enqueue): the upload context isn't ready (an in-progress MPU
-    ///   whose `object_versions.address` is still NULL, or Redis briefly unreachable).
+    /// - [`IncompleteSource`](Self::IncompleteSource): the SSD part's chunks were partly
+    ///   removed after its meta landed (a torn/aborted ingest); it is not whole yet.
     /// - [`Io`](Self::Io) with [`ErrorKind::NotFound`](std::io::ErrorKind::NotFound): the
     ///   SSD source/part vanished mid-drain — an overwrite, a concurrent clean, or a part
     ///   another cycle already drained and unlinked. The pool is healthy; there is simply
     ///   nothing to copy. Any OTHER `Io` error (`EIO`, `ENOTCONN`, permission, no-space…)
     ///   is a genuine write failure and still trips the breaker.
+    ///
+    /// (A not-ready backend enqueue is no longer a deferral: the drain commits `Replicated`
+    /// first and the enqueue is best-effort, retried by the agent's enqueue sweep.)
     ///
     /// Scoped by `ErrorKind`, not by which side raised it: in principle a pool-side
     /// `ENOENT` (the pool dir removed between `create_dir_all` and the file write) would
@@ -337,7 +352,7 @@ impl PartDrainError {
     #[must_use]
     pub fn is_benign_deferral(&self) -> bool {
         match self {
-            Self::Enqueue(_) | Self::IncompleteSource { .. } => true,
+            Self::IncompleteSource { .. } => true,
             Self::Io { source, .. } => source.kind() == std::io::ErrorKind::NotFound,
             _ => false,
         }
@@ -353,22 +368,21 @@ impl PartDrainError {
     /// unhealth, so it must not halt draining of a healthy pool from every OTHER part on the
     /// node — it defers this part instead (`breaker_signal_for` maps a non-benign,
     /// non-Ceph error to [`BreakerSignal::Deferred`]). A `Store`/claim-coordination error
-    /// (Postgres-domain) is likewise excluded, and `Enqueue` / `IncompleteSource` are benign
-    /// deferrals (see [`is_benign_deferral`](Self::is_benign_deferral)).
+    /// (Postgres-domain) is likewise excluded, and `IncompleteSource` is a benign
+    /// deferral (see [`is_benign_deferral`](Self::is_benign_deferral)).
     #[must_use]
     pub fn is_ceph_write_failure(&self) -> bool {
         match self {
             // SSD-side step (local-disk unhealth, whatever the errno — the fix for the
             // `Persist`-overload where a local SSD-read EIO tripped the node-global Ceph
-            // breaker), plus the non-Ceph domains (Postgres store/claim, enqueue-not-ready,
-            // incomplete source): none is evidence of pool unhealth. Matched BEFORE the
-            // general `Io` arm so an SSD-side `Io` is caught here first.
+            // breaker), plus the non-Ceph domains (Postgres store/claim, incomplete
+            // source): none is evidence of pool unhealth. Matched BEFORE the general `Io`
+            // arm so an SSD-side `Io` is caught here first.
             Self::Io {
                 step: DrainStep::SsdRead | DrainStep::Unlink,
                 ..
             }
             | Self::Store(_)
-            | Self::Enqueue(_)
             | Self::IncompleteSource { .. } => false,
             // Any remaining `Io` is a Ceph-side step (`Persist`/`Hash`/`Cleanup`): a non-ENOENT
             // error is genuine pool unhealth.
@@ -384,11 +398,11 @@ impl PartDrainError {
 }
 
 /// The circuit-breaker signal for a completed drain outcome — the one place that decides
-/// which failures count as `CephFS` unhealth. `Ok` succeeds; a benign deferral (enqueue
-/// not ready / vanished source / incomplete part) AND a store/claim-coordination error
-/// both leave the breaker untouched ([`BreakerSignal::Deferred`]); only a genuine
-/// Ceph-write failure trips it. Lives with the error type (not the agent) so the policy is
-/// unit-testable and the agent worker is a thin caller.
+/// which failures count as `CephFS` unhealth. `Ok` succeeds; a benign deferral (vanished
+/// source / incomplete part) AND a store/claim-coordination error both leave the breaker
+/// untouched ([`BreakerSignal::Deferred`]); only a genuine Ceph-write failure trips it.
+/// Lives with the error type (not the agent) so the policy is unit-testable and the agent
+/// worker is a thin caller.
 #[must_use]
 pub fn breaker_signal_for(result: &Result<DrainOutcome, PartDrainError>) -> BreakerSignal {
     match result {
@@ -509,16 +523,23 @@ where
     ceph.finalize_part(part).await.map_err(PartDrainError::io(DrainStep::Persist))?;
     let verified = PartVerified(());
 
-    // Enqueue the backend upload BEFORE committing (at-least-once): the part is now
-    // durably on the pool and readable, so the uploader can serve it. If this fails the
-    // part stays `draining` and a re-drain re-enqueues — no upload is lost, and the dup
-    // is harmless (idempotent uploader). The drain is thus the sole upload producer with
-    // no separate notify/sweep.
-    enqueuer.enqueue(part).await.map_err(PartDrainError::enqueue)?;
-
-    // Commit Replicated. Only past this point — a durable, verified, committed copy
-    // exists AND its upload is enqueued — is removing the SSD part safe.
+    // Commit Replicated as soon as the verified copy is durable on the pool — the Ceph
+    // commit is DECOUPLED from the address-gated backend enqueue. Only past this point does a
+    // durable, verified, committed copy exist, so removing the SSD part is safe (the backend
+    // uploader reads the chunks from the shared pool, not this SSD source).
     store.mark_replicated(claim, &verified).await.map_err(PartDrainError::store)?;
+
+    // Best-effort backend enqueue, decoupled from the commit. For a simple PUT or a completed
+    // MPU the address is ready, so this publishes the UploadChainRequest and stamps
+    // `upload_enqueued_at` inline. For an in-flight MPU the address is still NULL and the enqueue
+    // errors — the part stays `replicated` with `upload_enqueued_at` NULL, and the agent's enqueue
+    // sweep re-publishes it once CompleteMultipartUpload writes the address (idempotent at the
+    // consumer). A not-ready/failed enqueue is intentionally swallowed here: it must NEVER
+    // un-commit the part or fail the drain. Before this change an MPU part deferred and re-copied
+    // its whole self to the pool on every poll until the object completed; now it copies once.
+    if enqueuer.enqueue(part).await.is_ok() {
+        store.mark_upload_enqueued(part).await.map_err(PartDrainError::store)?;
+    }
 
     ssd.remove_part(part).await.map_err(PartDrainError::io(DrainStep::Unlink))?;
     Ok(DrainOutcome::Replicated)
@@ -545,7 +566,7 @@ mod tests {
     const UUID: &str = "466916c0-d61b-4518-b81b-9576b574270a";
 
     #[test]
-    fn is_benign_deferral_spares_the_breaker_only_for_enqueue_and_vanished_source() {
+    fn is_benign_deferral_spares_the_breaker_only_for_incomplete_and_vanished_source() {
         // ENOENT reading the SSD source (overwrite / concurrent clean / already drained)
         // is benign — the pool is healthy, there is just nothing to copy. It must NOT trip
         // the node-global Ceph breaker.
@@ -554,10 +575,6 @@ mod tests {
             source: io::Error::from(io::ErrorKind::NotFound),
         };
         assert!(vanished.is_benign_deferral(), "a vanished SSD source (ENOENT) is a benign deferral");
-
-        // Not-ready upload context is likewise benign (in-progress MPU / Redis blip).
-        let not_ready = PartDrainError::enqueue(io::Error::from(io::ErrorKind::ConnectionRefused));
-        assert!(not_ready.is_benign_deferral(), "an enqueue failure is a benign deferral");
 
         // An incomplete SSD part (chunks removed after meta landed) is benign — the pool
         // is healthy; the part just isn't whole yet. It defers, not trips the breaker.
@@ -593,9 +610,8 @@ mod tests {
     #[test]
     fn is_ceph_write_failure_only_for_real_pool_io_and_mismatch() {
         // WI-10: only genuine Ceph-write faults trip the node-global breaker. A real pool
-        // I/O error and a byte-mismatch do; a store/claim error, an enqueue deferral, an
-        // ENOENT vanished source, and an incomplete SSD part do NOT (they are not evidence
-        // the pool is unhealthy).
+        // I/O error and a byte-mismatch do; a store/claim error, an ENOENT vanished source,
+        // and an incomplete SSD part do NOT (they are not evidence the pool is unhealthy).
         let real_io = PartDrainError::Io {
             step: DrainStep::Persist,
             source: io::Error::from(io::ErrorKind::Other),
@@ -618,8 +634,6 @@ mod tests {
             !store_err.is_ceph_write_failure(),
             "a store/claim error is a Postgres-domain fault, not Ceph"
         );
-        let enqueue = PartDrainError::enqueue(io::Error::from(io::ErrorKind::ConnectionRefused));
-        assert!(!enqueue.is_ceph_write_failure(), "an enqueue deferral is not a Ceph failure");
         let incomplete = PartDrainError::IncompleteSource { declared: 3, present: 2 };
         assert!(!incomplete.is_ceph_write_failure(), "an incomplete SSD part is not a Ceph failure");
 
@@ -659,9 +673,12 @@ mod tests {
         // (breaker untouched); only a genuine Ceph-write failure -> CephFailure.
         assert_eq!(breaker_signal_for(&Ok(DrainOutcome::Replicated)), BreakerSignal::CephSuccess);
         assert_eq!(
-            breaker_signal_for(&Err(PartDrainError::enqueue(io::Error::from(io::ErrorKind::ConnectionRefused)))),
+            breaker_signal_for(&Err(PartDrainError::Io {
+                step: DrainStep::SsdRead,
+                source: io::Error::from(io::ErrorKind::NotFound),
+            })),
             BreakerSignal::Deferred,
-            "an enqueue deferral does not trip the breaker",
+            "a vanished SSD source (ENOENT) does not trip the breaker",
         );
         assert_eq!(
             breaker_signal_for(&Err(PartDrainError::IncompleteSource { declared: 3, present: 2 })),
@@ -733,10 +750,14 @@ mod tests {
         /// Chunk index -> how many more persist attempts corrupt it, then succeed. Models a
         /// TRANSIENT torn write recovered by the bounded copy-retry (decremented per persist).
         corrupt_attempts: HashMap<u32, u32>,
-        /// When set, the upload enqueue fails (to test the at-least-once seam).
+        /// When set, the upload enqueue fails (address not ready / Redis blip) — the
+        /// decoupled enqueue is best-effort, so the drain still commits and the sweep retries.
         enqueue_fault: bool,
         /// Parts the enqueuer was asked to enqueue, in order.
         enqueued: Vec<String>,
+        /// Parts stamped `upload_enqueued_at` via `mark_upload_enqueued`, in order — set only
+        /// after a successful inline enqueue.
+        upload_stamped: Vec<String>,
         /// When set, `is_version_servable` returns true, so a persistent mismatch marks the
         /// part `Corrupt` (R4) instead of `Failed`. Default false = the abandoned-upload shape.
         servable: bool,
@@ -818,6 +839,10 @@ mod tests {
 
         fn enqueued(&self) -> Vec<String> {
             self.world.lock().unwrap().enqueued.clone()
+        }
+
+        fn upload_stamped(&self) -> Vec<String> {
+            self.world.lock().unwrap().upload_stamped.clone()
         }
 
         fn clear_faults(&self) {
@@ -1008,6 +1033,14 @@ mod tests {
             }
         }
 
+        fn mark_upload_enqueued(&self, part: &PartKey) -> impl Future<Output = Result<(), io::Error>> + Send {
+            let key = key_of(part);
+            async move {
+                self.world.lock().unwrap().upload_stamped.push(key);
+                Ok(())
+            }
+        }
+
         fn mark_failed(&self, part: &ClaimedPart, _reason: &str) -> impl Future<Output = Result<(), io::Error>> + Send {
             let key = key_of(part.part());
             async move {
@@ -1066,20 +1099,40 @@ mod tests {
         assert!(pooled.has_meta, "meta.json written");
         assert!(!fakes.ssd_has(&part), "SSD part unlinked only after commit");
         assert_eq!(fakes.enqueued(), vec![key_of(&part)], "the backend upload was enqueued");
+        assert_eq!(
+            fakes.upload_stamped(),
+            vec![key_of(&part)],
+            "a successful inline enqueue stamps upload_enqueued_at",
+        );
     }
 
     #[tokio::test]
-    async fn an_enqueue_failure_never_commits_and_preserves_the_ssd_copy() {
-        // At-least-once: if enqueuing the upload fails, the part is NOT committed and the
-        // SSD copy is kept, so a re-drain re-enqueues — no upload is lost.
+    async fn a_not_ready_enqueue_still_commits_replicated_and_leaves_it_unstamped() {
+        // Decoupled commit: if the backend enqueue is not ready (an in-flight MPU whose
+        // address is NULL) the drain STILL commits Replicated and unlinks the SSD copy — the
+        // part is Ceph-durable now, and the agent's enqueue sweep re-publishes the backend
+        // upload once the address lands. upload_enqueued_at stays unstamped so the sweep
+        // knows this part is still outstanding. (The old behavior deferred + re-copied here.)
         let part = part();
         let fakes = Fakes::seeded(&part, &[(0, "h0"), (1, "h1")]).enqueue_fault();
 
-        let err = drain_part(&fakes, &fakes, &fakes, &fakes, &claim(&part)).await.unwrap_err();
+        let outcome = drain_part(&fakes, &fakes, &fakes, &fakes, &claim(&part)).await.unwrap();
 
-        assert!(matches!(err, PartDrainError::Enqueue(_)), "got: {err:?}");
-        assert_eq!(fakes.status_of(&part), Some(ReplicationState::Pending), "must NOT commit Replicated");
-        assert!(fakes.ssd_has(&part), "SSD copy kept for the re-drain");
+        assert_eq!(outcome, DrainOutcome::Replicated, "a not-ready enqueue does not fail the drain");
+        assert_eq!(
+            fakes.status_of(&part),
+            Some(ReplicationState::Replicated),
+            "the Ceph commit is decoupled from the enqueue",
+        );
+        assert!(!fakes.ssd_has(&part), "the SSD copy is freed (the uploader reads from the pool)");
+        assert!(
+            fakes.upload_stamped().is_empty(),
+            "a not-ready enqueue leaves upload_enqueued_at NULL for the sweep to pick up",
+        );
+        assert!(
+            fakes.pool_part(&part).is_some_and(|p| p.has_meta),
+            "the verified part is durable on the pool",
+        );
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -265,12 +265,19 @@ impl Store {
         Ok(())
     }
 
-    /// Deletes terminal (`replicated`/`failed`) replication rows older than `retention`,
-    /// returning how many were removed. Terminal rows are inert — nothing returns one to a
-    /// live state (`release_part`/`defer_part` are guarded on `status='draining'`) — so
-    /// aged ones are pure debris that bloat the hot `claim_part` / reconcile scans. NEVER
-    /// touches `pending`/`draining` (live) rows. Idempotent and safe to run concurrently:
-    /// a row deleted by one sweep simply is not matched by another.
+    /// Deletes terminal replication rows older than `retention`, returning how many were
+    /// removed. Terminal rows are inert — nothing returns one to a live state
+    /// (`release_part`/`defer_part` are guarded on `status='draining'`) — so aged ones are
+    /// pure debris that bloat the hot `claim_part` / reconcile scans. NEVER touches
+    /// `pending`/`draining` (live) rows. Idempotent and safe to run concurrently: a row
+    /// deleted by one sweep simply is not matched by another.
+    ///
+    /// "Terminal" here is `failed` OR a `replicated` row whose backend upload has ALREADY
+    /// been enqueued (`upload_enqueued_at IS NOT NULL`). A `replicated` row still awaiting its
+    /// enqueue (`upload_enqueued_at IS NULL` — an in-flight MPU part committed to Ceph but not
+    /// yet published) is the enqueue sweep's worklist, so deleting it would DROP the backend
+    /// upload; it is spared until the sweep stamps it (or the reaper flips it `failed` as an
+    /// abandoned orphan, which this then GCs).
     ///
     /// # Errors
     ///
@@ -278,7 +285,8 @@ impl Store {
     pub async fn gc_terminal_status_rows(&self, retention: Duration) -> Result<u64> {
         let affected = sqlx::query(
             "DELETE FROM cephor_replication_status \
-             WHERE status IN ('replicated', 'failed') AND updated_at < now() - (interval '1 second' * $1)",
+             WHERE (status = 'failed' OR (status = 'replicated' AND upload_enqueued_at IS NOT NULL)) \
+               AND updated_at < now() - (interval '1 second' * $1)",
         )
         .bind(retention.as_secs_f64())
         .execute(&self.pool)
@@ -572,6 +580,31 @@ impl Store {
         rows.into_iter().map(PartRow::into_pending).collect()
     }
 
+    /// The enqueue sweep's worklist: up to `limit` of THIS node's `replicated` parts whose
+    /// backend upload has not yet been published (`upload_enqueued_at IS NULL`), oldest-
+    /// committed first. These are parts drained to the pool before their object's address was
+    /// finalized (an in-flight MPU) — the sweep re-attempts `enqueue` for each and, on success,
+    /// stamps [`mark_upload_enqueued`](PartReplicationStore::mark_upload_enqueued). Node-scoped
+    /// like `claim_part` (a part's upload identity is loaded via `load_upload_context`, but the
+    /// worklist is this node's own committed parts). Uses the `cephor_replication_unenqueued_idx`
+    /// partial index, so the scan is proportional to the small outstanding set.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Database`]; [`StoreError::Invalid`] if a stored part is malformed.
+    pub async fn list_replicated_unenqueued_parts(&self, limit: u32) -> Result<Vec<PartKey>> {
+        let rows = sqlx::query_as::<_, PartRow>(
+            "SELECT object_id, version, part_number FROM cephor_replication_status \
+             WHERE node_id = $1 AND status = 'replicated' AND upload_enqueued_at IS NULL \
+             ORDER BY updated_at LIMIT $2",
+        )
+        .bind(self.node_id.as_deref())
+        .bind(i64::from(limit))
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(PartRow::into_part).collect()
+    }
+
     /// Loads the non-derivable fields the agent needs to build a part's backend
     /// `UploadChainRequest` (s3-2.1 PR-11, drain-direct enqueue): `bucket_name`,
     /// `object_key`, the main-account `address`, and the latest `upload_id` (MPU only).
@@ -700,6 +733,24 @@ impl PartReplicationStore for Store {
                 part: part.relative_dir().to_string_lossy().into_owned().into(),
             });
         }
+        Ok(())
+    }
+
+    async fn mark_upload_enqueued(&self, part: &PartKey) -> Result<()> {
+        // Stamp the backend-enqueue completion. Guarded on `status = 'replicated'` (never a
+        // claim, since the enqueue sweep holds none): only a Ceph-durable part can have its
+        // upload published. Idempotent — a re-stamp (inline enqueue racing the sweep, or a
+        // re-drive) just re-writes now(). Zero rows (the part left `replicated`, e.g. a reaper
+        // flipped it `failed`) is a harmless no-op: there is nothing to publish for it anymore.
+        sqlx::query(
+            "UPDATE cephor_replication_status SET upload_enqueued_at = now() \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'replicated'",
+        )
+        .bind(part.object().as_str())
+        .bind(i64::from(part.version().get()))
+        .bind(i64::from(part.part().get()))
+        .execute(&self.pool)
+        .await?;
         Ok(())
     }
 
@@ -1167,36 +1218,56 @@ mod part_tests {
     /// reclaim age reads deterministically older than any plausible grace.
     #[sqlx::test]
     async fn gc_terminal_status_rows_prunes_only_aged_terminal_rows(pool: PgPool) {
-        // WI-17: prune aged replicated/failed rows; keep a FRESH terminal row and any
-        // pending/draining (live) row regardless of age.
+        // WI-17 + Tier-2: prune aged `failed` rows and aged `replicated` rows whose backend
+        // upload was ALREADY enqueued (upload_enqueued_at set). Keep: a FRESH terminal row, any
+        // pending/draining (live) row, AND — the Tier-2 guard — an aged `replicated` row still
+        // awaiting its enqueue (upload_enqueued_at NULL), the enqueue sweep's worklist: pruning
+        // it would drop the backend upload.
         let store = Store::from_pool(pool.clone());
-        let fresh = part(UUID_A, 5, 1);
-        let old_replicated = part(UUID_A, 5, 2);
-        let old_failed = part(UUID_A, 5, 3);
-        let pending = part(UUID_A, 5, 4);
-        for p in [&fresh, &old_replicated, &old_failed, &pending] {
+        let fresh = part(UUID_A, 5, 1); // replicated + enqueued, young -> kept (age gate)
+        let old_replicated_enqueued = part(UUID_A, 5, 2); // aged + enqueued -> pruned
+        let old_replicated_unenqueued = part(UUID_A, 5, 5); // aged, NOT enqueued -> spared (worklist)
+        let old_failed = part(UUID_A, 5, 3); // aged failed -> pruned
+        let pending = part(UUID_A, 5, 4); // live -> kept
+        for p in [&fresh, &old_replicated_enqueued, &old_replicated_unenqueued, &old_failed, &pending] {
             store.record_landed_part(p).await.unwrap();
         }
-        // Fresh: replicated but updated_at ~now, so it is younger than the retention.
-        sqlx::query("UPDATE cephor_replication_status SET status = 'replicated' WHERE object_id = $1 AND version = $2 AND part_number = $3")
-            .bind(fresh.object().as_str())
-            .bind(i64::from(fresh.version().get()))
-            .bind(i64::from(fresh.part().get()))
-            .execute(&pool)
-            .await
-            .unwrap();
-        force_terminal(&pool, &old_replicated, "replicated").await; // backdated 2h
+        // Fresh: replicated + enqueued but updated_at ~now, so it is younger than the retention —
+        // isolating the age gate from the enqueue guard.
+        sqlx::query(
+            "UPDATE cephor_replication_status SET status = 'replicated', upload_enqueued_at = now() \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(fresh.object().as_str())
+        .bind(i64::from(fresh.version().get()))
+        .bind(i64::from(fresh.part().get()))
+        .execute(&pool)
+        .await
+        .unwrap();
+        force_terminal(&pool, &old_replicated_enqueued, "replicated").await; // backdated 2h
+        // mark_upload_enqueued leaves updated_at untouched, so the row stays aged AND enqueued.
+        store.mark_upload_enqueued(&old_replicated_enqueued).await.unwrap();
+        force_terminal(&pool, &old_replicated_unenqueued, "replicated").await; // backdated 2h, left unstamped
         force_terminal(&pool, &old_failed, "failed").await; // backdated 2h
 
         let pruned = store.gc_terminal_status_rows(Duration::from_hours(1)).await.unwrap();
 
-        assert_eq!(pruned, 2, "only the two aged terminal rows are pruned");
+        assert_eq!(pruned, 2, "only the aged failed + aged enqueued-replicated rows are pruned");
         assert_eq!(
             store.status(&fresh).await.unwrap(),
             Some(ReplicationState::Replicated),
             "a fresh terminal row is kept"
         );
-        assert_eq!(store.status(&old_replicated).await.unwrap(), None, "the aged replicated row was pruned");
+        assert_eq!(
+            store.status(&old_replicated_enqueued).await.unwrap(),
+            None,
+            "the aged, already-enqueued replicated row was pruned"
+        );
+        assert_eq!(
+            store.status(&old_replicated_unenqueued).await.unwrap(),
+            Some(ReplicationState::Replicated),
+            "an aged replicated row still awaiting its enqueue is SPARED (the sweep worklist)"
+        );
         assert_eq!(store.status(&old_failed).await.unwrap(), None, "the aged failed row was pruned");
         assert_eq!(
             store.status(&pending).await.unwrap(),
@@ -2123,6 +2194,65 @@ mod part_tests {
         assert!(
             store.claim_part().await.unwrap().is_some(),
             "release clears the backoff, so a Ceph-failed part retries immediately",
+        );
+    }
+
+    /// Drives one part `pending → draining → replicated` (the drain's commit path) and returns it.
+    async fn seed_replicated(store: &Store, uuid: &str, version: u32, part_number: u32) -> crate::apipart::PartKey {
+        use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
+        use crate::partdrain::PartVerified;
+        use core::str::FromStr;
+        let part = PartKey::new(ObjectId::from_str(uuid).unwrap(), Version::new(version), PartNumber::new(part_number));
+        store.record_landed_part(&part).await.unwrap();
+        let claim = store.claim_part().await.unwrap().expect("claims the seeded pending part");
+        assert_eq!(claim.part(), &part);
+        store.mark_replicated(&claim, &PartVerified::for_test()).await.unwrap();
+        part
+    }
+
+    #[sqlx::test]
+    async fn the_enqueue_sweep_worklist_tracks_the_backend_publish(pool: PgPool) {
+        // Tier-2: a part committed `replicated` before its address landed is on the sweep
+        // worklist until mark_upload_enqueued stamps it (what the enqueue sweep does after a
+        // successful publish). The worklist is node-scoped and ordered by commit time.
+        let store = Store::from_pool(pool);
+        let part = seed_replicated(&store, "466916c0-d61b-4518-b81b-9576b574270a", 5, 1).await;
+
+        let before = store.list_replicated_unenqueued_parts(10).await.unwrap();
+        assert_eq!(before, vec![part.clone()], "a replicated, un-enqueued part is on the worklist");
+
+        store.mark_upload_enqueued(&part).await.unwrap();
+        assert!(
+            store.list_replicated_unenqueued_parts(10).await.unwrap().is_empty(),
+            "once stamped, the part drops off the sweep worklist",
+        );
+        // Idempotent: a second stamp (inline enqueue racing the sweep) is a harmless no-op.
+        store.mark_upload_enqueued(&part).await.unwrap();
+    }
+
+    #[sqlx::test]
+    async fn gc_spares_a_replicated_row_awaiting_enqueue_but_reaps_a_stamped_one(pool: PgPool) {
+        // The GC guard: gc_terminal_status_rows must NOT delete a `replicated` row whose backend
+        // upload is still outstanding (upload_enqueued_at IS NULL) — that would drop the enqueue
+        // sweep's worklist item and lose the backend upload. A stamped `replicated` row is
+        // genuinely terminal and IS reaped.
+        let store = Store::from_pool(pool);
+        let unenqueued = seed_replicated(&store, "466916c0-d61b-4518-b81b-9576b574270a", 5, 1).await;
+        let enqueued = seed_replicated(&store, "466916c0-d61b-4518-b81b-9576b574270a", 5, 2).await;
+        store.mark_upload_enqueued(&enqueued).await.unwrap();
+
+        // Retention ZERO makes every row "aged"; only the stamped one is eligible.
+        let removed = store.gc_terminal_status_rows(Duration::ZERO).await.unwrap();
+        assert_eq!(removed, 1, "only the stamped (fully terminal) replicated row is reaped");
+        assert_eq!(
+            <Store as PartReplicationStore>::status(&store, &unenqueued).await.unwrap(),
+            Some(crate::state::ReplicationState::Replicated),
+            "the un-enqueued row is spared so the enqueue sweep can still publish it",
+        );
+        assert_eq!(
+            <Store as PartReplicationStore>::status(&store, &enqueued).await.unwrap(),
+            None,
+            "the stamped row was GC'd",
         );
     }
 }

--- a/hippius_s3/sql/queries/count_aged_pending_orphans.sql
+++ b/hippius_s3/sql/queries/count_aged_pending_orphans.sql
@@ -7,7 +7,9 @@
 -- that leak so the soak gate can assert it is bounded and its slope is ~ 0.
 --
 -- It counts the same population SHAPE list_orphan_replication_versions.sql sweeps — an object
--- version that is (a) still ACTIVE on the drain (status IN ('pending','draining')),
+-- version that is (a) still non-terminal + not-yet-uploaded on the drain (status IN
+-- ('pending','draining') OR 'replicated' with upload_enqueued_at IS NULL — the Tier-2
+-- decoupled-commit orphan the sweep also flips 'failed'),
 -- (b) UNSERVABLE (the abandoned/leaked shape: address IS NULL AND size_bytes <= 0 AND
 -- md5_hash = ''), (c) idle past the grace (its most-recently-landed part older than
 -- $1 seconds — landed_at is the true idle signal, never bumped by drain re-claim/defer
@@ -44,7 +46,8 @@ FROM (
     JOIN object_versions ov
            ON ov.object_id = crs.object_id::uuid
           AND ov.object_version = crs.version
-    WHERE crs.status IN ('pending', 'draining')
+    WHERE (crs.status IN ('pending', 'draining')
+           OR (crs.status = 'replicated' AND crs.upload_enqueued_at IS NULL))
       AND ov.address IS NULL
       AND ov.size_bytes <= 0
       AND COALESCE(ov.md5_hash, '') = ''

--- a/hippius_s3/sql/queries/fail_replication_status_for_version.sql
+++ b/hippius_s3/sql/queries/fail_replication_status_for_version.sql
@@ -5,12 +5,39 @@
 -- claim_part (not re-claimed) on EVERY node, so the per-node drain stops re-copying and
 -- re-deferring the parts — even though the node-local SSD copies (unreachable from a
 -- central caller) remain for the orphan GC to reclaim. Deleting the rows instead would
--- be undone: each node's reconciler re-records a part it still sees on local SSD. Only
--- 'pending'/'draining' rows are touched; a 'replicated' row is legitimately done.
+-- be undone: each node's reconciler re-records a part it still sees on local SSD.
+--
+-- Two classes are failed:
+--   * 'pending'/'draining' — an active, never-committed part (unchanged behavior);
+--   * 'replicated' with upload_enqueued_at IS NULL AND the version UNSERVABLE — the Tier-2
+--     decoupled-commit orphan: a part committed to the pool before its address was written,
+--     whose backend upload the enqueue sweep can never publish because the abandoned object
+--     never got an address. Without failing it, the janitor's replication gate pins its pool
+--     copy forever (no chunk_backend rows). The UNSERVABLE guard (address IS NULL AND
+--     size_bytes<=0 AND md5_hash='') is MANDATORY on this arm: it keeps a NULL-$2 abort of one
+--     abandoned upload from flipping a *different, servable* version's part that is only
+--     momentarily replicated+unenqueued (an inline enqueue that hit a transient Redis blip) —
+--     that part is still on the enqueue-sweep worklist and must be published, not failed. The
+--     pending/draining arm keeps its original un-servability-gated behavior (the caller — the
+--     reaper's abandoned/orphan selection — already scoped it).
 -- A NULL $2 fails every still-active row for the object regardless of version: an
 -- abandoned upload (address IS NULL) is junk at every version, and legacy parts can
 -- carry a NULL object_version, so keying on version alone would strand them.
 -- Parameters: $1: object_id (text), $2: object_version (bigint, NULL = all versions)
-UPDATE cephor_replication_status
+UPDATE cephor_replication_status crs
 SET status = 'failed', updated_at = now(), claimed_at = NULL
-WHERE object_id = $1 AND ($2::bigint IS NULL OR version = $2) AND status IN ('pending', 'draining')
+WHERE crs.object_id = $1 AND ($2::bigint IS NULL OR crs.version = $2)
+  AND (
+        crs.status IN ('pending', 'draining')
+        OR (
+             crs.status = 'replicated' AND crs.upload_enqueued_at IS NULL
+             AND EXISTS (
+               SELECT 1 FROM object_versions ov
+               WHERE ov.object_id = crs.object_id::uuid
+                 AND ov.object_version = crs.version
+                 AND ov.address IS NULL
+                 AND ov.size_bytes <= 0
+                 AND COALESCE(ov.md5_hash, '') = ''
+             )
+           )
+      )

--- a/hippius_s3/sql/queries/list_orphan_replication_versions.sql
+++ b/hippius_s3/sql/queries/list_orphan_replication_versions.sql
@@ -6,9 +6,20 @@
 -- is the true backstop: it finds the leaked version from the drain rows alone.
 --
 -- A version is selected to be marked 'failed' iff ALL hold:
---   (a) it still has an ACTIVE drain row (status IN ('pending','draining')) — a
---       'replicated' row is legitimately done and a 'failed' row is already terminal, so
---       touching either would only churn the sweep;
+--   (a) it still has a NON-TERMINAL, NOT-YET-UPLOADED drain row — status IN
+--       ('pending','draining'), OR status='replicated' with upload_enqueued_at IS NULL. The
+--       latter is the Tier-2 decoupled-commit class: a part that drained to the pool before its
+--       object's address was written (an in-flight MPU) commits 'replicated' immediately, and
+--       its backend upload is enqueued LATER by the enqueue sweep. If the object is then
+--       ABANDONED the address never lands, so the part sits 'replicated' + unenqueued forever —
+--       invisible to the old pending/draining-only sweep, its pool copy pinned by the janitor's
+--       replication gate (no chunk_backend rows are ever written). Including it flips it 'failed'
+--       so janitor_part_terminally_abandoned.sql can reclaim the pool copy. A 'replicated' row
+--       that WAS enqueued (upload_enqueued_at set) means the address existed → the object
+--       completed → legitimately done, so it is excluded; a 'failed' row is already terminal. The
+--       version-level UNSERVABLE gate (b) still protects a servable version whose part is only
+--       momentarily replicated+unenqueued (an inline enqueue that hit a transient Redis blip):
+--       such a version can serve a GET, so it is never selected;
 --   (b) the version is UNSERVABLE — address IS NULL AND size_bytes<=0 AND md5_hash='' —
 --       the exact download-servability predicate janitor_part_terminally_abandoned.sql
 --       uses. The size/md5 clauses are NON-redundant with address IS NULL: address is
@@ -36,7 +47,8 @@ FROM cephor_replication_status crs
 JOIN object_versions ov
        ON ov.object_id = crs.object_id::uuid
       AND ov.object_version = crs.version
-WHERE crs.status IN ('pending', 'draining')
+WHERE (crs.status IN ('pending', 'draining')
+       OR (crs.status = 'replicated' AND crs.upload_enqueued_at IS NULL))
   AND ov.address IS NULL
   AND ov.size_bytes <= 0
   AND COALESCE(ov.md5_hash, '') = ''

--- a/hippius_s3/workers/unpinner.py
+++ b/hippius_s3/workers/unpinner.py
@@ -391,51 +391,50 @@ async def process_unpin_request(
 
             span.set_attribute("num_identifiers", len(rows))
 
-            async with backend_client_factory() as client:
-                # A9: the soft-delete is now GATED on a successful backend DELETE. Marking the
-                # chunk_backend row deleted while the backend object still exists would strand the
-                # pin forever (nothing retries a soft-deleted row) — a silent leak. So on an unpin
-                # failure we do NOT soft-delete; we record the failure and re-raise after the
-                # batch so process_unpin_request routes the whole request to retry/DLQ (the
-                # backend DELETE and the soft-delete are both idempotent, so a full retry is safe).
-                failures: list[Exception] = []
+            # A9: the soft-delete is now GATED on a successful backend DELETE. Marking the
+            # chunk_backend row deleted while the backend object still exists would strand the
+            # pin forever (nothing retries a soft-deleted row) — a silent leak. So on an unpin
+            # failure we do NOT soft-delete; we record the failure and re-raise after the
+            # batch so process_unpin_request routes the whole request to retry/DLQ (the
+            # backend DELETE and the soft-delete are both idempotent, so a full retry is safe).
+            failures: list[Exception] = []
 
-                async def _unpin_all(active_client: Any) -> None:
-                    async def _unpin_one(row: Any) -> None:
-                        identifier = row["backend_identifier"]
-                        chunk_id = row["chunk_id"]
-                        async with sem:
-                            try:
-                                await active_client.unpin_file(identifier, account_ss58=request.address)
-                                worker_logger.info(f"Unpinned {backend_name} identifier={identifier}")
-                            except Exception as unpin_err:
-                                worker_logger.warning(
-                                    f"Failed to unpin {backend_name} identifier={identifier}: {unpin_err}"
+            async def _unpin_all(active_client: Any) -> None:
+                async def _unpin_one(row: Any) -> None:
+                    identifier = row["backend_identifier"]
+                    chunk_id = row["chunk_id"]
+                    async with sem:
+                        try:
+                            await active_client.unpin_file(identifier, account_ss58=request.address)
+                            worker_logger.info(f"Unpinned {backend_name} identifier={identifier}")
+                        except Exception as unpin_err:
+                            worker_logger.warning(
+                                f"Failed to unpin {backend_name} identifier={identifier}: {unpin_err}"
+                            )
+                            failures.append(unpin_err)
+                            return  # do NOT soft-delete a still-pinned backend object
+
+                        try:
+                            async with db_pool.acquire() as conn:
+                                await conn.fetchval(
+                                    get_query("soft_delete_chunk_backend_by_chunk_id"),
+                                    backend_name,
+                                    chunk_id,
                                 )
-                                failures.append(unpin_err)
-                                return  # do NOT soft-delete a still-pinned backend object
+                        except Exception as db_err:
+                            worker_logger.warning(
+                                f"Failed to soft-delete chunk_backend row chunk_id={chunk_id}: {db_err}"
+                            )
+                            failures.append(db_err)
 
-                            try:
-                                async with db_pool.acquire() as conn:
-                                    await conn.fetchval(
-                                        get_query("soft_delete_chunk_backend_by_chunk_id"),
-                                        backend_name,
-                                        chunk_id,
-                                    )
-                            except Exception as db_err:
-                                worker_logger.warning(
-                                    f"Failed to soft-delete chunk_backend row chunk_id={chunk_id}: {db_err}"
-                                )
-                                failures.append(db_err)
-
-                    await asyncio.gather(*[_unpin_one(row) for row in rows])
-                    if failures:
-                        # Surface a partial failure so process_unpin_request's handler routes the whole
-                        # request to retry/DLQ. Re-raise the FIRST underlying exception (not a generic
-                        # wrapper) so its transient/permanent classification is preserved — a transient
-                        # backend blip retries, a permanent error DLQs. Succeeded identifiers are already
-                        # soft-deleted; the idempotent re-unpin tolerates their 404 on retry.
-                        raise failures[0]
+                await asyncio.gather(*[_unpin_one(row) for row in rows])
+                if failures:
+                    # Surface a partial failure so process_unpin_request's handler routes the whole
+                    # request to retry/DLQ. Re-raise the FIRST underlying exception (not a generic
+                    # wrapper) so its transient/permanent classification is preserved — a transient
+                    # backend blip retries, a permanent error DLQs. Succeeded identifiers are already
+                    # soft-deleted; the idempotent re-unpin tolerates their 404 on retry.
+                    raise failures[0]
 
             # Reuse the loop's live client when supplied; only build (and close) a per-request client
             # for standalone callers/tests that don't hand one in.


### PR DESCRIPTION
## Summary

Makes drain replication **upload-geometry-agnostic**: an in-flight MPU part reaches `replicated` (downloadable-from-Ceph) on its **first** drain instead of deferring + re-copying every poll until `CompleteMultipartUpload`.

**The problem.** A part's backend `UploadChainRequest` needs `object_versions.address`, which is NULL until CompleteMPU. `drain_part` enqueued *before* committing `replicated`, so an in-flight MPU part copied to the pool, failed the enqueue (address NULL), deferred, and on the next poll **re-copied its whole self to CephFS again** — repeated every ~5s until the object completed. Wasted Ceph write bandwidth, drove AIMD back-off, and pinned the SSD copy until Complete.

**The fix.** Commit `replicated` as soon as the verified copy is durable on the pool (no address needed) and free the SSD copy; a new node-scoped **enqueue sweep** publishes the backend upload once the address lands. The backend uploader (arion + s3-backup/OVH) reads chunks from the **shared pool**, not the SSD ingest, so early unlink is safe.

## Changes (largest first)

- **Reaper/janitor leak fix** — decoupling shifts abandoned-MPU cleanup: a never-completed MPU part now becomes `replicated`+unenqueued (not `pending`), which the pending/draining-only orphan sweep couldn't see, leaking the pool copy forever (janitor replication gate never clears). The orphan sweep (`list_orphan_replication_versions`), the fail query (`fail_replication_status_for_version`, **unservable-gated** so it can't touch a servable version's momentarily-unenqueued part), and the gauge (`count_aged_pending_orphans`) now also reclaim the `replicated AND upload_enqueued_at IS NULL` class.
- **`partdrain`** — reorder `mark_replicated` before a best-effort enqueue; drop the now-dead `Enqueue` error variant + its benign-deferral classification.
- **`store`** — `mark_upload_enqueued` + `list_replicated_unenqueued_parts` (sweep worklist); `gc_terminal_status_rows` spares a `replicated` row still awaiting its enqueue (else the backend upload is dropped).
- **migration 0012** — `upload_enqueued_at` column + partial worklist index.
- **agent** — enqueue-sweep worker; `CEPHOR_ENQUEUE_POLL_SECS` (default 5s).

## Safety / correctness

- Uploader reads from the shared Ceph pool (verified: arion-uploader + s3-backup both mount `object-cache-pvc`), so freeing the SSD copy before the backend upload is safe.
- Abandoned-MPU pool copy no longer leaks (reaper flips it `failed` → janitor `janitor_part_terminally_abandoned` reclaims → drain GCs the row).
- **s3-backup (OVH) needs no change**: consumes `ovh_upload_requests`, reads the pool read-only, has an `all_parts_on_pool` drain-gate, requires a non-NULL `address` (still guaranteed — the enqueue only fires when the address is ready), and has no cross-part ordering assumptions.

## Tests
- New: `store` worklist round-trip + GC-guard sqlx tests; `partdrain` not-ready-enqueue-still-commits; rewrote the two agent worker enqueue-deferral tests for the new semantics; updated the GC-prune test.
- `cargo test` core (214) + agent lib (101) green against Postgres; `clippy` + `fmt` clean.

## Base branch
Targets **`staging`**, not `main`: the `hippius-drain-*` crates exist only on `staging` today (main receives them via staging merges), so `main` is not a valid base for this diff. Stacks on the drain tuning (#250).

🤖 Generated with [Claude Code](https://claude.com/claude-code)