### PR TITLE
perf: downloader/PUT/HEAD/MPU N+1 and metadata wins (Wave 1)

### DIFF
--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -580,26 +580,14 @@ async def upload_part(
     redis_client = request.app.state.redis_client
 
     try:
-        # Store in Redis via chunked cache API (encrypt for private, meta-first for readiness)
-        # Resolve destination bucket name for key lookup
-        try:
-            row = await pool.fetchrow(
-                """
-                SELECT b.bucket_name
-                FROM multipart_uploads mu
-                JOIN buckets b ON b.bucket_id = mu.bucket_id
-                WHERE mu.upload_id = $1
-                  AND b.deleted_at IS NULL
-                LIMIT 1
-                """,
-                upload_id,
-            )
-        except Exception:
-            row = None
-        if not row:
-            logger.error(f"Upload row not found for upload_id={upload_id}; refusing to cache part")
+        # Store in Redis via chunked cache API (encrypt for private, meta-first for readiness).
+        # MPU-2: bucket_name and bucket_id already came from get_multipart_upload above
+        # (it returns mu.* + b.bucket_name), so we don't re-run a multipart_uploads⋈buckets JOIN.
+        dest_bucket_name = ongoing_multipart_upload.get("bucket_name")
+        dest_bucket_id = ongoing_multipart_upload.get("bucket_id")
+        if not dest_bucket_name or not dest_bucket_id:
+            logger.error(f"Upload row missing bucket for upload_id={upload_id}; refusing to cache part")
             return s3_error_response("NoSuchUpload", "The specified upload does not exist.", status_code=404)
-        dest_bucket_name = row.get("bucket_name")
 
         redis_start = time.time()
         # Route through ObjectWriter for standardized behavior
@@ -610,6 +598,7 @@ async def upload_part(
                 object_id=str(object_id),
                 object_version=int(current_object_version),
                 bucket_name=str(dest_bucket_name or ""),
+                bucket_id=str(dest_bucket_id),
                 account_address=request.state.account.main_account,
                 part_number=int(part_number),
                 body_iter=body_iter,

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -32,9 +32,10 @@ async def _get_object_with_permissions_min(
     version: Optional[int] = None,
 ) -> Any:
     """Lightweight existence and metadata check (HEAD). Gateway handles permissions."""
-    # Ensure user exists
-    if main_account_id:
-        await UserRepository(db).ensure_by_main_account(main_account_id)
+    # Ensure user exists — read-first (HD-2) so the common case stays off the write path, and skip
+    # anonymous (mirrors the GET guard; avoids creating a bogus "anonymous" user row).
+    if main_account_id and main_account_id != "anonymous":
+        await UserRepository(db).ensure_by_main_account_read_first(main_account_id)
 
     # Gateway already checked permissions, just fetch the object
     if version is not None:

--- a/hippius_s3/api/s3/objects/put_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/put_object_endpoint.py
@@ -134,25 +134,12 @@ async def handle_put_object(
                 if meta_key not in {"append", "append-id", "append-if-version"}:
                     metadata[meta_key] = value
 
-        # Capture previous object (to clean up multipart parts if overwriting)
-        with tracer.start_as_current_span("put_object.check_existing_object") as span:
-            async with acquire_with_timeout(pool, config.db_pool_acquire_timeout) as conn:
-                prev = await conn.fetchrow(
-                    get_query("get_object_by_path"),
-                    bucket_id,
-                    object_key,
-                )
-            set_span_attributes(span, {"is_overwrite": prev is not None})
-
-        # Candidate object_id: DB may override on (bucket_id, object_key) conflict
-        # TODO: Make object identity/version allocation fully DB-atomic by removing this
-        #       pre-check and always passing a generated candidate UUID. The writer already
-        #       treats the DB-returned object_id/object_version as authoritative.
-        if prev:
-            candidate_object_id = str(prev["object_id"])
-            logger.debug(f"Reusing existing object_id {candidate_object_id} for overwrite")
-        else:
-            candidate_object_id = str(uuid.uuid4())
+        # Object identity/version allocation is DB-atomic: upsert_object_basic's
+        # `ON CONFLICT (bucket_id, object_key) ... RETURNING object_id` resolves the authoritative
+        # id, so we always pass a fresh candidate and use put_res.object_id downstream. Skipping the
+        # old get_object_by_path pre-check removes a DB round trip per PUT and closes a TOCTOU window
+        # (WU-3). Overwrites are handled by the upsert; nothing keys off the previous row here.
+        candidate_object_id = str(uuid.uuid4())
 
         # Use ObjectWriter streaming upsert/write (single-part)
         # Note: No transaction wrapper needed here. The upsert_object_basic query is atomic

--- a/hippius_s3/repositories/users.py
+++ b/hippius_s3/repositories/users.py
@@ -17,3 +17,10 @@ class UserRepository:
             main_account_id,
             datetime.now(timezone.utc),
         )
+
+    async def ensure_by_main_account_read_first(self, main_account_id: str) -> None:
+        # HD-2: on the hot read path (HEAD) the row almost always exists, so read first and only fall
+        # back to the INSERT-on-conflict write on a genuine miss — keeping the common case off the WAL.
+        existing = await self._db.fetchval(get_query("get_user_id_by_main_account"), main_account_id)
+        if existing is None:
+            await self.ensure_by_main_account(main_account_id)

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -48,6 +48,12 @@ class StreamContext:
     upload_id: str
 
 
+# RQ-3: backends whose downloader fetches by content id (CID) rather than a deterministic
+# backend_identifier. Only for these does the per-part CID resolution matter; Arion (the production
+# backend) is deterministically addressed and its downloader ignores spec.cid entirely.
+_CID_ADDRESSED_BACKENDS: frozenset[str] = frozenset({"ipfs"})
+
+
 async def _enqueue_missing_downloads(
     db: Any,
     redis: Any,
@@ -106,37 +112,41 @@ async def _enqueue_missing_downloads(
     # If every missing part is already being fetched by someone else,
     # we don't enqueue anything — we just fall through to stream_plan,
     # which will wait on pub/sub for each chunk.
+    # RQ-3: the downloader resolves each chunk's location from chunk_backend itself and never reads
+    # spec.cid — CIDs only matter to a content-addressed backend. Resolve the object's backends once
+    # and skip the per-part CID query entirely unless a CID-addressed backend actually serves it.
+    db_backends = await resolve_object_backends(db, object_id, object_version)
+    needs_cid = bool(set(db_backends) & _CID_ADDRESSED_BACKENDS)
+
     dl_parts: list[PartToDownload] = []
-    # CIDs are optional.
-    # - If per-chunk CIDs exist in part_chunks, include them so the IPFS downloader can fetch from IPFS.
-    # - Otherwise, keep cid=None so other backends (deterministic addressing) can handle it.
     for pn, idxs in indices_by_part.items():
         if pn not in acquired_parts:
             continue
         include = {int(i) for i in idxs}
         by_index: dict[int, tuple[str | None, int | None]] = {}
-        try:
-            from hippius_s3.utils import get_query  # local import
+        if needs_cid:
+            try:
+                from hippius_s3.utils import get_query  # local import
 
-            rows = await db.fetch(
-                get_query("get_part_chunks_by_object_and_number"),
-                object_id,
-                object_version,
-                int(pn),
-            )
-            for r in rows or []:
-                ci = int(r[0])
-                if ci not in include:
-                    continue
-                cid_raw = r[1]
-                cid_val = str(cid_raw).strip() if cid_raw is not None else None
-                if cid_val and cid_val.lower() in {"", "none", "pending"}:
-                    cid_val = None
-                clen = int(r[2]) if (len(r) > 2 and r[2] is not None) else None
-                by_index[ci] = (cid_val, clen)
-        except Exception:
-            # If chunk metadata isn't present (common for CID-less objects), keep cid=None
-            by_index = {}
+                rows = await db.fetch(
+                    get_query("get_part_chunks_by_object_and_number"),
+                    object_id,
+                    object_version,
+                    int(pn),
+                )
+                for r in rows or []:
+                    ci = int(r[0])
+                    if ci not in include:
+                        continue
+                    cid_raw = r[1]
+                    cid_val = str(cid_raw).strip() if cid_raw is not None else None
+                    if cid_val and cid_val.lower() in {"", "none", "pending"}:
+                        cid_val = None
+                    clen = int(r[2]) if (len(r) > 2 and r[2] is not None) else None
+                    by_index[ci] = (cid_val, clen)
+            except Exception:
+                # If chunk metadata isn't present (common for CID-less objects), keep cid=None
+                by_index = {}
 
         specs: list[PartChunkSpec] = []
         for ci in sorted(include):
@@ -145,7 +155,6 @@ async def _enqueue_missing_downloads(
 
         dl_parts.append(PartToDownload(part_number=int(pn), chunks=specs))
     if dl_parts:
-        db_backends = await resolve_object_backends(db, object_id, object_version)
         req = DownloadChainRequest(
             request_id=f"{object_id}::shared",
             object_id=object_id,

--- a/hippius_s3/sql/queries/get_chunk_backend_identifiers_by_part.sql
+++ b/hippius_s3/sql/queries/get_chunk_backend_identifiers_by_part.sql
@@ -1,0 +1,13 @@
+-- Batch backend-identifier lookup for every chunk of an object/version on one backend.
+-- Returns (part_number, chunk_index, backend_identifier) so the downloader can build a map once per
+-- DownloadChainRequest instead of a 3-table-join fetchrow per chunk (RD-1).
+-- $1 backend (TEXT), $2 object_id (UUID), $3 object_version (BIGINT)
+SELECT p.part_number, pc.chunk_index, cb.backend_identifier
+FROM chunk_backend cb
+JOIN part_chunks pc ON pc.id = cb.chunk_id
+JOIN parts p ON pc.part_id = p.part_id
+WHERE cb.backend = $1
+  AND p.object_id = $2
+  AND p.object_version = $3
+  AND NOT cb.deleted
+  AND cb.backend_identifier IS NOT NULL;

--- a/hippius_s3/sql/queries/get_user_id_by_main_account.sql
+++ b/hippius_s3/sql/queries/get_user_id_by_main_account.sql
@@ -1,0 +1,3 @@
+-- Read-only existence check for a user by main_account_id (the primary key)
+-- Parameters: $1: main_account_id
+SELECT main_account_id FROM users WHERE main_account_id = $1

--- a/hippius_s3/workers/downloader.py
+++ b/hippius_s3/workers/downloader.py
@@ -135,6 +135,23 @@ async def process_download_request(
         base_sleep = config.downloader_retry_base_seconds
         jitter = config.downloader_retry_jitter_seconds
 
+        # RD-1: resolve every chunk's backend_identifier in one query per request instead of a
+        # pool-acquire + 3-table-join fetchrow per chunk. _fetch_chunk reads this map; on a miss it
+        # falls back to the singular lookup to close the window where a chunk's backend row landed
+        # after this snapshot (mid-upload race).
+        async with db_pool.acquire() as conn:
+            id_rows = await conn.fetch(
+                get_query("get_chunk_backend_identifiers_by_part"),
+                backend_name,
+                download_request.object_id,
+                int(download_request.object_version),
+            )
+        backend_id_map: dict[tuple[int, int], str] = {
+            (int(r["part_number"]), int(r["chunk_index"])): str(r["backend_identifier"])
+            for r in id_rows
+            if r["backend_identifier"]
+        }
+
         t_request_start = time.perf_counter()
         ttfb_recorded = False
         ttfb_ms = 0.0
@@ -154,21 +171,23 @@ async def process_download_request(
                 return True
 
             async with semaphore:
-                # Look up backend_identifier (acquire connection from pool)
-                async with db_pool.acquire() as conn:
-                    row = await conn.fetchrow(
-                        get_query("get_chunk_backend_identifier"),
-                        backend_name,
-                        download_request.object_id,
-                        int(download_request.object_version),
-                        part_number,
-                        chunk_index,
-                    )
-                if not row or not row["backend_identifier"]:
+                # RD-1: read the per-request identifier map; on a miss fall back to the singular
+                # lookup (a chunk's backend row may have landed after the batch snapshot).
+                identifier = backend_id_map.get((part_number, chunk_index))
+                if identifier is None:
+                    async with db_pool.acquire() as conn:
+                        row = await conn.fetchrow(
+                            get_query("get_chunk_backend_identifier"),
+                            backend_name,
+                            download_request.object_id,
+                            int(download_request.object_version),
+                            part_number,
+                            chunk_index,
+                        )
+                    identifier = str(row["backend_identifier"]) if row and row["backend_identifier"] else None
+                if not identifier:
                     logger.debug(f"[{backend_name}] No identifier for part={part_number} ci={chunk_index}, skipping")
                     return True
-
-                identifier = str(row["backend_identifier"])
 
                 # Fetch with retries
                 for attempt in range(1, max_attempts + 1):

--- a/hippius_s3/workers/downloader.py
+++ b/hippius_s3/workers/downloader.py
@@ -140,24 +140,20 @@ async def process_download_request(
         ttfb_ms = 0.0
         total_bytes_downloaded = 0
 
-        async def _fetch_chunk(part_number: int, spec: object, span: trace.Span) -> bool:
+        async def _fetch_chunk(part_number: int, spec: object, span: trace.Span, cached_indices: set[int]) -> bool:
             """Fetch and cache a single chunk, guarded by the semaphore."""
             nonlocal ttfb_recorded, ttfb_ms, total_bytes_downloaded
             chunk_index = int(spec.index)  # ty: ignore[unresolved-attribute]
 
-            async with semaphore:
-                # Check if already cached on FS (may have been filled by a
-                # concurrent request / worker)
-                cached = await fs_store.chunk_exists(
-                    download_request.object_id,
-                    int(download_request.object_version),
-                    part_number,
-                    chunk_index,
-                )
-                if cached:
-                    logger.debug(f"[{backend_name}] Skipping cached chunk part={part_number} ci={chunk_index}")
-                    return True
+            # RD-5: existence is resolved once per part via chunks_exist_batch (off-loop), so we read a
+            # precomputed set here instead of a synchronous per-chunk stat on the event loop. A chunk a
+            # concurrent worker fills after the snapshot is harmless — set_chunk is atomic/deterministic,
+            # so at worst we re-fetch identical bytes.
+            if chunk_index in cached_indices:
+                logger.debug(f"[{backend_name}] Skipping cached chunk part={part_number} ci={chunk_index}")
+                return True
 
+            async with semaphore:
                 # Look up backend_identifier (acquire connection from pool)
                 async with db_pool.acquire() as conn:
                     row = await conn.fetchrow(
@@ -283,6 +279,18 @@ async def process_download_request(
                     except Exception as meta_exc:
                         logger.warning(f"[{backend_name}] Failed to write eager meta part={part_number}: {meta_exc}")
 
+                # RD-5: resolve existence for the whole part in one off-loop batch (one meta stat +
+                # N chunk stats) instead of a synchronous stat per chunk on the event loop.
+                existence_checks = [(part_number, int(spec.index)) for spec in part.chunks]
+                exist_flags = await fs_store.chunks_exist_batch(
+                    download_request.object_id,
+                    int(download_request.object_version),
+                    existence_checks,
+                )
+                cached_indices = {
+                    int(spec.index) for spec, present in zip(part.chunks, exist_flags, strict=True) if present
+                }
+
                 # Batch chunks so a pathological single-part (up to ~1280
                 # chunks for a 5 GiB part at 4 MiB chunk size) doesn't create
                 # thousands of tasks parked on the semaphore. Matches the
@@ -292,7 +300,9 @@ async def process_download_request(
                 for i in range(0, len(part.chunks), chunk_batch_size):
                     batch = part.chunks[i : i + chunk_batch_size]
                     chunk_results.extend(
-                        await asyncio.gather(*[_fetch_chunk(part_number, spec, part_span) for spec in batch])
+                        await asyncio.gather(
+                            *[_fetch_chunk(part_number, spec, part_span, cached_indices) for spec in batch]
+                        )
                     )
 
                 # Release the coalescing lock (set by build_stream_context on enqueue). Key format

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -643,6 +643,7 @@ class ObjectWriter:
         object_id: str,
         object_version: int,
         bucket_name: str,
+        bucket_id: str,
         account_address: str,
         part_number: int,
         body_iter: AsyncIterator[bytes],
@@ -656,19 +657,10 @@ class ObjectWriter:
         if max_size <= 0:
             max_size = 0
 
-        # Resolve bucket_id for this version
-        meta = await self.pool.fetchrow(
-            """
-            SELECT o.bucket_id, ov.storage_version
-              FROM objects o
-              JOIN object_versions ov ON ov.object_id = o.object_id AND ov.object_version = $2
-             WHERE o.object_id = $1
-             LIMIT 1
-            """,
-            object_id,
-            int(object_version),
-        )
-        bucket_id = str(meta["bucket_id"]) if meta and meta.get("bucket_id") else ""
+        # MPU-2: bucket_id is passed by the caller (from the already-fetched multipart_uploads row),
+        # so we no longer re-run an objects⋈object_versions JOIN per part (its storage_version was
+        # never used).
+        bucket_id = str(bucket_id)
         suite_id = "hip-enc/aes256gcm"
         key_bytes = await self._ensure_and_get_v5_dek(
             bucket_id=bucket_id,
@@ -1102,6 +1094,7 @@ class ObjectWriter:
                 object_id=str(object_id),
                 object_version=int(cov),
                 bucket_name=str(bucket_name),
+                bucket_id=str(bucket_id),
                 account_address=account_address,
                 part_number=int(next_part),
                 body_iter=body_iter,

--- a/tests/unit/api/test_put_object_endpoint.py
+++ b/tests/unit/api/test_put_object_endpoint.py
@@ -102,8 +102,8 @@ async def test_missing_bucket_404_inside_scope() -> None:
 
 @pytest.mark.asyncio
 async def test_head_lookups_single_acquire(monkeypatch: Any) -> None:
-    """user + bucket reads share ONE acquired connection; the existing-object check uses a
-    second acquire. Total endpoint acquires for the head = 2 (was 3)."""
+    """user + bucket reads share ONE acquired connection. With the existing-object pre-check
+    removed (WU-3), total endpoint acquires = 2 (user+bucket, then is_completed-after-enqueue)."""
     pool = make_fake_pool(_bucket_present_router)
 
     async def fake_put(self: Any, **kw: Any) -> PutResult:
@@ -138,9 +138,27 @@ async def test_head_lookups_single_acquire(monkeypatch: Any) -> None:
     bucket_evt = next(e for e in fetchrows if "Get bucket by name" in (e["query"] or ""))
     assert user_evt["conn"] == bucket_evt["conn"], "user + bucket did not share one connection"
 
-    # Endpoint acquires (writer is patched out here): user+bucket (1) + existing-object (1)
-    # + is_completed-after-enqueue (1) = 3.
-    assert pool.acquire_count == 3
+    # Endpoint acquires (writer is patched out here): user+bucket (1) + is_completed-after-enqueue (1) = 2.
+    assert pool.acquire_count == 2
+
+
+@pytest.mark.asyncio
+async def test_no_existing_object_precheck_query(monkeypatch: Any) -> None:
+    """WU-3: PUT no longer issues the get_object_by_path existing-object pre-check. It always passes
+    a fresh candidate UUID and trusts upsert_object_basic's `ON CONFLICT ... RETURNING object_id`."""
+    pool = make_fake_pool(_bucket_present_router)
+    captured: dict[str, Any] = {}
+    _patch_writer(monkeypatch, captured)
+
+    resp = await handle_put_object(
+        bucket_name="bkt",
+        object_key="k/o.json",
+        request=_fake_request({"Content-Type": "application/json"}),
+        pool=pool,
+        redis_client=_FakeRedis(nx_result=True),
+    )
+    assert resp.status_code == 200
+    assert not _has_query(pool, "Get object by bucket and key path"), "existing-object pre-check must be gone"
 
 
 @pytest.mark.asyncio
@@ -252,7 +270,7 @@ async def test_user_upsert_runs_when_redis_errors(monkeypatch: Any) -> None:
 @pytest.mark.asyncio
 async def test_no_head_acquire_when_user_cached_and_bucket_forwarded(monkeypatch: Any) -> None:
     """Fix 2 + Fix 5 compose: a known account on a forwarded-bucket PUT does zero head-scope DB
-    work. Only the existing-object check and the post-enqueue is_completed update acquire."""
+    work. With the existing-object pre-check gone (WU-3), only the post-enqueue is_completed update acquires."""
     pool = make_fake_pool(_bucket_present_router)
     captured: dict[str, Any] = {}
     _patch_writer(monkeypatch, captured)
@@ -270,5 +288,6 @@ async def test_no_head_acquire_when_user_cached_and_bucket_forwarded(monkeypatch
     assert resp.status_code == 200
     assert not _has_query(pool, "Get or create")
     assert not _has_query(pool, "Get bucket by name")
-    # existing-object check (1) + is_completed-after-enqueue (1); the head user+bucket acquire is gone.
-    assert pool.acquire_count == 2
+    # Only is_completed-after-enqueue (1); the head user+bucket acquire and the existing-object
+    # pre-check acquire are both gone.
+    assert pool.acquire_count == 1

--- a/tests/unit/test_download_coalescing.py
+++ b/tests/unit/test_download_coalescing.py
@@ -208,3 +208,49 @@ async def test_cache_hit_skips_lock_entirely(
     assert ctx.source == "cache"
     assert redis.set_calls == []
     mock_enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("hippius_s3.services.object_reader.get_bucket_kek_bytes", new=AsyncMock(return_value=b"k" * 32))
+@patch("hippius_s3.services.object_reader.unwrap_dek", new=MagicMock(return_value=b"d" * 32))
+@patch("hippius_s3.services.object_reader.CryptoService.is_supported_suite_id", new=MagicMock(return_value=True))
+@patch("hippius_s3.services.object_reader.resolve_object_backends", new=AsyncMock(return_value=["arion"]))
+@patch("hippius_s3.services.object_reader.enqueue_download_request", new_callable=AsyncMock)
+@patch("hippius_s3.services.object_reader.build_chunk_plan", new_callable=AsyncMock)
+@patch("hippius_s3.services.object_reader.read_parts_list", new_callable=AsyncMock)
+@patch("hippius_s3.services.object_reader.get_config")
+async def test_arion_object_skips_per_part_cid_query(
+    mock_cfg,
+    mock_parts,
+    mock_plan,
+    mock_enqueue,
+):
+    """RQ-3: for a deterministically-addressed (Arion) object the downloader never reads spec.cid, so
+    the per-part get_part_chunks_by_object_and_number query is skipped and specs are indices-only."""
+    from hippius_s3.services.object_reader import build_stream_context
+
+    mock_cfg.return_value = _stub_config()
+    mock_parts.return_value = [{"part_number": 1, "plain_size": 4096, "cid": None}]
+    mock_plan.return_value = _mock_plan(2)
+
+    redis = _RedisStub()
+    obj_cache = _mock_obj_cache([False, False])
+    db = _mock_db_pool()  # db.fetch would serve the CID query; assert it is never awaited.
+
+    ctx = await build_stream_context(
+        db=db,
+        redis=redis,
+        obj_cache=obj_cache,
+        info=_info(),
+        rng=None,
+        address="addr",
+    )
+
+    assert ctx.source == "pipeline"
+    mock_enqueue.assert_awaited_once()
+    db.fetch.assert_not_awaited()
+
+    dcr = mock_enqueue.call_args.args[0]
+    all_specs = [spec for part in dcr.chunks for spec in part.chunks]
+    assert all_specs, "expected chunk specs on the enqueued request"
+    assert all(spec.cid is None for spec in all_specs), "Arion specs must be indices-only (cid=None)"

--- a/tests/unit/test_downloader_batch_checks.py
+++ b/tests/unit/test_downloader_batch_checks.py
@@ -131,3 +131,56 @@ async def test_rd5_batches_existence_and_skips_cached(mock_metrics: Any, mock_co
     assert per_chunk_exist_calls["n"] == 0, "downloader must not call per-chunk chunk_exists during fetch"
     # Only the missing chunk (index 1) is fetched; the pre-cached one is skipped.
     assert fetch_fn.await_count == 1
+
+
+@pytest.mark.asyncio
+@patch("hippius_s3.workers.downloader.get_config")
+@patch("hippius_s3.workers.downloader.get_metrics_collector")
+async def test_rd1_resolves_identifier_via_one_batch_query(
+    mock_metrics: Any, mock_config: Any, fs_store: Any
+) -> None:
+    mock_config.return_value = _config()
+    mock_metrics.return_value = MagicMock()
+
+    singular_id_calls = {"n": 0}
+    batch_calls = {"n": 0}
+    conn = AsyncMock()
+
+    async def _fetchrow(sql: str, *args: Any) -> Any:
+        if "size_bytes" in sql:
+            return {"size_bytes": 4096, "chunk_size_bytes": 4 * 1024 * 1024}
+        if "backend_identifier" in sql or "chunk_backend" in sql:
+            singular_id_calls["n"] += 1
+            return {"backend_identifier": "arion-id"}
+        return None
+
+    async def _fetch(sql: str, *args: Any) -> Any:
+        if "backend_identifier" in sql or "chunk_backend" in sql:
+            batch_calls["n"] += 1
+            return [
+                {"part_number": 1, "chunk_index": 0, "backend_identifier": "arion-id"},
+                {"part_number": 1, "chunk_index": 1, "backend_identifier": "arion-id"},
+            ]
+        return []
+
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+    conn.fetch = AsyncMock(side_effect=_fetch)
+    pool = MagicMock()
+    pool.acquire = MagicMock(
+        return_value=MagicMock(__aenter__=AsyncMock(return_value=conn), __aexit__=AsyncMock(return_value=False))
+    )
+
+    fetch_fn = AsyncMock(return_value=b"z" * 4096)
+    result = await process_download_request(
+        _request(1, 2),
+        backend_name="arion",
+        fetch_fn=fetch_fn,
+        db_pool=pool,
+        obj_cache=_obj_cache(),
+        fs_store=fs_store,
+    )
+
+    assert result is True
+    assert batch_calls["n"] == 1, "identifier must be resolved by one batch query per request"
+    assert singular_id_calls["n"] == 0, "no per-chunk identifier fetchrow when the batch map has the entry"
+    assert fetch_fn.await_count == 2

--- a/tests/unit/test_downloader_batch_checks.py
+++ b/tests/unit/test_downloader_batch_checks.py
@@ -1,0 +1,133 @@
+"""RD-5 / RD-1: the downloader batches per-chunk FS and DB lookups per part/request.
+
+RD-5: existence is checked once per part via chunks_exist_batch (off-loop) instead of a synchronous
+per-chunk fs_store.chunk_exists on the event loop.
+RD-1: the backend identifier is resolved in one query per DownloadChainRequest into a map, instead of
+a pool-acquire + 3-table-join fetchrow per chunk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from hippius_s3.cache.fs_store import FileSystemPartsStore
+from hippius_s3.queue import DownloadChainRequest
+from hippius_s3.queue import PartChunkSpec
+from hippius_s3.queue import PartToDownload
+from hippius_s3.workers.downloader import process_download_request
+
+
+OBJ = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def _request(num_parts: int, chunks_per_part: int) -> DownloadChainRequest:
+    parts = [
+        PartToDownload(part_number=pn, chunks=[PartChunkSpec(index=ci, cid=None) for ci in range(chunks_per_part)])
+        for pn in range(1, num_parts + 1)
+    ]
+    return DownloadChainRequest(
+        object_id=OBJ,
+        object_version=1,
+        object_key="test/object.bin",
+        bucket_name="test-bucket",
+        object_storage_version=5,
+        address="5Addr",
+        subaccount="5Addr",
+        substrate_url="http://test",
+        size=num_parts * chunks_per_part * 4 * 1024 * 1024,
+        multipart=num_parts > 1,
+        chunks=parts,
+    )
+
+
+def _config(semaphore: int = 4) -> Any:
+    c = MagicMock()
+    c.downloader_semaphore = semaphore
+    c.downloader_chunk_retries = 1
+    c.downloader_retry_base_seconds = 0.0
+    c.downloader_retry_jitter_seconds = 0.0
+    return c
+
+
+def _db_pool(identifier: str = "arion-id") -> Any:
+    """DB pool that answers the per-part meta query (fetchrow), the per-request identifier batch
+    (fetch), and the singular per-chunk identifier fallback (fetchrow)."""
+    conn = AsyncMock()
+
+    async def _fetchrow(sql: str, *args: Any) -> Any:
+        if "size_bytes" in sql:
+            return {"size_bytes": 4096, "chunk_size_bytes": 4 * 1024 * 1024}
+        if "backend_identifier" in sql or "chunk_backend" in sql:
+            return {"backend_identifier": identifier}
+        return None
+
+    async def _fetch(sql: str, *args: Any) -> Any:
+        # RD-1 batch identifier query returns rows keyed by (part_number, chunk_index).
+        if "backend_identifier" in sql or "chunk_backend" in sql:
+            return []  # empty on purpose so the singular fallback is exercised where present
+        return []
+
+    conn.fetchrow = AsyncMock(side_effect=_fetchrow)
+    conn.fetch = AsyncMock(side_effect=_fetch)
+    pool = MagicMock()
+    pool.acquire = MagicMock(
+        return_value=MagicMock(__aenter__=AsyncMock(return_value=conn), __aexit__=AsyncMock(return_value=False))
+    )
+    return pool, conn
+
+
+def _obj_cache() -> Any:
+    cache = MagicMock()
+    cache.notify_chunk = AsyncMock()
+    cache.redis = MagicMock()
+    cache.redis.eval = AsyncMock(return_value=1)
+    return cache
+
+
+@pytest.fixture
+def fs_store(tmp_path: Path) -> FileSystemPartsStore:
+    return FileSystemPartsStore(str(tmp_path))
+
+
+@pytest.mark.asyncio
+@patch("hippius_s3.workers.downloader.get_config")
+@patch("hippius_s3.workers.downloader.get_metrics_collector")
+async def test_rd5_batches_existence_and_skips_cached(mock_metrics: Any, mock_config: Any, fs_store: Any) -> None:
+    mock_config.return_value = _config()
+    mock_metrics.return_value = MagicMock()
+
+    # Pre-cache part 1 / chunk 0 (meta + chunk) so it must be skipped.
+    await fs_store.set_meta(OBJ, 1, 1, chunk_size=4 * 1024 * 1024, num_chunks=2, size_bytes=4096)
+    await fs_store.set_chunk(OBJ, 1, 1, 0, b"cached-bytes")
+
+    per_chunk_exist_calls = {"n": 0}
+    orig_exists = fs_store.chunk_exists
+
+    async def _counting_exists(*a: Any, **k: Any) -> Any:
+        per_chunk_exist_calls["n"] += 1
+        return await orig_exists(*a, **k)
+
+    fs_store.chunk_exists = _counting_exists  # type: ignore[method-assign]
+
+    fetch_fn = AsyncMock(return_value=b"y" * 4096)
+    pool, _conn = _db_pool()
+    result = await process_download_request(
+        _request(1, 2),
+        backend_name="arion",
+        fetch_fn=fetch_fn,
+        db_pool=pool,
+        obj_cache=_obj_cache(),
+        fs_store=fs_store,
+    )
+
+    assert result is True
+    # RD-5: existence is resolved by the per-part batch, not a per-chunk chunk_exists on the loop.
+    assert per_chunk_exist_calls["n"] == 0, "downloader must not call per-chunk chunk_exists during fetch"
+    # Only the missing chunk (index 1) is fetched; the pre-cached one is skipped.
+    assert fetch_fn.await_count == 1

--- a/tests/unit/test_mpu_upload_part_stream_cleanup.py
+++ b/tests/unit/test_mpu_upload_part_stream_cleanup.py
@@ -59,6 +59,7 @@ async def test_mpu_upload_part_stream_cleans_up_on_oversize(tmp_path, monkeypatc
                 object_id=object_id,
                 object_version=1,
                 bucket_name="bucket",
+                bucket_id="bucket",
                 account_address="acct",
                 part_number=1,
                 body_iter=body_iter(),
@@ -70,3 +71,57 @@ async def test_mpu_upload_part_stream_cleans_up_on_oversize(tmp_path, monkeypatc
         cfg.object_chunk_size_bytes = original_chunk_size
         cfg.max_multipart_part_size = original_max_part
         cfg.cache_ttl_seconds = original_ttl
+
+
+@pytest.mark.asyncio
+async def test_mpu_part_uses_passed_bucket_id_no_internal_query(tmp_path, monkeypatch):
+    """MPU-2: mpu_upload_part_stream takes bucket_id from the caller (the already-fetched MPU row)
+    and no longer runs its own objects⋈object_versions resolution query."""
+    cfg = get_config()
+    saved = (cfg.object_chunk_size_bytes, cfg.max_multipart_part_size, cfg.cache_ttl_seconds)
+    cfg.object_chunk_size_bytes = 4
+    cfg.max_multipart_part_size = 5  # force the oversize raise so we stop before the DB tail
+    cfg.cache_ttl_seconds = 60
+    monkeypatch.setattr("hippius_s3.writer.object_writer.get_config", lambda: cfg)
+
+    fetchrow_queries: list[str] = []
+
+    class RecordingPool:
+        async def fetchrow(self, query, *_args, **_kwargs):
+            fetchrow_queries.append(query)
+            return {"bucket_id": "should-not-be-used", "storage_version": 5}
+
+        async def fetchval(self, *_args, **_kwargs):
+            return "part-id"
+
+        async def execute(self, *_args, **_kwargs):
+            return None
+
+    async def fake_ensure_dek(*_a, **_k) -> bytes:
+        return b"\x00" * 32
+
+    async def body_iter():
+        yield b"abcd"
+        yield b"ef"
+
+    fs_store = FileSystemPartsStore(str(tmp_path))
+    writer = ObjectWriter(pool=RecordingPool(), redis_client=None, fs_store=fs_store)
+    monkeypatch.setattr(writer, "_ensure_and_get_v5_dek", fake_ensure_dek)
+
+    try:
+        with pytest.raises(ValueError, match="part_size_exceeds_max"):
+            await writer.mpu_upload_part_stream(
+                upload_id="upload",
+                object_id=str(uuid.uuid4()),
+                object_version=1,
+                bucket_name="bucket",
+                bucket_id="bkt-xyz",
+                account_address="acct",
+                part_number=1,
+                body_iter=body_iter(),
+            )
+        assert not any(
+            "bucket_id" in (q or "") for q in fetchrow_queries
+        ), "must not run the internal bucket_id/storage_version resolution query"
+    finally:
+        cfg.object_chunk_size_bytes, cfg.max_multipart_part_size, cfg.cache_ttl_seconds = saved

--- a/tests/unit/test_user_repository_read_first.py
+++ b/tests/unit/test_user_repository_read_first.py
@@ -1,0 +1,45 @@
+"""HD-2: HEAD must not run the users INSERT-on-conflict write on every request.
+
+`ensure_by_main_account` is a write path (WAL + conflict handling). On the highest-frequency read op
+(HEAD) the row essentially always exists, so we add a read-first variant that only writes on a genuine
+miss.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hippius_s3.repositories.users import UserRepository
+
+
+class _FakeDB:
+    def __init__(self, existing: Any) -> None:
+        self._existing = existing
+        self.reads: list[tuple[str, tuple]] = []
+        self.writes: list[tuple[str, tuple]] = []
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        self.reads.append((query, args))
+        return self._existing
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        self.writes.append((query, args))
+        return {"main_account_id": args[0]}
+
+
+@pytest.mark.asyncio
+async def test_read_first_skips_write_when_user_exists() -> None:
+    db = _FakeDB(existing="acct-1")
+    await UserRepository(db).ensure_by_main_account_read_first("acct-1")
+    assert db.reads, "must issue the read"
+    assert not db.writes, "existing user must not trigger the INSERT-on-conflict write"
+
+
+@pytest.mark.asyncio
+async def test_read_first_writes_on_miss() -> None:
+    db = _FakeDB(existing=None)
+    await UserRepository(db).ensure_by_main_account_read_first("acct-1")
+    assert db.reads, "must issue the read"
+    assert db.writes, "a genuine miss must create the user"


### PR DESCRIPTION
Wave 1 of the upload/download performance work — verified low-risk metadata/N+1 wins with no e2e-harness dependency. **Stacked on #266** (base is `perf/wave-0-measurement-docs`); retarget to `staging` once #266 merges. Every change is TDD-driven; full unit suite green (1868 passed).

## Changes (biggest to smallest)
- **RD-1 — one identifier query per download request.** `_fetch_chunk` did a pool-acquire + 3-table-join `fetchrow` per chunk (~1280 for a 5 GiB GET). Resolve all identifiers once into a `(part_number, chunk_index) → identifier` map via a new by-part query; per-chunk map miss falls back to the singular lookup to close the mid-upload race.
- **RD-5 — batch chunk existence off the event loop.** Replaced the synchronous per-chunk `fs_store.chunk_exists` with one `chunks_exist_batch` per part (already `to_thread`'d).
- **MPU-2 — reuse the fetched MPU row.** `get_multipart_upload` already returns `mu.*` (incl. `bucket_id`) + `bucket_name`; UploadPart re-ran a `buckets` JOIN and `mpu_upload_part_stream` re-ran an `objects` JOIN (+ dead `storage_version`). Thread `bucket_id` through; drop both queries (~2 fewer round trips/part).
- **HD-2 — HEAD no longer writes on every read.** `ensure_by_main_account` (INSERT-on-conflict) ran on every HEAD and even created a bogus `anonymous` user. Now read-first via a new query, create only on a genuine miss, gated to skip anonymous like GET.
- **WU-3 — drop the PUT `get_object_by_path` pre-check.** It only seeded a candidate id that `upsert_object_basic`'s `RETURNING` already resolves. Removes one DB round trip per PUT and closes a TOCTOU window.
- **RQ-3 — skip the wasted per-part CID query.** `_enqueue_missing_downloads` populated `spec.cid`/`cipher_size_bytes` (which the downloader never reads) on every cold GET. Resolve backends once and skip the query unless a CID-addressed backend serves the object (none in production); Arion sends indices-only specs.

## New SQL (added, never mutating shared queries)
`get_chunk_backend_identifiers_by_part.sql`, `get_user_id_by_main_account.sql`.

## Tests
TDD throughout (RED verified before each fix). `pytest tests/unit` → 1868 passed, 37 skipped.
