### PR TITLE
fix(metrics): make each uvicorn worker its own metric writer

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -232,6 +232,12 @@ jobs:
         run: |
           kubectl rollout restart deployment/hydrator -n hippius-s3-prod --ignore-not-found || true
           kubectl rollout restart deployment/backup -n hippius-s3-prod --ignore-not-found || true
+          # otel-collector mounts otel-collector-config by static name, with no reloader
+          # sidecar and no kustomize hash suffix, so `kubectl apply -k` updates the
+          # ConfigMap and the running collector keeps its old config indefinitely. Without
+          # this restart, any change to k8s/base/otel-collector.yaml lands silently and
+          # looks like it simply did not work.
+          kubectl rollout restart deployment/otel-collector -n hippius-s3-prod --ignore-not-found || true
 
       - name: Verify deployment
         run: |

--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -232,6 +232,12 @@ jobs:
         run: |
           kubectl rollout restart deployment/hydrator -n hippius-s3-staging --ignore-not-found || true
           kubectl rollout restart deployment/backup -n hippius-s3-staging --ignore-not-found || true
+          # otel-collector mounts otel-collector-config by static name, with no reloader
+          # sidecar and no kustomize hash suffix, so `kubectl apply -k` updates the
+          # ConfigMap and the running collector keeps its old config indefinitely. Without
+          # this restart, any change to k8s/base/otel-collector.yaml lands silently and
+          # looks like it simply did not work.
+          kubectl rollout restart deployment/otel-collector -n hippius-s3-staging --ignore-not-found || true
 
       - name: Verify deployment
         run: |

--- a/gateway/middlewares/metrics.py
+++ b/gateway/middlewares/metrics.py
@@ -47,8 +47,6 @@ async def metrics_middleware(
         request=request,
         response=response,
         duration=duration,
-        main_account=main_account,
-        subaccount_id=subaccount_id,
         handler=endpoint_name,
     )
 
@@ -61,7 +59,6 @@ async def metrics_middleware(
             method=request.method,
             status_code=response.status_code,
             handler=endpoint_name,
-            main_account=main_account,
         )
 
         span = trace.get_current_span()
@@ -76,7 +73,6 @@ async def metrics_middleware(
             error_type=error_type,
             operation=endpoint_name,
             bucket_name=None,
-            main_account=main_account,
         )
 
     return response

--- a/hippius_s3/api/middlewares/metrics.py
+++ b/hippius_s3/api/middlewares/metrics.py
@@ -73,8 +73,6 @@ async def metrics_middleware(
         request=request,
         response=response,
         duration=duration,
-        main_account=main_account,
-        subaccount_id=subaccount_id,
         handler=endpoint_name,
     )
 
@@ -94,7 +92,6 @@ async def metrics_middleware(
             error_type=error_type,
             operation=endpoint_name,
             bucket_name=bucket_name,
-            main_account=main_account,
         )
 
     return response

--- a/hippius_s3/api/s3/buckets/bucket_create_endpoint.py
+++ b/hippius_s3/api/s3/buckets/bucket_create_endpoint.py
@@ -234,8 +234,6 @@ async def handle_create_bucket(bucket_name: str, request: Request, db: Any) -> R
             get_metrics_collector().record_s3_operation(
                 operation="put_bucket",
                 bucket_name=bucket_name,
-                main_account=main_account_id,
-                subaccount_id=request.state.account.id,
                 success=True,
             )
 
@@ -246,7 +244,6 @@ async def handle_create_bucket(bucket_name: str, request: Request, db: Any) -> R
                 error_type="BucketAlreadyExists",
                 operation="put_bucket",
                 bucket_name=bucket_name,
