### PR TITLE
perf: non-locking MPU DEK read + coalesce-lock release on timeout (Wave 2b)

### DIFF
--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from dataclasses import dataclass
@@ -46,6 +47,31 @@ class StreamContext:
     suite_id: str | None
     bucket_id: str
     upload_id: str
+
+
+# RQ-4: compare-and-delete Lua — delete the coalesce lock only while it still holds our token, so we
+# never steal a lock a later streamer/downloader re-acquired. Fixed script (no user input in the body);
+# mirrors the downloader's release. The key format must match _enqueue_missing_downloads exactly.
+_COALESCE_LOCK_RELEASE_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+
+
+async def _release_coalesce_locks(
+    redis: Any,
+    *,
+    object_id: str,
+    object_version: int,
+    part_numbers: set[int],
+    ray_token: str,
+) -> None:
+    """Best-effort CAD-release of this streamer's per-part coalesce locks (RQ-4).
+
+    Called when the first-chunk wait times out so the next GET re-enqueues immediately instead of
+    waiting out the lock TTL. CAD-on-token means locks we don't own (lost the coalesce race) no-op.
+    """
+    for pn in part_numbers:
+        lock_key = f"download_in_progress:{object_id}:v:{int(object_version)}:part:{int(pn)}"
+        with contextlib.suppress(Exception):
+            await redis.eval(_COALESCE_LOCK_RELEASE_LUA, 1, lock_key, ray_token)
 
 
 # RQ-3: backends whose downloader fetches by content id (CID) rather than a deterministic
