### PR TITLE
perf(gateway): skip account fetch on access-key reads (Wave 5)

### DIFF
--- a/gateway/middlewares/account.py
+++ b/gateway/middlewares/account.py
@@ -185,15 +185,27 @@ async def account_middleware(
         account_address = request.state.account_address
 
         try:
-            redis_accounts_client = request.app.state.redis_accounts
-            request.state.account = await fetch_account_by_main_address(
-                account_address,
-                redis_accounts_client,
-                config.substrate_url,
-            )
             request.state.account_id = account_address
 
-            if request.method in ["PUT", "POST", "DELETE"]:
+            # GW-4: reads (GET/HEAD) carry no credit gate and the internal API never reads the credit
+            # fields, so skip the redis-accounts fetch on the hottest path and stamp a lightweight
+            # account (main_account is still needed for audit/header stamping). Only mutating methods
+            # fetch the real account and run the credit/can_upload checks.
+            if request.method not in ["PUT", "POST", "DELETE"]:
+                request.state.account = HippiusAccount(
+                    id=account_address,
+                    main_account=account_address,
+                    has_credits=False,
+                    upload=False,
+                    delete=False,
+                )
+            else:
+                redis_accounts_client = request.app.state.redis_accounts
+                request.state.account = await fetch_account_by_main_address(
+                    account_address,
+                    redis_accounts_client,
+                    config.substrate_url,
+                )
                 logger.debug(f"Checking credit for {request.method} operation: {path}")
 
                 if not request.state.account.has_credits:

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -243,7 +243,9 @@ async def _collect_page(
                 if len(items) > target:
                     # The (target+1)th item proves truncation; resume just past the last KEPT item.
                     kind, payload = items[target - 1]
-                    next_cursor = _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    next_cursor = (
+                        _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    )
                     return items[:target], True, next_cursor
 
             if len(batch) < batch_limit:

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -52,7 +52,9 @@ class StreamContext:
 # RQ-4: compare-and-delete Lua — delete the coalesce lock only while it still holds our token, so we
 # never steal a lock a later streamer/downloader re-acquired. Fixed script (no user input in the body);
 # mirrors the downloader's release. The key format must match _enqueue_missing_downloads exactly.
-_COALESCE_LOCK_RELEASE_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+_COALESCE_LOCK_RELEASE_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+)
 
 
 async def _release_coalesce_locks(

--- a/tests/unit/gateway/test_account_middleware.py
+++ b/tests/unit/gateway/test_account_middleware.py
@@ -455,3 +455,48 @@ async def test_can_upload_cache_key_is_per_account(mock_config_no_bypass: Any, m
         await client.put("/test-bucket/test-key", content=b"hello", headers={"content-length": "5"})
 
     mock_redis.get.assert_called_with("can_upload:5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
+
+
+@pytest.mark.asyncio
+async def test_gw4_get_skips_account_fetch_but_put_fetches(
+    mock_config_no_bypass: Any, monkeypatch: Any
+) -> None:
+    """GW-4: access-key GET/HEAD carry no credit gate and the API ignores the credit fields, so the
+    redis-accounts fetch is skipped on reads; mutating methods still fetch and gate."""
+    from gateway.middlewares import account as account_mod
+
+    monkeypatch.setattr("gateway.middlewares.account.config", mock_config_no_bypass)
+    addr = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+    calls = {"n": 0}
+
+    async def spy_fetch(address: str, redis_client: Any, substrate_url: str) -> HippiusAccount:
+        calls["n"] += 1
+        return HippiusAccount(id=addr, main_account=addr, has_credits=True, upload=True, delete=True)
+
+    monkeypatch.setattr("gateway.middlewares.account.fetch_account_by_main_address", spy_fetch)
+    monkeypatch.setattr(account_mod, "_check_can_upload", AsyncMock(return_value=None))
+
+    app = FastAPI()
+    app.state.redis_accounts = AsyncMock()
+
+    @app.api_route("/b/k", methods=["GET", "PUT"])
+    async def ep(request: Request) -> dict[str, str]:
+        return {"account_id": request.state.account_id}
+
+    async def inject(request: Request, call_next: Any) -> Any:
+        request.state.auth_method = "access_key"
+        request.state.account_address = addr
+        return await call_next(request)
+
+    app.middleware("http")(account_mod.account_middleware)
+    app.middleware("http")(inject)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        r_get = await client.get("/b/k")
+        assert r_get.status_code == 200
+        assert r_get.json()["account_id"] == addr
+        assert calls["n"] == 0, "GET must not fetch the account (GW-4)"
+
+        r_put = await client.put("/b/k", content=b"x", headers={"content-length": "1"})
+        assert r_put.status_code == 200
+        assert calls["n"] == 1, "PUT must still fetch the account for the credit gate"


### PR DESCRIPTION
Wave 5 — gateway fixed-request-floor. **Stacked on #271** (base `perf/wave-4-net-pool-config`). GW-2 (overhead measurement) already landed in Wave 0. Full unit suite green (1880 passed).

## Change
- **GW-4 — skip the account fetch on access-key GET/HEAD.** `account_middleware` did a redis-accounts GET on every access-key request, but the credit/can_upload gate only runs for PUT/POST/DELETE and the internal API never reads the credit fields on reads (verified: `has_credits`/`upload`/`delete` are set by `parse_internal_headers` but read nowhere on any method). Skip the fetch on reads and stamp a lightweight account (main_account preserved for audit/headers); mutating methods still fetch and gate. New test asserts GET issues no fetch and PUT still does.

## Deferred (need care/decision beyond a unit test)
- **GW-1** — the speculative MGET of the two redis-acl lookups is the only viable pipelining (auth→acl→account is a hard data dependency, per the review). It must be proven **decision-neutral** vs the master-token bypass — needs a dedicated ACL review + e2e, so it's not bundled with a mechanical change.
- **GW-5** — caching the decrypted access-key secret (holds a plaintext secret in process memory for the TTL) is security-sensitive; wants explicit sign-off.
- **GW-67** — `model_construct()` on trusted caches + guarding the ACL INFO log: the log guard changes default-level output, so it needs a Loki-dashboard check first (per the review).
- **GW-3** — no-op in default config (`ats_cache_endpoints` empty); low priority.