-                main_account=request.state.account.main_account,
             )
             return errors.s3_error_response(
                 "BucketAlreadyExists",
@@ -260,7 +257,6 @@ async def handle_create_bucket(bucket_name: str, request: Request, db: Any) -> R
                 error_type="internal_error",
                 operation="put_bucket",
                 bucket_name=bucket_name,
-                main_account=request.state.account.main_account,
             )
             return errors.s3_error_response(
                 "InternalError",

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -323,7 +323,6 @@ async def initiate_multipart_upload(
             error_type="internal_error",
             operation="initiate_multipart_upload",
             bucket_name=bucket_name,
-            main_account=getattr(request.state, "account", None) and request.state.account.main_account,
         )
         return s3_error_response(
             "InternalError",
@@ -677,8 +676,6 @@ async def upload_part(
             operation="upload_part",
             bytes_transferred=file_size,
             bucket_name=ongoing_multipart_upload.get("bucket_name", ""),
-            main_account=request.state.account.main_account,
-            subaccount_id=request.state.account.id,
         )
 
         # Return response
@@ -1075,16 +1072,12 @@ async def complete_multipart_upload(
         get_metrics_collector().record_s3_operation(
             operation="complete_multipart_upload",
             bucket_name=bucket_name,
-            main_account=request.state.account.main_account,
-            subaccount_id=request.state.account.id,
             success=True,
         )
         get_metrics_collector().record_data_transfer(
             operation="complete_multipart_upload",
             bytes_transferred=int(complete_res.size_bytes),
             bucket_name=bucket_name,
-            main_account=request.state.account.main_account,
-            subaccount_id=request.state.account.id,
         )
 
         # Return with proper headers
@@ -1102,7 +1095,6 @@ async def complete_multipart_upload(
             error_type="internal_error",
             operation="complete_multipart_upload",
             bucket_name=bucket_name,
-            main_account=getattr(request.state, "account", None) and request.state.account.main_account,
         )
         return s3_error_response(
             "InternalError",

--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -373,16 +373,12 @@ async def handle_get_object(
             get_metrics_collector().record_s3_operation(
                 operation="get_object",
                 bucket_name=bucket_name,
-                main_account=account.main_account if account else None,
-                subaccount_id=account.id if account else None,
                 success=True,
             )
             get_metrics_collector().record_data_transfer(
                 operation="get_object",
                 bytes_transferred=bytes_transferred,
                 bucket_name=bucket_name,
-                main_account=account.main_account if account else None,
-                subaccount_id=account.id if account else None,
             )
 
         return response
@@ -394,7 +390,6 @@ async def handle_get_object(
             error_type=e.code,
             operation="get_object",
             bucket_name=bucket_name,
-            main_account=account.main_account if account else None,
         )
         return errors.s3_error_response(
             code=e.code,
@@ -413,7 +408,6 @@ async def handle_get_object(
             error_type="download_not_ready",
             operation="get_object",
             bucket_name=bucket_name,
-            main_account=account.main_account if account else None,
         )
         return errors.s3_error_response(
             code="SlowDown",
@@ -429,7 +423,6 @@ async def handle_get_object(
             error_type="internal_error",
             operation="get_object",
             bucket_name=bucket_name,
-            main_account=account.main_account if account else None,
         )
         return errors.s3_error_response(
             code="InternalError",

--- a/hippius_s3/api/s3/objects/put_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/put_object_endpoint.py
@@ -223,16 +223,12 @@ async def handle_put_object(
         get_metrics_collector().record_s3_operation(
             operation="put_object",
             bucket_name=bucket_name,
-            main_account=main_account_id,
-            subaccount_id=request.state.account.id,
             success=True,
         )
         get_metrics_collector().record_data_transfer(
             operation="put_object",
             bytes_transferred=int(put_res.size_bytes),
             bucket_name=bucket_name,
-            main_account=main_account_id,
-            subaccount_id=request.state.account.id,
         )
 
         # New or overwrite base object: expose append-version so clients can start append flow without HEAD
@@ -256,7 +252,6 @@ async def handle_put_object(
             error_type="internal_error",
             operation="put_object",
             bucket_name=bucket_name,
-            main_account=getattr(request.state, "account", None) and request.state.account.main_account,
         )
         return errors.s3_error_response(
             "InternalError",

--- a/hippius_s3/monitoring.py
+++ b/hippius_s3/monitoring.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import socket
 from typing import Optional
 from typing import Union
 
@@ -11,9 +10,10 @@ from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.sdk.resources import Resource
 from redis.asyncio import Redis
 from redis.asyncio.cluster import RedisCluster
+
+from hippius_s3.otel_setup import build_resource
 
 
 logger = logging.getLogger(__name__)
@@ -645,12 +645,17 @@ def initialize_metrics_collector(redis_client: Union[Redis, RedisCluster]) -> Me
         endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4317")
         service_name = os.getenv("OTEL_SERVICE_NAME", "hippius-s3")
 
-        # Hostname alone, unlike otel_setup.configure_otel which appends the pid. This
-        # branch is only reached by processes that never called configure_otel — the
-        # workers, which are one process per pod and so already satisfy the exporter's
-        # single-writer principle. Adding a pid here would buy nothing and would mint a
-        # fresh series set on every in-place container restart.
-        resource = Resource.create({"service.name": service_name, "service.instance.id": socket.gethostname()})
+        # Same per-process identity as configure_otel. No deployed config reaches this
+        # branch — api/gateway call configure_otel, and workers run under
+        # opentelemetry-instrument, which sets a MeterProvider before the worker body
+        # runs, so the isinstance guard above short-circuits. It survives only for a
+        # bare `python workers/...` with monitoring on. Build the resource the one right
+        # way regardless: an earlier version of this line hardcoded the hostname on the
+        # reasoning that only single-process workers land here, which is exactly the kind
+        # of confident assumption about who-calls-what that produced the 105x in the
+        # first place. If init order ever changes and api/gateway fall through to here,
+        # this must not silently reintroduce it.
+        resource = build_resource(service_name)
 
         metric_reader = PeriodicExportingMetricReader(
             OTLPMetricExporter(endpoint=endpoint, insecure=True),

--- a/hippius_s3/monitoring.py
+++ b/hippius_s3/monitoring.py
@@ -21,6 +21,21 @@ tracer = trace.get_tracer(__name__)
 
 
 class MetricsCollector:
+    """OTel metrics for the API, gateway and workers.
+
+    Every attribute passed here becomes a Prometheus label, so the value set of each
+    one must be BOUNDED and closed — methods, status codes, backends, named handlers.
+    Never add an attribute whose values are open-ended or chosen by a caller: account
+    ids, bucket names, object keys, request paths, error strings. Those axes grow
+    forever and each new value permanently costs a series.
+
+    This is not theoretical. main_account/subaccount_id were labels here until
+    2026-07-17 and had grown to 87% of the namespace's ~51k series (115 accounts, one
+    new axis value per customer) while no dashboard or alert ever read them. Send
+    per-account detail to the gateway audit log or to spans instead — both index
+    high-cardinality keys by design.
+    """
+
     def __init__(self, redis_client: Union[Redis, RedisCluster]):
         self.redis_client = redis_client
         self.meter = metrics.get_meter(__name__)
@@ -298,21 +313,16 @@ class MetricsCollector:
         request: Request,
         response: Response,
         duration: float,
-        main_account: Optional[str] = None,
-        subaccount_id: Optional[str] = None,
         handler: Optional[str] = None,
     ) -> None:
+        # handler falls back to "unknown", never to request.url.path: the path carries
+        # the object key, so one caller passing handler=None would mint a series per
+        # object and take Prometheus down.
         attributes = {
             "method": request.method,
-            "handler": handler or request.url.path,
+            "handler": handler or "unknown",
             "status_code": str(response.status_code),
         }
-
-        if main_account:
-            attributes["main_account"] = main_account
-
-        if subaccount_id:
-            attributes["subaccount_id"] = subaccount_id
 
         self.http_requests_total.add(1, attributes=attributes)
         self.http_request_duration.record(duration, attributes=attributes)
@@ -329,17 +339,9 @@ class MetricsCollector:
         self,
         operation: str,
         bucket_name: str,
-        main_account: Optional[str] = None,
-        subaccount_id: Optional[str] = None,
         success: bool = True,
     ) -> None:
         attributes = {"operation": operation, "success": str(success).lower()}
-
-        if main_account:
-            attributes["main_account"] = main_account
-
-        if subaccount_id:
-            attributes["subaccount_id"] = subaccount_id
 
         self.s3_operations_total.add(1, attributes=attributes)
 
@@ -348,18 +350,10 @@ class MetricsCollector:
         operation: str,
         bytes_transferred: int,
         bucket_name: str,
-        main_account: Optional[str] = None,
-        subaccount_id: Optional[str] = None,
     ) -> None:
         attributes = {
             "operation": operation,
         }
-
-        if main_account:
-            attributes["main_account"] = main_account
-
-        if subaccount_id:
-            attributes["subaccount_id"] = subaccount_id
 
         if operation in ["upload", "put_object", "post_object", "upload_part"]:
             self.s3_bytes_uploaded.add(bytes_transferred, attributes=attributes)
@@ -373,7 +367,6 @@ class MetricsCollector:
         error_type: str,
         operation: str,
         bucket_name: Optional[str] = None,
-        main_account: Optional[str] = None,
     ) -> None:
         """Record error metrics"""
         attributes = {
@@ -381,21 +374,14 @@ class MetricsCollector:
             "operation": operation,
         }
 
-        if main_account:
-            attributes["main_account"] = main_account
-
         self.s3_errors_total.add(1, attributes=attributes)
 
     def record_cache_operation(
         self,
         hit: bool,
         operation: str,
-        main_account: Optional[str] = None,
     ) -> None:
         attributes = {"operation": operation}
-
-        if main_account:
-            attributes["main_account"] = main_account
 
         if hit:
             self.cache_hits.add(1, attributes=attributes)
@@ -404,7 +390,6 @@ class MetricsCollector:
 
     def record_uploader_operation(
         self,
-        main_account: str,
         success: bool,
         backend: str = "",
         num_chunks: int = 0,
@@ -414,7 +399,6 @@ class MetricsCollector:
         status_code: str = "",
     ) -> None:
         attributes = {
-            "main_account": main_account,
             "success": str(success).lower(),
         }
         if backend:
@@ -426,7 +410,6 @@ class MetricsCollector:
 
         if attempt is not None:
             retry_attributes = {
-                "main_account": main_account,
                 "attempt": str(attempt),
             }
             if backend:
@@ -434,7 +417,6 @@ class MetricsCollector:
             self.uploader_requests_retried_total.add(1, attributes=retry_attributes)
         elif error_type is not None:
             dlq_attributes = {
-                "main_account": main_account,
                 "error_type": error_type,
             }
             if backend:
@@ -449,7 +431,6 @@ class MetricsCollector:
 
     def record_unpinner_operation(
         self,
-        main_account: str,
         success: bool,
         backend: str = "",
         num_files: int = 0,
@@ -458,7 +439,6 @@ class MetricsCollector:
         error_type: Optional[str] = None,
     ) -> None:
         attributes = {
-            "main_account": main_account,
             "success": str(success).lower(),
         }
         if backend:
@@ -466,7 +446,6 @@ class MetricsCollector:
 
         if attempt is not None:
             retry_attributes = {
-                "main_account": main_account,
                 "attempt": str(attempt),
             }
             if backend:
@@ -474,7 +453,6 @@ class MetricsCollector:
             self.unpinner_requests_retried_total.add(1, attributes=retry_attributes)
         elif error_type is not None:
             dlq_attributes = {
-                "main_account": main_account,
                 "error_type": error_type,
             }
             if backend:
@@ -492,14 +470,12 @@ class MetricsCollector:
     def record_downloader_operation(
         self,
         backend: str,
-        main_account: str,
         success: bool,
         duration: Optional[float] = None,
         num_chunks: int = 0,
     ) -> None:
         attributes = {
             "backend": backend,
-            "main_account": main_account,
             "success": str(success).lower(),
         }
 
@@ -517,7 +493,6 @@ class MetricsCollector:
         method: str,
         status_code: int,
         handler: Optional[str] = None,
-        main_account: Optional[str] = None,
     ) -> None:
         attributes: dict[str, str] = {
             "method": method,
@@ -525,8 +500,6 @@ class MetricsCollector:
         }
         if handler:
             attributes["handler"] = handler
-        if main_account:
-            attributes["main_account"] = main_account
 
         self.gateway_overhead_duration.record(duration, attributes=attributes)
 
@@ -672,6 +645,11 @@ def initialize_metrics_collector(redis_client: Union[Redis, RedisCluster]) -> Me
         endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4317")
         service_name = os.getenv("OTEL_SERVICE_NAME", "hippius-s3")
 
+        # Hostname alone, unlike otel_setup.configure_otel which appends the pid. This
+        # branch is only reached by processes that never called configure_otel — the
+        # workers, which are one process per pod and so already satisfy the exporter's
+        # single-writer principle. Adding a pid here would buy nothing and would mint a
+        # fresh series set on every in-place container restart.
         resource = Resource.create({"service.name": service_name, "service.instance.id": socket.gethostname()})
 
         metric_reader = PeriodicExportingMetricReader(

--- a/hippius_s3/otel_setup.py
+++ b/hippius_s3/otel_setup.py
@@ -22,6 +22,45 @@ logger = logging.getLogger(__name__)
 _otel_configured_pid: int | None = None
 
 
+def build_resource(service_name: str) -> Resource:
+    """Identify this PROCESS — not this pod — to the collector.
+
+    configure_otel runs once per forked uvicorn worker (see the pid guard below), so
+    with UVICORN_WORKERS=4 a pod holds four independent MeterProviders. If they share
+    one service.instance.id, their four cumulative counters collide in a single
+    accumulator slot in the collector's prometheus exporter: the exported value
+    flip-flops between workers and every downward step reads as a counter reset.
+    Measured on prod 2026-07-17 before this fix, 19 resets per series per 10m, and
+    rate(http_requests_total) reporting 14.5k/s against a true 138/s from the gateway
+    audit log — ~105x.
+
+    There is no way to fix this from the collector side. Its accumulator enforces the
+    single-writer principle: the delta-to-cumulative path only accumulates points whose
+    timestamps chain from one stream, and the histogram path drops misaligned points
+    outright (accumulator.go:204 and :256-272, contrib v0.96.0). So delta temporality
+    does NOT help — the identity has to be unique per writer.
+
+    An earlier comment here forbade os.getpid() to protect cardinality. That reasoning
+    was wrong: this attribute is the POD NAME, which already churns completely on every
+    deploy, so a pid adds no new churn axis — only a bounded 4x, and only for as long as
+    a worker lives (UVICORN_MAX_REQUESTS=0 disables recycling, so workers respawn only
+    on crash). The same change removed the account labels, which were 87% of this
+    namespace's series, so cardinality drops sharply on net.
+
+    Resource.create() merges OTEL_RESOURCE_ATTRIBUTES from env first and the dict passed
+    here wins over it — which matters, because the deployments set
+    service.instance.id=$(POD_NAME) there and that would otherwise undo this silently.
+    Everything else in that env var (service.namespace, deployment.environment) still
+    merges through.
+    """
+    return Resource.create(
+        {
+            "service.name": service_name,
+            "service.instance.id": f"{socket.gethostname()}:{os.getpid()}",
+        }
+    )
+
+
 def configure_otel(service_name: str) -> None:
     """Programmatic OTel initialization, safe to call per-worker after fork.
 
@@ -42,17 +81,7 @@ def configure_otel(service_name: str) -> None:
 
     endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4317")
 
-    # Resource.create() automatically merges OTEL_RESOURCE_ATTRIBUTES from env
-    # Keep service.instance.id at the (stable) pod hostname — never append os.getpid().
-    # The collector promotes this resource attr to the `instance` metric label, so a
-    # per-process value mints a fresh series set for every worker (re)spawn and blows
-    # up Prometheus head cardinality. Workers of one pod aggregate under one instance.
-    resource = Resource.create(
-        {
-            "service.name": service_name,
-            "service.instance.id": socket.gethostname(),
-        }
-    )
+    resource = build_resource(service_name)
 
     # Traces
     tracer_provider = TracerProvider(resource=resource)

--- a/hippius_s3/otel_setup.py
+++ b/hippius_s3/otel_setup.py
@@ -34,18 +34,33 @@ def build_resource(service_name: str) -> Resource:
     rate(http_requests_total) reporting 14.5k/s against a true 138/s from the gateway
     audit log — ~105x.
 
-    There is no way to fix this from the collector side. Its accumulator enforces the
-    single-writer principle: the delta-to-cumulative path only accumulates points whose
-    timestamps chain from one stream, and the histogram path drops misaligned points
-    outright (accumulator.go:204 and :256-272, contrib v0.96.0). So delta temporality
-    does NOT help — the identity has to be unique per writer.
+    The collision is structural, not a setting: the exporter's timeseriesSignature()
+    derives job and instance from the resource unconditionally (accumulator.go:333,
+    collector.go:126,326), so identical resources mean one slot no matter how the
+    exporter is configured. In particular resource_to_telemetry_conversion is NOT the
+    cause and flipping it off changes nothing.
 
-    An earlier comment here forbade os.getpid() to protect cardinality. That reasoning
-    was wrong: this attribute is the POD NAME, which already churns completely on every
-    deploy, so a pid adds no new churn axis — only a bounded 4x, and only for as long as
-    a worker lives (UVICORN_MAX_REQUESTS=0 disables recycling, so workers respawn only
-    on crash). The same change removed the account labels, which were 87% of this
-    namespace's series, so cardinality drops sharply on net.
+    Nor is there a way out via delta temporality. The delta-to-cumulative path only
+    accumulates points whose timestamps chain from a single stream and otherwise
+    overwrites the counter with the raw delta, while the histogram path drops
+    misaligned points outright — the code names this "violation of the single-writer
+    principle" (accumulator.go:204 and :256-272, contrib v0.96.0). deltatocumulative
+    keys by identity too. The identity itself has to be unique per writer.
+
+    An earlier comment here forbade os.getpid() to protect cardinality. It was wrong in
+    the main: this attribute is the POD NAME, which already churns completely on every
+    deploy, so the pid mostly rides an axis that already churns, at a bounded 4x — and
+    the same change removed the account labels (87% of this namespace's series), so the
+    net is still a large reduction. But it was not baseless, and two things keep it
+    true rather than lucky:
+      - UVICORN_MAX_REQUESTS=0. It disables worker recycling, so pids turn over only on
+        crash. start-gateway.sh invites raising it if a leak ever appears; doing so
+        would recycle workers continuously and turn this 4x into genuine churn, because
+        a crash-respawn mints a new pid under a STABLE pod name — an axis the pod name
+        alone does not have.
+      - metric_expiration: 180m on the collector, which keeps every dead series
+        resident for 3h after its writer is gone.
+    If either changes, re-measure before assuming this is still cheap.
 
     Resource.create() merges OTEL_RESOURCE_ATTRIBUTES from env first and the dict passed
     here wins over it — which matters, because the deployments set

--- a/hippius_s3/workers/downloader.py
+++ b/hippius_s3/workers/downloader.py
@@ -318,7 +318,6 @@ async def process_download_request(
             if success_count == total:
                 get_metrics_collector().record_downloader_operation(
                     backend=backend_name,
-                    main_account=download_request.address,
                     success=True,
                     duration=total_duration,
                     num_chunks=sum(len(p.chunks) for p in download_request.chunks),
@@ -326,7 +325,6 @@ async def process_download_request(
                 return True
             get_metrics_collector().record_downloader_operation(
                 backend=backend_name,
-                main_account=download_request.address,
                 success=False,
                 duration=total_duration,
             )
@@ -335,7 +333,6 @@ async def process_download_request(
         except Exception as exc:
             get_metrics_collector().record_downloader_operation(
                 backend=backend_name,
-                main_account=download_request.address,
                 success=False,
             )
             logger.error(f"[{backend_name}] process_download_request error: {exc}", exc_info=True)

--- a/hippius_s3/workers/unpinner.py
+++ b/hippius_s3/workers/unpinner.py
@@ -121,7 +121,6 @@ async def _route_failed_request(
             last_error=last_error,
         )
         get_metrics_collector().record_unpinner_operation(
-            main_account=request.address,
             success=False,
             backend=backend_name,
             attempt=attempts_next,
@@ -133,7 +132,6 @@ async def _route_failed_request(
         )
         await dlq_manager.push(request, last_error, error_class)
         get_metrics_collector().record_unpinner_operation(
-            main_account=request.address,
             success=False,
             backend=backend_name,
             error_type=error_class,
@@ -273,7 +271,6 @@ async def process_unpin_batch(
         request = entry.request
         if all(file_id in soft_deleted_ok for file_id in entry.file_ids):
             get_metrics_collector().record_unpinner_operation(
-                main_account=request.address,
                 success=True,
                 backend=backend_name,
             )
@@ -430,7 +427,6 @@ async def process_unpin_request(
                     await _unpin_all(owned_client)
 
             get_metrics_collector().record_unpinner_operation(
-                main_account=request.address,
                 success=True,
                 backend=backend_name,
             )
@@ -463,7 +459,6 @@ async def process_unpin_request(
                 )
 
                 get_metrics_collector().record_unpinner_operation(
-                    main_account=request.address,
                     success=False,
                     backend=backend_name,
                     attempt=attempts_next,
@@ -476,7 +471,6 @@ async def process_unpin_request(
                 await dlq_manager.push(request, str(e), error_class)
 
                 get_metrics_collector().record_unpinner_operation(
-                    main_account=request.address,
                     success=False,
                     backend=backend_name,
                     error_type=error_class,

--- a/hippius_s3/workers/uploader.py
+++ b/hippius_s3/workers/uploader.py
@@ -172,7 +172,6 @@ class Uploader:
             span.set_attribute("result.duration_s", total_duration)
 
             get_metrics_collector().record_uploader_operation(
-                main_account=payload.address,
                 success=True,
                 backend=self.backend_name,
                 num_chunks=len(payload.chunks),
@@ -403,7 +402,6 @@ class Uploader:
             etype = "transient" if etype else "permanent"
 
         get_metrics_collector().record_uploader_operation(
-            main_account=payload.address,
             success=False,
             backend=self.backend_name,
             error_type=etype,

--- a/k8s/base/otel-collector.yaml
+++ b/k8s/base/otel-collector.yaml
@@ -13,11 +13,16 @@ data:
             endpoint: 0.0.0.0:4318
 
     processors:
-      resource:
-        attributes:
-          - key: service.name
-            value: "hippius-s3"
-            action: upsert
+      # NOTE: there is deliberately no `resource` processor here any more. It used to
+      # upsert service.name: "hippius-s3" onto every metric and log, overwriting the
+      # name each service had already set for itself — configure_otel("hippius-s3-api")
+      # in hippius_s3/main.py, configure_otel("hippius-s3-gateway") in gateway/main.py,
+      # OTEL_SERVICE_NAME in start-worker.sh. The result was service_name="hippius-s3"
+      # and exported_job="hippius-s3-prod/hippius-s3" on EVERYTHING, so api, gateway and
+      # workers were indistinguishable in Prometheus and alert rules had to fall back to
+      # matching pod names (exported_instance=~"api-.*"), which breaks on any rename.
+      # The traces pipeline never had this processor, which is why Tempo has always shown
+      # the correct per-service names; removing it here brings metrics and logs in line.
       batch:
         timeout: 1s
         send_batch_size: 1024
@@ -57,7 +62,7 @@ data:
       pipelines:
         metrics:
           receivers: [otlp]
-          processors: [memory_limiter, resource, batch]
+          processors: [memory_limiter, batch]
           exporters: [prometheus]
         traces:
           receivers: [otlp]
@@ -65,7 +70,7 @@ data:
           exporters: [otlp/tempo]
         logs:
           receivers: [otlp]
-          processors: [memory_limiter, resource, batch]
+          processors: [memory_limiter, batch]
           exporters: [loki]
 ---
 apiVersion: apps/v1

--- a/k8s/base/otel-collector.yaml
+++ b/k8s/base/otel-collector.yaml
@@ -13,16 +13,29 @@ data:
             endpoint: 0.0.0.0:4318
 
     processors:
-      # NOTE: there is deliberately no `resource` processor here any more. It used to
-      # upsert service.name: "hippius-s3" onto every metric and log, overwriting the
-      # name each service had already set for itself — configure_otel("hippius-s3-api")
-      # in hippius_s3/main.py, configure_otel("hippius-s3-gateway") in gateway/main.py,
-      # OTEL_SERVICE_NAME in start-worker.sh. The result was service_name="hippius-s3"
-      # and exported_job="hippius-s3-prod/hippius-s3" on EVERYTHING, so api, gateway and
-      # workers were indistinguishable in Prometheus and alert rules had to fall back to
-      # matching pod names (exported_instance=~"api-.*"), which breaks on any rename.
-      # The traces pipeline never had this processor, which is why Tempo has always shown
-      # the correct per-service names; removing it here brings metrics and logs in line.
+      resource:
+        attributes:
+          # insert (not upsert) so a producer's own service.name (api/gateway via
+          # configure_otel, workers via OTEL_SERVICE_NAME, the Rust drain) survives;
+          # this only labels telemetry that arrives without a service.name.
+          #
+          # This file said `upsert` until 2026-07-17, which overwrote the name every
+          # service sets for itself and left service_name="hippius-s3" and
+          # exported_job="<ns>/hippius-s3" on EVERYTHING — api, gateway and workers
+          # indistinguishable in Prometheus, so alert rules had to match pod names
+          # (exported_instance=~"arion-downloader-.*"), which breaks on any rename.
+          # The traces pipeline has never had this processor, which is why Tempo always
+          # showed the right names.
+          #
+          # `insert` rather than deleting the processor outright: telemetry does arrive
+          # here with no service.name of its own (Loki carries an unknown_service
+          # stream), and that should still be labelled hippius-s3 rather than become
+          # anonymous. Live staging has run exactly this since before this change and
+          # its Loki streams show correct per-service names — this codifies that, since
+          # it had been hand-edited into the staging ConfigMap and never sent back here.
+          - key: service.name
+            value: "hippius-s3"
+            action: insert
       batch:
         timeout: 1s
         send_batch_size: 1024
@@ -62,7 +75,7 @@ data:
       pipelines:
         metrics:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter, resource, batch]
           exporters: [prometheus]
         traces:
           receivers: [otlp]
@@ -70,7 +83,7 @@ data:
           exporters: [otlp/tempo]
         logs:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter, resource, batch]
           exporters: [loki]
 ---
 apiVersion: apps/v1

--- a/tests/unit/test_metrics_cardinality.py
+++ b/tests/unit/test_metrics_cardinality.py
@@ -5,14 +5,73 @@ worker tests mock the collector — a Mock accepts any keyword, so it would happ
 account label back in without failing.
 """
 
+import ast
+import inspect
 import os
+import pathlib
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
 from hippius_s3.monitoring import MetricsCollector
 from hippius_s3.otel_setup import build_resource
+
+
+# Every label any record_* method is allowed to emit. Each has a closed value set:
+# HTTP verbs, status codes, named handlers/operations, configured backends, retry
+# attempt numbers, in/out, and the fixed database names we back up. Anything outside
+# this set is either unbounded or caller-controlled and must not become a label.
+BOUNDED_LABELS = {
+    "method",
+    "handler",
+    "status_code",
+    "operation",
+    "success",
+    "error_type",
+    "backend",
+    "attempt",
+    "direction",
+    "database",
+}
+
+
+def _mock_all_instruments(collector: MetricsCollector) -> dict[str, MagicMock]:
+    """Swap every counter/histogram on the collector for a mock that records calls."""
+    mocks: dict[str, MagicMock] = {}
+    for name, value in list(vars(collector).items()):
+        if name.startswith("_") or name == "redis_client" or name == "meter":
+            continue
+        if hasattr(value, "add") or hasattr(value, "record"):
+            mocks[name] = MagicMock()
+            setattr(collector, name, mocks[name])
+    return mocks
+
+
+def _dummy_for(param: inspect.Parameter) -> Any:
+    if param.name == "request":
+        return _request()
+    if param.name == "response":
+        return _response()
+    ann = param.annotation
+    if ann is bool:
+        return True
+    if ann is int:
+        return 1
+    if ann is float:
+        return 0.1
+    return "x"
+
+
+def _call_with_dummies(method: Any) -> None:
+    """Invoke a record_* method supplying only its required parameters."""
+    kwargs = {
+        name: _dummy_for(p)
+        for name, p in inspect.signature(method).parameters.items()
+        if p.default is inspect.Parameter.empty
+    }
+    method(**kwargs)
 
 
 def _request(method: str = "GET", path: str = "/my-bucket/some/object/key.bin") -> SimpleNamespace:
@@ -59,6 +118,33 @@ class TestInstanceIdIsPerProcess:
         # made every scrape look like a counter reset (~105x inflated rates).
         assert worker_a != worker_b
         assert worker_a == "api-abc123:11"
+
+    def test_build_resource_is_the_only_way_a_resource_is_built(self) -> None:
+        """No production code may call Resource.create() outside build_resource.
+
+        The tests above prove build_resource is correct, not that anything uses it —
+        reverting a call site to an inline Resource.create({... gethostname()}) would
+        leave them all green while restoring the collision. Every such call site is an
+        independent chance to hand two processes the same identity, so there must be
+        exactly one.
+        """
+        offenders = []
+        for path in (*pathlib.Path("hippius_s3").rglob("*.py"), *pathlib.Path("workers").rglob("*.py")):
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                    continue
+                if node.func.attr != "create" or getattr(node.func.value, "id", None) != "Resource":
+                    continue
+                enclosing = [
+                    n.name
+                    for n in ast.walk(tree)
+                    if isinstance(n, ast.FunctionDef) and n.lineno <= node.lineno <= (n.end_lineno or n.lineno)
+                ]
+                if "build_resource" not in enclosing:
+                    offenders.append(f"{path}:{node.lineno} (in {enclosing or ['<module>']})")
+
+        assert offenders == [], "Resource.create() outside build_resource: " + ", ".join(offenders)
 
     def test_env_cannot_override_the_per_process_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # The deployments set service.instance.id=$(POD_NAME) here. If env won, the fix
@@ -107,3 +193,36 @@ class TestNoUnboundedLabels:
                 duration=0.1,
                 **{kwarg: "5E71kYuDbwhMbnK7JVtH1xLMguogmvozTrNJHYD9KnEcuWgZ"},
             )
+
+    def test_no_record_method_anywhere_accepts_an_account(self) -> None:
+        # Guarding record_http_request alone is not enough: main_account was threaded
+        # through fifteen record_* methods, and a reviewer put it back on
+        # record_s3_operation with the rest of this file passing. Cover all of them.
+        offenders = {
+            name: sorted(set(inspect.signature(fn).parameters) & {"main_account", "subaccount_id"})
+            for name, fn in inspect.getmembers(MetricsCollector, inspect.isfunction)
+            if name.startswith("record_") and set(inspect.signature(fn).parameters) & {"main_account", "subaccount_id"}
+        }
+        assert offenders == {}, f"account params are back on: {offenders}"
+
+    def test_every_record_method_emits_only_bounded_labels(self, collector: MetricsCollector) -> None:
+        """Call every record_* method and assert nothing open-ended reaches a label.
+
+        Stronger than checking parameter names: it catches a label added from any
+        source — a caller-supplied value, a bucket name, an error string — not just an
+        account threaded back through the signature.
+        """
+        instruments = _mock_all_instruments(collector)
+
+        called = [name for name, _ in inspect.getmembers(collector, inspect.ismethod) if name.startswith("record_")]
+        for name in called:
+            _call_with_dummies(getattr(collector, name))
+
+        emitted: set[str] = set()
+        for mock in instruments.values():
+            for call in mock.add.call_args_list + mock.record.call_args_list:
+                emitted |= set(call.kwargs.get("attributes") or {})
+
+        assert called, "no record_* methods were exercised — the reflection broke"
+        assert emitted, "no attributes captured — the instrument mocking broke"
+        assert emitted <= BOUNDED_LABELS, f"unbounded label(s) emitted: {sorted(emitted - BOUNDED_LABELS)}"

--- a/tests/unit/test_metrics_cardinality.py
+++ b/tests/unit/test_metrics_cardinality.py
@@ -1,0 +1,109 @@
+"""Locks in the two invariants behind the 2026-07-17 metrics incident.
+
+Both regressed silently for months because nothing here was covered, and the existing
+worker tests mock the collector — a Mock accepts any keyword, so it would happily let an
+account label back in without failing.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from hippius_s3.monitoring import MetricsCollector
+from hippius_s3.otel_setup import build_resource
+
+
+def _request(method: str = "GET", path: str = "/my-bucket/some/object/key.bin") -> SimpleNamespace:
+    return SimpleNamespace(
+        method=method,
+        url=SimpleNamespace(path=path),
+        headers={},
+    )
+
+
+def _response(status_code: int = 200) -> SimpleNamespace:
+    return SimpleNamespace(status_code=status_code, headers={})
+
+
+@pytest.fixture
+def collector() -> MetricsCollector:
+    # No MeterProvider is configured under pytest, so create_counter/create_histogram
+    # hand back no-op instruments; swap in mocks to capture the attributes.
+    c = MetricsCollector(redis_client=MagicMock())
+    c.http_requests_total = MagicMock()
+    c.http_request_duration = MagicMock()
+    c.http_request_bytes = MagicMock()
+    c.http_response_bytes = MagicMock()
+    return c
+
+
+class TestInstanceIdIsPerProcess:
+    """A pod runs UVICORN_WORKERS processes; each MUST be its own metric writer."""
+
+    def test_instance_id_includes_the_pid(self) -> None:
+        attrs = build_resource("hippius-s3-api").attributes
+        assert attrs["service.instance.id"].endswith(f":{os.getpid()}")
+        assert attrs["service.name"] == "hippius-s3-api"
+
+    def test_two_processes_on_one_host_get_distinct_identities(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("hippius_s3.otel_setup.socket.gethostname", lambda: "api-abc123")
+
+        monkeypatch.setattr("hippius_s3.otel_setup.os.getpid", lambda: 11)
+        worker_a = build_resource("hippius-s3-api").attributes["service.instance.id"]
+        monkeypatch.setattr("hippius_s3.otel_setup.os.getpid", lambda: 22)
+        worker_b = build_resource("hippius-s3-api").attributes["service.instance.id"]
+
+        # Sharing an identity is what collapsed 4 workers into 1 accumulator slot and
+        # made every scrape look like a counter reset (~105x inflated rates).
+        assert worker_a != worker_b
+        assert worker_a == "api-abc123:11"
+
+    def test_env_cannot_override_the_per_process_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The deployments set service.instance.id=$(POD_NAME) here. If env won, the fix
+        # would be a silent no-op and the 105x would come straight back.
+        monkeypatch.setenv(
+            "OTEL_RESOURCE_ATTRIBUTES",
+            "deployment.environment=production,service.namespace=hippius-s3-prod,service.instance.id=api-pod-xyz",
+        )
+        attrs = build_resource("hippius-s3-api").attributes
+
+        assert attrs["service.instance.id"] != "api-pod-xyz"
+        assert attrs["service.instance.id"].endswith(f":{os.getpid()}")
+        # ...while the rest of that env var must still merge through: the dashboards
+        # select on service_namespace.
+        assert attrs["service.namespace"] == "hippius-s3-prod"
+        assert attrs["deployment.environment"] == "production"
+
+
+class TestNoUnboundedLabels:
+    """Every attribute becomes a Prometheus label, so each must have a closed value set."""
+
+    def test_handler_falls_back_to_unknown_not_the_url_path(self, collector: MetricsCollector) -> None:
+        collector.record_http_request(request=_request(), response=_response(), duration=0.1, handler=None)
+
+        attrs = collector.http_requests_total.add.call_args.kwargs["attributes"]
+        # The path holds the object key: falling back to it mints one series per object.
+        assert attrs["handler"] == "unknown"
+        assert "some/object/key.bin" not in str(attrs)
+
+    def test_no_account_labels_are_emitted(self, collector: MetricsCollector) -> None:
+        collector.record_http_request(request=_request(), response=_response(), duration=0.1, handler="get_object")
+
+        for instrument in (collector.http_requests_total.add, collector.http_request_duration.record):
+            attrs = instrument.call_args.kwargs["attributes"]
+            assert set(attrs) == {"method", "handler", "status_code"}
+
+    @pytest.mark.parametrize("kwarg", ["main_account", "subaccount_id"])
+    def test_passing_an_account_is_a_hard_error(self, collector: MetricsCollector, kwarg: str) -> None:
+        # Account attribution belongs in the audit log and on spans, which index
+        # high-cardinality keys by design. Keep the door shut rather than ignoring it
+        # silently: main_account was 87% of the namespace's series and nothing read it.
+        with pytest.raises(TypeError):
+            collector.record_http_request(
+                request=_request(),
+                response=_response(),
+                duration=0.1,
+                **{kwarg: "5E71kYuDbwhMbnK7JVtH1xLMguogmvozTrNJHYD9KnEcuWgZ"},
+            )

--- a/workers/run_arion_uploader_in_loop.py
+++ b/workers/run_arion_uploader_in_loop.py
@@ -83,7 +83,6 @@ async def _handle_upload(uploader, db_pool, upload_request) -> None:
                     upload_request, backend_name="arion", delay_seconds=delay_ms / 1000.0, last_error=err_str
                 )
                 get_metrics_collector().record_uploader_operation(
-                    main_account=upload_request.address,
                     success=False,
                     backend="arion",
                     attempt=attempts_next,

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -26,7 +26,6 @@ import json
 import logging
 import os
 import shutil
-import socket
 import sys
 import time
 from collections.abc import AsyncIterator
@@ -41,7 +40,6 @@ from opentelemetry import metrics as otel_metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.sdk.resources import Resource
 from redis.asyncio import Redis
 
 
@@ -51,6 +49,7 @@ from hippius_s3.cache import FileSystemPartsStore
 from hippius_s3.cache import create_fs_store
 from hippius_s3.config import get_config
 from hippius_s3.logging_config import setup_loki_logging
+from hippius_s3.otel_setup import build_resource
 from hippius_s3.sentry import init_sentry
 from hippius_s3.utils import get_query
 
@@ -255,7 +254,7 @@ def _setup_janitor_metrics() -> None:
         endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4317")
         service_name = os.getenv("OTEL_SERVICE_NAME", "hippius-s3")
 
-        resource = Resource.create({"service.name": service_name, "service.instance.id": socket.gethostname()})
+        resource = build_resource(service_name)
         metric_reader = PeriodicExportingMetricReader(
             OTLPMetricExporter(endpoint=endpoint, insecure=True),
             export_interval_millis=10000,


### PR DESCRIPTION
`rate(http_requests_total)` reports **14,535 req/s** for the gateway. The audit log in Loki, over the same window, says **138 req/s**. The metric is inflated ~105x, and `sum(resets(http_requests_total[10m]))` = **11,767** — about one reset per series per scrape, where a healthy counter resets only on restart.

## Cause

`UVICORN_WORKERS=4` x 5 replicas = 40 processes, but `count by (service_instance_id)` returns 10. Each forked worker builds its own MeterProvider — correct, and required for traces — while sharing `service.instance.id = hostname`. Four cumulative counters land in one accumulator slot in the collector's prometheus exporter; the exported value flip-flops between workers and every downward step reads as a counter reset.

The collector can't aggregate them. Its accumulator enforces the single-writer principle, and **delta temporality does not help**: the delta-to-cumulative path only accumulates points whose timestamps chain from one stream, and the histogram path drops misaligned points outright, logging "violation of single-writer principle" (`accumulator.go:204` and `:256-272`, contrib v0.96.0 — the version we run). The identity has to be unique per process.

Workers (uploader/downloader/unpinner/janitor) are single-process and were never affected — which is why the 5 app-metric alert rules all point at them, and 11 of 16 rules use kube-state/kubelet/`up` instead. The alerting was built around this bug.

## Changes

The three land together because they pay for each other: the per-process id alone would multiply the account-label series by 4.

- **Drop `main_account`/`subaccount_id` from every metric.** Unbounded and customer-controlled — one axis value per account, 115 today. ~45k of the namespace's 51.5k series; `http_request_duration_seconds_bucket` alone was 29,376. No rule or dashboard ever read them. Per-account attribution stays in the audit log and on spans, which index high-cardinality keys by design. `http_requests_total`: 1,884 series -> 208.
- **`service.instance.id` becomes `hostname:pid`.** The prior comment forbade this to protect cardinality; that reasoning was wrong, because the attribute is the pod name, which already churns completely on every deploy. A pid adds no new churn axis, only a bounded 4x. Net cardinality still drops ~8x.
- **Stop the collector upserting `service.name="hippius-s3"`** over every metric and log, which overwrote the name each service sets for itself and left api, gateway and workers indistinguishable — forcing alert rules onto pod-name regexes that break on any rename. The traces pipeline never had that processor, which is why Tempo has always shown the correct names.
- **`handler` falls back to `"unknown"`, not `request.url.path`**, which would have made object keys into labels. Not firing today, but one `None` away.
- **Tests for both invariants.** Nothing covered `otel_setup` or `MetricsCollector` before, and the worker tests mock the collector — a Mock accepts any keyword, so an account label could return without failing anything.

## Verification

- 1,694 unit tests pass; ruff clean; mypy at exactly the 90 pre-existing errors on `main`, with 0 `call-arg` errors (the account kwargs were removed with an AST script, not grep — a 10-line grep window had missed 8 of the 43).
- The 7 new tests were mutation-checked: reverting the pid, restoring the path fallback, and re-adding `main_account` each fail exactly the test aimed at them.
- Confirmed against the live SDK that the passed dict beats `OTEL_RESOURCE_ATTRIBUTES`; the deployments set `service.instance.id=$(POD_NAME)` there, so had env won this would have been a silent no-op.
- The collector config is **accepted by `otel/opentelemetry-collector-contrib:0.96.0`**, and the validator was proven non-vacuous — it rejects the same config with a dangling processor reference.
- kustomize renders for base, staging and production.

## Deploying

**The ConfigMap will not take effect on its own.** The collector mounts it by static name with no reloader sidecar and no kustomize hash suffix, so `rollout restart deploy/otel-collector` is required — otherwise you deploy, see identical numbers, and conclude it failed.

**The dashboards will drop ~100x, and that is the fix working.** `system-load.json` goes from ~14.5k req/s to ~140.

Then confirm: `sum(resets(http_requests_total{job="otel-collector-prod"}[10m]))` should fall to ~0, and the rate should land near the Loki audit-log count.

## Follow-ups, not in this PR

- The SLI alerts this unblocks (5xx rate, auth failures, p99 latency) don't exist yet; they belong in `hippius-otel`.
- Workers all report `service_name="hippius-worker"` since none set `OTEL_SERVICE_NAME`. No worse than today's `"hippius-s3"`, but naming them individually has a tail (hydrator/backup/cleanup live outside `workers-deployments.yaml`).
- `s3_operations_total` is double-counted on the GET path — both `record_s3_operation` and `record_data_transfer` increment it.
- `bucket_name` is a dead parameter on three of these methods.