@@ -359,6 +385,20 @@ async def read_response(
         # ChunkNotReadyError: the downloader gave up fast on a backend miss and notified anyway, so
         # the peek woke to an empty cache. Same retryable outcome as a timeout — a 503, not a 500.
         await gen.aclose()
+        # RQ-4: release the coalesce locks this streamer set (CAD on our ray token) so the client's
+        # retry re-enqueues immediately rather than waiting out the lock TTL (default 600s).
+        await _release_coalesce_locks(
+            redis,
+            object_id=str(info["object_id"]),
+            object_version=int(ctx.object_version),
+            # Best-effort on the error path: a malformed plan item must never turn the 503 into a 500.
+            part_numbers={
+                int(getattr(item, "part_number", 0))
+                for item in ctx.plan
+                if getattr(item, "part_number", None) is not None
+            },
+            ray_token=str(info.get("ray_id") or "anonymous"),
+        )
         raise DownloadNotReadyError(
             "Parts not ready: first chunk did not arrive within the initial stream timeout"
         ) from exc

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -52,7 +52,9 @@ class StreamContext:
 # RQ-4: compare-and-delete Lua — delete the coalesce lock only while it still holds our token, so we
 # never steal a lock a later streamer/downloader re-acquired. Fixed script (no user input in the body);
 # mirrors the downloader's release. The key format must match _enqueue_missing_downloads exactly.
-_COALESCE_LOCK_RELEASE_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+_COALESCE_LOCK_RELEASE_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+)
 
 
 async def _release_coalesce_locks(

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -510,6 +510,31 @@ class ObjectWriter:
         from hippius_s3.services.kek_service import get_bucket_kek_bytes
         from hippius_s3.services.kek_service import get_or_create_active_bucket_kek
 
+        # MPU-1: fast, non-locking read first. Parts 2..N of an MPU share one object_version row whose
+        # envelope the first part already populated, so they unwrap the DEK concurrently instead of
+        # serializing on that row's FOR UPDATE lock. Only the create/rotate case (envelope still NULL,
+        # or rotate) escalates to the locked path below, whose in-lock re-check keeps the first-part
+        # race idempotent.
+        if not rotate:
+            pre = await self.pool.fetchrow(
+                """
+                SELECT storage_version, kek_id, wrapped_dek
+                  FROM object_versions
+                 WHERE object_id = $1 AND object_version = $2
+                """,
+                object_id,
+                int(object_version),
+            )
+            if pre is not None:
+                if int(pre.get("storage_version") or 0) < 5:
+                    raise RuntimeError("not_v5_object_version")
+                pre_kek_id = pre.get("kek_id")
+                pre_wrapped = pre.get("wrapped_dek")
+                if pre_kek_id and pre_wrapped:
+                    kek_bytes = await get_bucket_kek_bytes(bucket_id=bucket_id, kek_id=pre_kek_id)
+                    aad = f"hippius-dek:{bucket_id}:{object_id}:{int(object_version)}".encode("utf-8")
+                    return unwrap_dek(kek=kek_bytes, wrapped_dek=bytes(pre_wrapped), aad=aad)
+
         async with self.pool.acquire() as conn, conn.transaction():
             row = await conn.fetchrow(
                 """

--- a/tests/unit/services/test_release_coalesce_locks.py
+++ b/tests/unit/services/test_release_coalesce_locks.py
@@ -1,0 +1,54 @@
+"""RQ-4: on a first-chunk timeout the streamer compare-and-deletes its own coalesce locks so the
+next GET re-enqueues immediately, instead of the retry cadence being bounded by the 600s lock TTL.
+
+The CAD (delete only when the lock still holds our ray token) must match the key format and token
+semantics of _enqueue_missing_downloads (the SET NX) and the downloader's release exactly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hippius_s3.services.object_reader import _release_coalesce_locks
+
+
+class _RecordingRedis:
+    def __init__(self) -> None:
+        self.evals: list[tuple[str, int, str, str]] = []
+
+    async def eval(self, script: str, numkeys: int, key: str, token: str) -> int:
+        self.evals.append((script, numkeys, key, token))
+        return 1
+
+
+@pytest.mark.asyncio
+async def test_release_cads_each_part_on_the_ray_token() -> None:
+    redis = _RecordingRedis()
+    await _release_coalesce_locks(
+        redis, object_id="obj-1", object_version=3, part_numbers={1, 2}, ray_token="ray-9"
+    )
+
+    assert len(redis.evals) == 2
+    keys = {e[2] for e in redis.evals}
+    assert keys == {
+        "download_in_progress:obj-1:v:3:part:1",
+        "download_in_progress:obj-1:v:3:part:2",
+    }
+    assert all(e[3] == "ray-9" for e in redis.evals), "must compare-and-delete on our ray token"
+    # Compare-and-delete Lua: only DEL when GET still equals our token.
+    assert all("GET" in e[0] and "DEL" in e[0] for e in redis.evals)
+    assert all(e[1] == 1 for e in redis.evals), "one key per eval"
+
+
+@pytest.mark.asyncio
+async def test_release_is_best_effort_on_redis_error() -> None:
+    class _ErrRedis:
+        async def eval(self, *_a: Any, **_k: Any) -> int:
+            raise RuntimeError("redis down")
+
+    # Must not raise — a failed release just lets the TTL expire.
+    await _release_coalesce_locks(
+        _ErrRedis(), object_id="obj", object_version=1, part_numbers={1}, ray_token="t"
+    )

--- a/tests/unit/test_mpu_dek_non_locking_read.py
+++ b/tests/unit/test_mpu_dek_non_locking_read.py
@@ -1,0 +1,121 @@
+"""MPU-1: parts with an existing DEK envelope resolve it without the FOR UPDATE row lock.
+
+Every UploadPart called _ensure_and_get_v5_dek, which took `SELECT ... FROM object_versions ... FOR
+UPDATE` on the shared version row — serializing all concurrent parts through the DEK section. Parts
+2..N (envelope already populated by the first part) should read the DEK non-locking; only the
+create/rotate case needs the lock, and the first-part race stays idempotent via the in-lock recheck.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from hippius_s3.writer.object_writer import ObjectWriter
+
+
+class _ACtx:
+    def __init__(self, val: Any) -> None:
+        self._val = val
+
+    async def __aenter__(self) -> Any:
+        return self._val
+
+    async def __aexit__(self, *_a: Any) -> bool:
+        return False
+
+
+class _FakeConn:
+    def __init__(self, locked_row: Any) -> None:
+        self._locked_row = locked_row
+
+    async def fetchrow(self, *_a: Any, **_k: Any) -> Any:
+        return self._locked_row
+
+    async def execute(self, *_a: Any, **_k: Any) -> None:
+        return None
+
+    def transaction(self) -> _ACtx:
+        return _ACtx(None)
+
+
+class _FakePool:
+    def __init__(self, pre_row: Any, locked_row: Any) -> None:
+        self._pre_row = pre_row
+        self._locked_row = locked_row
+        self.pre_fetchrow_calls = 0
+        self.acquire_calls = 0
+
+    async def fetchrow(self, *_a: Any, **_k: Any) -> Any:  # the non-locking pre-check
+        self.pre_fetchrow_calls += 1
+        return self._pre_row
+
+    def acquire(self) -> _ACtx:  # the FOR UPDATE transaction path
+        self.acquire_calls += 1
+        return _ACtx(_FakeConn(self._locked_row))
+
+
+@pytest.fixture
+def crypto_stubs(monkeypatch: Any):
+    monkeypatch.setattr("hippius_s3.services.kek_service.get_bucket_kek_bytes", AsyncMock(return_value=b"k" * 32))
+    monkeypatch.setattr(
+        "hippius_s3.services.kek_service.get_or_create_active_bucket_kek",
+        AsyncMock(return_value=(uuid.uuid4(), b"k" * 32)),
+    )
+    monkeypatch.setattr("hippius_s3.services.envelope_service.unwrap_dek", MagicMock(return_value=b"d" * 32))
+    monkeypatch.setattr("hippius_s3.services.envelope_service.wrap_dek", MagicMock(return_value=b"w" * 48))
+    monkeypatch.setattr("hippius_s3.services.envelope_service.generate_dek", MagicMock(return_value=b"n" * 32))
+
+
+def _writer(pool: Any) -> ObjectWriter:
+    return ObjectWriter(pool=pool, redis_client=None, fs_store=SimpleNamespace())
+
+
+async def _call(writer: ObjectWriter, rotate: bool) -> bytes:
+    return await writer._ensure_and_get_v5_dek(
+        bucket_id="b",
+        object_id="o",
+        object_version=1,
+        chunk_size=4194304,
+        suite_id="hip-enc/aes256gcm",
+        rotate=rotate,
+    )
+
+
+@pytest.mark.asyncio
+async def test_existing_envelope_read_is_non_locking(crypto_stubs: Any) -> None:
+    populated = {"storage_version": 5, "kek_id": uuid.uuid4(), "wrapped_dek": b"w"}
+    pool = _FakePool(pre_row=populated, locked_row=populated)
+
+    dek = await _call(_writer(pool), rotate=False)
+
+    assert dek == b"d" * 32
+    assert pool.acquire_calls == 0, "an existing envelope must resolve without FOR UPDATE"
+    assert pool.pre_fetchrow_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_rotate_still_takes_the_lock(crypto_stubs: Any) -> None:
+    populated = {"storage_version": 5, "kek_id": uuid.uuid4(), "wrapped_dek": b"w"}
+    pool = _FakePool(pre_row=populated, locked_row=populated)
+
+    await _call(_writer(pool), rotate=True)
+
+    assert pool.acquire_calls == 1, "rotate must take the FOR UPDATE lock"
+
+
+@pytest.mark.asyncio
+async def test_null_envelope_falls_through_to_lock(crypto_stubs: Any) -> None:
+    # First part racing: envelope not yet written. Pre-check sees NULLs → must escalate to the lock
+    # so DEK creation is serialized and idempotent.
+    null_env = {"storage_version": 5, "kek_id": None, "wrapped_dek": None}
+    pool = _FakePool(pre_row=null_env, locked_row=null_env)
+
+    await _call(_writer(pool), rotate=False)
+
+    assert pool.acquire_calls == 1, "a NULL envelope must escalate to the FOR UPDATE create path"


### PR DESCRIPTION
Wave 2 (part 2) of the upload/download performance work — the correctness-sensitive MPU DEK lock and read-path coalesce-lock release. **Stacked on #268** (base `perf/wave-2-kek-coalescing`). TDD throughout; full unit suite green (1878 passed).

## Changes
- **MPU-1 (P2) — resolve an existing DEK envelope without `FOR UPDATE`.** `_ensure_and_get_v5_dek` took `SELECT ... object_versions ... FOR UPDATE` on the shared version row for every UploadPart, serializing all concurrent parts through the DEK section. Added a non-locking pre-check: parts whose envelope already exists (rotate=False) unwrap concurrently. Only the create/rotate case escalates to the locked path, whose in-lock re-check keeps the first-part DEK race idempotent. **The lock is not removed** — it remains the correctness guard for lazy DEK creation. Tests assert: existing envelope → no lock; rotate → locks; NULL envelope → locks.
- **RQ-4 (P3) — release coalesce locks on first-chunk timeout.** A first-chunk timeout raised a retryable 503 but left the per-part coalesce lock held, so the next GET couldn't re-enqueue until the lock TTL (default 600s) expired. CAD-release this streamer's locks on the ray token (mirrors the downloader's release exactly), so a client retry re-enqueues immediately. Best-effort — a release failure or malformed plan item never turns the 503 into a 500.

## Tests
New: `test_mpu_dek_non_locking_read.py`, `test_release_coalesce_locks.py`. RED verified before each fix. `pytest tests/unit` → 1878 passed.
