### PR TITLE
perf(kek): singleflight cold-bucket KEK unwrap/create + sliding active-id cache (Wave 2)

### DIFF
--- a/hippius_s3/services/kek_service.py
+++ b/hippius_s3/services/kek_service.py
@@ -369,6 +369,11 @@ async def _get_cached_active_kek_id(bucket_id: str) -> uuid.UUID | None:
         if expires_at <= now:
             _ACTIVE_KEK_CACHE.pop(str(bucket_id), None)
             return None
+        # KM-3: sliding window, symmetric with _get_cached_kek — refresh the TTL on read so a
+        # continuously-hot bucket doesn't re-SELECT the (unchanged) active kek_id every TTL. Reads
+        # stay correct regardless since decrypts key off the object row's stored kek_id; a future
+        # rotation feature must invalidate this entry when it flips the active KEK.
+        _ACTIVE_KEK_CACHE[str(bucket_id)] = (kek_id, now + ttl)
         return kek_id
 
 

--- a/hippius_s3/services/kek_service.py
+++ b/hippius_s3/services/kek_service.py
@@ -535,31 +535,39 @@ async def get_bucket_kek_bytes(*, bucket_id: str, kek_id: uuid.UUID) -> bytes:
     if not dsn:
         raise RuntimeError("kek_database_unavailable")
 
-    pool = await _get_pool(dsn)
-    async with pool.acquire() as conn:
-        await _maybe_ensure_tables(conn)
+    # KM-1: singleflight the cold unwrap so N concurrent GETs sharing a bucket's KEK collapse to one
+    # KMS round trip (mirrors the PUT path). The re-check inside the lock catches the fill by the
+    # winner; losers also stop competing for the keystore pool across the KMS call.
+    async with _kek_unwrap_lock(bucket_id, kek_id):
+        cached = await _get_cached_kek(bucket_id, kek_id)
+        if cached is not None:
+            return cached
 
-        row = await conn.fetchrow(
-            """
-            SELECT wrapped_kek_bytes, kms_key_id
-              FROM bucket_keks
-             WHERE bucket_id = $1
-               AND kek_id = $2
-             LIMIT 1
-            """,
-            uuid.UUID(str(bucket_id)),
-            uuid.UUID(str(kek_id)),
-        )
-        if row is None:
-            raise RuntimeError("kek_not_found")
+        pool = await _get_pool(dsn)
+        async with pool.acquire() as conn:
+            await _maybe_ensure_tables(conn)
 
-        # Unwrap the KEK
-        wrapped_kek_bytes = row["wrapped_kek_bytes"]
-        kms_key_id = row["kms_key_id"]
-        kek_bytes = await _unwrap_kek(bytes(wrapped_kek_bytes), kms_key_id, kek_id)
+            row = await conn.fetchrow(
+                """
+                SELECT wrapped_kek_bytes, kms_key_id
+                  FROM bucket_keks
+                 WHERE bucket_id = $1
+                   AND kek_id = $2
+                 LIMIT 1
+                """,
+                uuid.UUID(str(bucket_id)),
+                uuid.UUID(str(kek_id)),
+            )
+            if row is None:
+                raise RuntimeError("kek_not_found")
 
-        await _set_cached_kek(bucket_id, kek_id, kek_bytes)
-        return kek_bytes
+            # Unwrap the KEK
+            wrapped_kek_bytes = row["wrapped_kek_bytes"]
+            kms_key_id = row["kms_key_id"]
+            kek_bytes = await _unwrap_kek(bytes(wrapped_kek_bytes), kms_key_id, kek_id)
+
+            await _set_cached_kek(bucket_id, kek_id, kek_bytes)
+            return kek_bytes
 
 
 async def close_kek_pool() -> None:

--- a/hippius_s3/services/kek_service.py
+++ b/hippius_s3/services/kek_service.py
@@ -306,6 +306,24 @@ def _kek_unwrap_lock(bucket_id: str, kek_id: uuid.UUID) -> asyncio.Lock:
     return lock
 
 
