### PR TITLE
perf: metadata-path cleanups — HEAD append_version, UploadPartCopy batch, DELETE pre-check (Wave 3)

### DIFF
--- a/hippius_s3/api/s3/buckets/delete_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/delete_objects_endpoint.py
@@ -141,7 +141,7 @@ async def handle_delete_objects(bucket_name: str, request: Request, db: Any, red
             ET.SubElement(e, "Code").text = err.get("Code", "")
             ET.SubElement(e, "Message").text = err.get("Message", "")
 
-        xml_content = ET.tostring(resp_root, encoding="UTF-8", xml_declaration=True, pretty_print=True)
+        xml_content = ET.tostring(resp_root, encoding="UTF-8", xml_declaration=True, pretty_print=False)
         return Response(content=xml_content, media_type="application/xml", status_code=200)
 
     except Exception:

--- a/hippius_s3/api/s3/buckets/list_buckets_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_buckets_endpoint.py
@@ -28,7 +28,7 @@ async def handle_list_buckets(ctx: RequestContext, db: Any) -> Response:
             bucket = ET.SubElement(buckets, "Bucket")
             ET.SubElement(bucket, "Name").text = row["bucket_name"]
             ET.SubElement(bucket, "CreationDate").text = format_s3_timestamp(row["created_at"])
-        xml_content = ET.tostring(root, encoding="UTF-8", xml_declaration=True, pretty_print=True)
+        xml_content = ET.tostring(root, encoding="UTF-8", xml_declaration=True, pretty_print=False)
         return Response(content=xml_content, media_type="application/xml")
     except Exception:
         logger.exception("Error listing buckets via S3 protocol")

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -213,36 +213,38 @@ async def _collect_page(
     seen_prefixes: set[str] = set()
     query = get_query("list_objects")
 
-    while True:
-        batch = await pool.fetch(query, bucket_id, prefix, cursor, batch_limit)
-        if not batch:
-            return items, False, None
+    # LS-45: hold one pooled connection for the whole skip-scan instead of acquire/release per batch.
+    async with pool.acquire() as conn:
+        while True:
+            batch = await conn.fetch(query, bucket_id, prefix, cursor, batch_limit)
+            if not batch:
+                return items, False, None
 
-        for row in batch:
-            key = row["object_key"]
-            if cursor is not None and key < cursor:
-                # Row sorts before a collapsed-group boundary we already jumped — skip cheaply.
-                continue
-
-            di = key.find(delimiter, plen) if delimiter else -1
-            if di == -1:
-                items.append(("content", row))
-                cursor = _content_resume(key)
-            else:
-                common_prefix = key[: di + dlen]
-                cursor = _prefix_resume(common_prefix)
-                if common_prefix in seen_prefixes:
+            for row in batch:
+                key = row["object_key"]
+                if cursor is not None and key < cursor:
+                    # Row sorts before a collapsed-group boundary we already jumped — skip cheaply.
                     continue
-                seen_prefixes.add(common_prefix)
-                if cp_floor is not None and common_prefix <= cp_floor:
-                    continue
-                items.append(("prefix", common_prefix))
 
-            if len(items) > target:
-                # The (target+1)th item proves truncation; resume just past the last KEPT item.
-                kind, payload = items[target - 1]
-                next_cursor = _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
-                return items[:target], True, next_cursor
+                di = key.find(delimiter, plen) if delimiter else -1
+                if di == -1:
+                    items.append(("content", row))
+                    cursor = _content_resume(key)
+                else:
+                    common_prefix = key[: di + dlen]
+                    cursor = _prefix_resume(common_prefix)
+                    if common_prefix in seen_prefixes:
+                        continue
+                    seen_prefixes.add(common_prefix)
+                    if cp_floor is not None and common_prefix <= cp_floor:
+                        continue
+                    items.append(("prefix", common_prefix))
 
-        if len(batch) < batch_limit:
-            return items, False, None
+                if len(items) > target:
+                    # The (target+1)th item proves truncation; resume just past the last KEPT item.
+                    kind, payload = items[target - 1]
+                    next_cursor = _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    return items[:target], True, next_cursor
+
+            if len(batch) < batch_limit:
+                return items, False, None

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -243,7 +243,9 @@ async def _collect_page(
                 if len(items) > target:
                     # The (target+1)th item proves truncation; resume just past the last KEPT item.
                     kind, payload = items[target - 1]
-                    next_cursor = _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    next_cursor = (
+                        _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    )
                     return items[:target], True, next_cursor
 
             if len(batch) < batch_limit:

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -468,14 +468,15 @@ async def upload_part(
             rng = RangeRequest(start=int(range_start), end=int(range_end))
         plan = await build_chunk_plan(pool, object_id_str, parts, rng, object_version=src_ver)
 
-        # Enqueue downloader for any missing chunk indices in cache
+        # Enqueue downloader for any missing chunk indices in cache. CP-2: one batched existence
+        # check (off-loop, meta-gated) instead of a serial per-chunk stat, matching the GET path.
         obj_cache = RedisObjectPartsCache(request.app.state.redis_client)
+        checks = [(int(it.part_number), int(it.chunk_index)) for it in plan]
+        exist_flags = await obj_cache.chunks_exist_batch(object_id_str, src_ver, checks)
         indices_by_part: dict[int, list[int]] = {}
-        for it in plan:
-            exists = await obj_cache.chunk_exists(object_id_str, src_ver, int(it.part_number), int(it.chunk_index))
-            if not exists:
-                arr = indices_by_part.setdefault(int(it.part_number), [])
-                arr.append(int(it.chunk_index))
+        for it, present in zip(plan, exist_flags, strict=True):
+            if not present:
+                indices_by_part.setdefault(int(it.part_number), []).append(int(it.chunk_index))
         if indices_by_part:
             dl_parts: list[PartToDownload] = []
             for pn, idxs in indices_by_part.items():

--- a/hippius_s3/api/s3/objects/delete_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/delete_object_endpoint.py
@@ -14,7 +14,6 @@ from hippius_s3.config import get_config
 from hippius_s3.queue import UnpinChainRequest
 from hippius_s3.queue import enqueue_unpin_request
 from hippius_s3.repositories.buckets import BucketRepository
-from hippius_s3.repositories.objects import ObjectRepository
 from hippius_s3.repositories.users import UserRepository
 from hippius_s3.utils import get_query
 
@@ -49,13 +48,8 @@ async def handle_delete_object(
             bucket_id = bucket["bucket_id"]
             set_span_attributes(span, {"bucket_id": str(bucket_id)})
 
-        with tracer.start_as_current_span("delete_object.check_object_exists") as span:
-            result = await ObjectRepository(db).get_by_path(bucket_id, object_key)
-            object_exists = result is not None
-            set_span_attributes(span, {"object_exists": object_exists})
-            if not result:
-                return Response(status_code=204)
-
+        # HD-78: no existence pre-check — soft_delete_object's RETURNING already distinguishes
+        # absent/already-deleted (both → idempotent 204 below), so the pre-check was a wasted read.
         # Soft-delete the object (sets deleted_at, does NOT cascade-delete rows)
         with tracer.start_as_current_span("delete_object.soft_delete") as span:
             deleted = await db.fetchrow(get_query("soft_delete_object"), bucket_id, object_key)

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -234,22 +234,11 @@ async def handle_head_object(
         )
         headers["X-Hippius-Arion-File-Hash"] = arion_hash or "pending"
 
-        # Append version header if present
+        # Append version header if present. HD-3: the download query's outer SELECT now returns
+        # append_version, so no fallback JOIN is needed.
         with tracer.start_as_current_span("head_object.fetch_append_version") as span:
             try:
                 append_version = row.get("append_version")
-                if append_version is None:
-                    append_version = await db.fetchval(
-                        """
-                        SELECT ov.append_version
-                        FROM objects o
-                        JOIN object_versions ov
-                          ON ov.object_id = o.object_id
-                         AND ov.object_version = o.current_object_version
-                        WHERE o.object_id = $1
-                        """,
-                        row["object_id"],
-                    )
                 if append_version is not None:
                     headers["x-amz-meta-append-version"] = str(int(append_version))
                     set_span_attributes(span, {"append_version": int(append_version)})

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -52,7 +52,9 @@ class StreamContext:
 # RQ-4: compare-and-delete Lua — delete the coalesce lock only while it still holds our token, so we
 # never steal a lock a later streamer/downloader re-acquired. Fixed script (no user input in the body);
 # mirrors the downloader's release. The key format must match _enqueue_missing_downloads exactly.
-_COALESCE_LOCK_RELEASE_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+_COALESCE_LOCK_RELEASE_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+)
 
 
 async def _release_coalesce_locks(

--- a/hippius_s3/sql/queries/get_object_for_download_with_permissions.sql
+++ b/hippius_s3/sql/queries/get_object_for_download_with_permissions.sql
@@ -75,6 +75,7 @@ SELECT
     oi.is_public,
     oi.bucket_owner_id,
     oi.object_version,
+    oi.append_version,
     oi.encryption_version,
     oi.enc_suite_id,
     oi.enc_chunk_size_bytes,

--- a/hippius_s3/sql/queries/get_object_for_download_with_permissions_by_version.sql
+++ b/hippius_s3/sql/queries/get_object_for_download_with_permissions_by_version.sql
@@ -64,6 +64,7 @@ SELECT
     oi.is_public,
     oi.bucket_owner_id,
     oi.object_version,
+    oi.append_version,
     oi.encryption_version,
     oi.enc_suite_id,
     oi.enc_chunk_size_bytes,

--- a/tests/unit/api/s3/test_list_objects_pagination.py
+++ b/tests/unit/api/s3/test_list_objects_pagination.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from datetime import timezone
 from typing import Any
 from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
 import pytest
 from lxml import etree as ET  # ty: ignore[unresolved-import]
@@ -53,6 +54,17 @@ def _make_pool(
         pool.fetch = AsyncMock(side_effect=fetch_batches)
     else:
         pool.fetch = AsyncMock(return_value=list_rows or [])
+
+    # LS-45: _collect_page now holds one connection (`async with pool.acquire() as conn`) and calls
+    # conn.fetch. Make acquire() yield the pool itself so conn.fetch is the same mock the tests assert on.
+    class _Acq:
+        async def __aenter__(self_: Any) -> Any:
+            return pool
+
+        async def __aexit__(self_: Any, *_a: Any) -> bool:
+            return False
+
+    pool.acquire = MagicMock(return_value=_Acq())
     return pool
 
 


### PR DESCRIPTION
Wave 3 — metadata-path N+1 and query cleanups. **Stacked on #269** (base `perf/wave-2b-mpu-dek-coalesce`). Full unit suite green (1878 passed).

## Changes
- **HD-3 — return append_version in the download query.** The CTE computed `append_version` but the outer SELECT dropped it, so HEAD's `row.get("append_version")` was always None and fired a fallback JOIN on every request. Added `oi.append_version` to both the main and `_by_version` outer SELECTs; deleted the fallback.
- **CP-2 — batch UploadPartCopy source-existence.** One `chunks_exist_batch` instead of a serial per-chunk stat, matching the GET path.
- **HD-78 — drop the DELETE existence pre-check** (`soft_delete_object`'s RETURNING already yields the idempotent 204) and emit compact XML (`pretty_print=False`) for DeleteObjects/ListBuckets.
- **LS-45 — one pooled connection per ListObjects skip-scan** instead of acquire/release per batch.

## Tests
Existing suites gate these (pagination 41, HEAD, delete-soft, stream-context). Pagination fake pool updated for the single-acquire change. `pytest tests/unit` → 1878 passed.

## Deferred within this area (need the multi-part MPU e2e harness first, §2 of the plan)
MPU-3 (CompleteMPU 3× parts read), HD-4/5 (HEAD light query), HD-1 (bulk-delete batch), RD-3 (parts read 3→1), LS-1 (SQL delimiter rollup) — client-visible ETag/header/pagination contracts that want e2e before merge.
