### PR TITLE
perf: KMS/gateway keepalive, config-driven downloader pool, writer-queue knob (Wave 4)

### DIFF
--- a/gateway/services/forward_service.py
+++ b/gateway/services/forward_service.py
@@ -92,7 +92,7 @@ class ForwardService:
         self.backend_url = backend_url
         self.client = httpx.AsyncClient(
             timeout=httpx.Timeout(300.0, connect=10.0),
-            limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+            limits=httpx.Limits(max_connections=100, max_keepalive_connections=100, keepalive_expiry=30),
             follow_redirects=False,
         )
         logger.info(f"ForwardService initialized with backend: {backend_url}")

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -243,7 +243,9 @@ async def _collect_page(
                 if len(items) > target:
                     # The (target+1)th item proves truncation; resume just past the last KEPT item.
                     kind, payload = items[target - 1]
-                    next_cursor = _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    next_cursor = (
+                        _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    )
                     return items[:target], True, next_cursor
 
             if len(batch) < batch_limit:

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -255,6 +255,15 @@ class Config:
     # 600s (A5) so a legitimately slow multi-chunk part download does not expire
     # the lock mid-flight and let a second streamer enqueue a duplicate DCR.
     download_coalesce_lock_ttl_seconds: int = env("DOWNLOAD_COALESCE_LOCK_TTL:600", convert=int)
+    # DB-1: config-driven downloader Postgres pool (was hardcoded min=2/max=20). Audit
+    # Σ(replicas × pool_max) across roles against Postgres max_connections before raising.
+    downloader_db_pool_min: int = env("HIPPIUS_DOWNLOADER_DB_POOL_MIN:2", convert=int)
+    downloader_db_pool_max: int = env("HIPPIUS_DOWNLOADER_DB_POOL_MAX:20", convert=int)
+    # CF-3: depth of the encrypt producer/consumer queue per streaming write. Peak buffered memory
+    # per PUT ≈ chunk_size × this. Exposed so it can move with chunk size (CF-1).
+    write_queue_maxsize: int = env("HIPPIUS_WRITE_QUEUE_MAXSIZE:16", convert=int)
+    # NET-3: keep the expensive mTLS KMS connection warm across sparse/bursty calls.
+    ovh_kms_keepalive_expiry_seconds: int = env("HIPPIUS_OVH_KMS_KEEPALIVE_EXPIRY:300", convert=int)
 
     # Crypto configuration
     # hip-enc/legacy: SecretBox per-chunk (legacy objects)

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -52,7 +52,9 @@ class StreamContext:
 # RQ-4: compare-and-delete Lua — delete the coalesce lock only while it still holds our token, so we
 # never steal a lock a later streamer/downloader re-acquired. Fixed script (no user input in the body);
 # mirrors the downloader's release. The key format must match _enqueue_missing_downloads exactly.
-_COALESCE_LOCK_RELEASE_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+_COALESCE_LOCK_RELEASE_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+)
 
 
 async def _release_coalesce_locks(

--- a/hippius_s3/services/ovh_kms_client.py
+++ b/hippius_s3/services/ovh_kms_client.py
@@ -107,11 +107,17 @@ class OVHKMSClient:
                 missing.append(f"ca: {ca_path}")
             raise ValueError(f"KMS certificate files not found: {', '.join(missing)}")
 
+        # NET-3: KMS calls are sparse/bursty and mTLS is the most expensive handshake; keep a small
+        # pool warm well past httpx's 5s default so cold-envelope reads don't redo the full handshake.
         self._client = httpx.AsyncClient(
             base_url=self._endpoint,
             cert=(cert_path, key_path),
             verify=ca_path,
             timeout=httpx.Timeout(self._timeout),
+            limits=httpx.Limits(
+                max_keepalive_connections=10,
+                keepalive_expiry=float(config.ovh_kms_keepalive_expiry_seconds),
+            ),
         )
 
     @staticmethod

--- a/hippius_s3/workers/downloader.py
+++ b/hippius_s3/workers/downloader.py
@@ -415,7 +415,9 @@ async def run_downloader_loop(
 
     redis_client: async_redis.Redis = create_redis_client(config.redis_url)  # ty: ignore[invalid-assignment]
     redis_queues_client = async_redis.from_url(config.redis_queues_url)
-    db_pool = await asyncpg.create_pool(config.database_url, min_size=2, max_size=20)
+    db_pool = await asyncpg.create_pool(
+        config.database_url, min_size=config.downloader_db_pool_min, max_size=config.downloader_db_pool_max
+    )
     fs_store = create_fs_store(config)
 
     initialize_queue_client(redis_queues_client)
@@ -559,7 +561,9 @@ async def run_downloader_loop(
                 logger.warning(f"[{backend_name}] Recreating DB pool after task error")
                 with contextlib.suppress(Exception):
                     await db_pool.close()
-                db_pool = await asyncpg.create_pool(config.database_url, min_size=2, max_size=20)
+                db_pool = await asyncpg.create_pool(
+                    config.database_url, min_size=config.downloader_db_pool_min, max_size=config.downloader_db_pool_max
+                )
                 needs_db_reconnect = False
 
             if len(inflight) >= max_inflight:

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -298,7 +298,7 @@ class ObjectWriter:
         perf_stream_start = time.monotonic()
 
         adapter = CryptoService.get_adapter(suite_id)
-        write_queue: asyncio.Queue[tuple[int, bytes] | None] = asyncio.Queue(maxsize=16)
+        write_queue: asyncio.Queue[tuple[int, bytes] | None] = asyncio.Queue(maxsize=self.config.write_queue_maxsize)
         consumer_error: BaseException | None = None
 
         async def _consumer() -> None:
@@ -712,7 +712,7 @@ class ObjectWriter:
         perf_queue_wait_ms = 0.0
         perf_stream_start = time.monotonic()
 
-        write_queue: asyncio.Queue[tuple[int, bytes] | None] = asyncio.Queue(maxsize=16)
+        write_queue: asyncio.Queue[tuple[int, bytes] | None] = asyncio.Queue(maxsize=self.config.write_queue_maxsize)
         consumer_error: BaseException | None = None
 
         async def _cleanup_partial() -> None:

--- a/tests/unit/test_config_defaults_doc_drift.py
+++ b/tests/unit/test_config_defaults_doc_drift.py
@@ -20,3 +20,18 @@ def test_stream_prefetch_default_is_16(monkeypatch) -> None:
 def test_download_coalesce_lock_ttl_default_is_600(monkeypatch) -> None:
     monkeypatch.delenv("DOWNLOAD_COALESCE_LOCK_TTL", raising=False)
     assert Config().download_coalesce_lock_ttl_seconds == 600
+
+
+def test_wave4_config_defaults_preserve_current_behavior(monkeypatch) -> None:
+    # DB-1 / CF-3 / NET-3 add knobs but their defaults must not change current behavior.
+    for var in (
+        "HIPPIUS_DOWNLOADER_DB_POOL_MIN",
+        "HIPPIUS_DOWNLOADER_DB_POOL_MAX",
+        "HIPPIUS_WRITE_QUEUE_MAXSIZE",
+        "HIPPIUS_OVH_KMS_KEEPALIVE_EXPIRY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    cfg = Config()
+    assert (cfg.downloader_db_pool_min, cfg.downloader_db_pool_max) == (2, 20)
+    assert cfg.write_queue_maxsize == 16
+    assert cfg.ovh_kms_keepalive_expiry_seconds == 300


### PR DESCRIPTION
Wave 4 — network keepalive, pool, and config-knob tuning. **Stacked on #270** (base `perf/wave-3-metadata-paths`). Full unit suite green (1879 passed). All defaults preserve current behavior; changes are low-risk and non-benchmark-gated.

## Changes
- **NET-3 — keep the mTLS KMS pool warm.** The KMS client used httpx's 5s keepalive default, so sparse cold-envelope reads redid the expensive mTLS handshake. Set `keepalive_expiry` (env `HIPPIUS_OVH_KMS_KEEPALIVE_EXPIRY`, default 300) + `max_keepalive_connections=10`.
- **NET-4 — gateway forward keepalive.** The gateway→API hop (100% of traffic) had `max_keepalive_connections=20` vs `max_connections=100` and a 5s expiry. Raised to 100 / `keepalive_expiry=30`.
- **DB-1 — config-driven downloader Postgres pool.** Was hardcoded `min=2/max=20`; now `HIPPIUS_DOWNLOADER_DB_POOL_MIN/MAX` (defaults unchanged). Audit `Σ(replicas × pool_max)` vs Postgres `max_connections` before raising.
- **CF-3 — expose the encrypt-queue depth** (`HIPPIUS_WRITE_QUEUE_MAXSIZE`, default 16) so per-PUT buffered memory can move with chunk size.

## Tests
Config drift-guard test asserts all four defaults are unchanged. `pytest tests/unit` → 1879 passed.

## Deferred (need an Arion capacity check / load benchmark, or prod-config reconciliation — per §5 of the plan)
- **NET-1 / RD-4** — per-role Arion `httpx.Limits` + single per-pod downloader semaphore. Must be co-sized (semaphore ≈ max_connections) and load-tested; a mis-sized pool causes PoolTimeout or overwhelms Arion.
- **WU-4/NET-6** — exponential backoff + jitter and semaphore-release across retries. Exponential backoff *without* the semaphore-release would hold Arion POST slots longer under a herd (worse), and the decorator's timing interacts with the deployed retry configmap — needs both parts + reconciliation together.
- **NET-2** — HTTP/2 (adds `h2` dependency; benchmark Arion before enabling).
- **CF-1 / CF-2** — chunk-size 8 MiB and uploader-concurrency raises: memory/capacity-gated, ship with a benchmark (CF-1 pairs with lowering prefetch).
- **NET-5** — shared gateway `HippiusApiClient` (lifecycle change; low risk, batched into a later gateway PR).