+# KM-2: per-bucket lock coalescing the fetch-or-create of a bucket's active KEK, so a first-PUT
+# burst on a new bucket does one KMS generate rather than N generates + (N-1) decrypts. Same
+# idle-eviction discipline as the unwrap-lock map.
+_kek_create_locks: dict[str, asyncio.Lock] = {}
+
+
+def _kek_create_lock(bucket_id: str) -> asyncio.Lock:
+    key = str(bucket_id)
+    lock = _kek_create_locks.get(key)
+    if lock is None:
+        if len(_kek_create_locks) >= _KEK_LOCK_MAP_MAX:
+            for k in [k for k, v in _kek_create_locks.items() if not v.locked()]:
+                del _kek_create_locks[k]
+        lock = asyncio.Lock()
+        _kek_create_locks[key] = lock
+    return lock
+
+
 async def _get_cached_kek(bucket_id: str, kek_id: uuid.UUID) -> bytes | None:
     cfg = get_config()
     ttl = int(cfg.kek_cache_ttl_seconds)
@@ -438,87 +456,97 @@ async def get_or_create_active_bucket_kek(
         if cached_bytes is not None:
             return cached_active_kek_id, cached_bytes
 
-    pool = await _get_pool(dsn)
-    async with pool.acquire() as conn:
-        await _maybe_ensure_tables(conn)
+    # KM-2: singleflight the cold fetch-or-create per bucket (outside the pool so waiters don't hold
+    # a keystore connection), re-checking the cache inside the lock so a first-PUT burst on a new
+    # bucket resolves to one KMS generate. The 23505 handler below stays as the cross-pod backstop.
+    async with _kek_create_lock(bucket_id):
+        cached_active_kek_id = await _get_cached_active_kek_id(bucket_id)
+        if cached_active_kek_id is not None:
+            cached_bytes = await _get_cached_kek(bucket_id, cached_active_kek_id)
+            if cached_bytes is not None:
+                return cached_active_kek_id, cached_bytes
 
-        async def _fetch_active() -> asyncpg.Record | None:
-            return await conn.fetchrow(
-                """
-                SELECT kek_id, wrapped_kek_bytes, kms_key_id
-                  FROM bucket_keks
-                 WHERE bucket_id = $1
-                   AND status = 'active'
-                 ORDER BY created_at DESC
-                 LIMIT 1
-                """,
-                uuid.UUID(str(bucket_id)),
-            )
+        pool = await _get_pool(dsn)
+        async with pool.acquire() as conn:
+            await _maybe_ensure_tables(conn)
 
-        row = await _fetch_active()
+            async def _fetch_active() -> asyncpg.Record | None:
+                return await conn.fetchrow(
+                    """
+                    SELECT kek_id, wrapped_kek_bytes, kms_key_id
+                      FROM bucket_keks
+                     WHERE bucket_id = $1
+                       AND status = 'active'
+                     ORDER BY created_at DESC
+                     LIMIT 1
+                    """,
+                    uuid.UUID(str(bucket_id)),
+                )
 
-        if row is not None:
-            kek_id = uuid.UUID(str(row["kek_id"]))
-            await _set_cached_active_kek_id(bucket_id, kek_id)
+            row = await _fetch_active()
 
-            # Check for cached KEK first
-            cached = await _get_cached_kek(bucket_id, kek_id)
-            if cached is not None:
-                return kek_id, cached
+            if row is not None:
+                kek_id = uuid.UUID(str(row["kek_id"]))
+                await _set_cached_active_kek_id(bucket_id, kek_id)
 
-            # A14 singleflight: coalesce concurrent cold misses. Hold the per-key lock, then
-            # RE-CHECK the cache — the first waiter's unwrap+cache means every later waiter hits
-            # the cache and skips its own KMS call.
-            async with _kek_unwrap_lock(bucket_id, kek_id):
+                # Check for cached KEK first
                 cached = await _get_cached_kek(bucket_id, kek_id)
                 if cached is not None:
                     return kek_id, cached
-                wrapped_kek_bytes = row["wrapped_kek_bytes"]
-                kms_key_id = row["kms_key_id"]
-                kek_bytes = await _unwrap_kek(bytes(wrapped_kek_bytes), kms_key_id, kek_id)
-                await _set_cached_kek(bucket_id, kek_id, kek_bytes)
-                return kek_id, kek_bytes
 
-        # Create new KEK (KMS generates the key, or we generate locally)
-        kek_id = uuid.uuid4()
-        kek_bytes, wrapped_kek_bytes, kms_key_id = await _create_wrapped_kek(f"new KEK for bucket {bucket_id}")
-
-        try:
-            await conn.execute(
-                """
-                INSERT INTO bucket_keks (bucket_id, kek_id, wrapped_kek_bytes, kms_key_id, status)
-                VALUES ($1, $2, $3, $4, 'active')
-                """,
-                uuid.UUID(str(bucket_id)),
-                kek_id,
-                wrapped_kek_bytes,
-                kms_key_id,
-            )
-        except Exception as e:
-            # Handle race condition: another process created the KEK
-            if getattr(e, "sqlstate", "") == "23505":
-                row = await _fetch_active()
-                if row is not None:
-                    kek_id = uuid.UUID(str(row["kek_id"]))
-                    await _set_cached_active_kek_id(bucket_id, kek_id)
-
-                    # Check cache first
+                # A14 singleflight: coalesce concurrent cold misses. Hold the per-key lock, then
+                # RE-CHECK the cache — the first waiter's unwrap+cache means every later waiter hits
+                # the cache and skips its own KMS call.
+                async with _kek_unwrap_lock(bucket_id, kek_id):
                     cached = await _get_cached_kek(bucket_id, kek_id)
                     if cached is not None:
                         return kek_id, cached
-
-                    # Unwrap the KEK
-                    wrapped = row["wrapped_kek_bytes"]
-                    key_id = row["kms_key_id"]
-                    kek_bytes = await _unwrap_kek(bytes(wrapped), key_id, kek_id)
-
+                    wrapped_kek_bytes = row["wrapped_kek_bytes"]
+                    kms_key_id = row["kms_key_id"]
+                    kek_bytes = await _unwrap_kek(bytes(wrapped_kek_bytes), kms_key_id, kek_id)
                     await _set_cached_kek(bucket_id, kek_id, kek_bytes)
                     return kek_id, kek_bytes
-            raise
 
-        await _set_cached_active_kek_id(bucket_id, kek_id)
-        await _set_cached_kek(bucket_id, kek_id, kek_bytes)
-        return kek_id, kek_bytes
+            # Create new KEK (KMS generates the key, or we generate locally)
+            kek_id = uuid.uuid4()
+            kek_bytes, wrapped_kek_bytes, kms_key_id = await _create_wrapped_kek(f"new KEK for bucket {bucket_id}")
+
+            try:
+                await conn.execute(
+                    """
+                    INSERT INTO bucket_keks (bucket_id, kek_id, wrapped_kek_bytes, kms_key_id, status)
+                    VALUES ($1, $2, $3, $4, 'active')
+                    """,
+                    uuid.UUID(str(bucket_id)),
+                    kek_id,
+                    wrapped_kek_bytes,
+                    kms_key_id,
+                )
+            except Exception as e:
+                # Handle race condition: another process created the KEK
+                if getattr(e, "sqlstate", "") == "23505":
+                    row = await _fetch_active()
+                    if row is not None:
+                        kek_id = uuid.UUID(str(row["kek_id"]))
+                        await _set_cached_active_kek_id(bucket_id, kek_id)
+
+                        # Check cache first
+                        cached = await _get_cached_kek(bucket_id, kek_id)
+                        if cached is not None:
+                            return kek_id, cached
+
+                        # Unwrap the KEK
+                        wrapped = row["wrapped_kek_bytes"]
+                        key_id = row["kms_key_id"]
+                        kek_bytes = await _unwrap_kek(bytes(wrapped), key_id, kek_id)
+
+                        await _set_cached_kek(bucket_id, kek_id, kek_bytes)
+                        return kek_id, kek_bytes
+                raise
+
+            await _set_cached_active_kek_id(bucket_id, kek_id)
+            await _set_cached_kek(bucket_id, kek_id, kek_bytes)
+            return kek_id, kek_bytes
 
 
 async def get_bucket_kek_bytes(*, bucket_id: str, kek_id: uuid.UUID) -> bytes:

--- a/tests/unit/services/test_kek_active_cache.py
+++ b/tests/unit/services/test_kek_active_cache.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 from types import SimpleNamespace
 from typing import Any
@@ -104,3 +105,39 @@ async def test_requery_after_active_cache_eviction(monkeypatch: Any, kek_env: An
 
     await kek_service.get_or_create_active_bucket_kek(bucket_id=bucket_id)
     assert conn.fetchrow_calls == 2, "eviction must force a fresh active-kek lookup"
+
+
+@pytest.mark.asyncio
+async def test_active_kek_id_cache_slides_on_read(monkeypatch: Any) -> None:
+    """KM-3: reading the active-kek-id refreshes its TTL (sliding), like the plaintext KEK cache, so
+    a continuously-hot bucket doesn't pay a keystore SELECT every TTL to re-learn an unchanged id."""
+    cfg = SimpleNamespace(kek_cache_ttl_seconds=100, encryption_database_url="postgres://x")
+    monkeypatch.setattr(kek_service, "get_config", lambda: cfg)
+    kek_service._ACTIVE_KEK_CACHE.clear()
+
+    bucket_id = str(uuid.uuid4())
+    kek_id = uuid.uuid4()
+    # Entry about to expire (1s left) — a read must slide it to ~now+ttl.
+    kek_service._ACTIVE_KEK_CACHE[bucket_id] = (kek_id, time.monotonic() + 1)
+    aged_expiry = kek_service._ACTIVE_KEK_CACHE[bucket_id][1]
+
+    got = await kek_service._get_cached_active_kek_id(bucket_id)
+    slid_expiry = kek_service._ACTIVE_KEK_CACHE[bucket_id][1]
+
+    assert got == kek_id
+    assert slid_expiry > aged_expiry + 50, "read must slide the TTL forward to ~now+ttl"
+
+    kek_service._ACTIVE_KEK_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_active_kek_id_expired_entry_not_resurrected(monkeypatch: Any) -> None:
+    cfg = SimpleNamespace(kek_cache_ttl_seconds=100, encryption_database_url="postgres://x")
+    monkeypatch.setattr(kek_service, "get_config", lambda: cfg)
+    kek_service._ACTIVE_KEK_CACHE.clear()
+
+    bucket_id = str(uuid.uuid4())
+    kek_service._ACTIVE_KEK_CACHE[bucket_id] = (uuid.uuid4(), time.monotonic() - 1)  # already expired
+    assert await kek_service._get_cached_active_kek_id(bucket_id) is None
+    assert bucket_id not in kek_service._ACTIVE_KEK_CACHE
+    kek_service._ACTIVE_KEK_CACHE.clear()

--- a/tests/unit/services/test_kek_singleflight.py
+++ b/tests/unit/services/test_kek_singleflight.py
@@ -1,0 +1,98 @@
+"""KM-1: the GET-path KEK unwrap (get_bucket_kek_bytes) must singleflight cold misses.
+
+The A14 singleflight (_kek_unwrap_lock) was wired only into the PUT path, so N concurrent cold GETs
+sharing a bucket's active KEK each hit KMS. Mirror it here: N concurrent cold reads for the same
+(bucket, kek) collapse to one KMS unwrap; distinct keks still unwrap independently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hippius_s3.services import kek_service
+
+
+class _FakeConn:
+    async def fetchrow(self, *_a: Any, **_k: Any) -> Any:
+        return {"wrapped_kek_bytes": b"wrapped", "kms_key_id": "local"}
+
+    async def execute(self, *_a: Any, **_k: Any) -> None:
+        return None
+
+
+class _FakePool:
+    def acquire(self) -> Any:
+        class _Ctx:
+            async def __aenter__(self_: Any) -> _FakeConn:
+                return _FakeConn()
+
+            async def __aexit__(self_: Any, *_a: Any) -> bool:
+                return False
+
+        return _Ctx()
+
+
+@pytest.fixture
+def kek_env(monkeypatch: Any):
+    cfg = SimpleNamespace(kek_cache_ttl_seconds=3600, encryption_database_url="postgres://x")
+    monkeypatch.setattr(kek_service, "get_config", lambda: cfg)
+
+    async def fake_get_pool(_dsn: str) -> _FakePool:
+        return _FakePool()
+
+    async def fake_ensure(_c: Any) -> None:
+        return None
+
+    monkeypatch.setattr(kek_service, "_get_pool", fake_get_pool)
+    monkeypatch.setattr(kek_service, "_maybe_ensure_tables", fake_ensure)
+    kek_service._KEK_CACHE.clear()
+    kek_service._kek_unwrap_locks.clear()
+    yield
+    kek_service._KEK_CACHE.clear()
+    kek_service._kek_unwrap_locks.clear()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_reads_collapse_to_one_unwrap(monkeypatch: Any, kek_env: Any) -> None:
+    calls = {"n": 0}
+
+    async def counting_unwrap(_w: bytes, _kid: str, _k: uuid.UUID) -> bytes:
+        calls["n"] += 1
+        await asyncio.sleep(0.05)  # hold the window open so all callers race the cold miss
+        return b"\x22" * 32
+
+    monkeypatch.setattr(kek_service, "_unwrap_kek", counting_unwrap)
+
+    bucket_id = str(uuid.uuid4())
+    kek_id = uuid.uuid4()
+    results = await asyncio.gather(
+        *[kek_service.get_bucket_kek_bytes(bucket_id=bucket_id, kek_id=kek_id) for _ in range(8)]
+    )
+
+    assert calls["n"] == 1, "concurrent cold reads must collapse to a single KMS unwrap"
+    assert all(r == b"\x22" * 32 for r in results)
+
+
+@pytest.mark.asyncio
+async def test_distinct_keks_do_not_collapse(monkeypatch: Any, kek_env: Any) -> None:
+    calls = {"n": 0}
+
+    async def counting_unwrap(_w: bytes, _kid: str, _k: uuid.UUID) -> bytes:
+        calls["n"] += 1
+        await asyncio.sleep(0.02)
+        return b"\x33" * 32
+
+    monkeypatch.setattr(kek_service, "_unwrap_kek", counting_unwrap)
+
+    bucket_id = str(uuid.uuid4())
+    k1, k2 = uuid.uuid4(), uuid.uuid4()
+    await asyncio.gather(
+        kek_service.get_bucket_kek_bytes(bucket_id=bucket_id, kek_id=k1),
+        kek_service.get_bucket_kek_bytes(bucket_id=bucket_id, kek_id=k2),
+    )
+    assert calls["n"] == 2, "distinct keks must each unwrap (no cross-key collapse)"

--- a/tests/unit/services/test_kek_singleflight.py
+++ b/tests/unit/services/test_kek_singleflight.py
@@ -96,3 +96,55 @@ async def test_distinct_keks_do_not_collapse(monkeypatch: Any, kek_env: Any) -> 
         kek_service.get_bucket_kek_bytes(bucket_id=bucket_id, kek_id=k2),
     )
     assert calls["n"] == 2, "distinct keks must each unwrap (no cross-key collapse)"
+
+
+class _NoActiveConn:
+    """Keystore conn for a brand-new bucket: no active KEK row; INSERT succeeds (no unique clash)."""
+
+    async def fetchrow(self, *_a: Any, **_k: Any) -> Any:
+        return None
+
+    async def execute(self, *_a: Any, **_k: Any) -> None:
+        return None
+
+
+class _NoActivePool:
+    def acquire(self) -> Any:
+        class _Ctx:
+            async def __aenter__(self_: Any) -> _NoActiveConn:
+                return _NoActiveConn()
+
+            async def __aexit__(self_: Any, *_a: Any) -> bool:
+                return False
+
+        return _Ctx()
+
+
+@pytest.mark.asyncio
+async def test_first_put_burst_creates_one_kek(monkeypatch: Any, kek_env: Any) -> None:
+    """KM-2: N concurrent first-PUTs on a bucket with no KEK must generate exactly one KEK."""
+
+    async def fake_get_pool(_dsn: str) -> _NoActivePool:
+        return _NoActivePool()
+
+    monkeypatch.setattr(kek_service, "_get_pool", fake_get_pool)
+    kek_service._ACTIVE_KEK_CACHE.clear()
+    kek_service._kek_create_locks.clear()
+
+    calls = {"n": 0}
+
+    async def counting_create(_desc: str) -> tuple[bytes, bytes, str]:
+        calls["n"] += 1
+        await asyncio.sleep(0.05)
+        return (b"\x44" * 32, b"wrapped", "local")
+
+    monkeypatch.setattr(kek_service, "_create_wrapped_kek", counting_create)
+
+    bucket_id = str(uuid.uuid4())
+    results = await asyncio.gather(
+        *[kek_service.get_or_create_active_bucket_kek(bucket_id=bucket_id) for _ in range(8)]
+    )
+
+    assert calls["n"] == 1, "a first-PUT burst must generate exactly one KEK"
+    kek_ids = {kid for kid, _ in results}
+    assert len(kek_ids) == 1, "all callers must converge on the same KEK"


### PR DESCRIPTION
Wave 2 (KEK coalescing) of the upload/download performance work. **Stacked on #267** (base `perf/wave-1-metadata-wins`); retarget down the chain as the lower PRs merge. TDD throughout; full unit suite green (1873 passed).

## Changes
- **KM-1 (P1) — singleflight the GET-path KEK unwrap.** `get_bucket_kek_bytes` went straight to `fetchrow` + `_unwrap_kek` (KMS mTLS) with no coalescing, so N concurrent cold GETs on a bucket's KEK each hit KMS. Wrapped the cold unwrap in the existing `_kek_unwrap_lock` with an in-lock cache re-check (mirrors the PUT path) — collapses N round trips to one and eases keystore-pool pinning under a KMS slowdown.
- **KM-2 (P2) — singleflight cold-bucket KEK creation.** A first-PUT burst on a new bucket had every caller call `_create_wrapped_kek` (KMS generate); one won the unique index, the losers each did a KMS decrypt. Added a per-bucket create lock with in-lock re-check, keeping the `23505` unique-index handler as the cross-pod backstop.
- **KM-3 (P3) — slide the active-kek-id cache TTL on read.** It expired every TTL regardless of traffic (unlike the plaintext KEK cache), so a hot bucket paid a keystore SELECT every 300s to re-learn an unchanged id. Now refreshes on read. Reads stay correct (decrypts key off the object row's stored `kek_id`); a future rotation feature must invalidate on flip (noted in the code).

## Tests
New: `tests/unit/services/test_kek_singleflight.py` (concurrent-collapse for unwrap + create; distinct-kek non-collapse) and two sliding-TTL cases in `test_kek_active_cache.py`. RED verified before each fix. `pytest tests/unit` → 1873 passed.
