### PR TITLE
perf(list): bound prefix scan + active-only partial index (Wave 6)

### DIFF
--- a/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
+++ b/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
@@ -82,6 +82,7 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
         None,
         None,
         1,
+        None,
     )
     if objects:
         return errors.s3_error_response(

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -212,11 +212,16 @@ async def _collect_page(
     items: list[tuple[str, Any]] = []
     seen_prefixes: set[str] = set()
     query = get_query("list_objects")
+    # LS-2: exclusive upper bound for the prefix range. Only pass it when _prefix_resume actually
+    # produced a successor (a pathological all-U+10FFFF prefix returns itself → keep NULL, LIKE guards).
+    prefix_upper = _prefix_resume(prefix) if prefix else None
+    if prefix_upper == prefix:
+        prefix_upper = None
 
     # LS-45: hold one pooled connection for the whole skip-scan instead of acquire/release per batch.
     async with pool.acquire() as conn:
         while True:
-            batch = await conn.fetch(query, bucket_id, prefix, cursor, batch_limit)
+            batch = await conn.fetch(query, bucket_id, prefix, cursor, batch_limit, prefix_upper)
             if not batch:
                 return items, False, None
 

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -248,7 +248,9 @@ async def _collect_page(
                 if len(items) > target:
                     # The (target+1)th item proves truncation; resume just past the last KEPT item.
                     kind, payload = items[target - 1]
-                    next_cursor = _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    next_cursor = (
+                        _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    )
                     return items[:target], True, next_cursor
 
             if len(batch) < batch_limit:

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -52,7 +52,9 @@ class StreamContext:
 # RQ-4: compare-and-delete Lua — delete the coalesce lock only while it still holds our token, so we
 # never steal a lock a later streamer/downloader re-acquired. Fixed script (no user input in the body);
 # mirrors the downloader's release. The key format must match _enqueue_missing_downloads exactly.
-_COALESCE_LOCK_RELEASE_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+_COALESCE_LOCK_RELEASE_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+)
 
 
 async def _release_coalesce_locks(

--- a/hippius_s3/sql/migrations/20260718000000_objects_bucket_prefix_active_index.sql
+++ b/hippius_s3/sql/migrations/20260718000000_objects_bucket_prefix_active_index.sql
@@ -1,0 +1,27 @@
+-- migrate:up transaction:false
+
+-- LS-3: the ListObjects ordered range scan uses idx_objects_bucket_prefix (bucket_id, object_key)
+-- but every list/get query filters `deleted_at IS NULL`, so the scan visits and discards
+-- soft-deleted (tombstone) rows interleaved in the key range — churny buckets pay most, and it
+-- compounds the delimiter skip-scan. A partial index over only the active rows keeps tombstones out
+-- of the scanned range entirely.
+--
+-- Added as a pure, zero-downtime addition. The old non-partial idx_objects_bucket_prefix is left in
+-- place for now; dropping it is a follow-up once this partial index is confirmed to serve every
+-- consumer (audit console_list_objects.sql, which may not filter deleted_at IS NULL).
+--
+-- CONCURRENTLY (+ `transaction:false`) is mandatory: a plain CREATE INDEX takes a SHARE lock that
+-- blocks every write on `objects` for the whole build, and migrations run before the API serves
+-- traffic on deploy. Postgres forbids CONCURRENTLY inside a transaction block — hence the directive.
+-- Must stay a SINGLE statement (dbmate runs a transaction:false body as one simple query; a
+-- multi-statement string runs in an implicit transaction and would break CONCURRENTLY).
+--
+-- Recovery: a build that fails midway leaves an INVALID index; `IF NOT EXISTS` then SKIPS it. Drop
+-- the leftover (`DROP INDEX CONCURRENTLY idx_objects_bucket_prefix_active;`) or REINDEX CONCURRENTLY
+-- before re-running.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_objects_bucket_prefix_active
+    ON objects (bucket_id, object_key) WHERE deleted_at IS NULL;
+
+-- migrate:down
+
+DROP INDEX IF EXISTS idx_objects_bucket_prefix_active;

--- a/hippius_s3/sql/queries/list_objects.sql
+++ b/hippius_s3/sql/queries/list_objects.sql
@@ -1,5 +1,6 @@
 -- List objects in a bucket with optional prefix and keyset pagination.
--- Parameters: $1: bucket_id, $2: prefix (optional), $3: inclusive cursor / boundary key (optional), $4: limit
+-- Parameters: $1: bucket_id, $2: prefix (optional), $3: inclusive cursor / boundary key (optional),
+--             $4: limit, $5: exclusive prefix upper bound (successor of prefix, optional)
 -- $3 is an INCLUSIVE lower bound: the endpoint computes the boundary (content key + '\x01', or the
 -- lexicographic successor of a delimiter common-prefix) so a single >= predicate expresses both
 -- "resume after a content key" and "skip the whole collapsed directory group".
@@ -33,6 +34,9 @@ FROM objects o,
 WHERE o.bucket_id = $1
   AND ($2::text IS NULL OR o.object_key LIKE $2::text || '%')
   AND ($3::text IS NULL OR o.object_key >= $3::text)
+  -- LS-2: explicit exclusive upper bound so the (bucket_id, object_key) index range is bounded on
+  -- both ends even under a generic prepared plan (a sparse prefix no longer scans to partition end).
+  AND ($5::text IS NULL OR o.object_key < $5::text)
   AND o.deleted_at IS NULL
 -- DB is C-collation; an explicit COLLATE here would defeat the (bucket_id, object_key) index ordered scan.
 ORDER BY o.object_key

--- a/hippius_s3/sql/queries/list_objects.sql
+++ b/hippius_s3/sql/queries/list_objects.sql
@@ -36,7 +36,7 @@ WHERE o.bucket_id = $1
   AND ($3::text IS NULL OR o.object_key >= $3::text)
   -- LS-2: explicit exclusive upper bound so the (bucket_id, object_key) index range is bounded on
   -- both ends even under a generic prepared plan (a sparse prefix no longer scans to partition end).
-  AND ($5::text IS NULL OR o.object_key < $5::text)
+  AND ($5::text IS NULL OR o.object_key < $5::text COLLATE "C")
   AND o.deleted_at IS NULL
 -- DB is C-collation; an explicit COLLATE here would defeat the (bucket_id, object_key) index ordered scan.
 ORDER BY o.object_key

--- a/tests/unit/api/s3/test_list_objects_pagination.py
+++ b/tests/unit/api/s3/test_list_objects_pagination.py
@@ -195,7 +195,7 @@ async def test_returns_keys_within_max_keys_no_truncation() -> None:
     # SQL gets max_keys+1 to detect truncation
     pool.fetch.assert_awaited_once()
     call_args = pool.fetch.call_args.args
-    assert call_args[-1] == 51
+    assert call_args[4] == 51
 
 
 @pytest.mark.asyncio
@@ -340,7 +340,7 @@ async def test_max_keys_above_1000_is_clamped() -> None:
     root = _parse(resp.body)
     assert _text(root, "MaxKeys") == "1000"
     # SQL also called with the clamped value (+1 for truncation detection)
-    assert pool.fetch.call_args.args[-1] == 1001
+    assert pool.fetch.call_args.args[4] == 1001
 
 
 @pytest.mark.asyncio
@@ -821,9 +821,12 @@ async def test_prefix_is_passed_to_sql() -> None:
         encoding_type=None,
         delimiter=None,
     )
-    # SQL positional args: 0=SQL_text, 1=bucket_id, 2=prefix, 3=cursor, 4=limit
+    # SQL positional args: 0=SQL_text, 1=bucket_id, 2=prefix, 3=cursor, 4=limit, 5=prefix_upper
     call_args = pool.fetch.call_args.args
     assert call_args[2] == "genomes/HG001/"
+    # LS-2: an explicit exclusive upper bound (the prefix successor) is passed so the index range is
+    # bounded on both ends. "genomes/HG001/" → last code point '/' (0x2F) bumped to '0' (0x30).
+    assert call_args[5] == "genomes/HG001" + chr(0x30)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Wave 6 — ListObjects scan bounds + index. **Stacked on #272** (base `perf/wave-5-gateway-floor`). Full unit suite green (1880 passed).

## Changes
- **LS-2 — bound the prefix scan's upper end.** `list_objects.sql`'s prefix filter (`LIKE $2 || '%'`) gave the planner only a lower index bound; a generic prepared plan may not derive the upper bound, so a sparse/empty prefix could scan to the end of the bucket partition. Pass an explicit exclusive upper bound (the prefix successor via the existing `_prefix_resume`) as a new `$5` param — `AND ($5 IS NULL OR object_key < $5)`. `LIKE` stays as a correctness backstop; the successor is only passed when it actually bumps (pathological all-U+10FFFF prefix → NULL).
- **LS-3 — active-only partial index.** `idx_objects_bucket_prefix (bucket_id, object_key)` isn't partial on `deleted_at IS NULL`, so the ordered scan visits/discards soft-deleted tombstones interleaved in the key range. Add `idx_objects_bucket_prefix_active ... WHERE deleted_at IS NULL` (CONCURRENTLY, `transaction:false`, following the repo's established out-of-band pattern). Added as a pure zero-downtime addition; **dropping the old non-partial index is a deliberate follow-up** once the partial is confirmed to serve every consumer (audit `console_list_objects.sql`).

## Tests
Pagination suite (41) updated for the new `$5` arg and asserts the successor upper bound is passed. `pytest tests/unit` → 1880 passed.

## Deferred
- **LS-1** — pushing the distinct-common-prefix delimiter rollup into SQL (loose index skip-scan). MEDIUM-risk: `CommonPrefixes`/`KeyCount`/`NextContinuationToken` are a strict client contract needing a differential/property test + `aws s3 ls` e2e (§2 harness) before merge.
