### PR TITLE
perf(drain): 1 MiB hash buffer + drain-poll doc fix (Wave 7)

### DIFF
--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -13,8 +13,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 use thiserror::Error;
 
-/// Drain-poll floor when `CEPHOR_DRAIN_POLL_SECS` is unset (the `chunk_landed`
-/// trigger wakes the worker sooner; this is only the backstop).
+/// Drain-poll period when `CEPHOR_DRAIN_POLL_SECS` is unset. The drain is purely polling — there is
+/// no api NOTIFY / `chunk_landed` wake in the part model (the reconciler is the sole trigger, see
+/// `runtime.rs`), so a part landing just after a poll waits up to this interval to be claimed (DR-6).
 const DEFAULT_DRAIN_POLL: Duration = Duration::from_secs(5);
 /// Reconciler scan period when `CEPHOR_RECONCILE_POLL_SECS` is unset.
 const DEFAULT_RECONCILE_POLL: Duration = Duration::from_mins(1);

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -30,7 +30,10 @@ use tokio::io::AsyncWriteExt;
 
 /// Streaming hash read buffer. Bounds memory so multi-gigabyte chunks are never
 /// read whole into memory just to hash them.
-const HASH_BUF_BYTES: usize = 1 << 16;
+// DR-3: 1 MiB (was 64 KiB). tokio::fs dispatches each read/write to the blocking pool, so a small
+// buffer means ~128 dispatches per 4 MiB chunk copy + ~64 for the readback hash; 1 MiB cuts that
+// ~16x. Peak memory is bounded by drain concurrency × this buffer (a few MiB at the default).
+const HASH_BUF_BYTES: usize = 1 << 20;
 
 /// Confine an identifier to a single path component beneath a root.
 ///

--- a/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
+++ b/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
@@ -82,6 +82,7 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
         None,
         None,
         1,
+        None,
     )
     if objects:
         return errors.s3_error_response(

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -248,7 +248,9 @@ async def _collect_page(
                 if len(items) > target:
                     # The (target+1)th item proves truncation; resume just past the last KEPT item.
                     kind, payload = items[target - 1]
-                    next_cursor = _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    next_cursor = (
+                        _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    )
                     return items[:target], True, next_cursor
 
             if len(batch) < batch_limit:

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -52,7 +52,9 @@ class StreamContext:
 # RQ-4: compare-and-delete Lua — delete the coalesce lock only while it still holds our token, so we
 # never steal a lock a later streamer/downloader re-acquired. Fixed script (no user input in the body);
 # mirrors the downloader's release. The key format must match _enqueue_missing_downloads exactly.
-_COALESCE_LOCK_RELEASE_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+_COALESCE_LOCK_RELEASE_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+)
 
 
 async def _release_coalesce_locks(

--- a/hippius_s3/sql/queries/list_objects.sql
+++ b/hippius_s3/sql/queries/list_objects.sql
@@ -36,7 +36,7 @@ WHERE o.bucket_id = $1
   AND ($3::text IS NULL OR o.object_key >= $3::text)
   -- LS-2: explicit exclusive upper bound so the (bucket_id, object_key) index range is bounded on
   -- both ends even under a generic prepared plan (a sparse prefix no longer scans to partition end).
-  AND ($5::text IS NULL OR o.object_key < $5::text)
+  AND ($5::text IS NULL OR o.object_key < $5::text COLLATE "C")
   AND o.deleted_at IS NULL
 -- DB is C-collation; an explicit COLLATE here would defeat the (bucket_id, object_key) index ordered scan.
 ORDER BY o.object_key


### PR DESCRIPTION
Wave 7 — Rust drain, the low-risk no-sign-off subset. **Stacked on #273** (base `perf/wave-6-listobjects`). `cargo fmt --check` clean, `cargo clippy` clean, localfs tests (24) pass. (The DB-gated sqlx tests need a live Postgres and aren't run locally.)

## Changes
- **DR-3 — hash/copy buffer 64 KiB → 1 MiB.** `tokio::fs` dispatches each read/write to the blocking pool, so a 64 KiB buffer meant ~128 dispatches per 4 MiB chunk copy + ~64 for the readback hash. 1 MiB cuts that ~16×. Peak memory bounded by `drain concurrency × buffer` (a few MiB at the default). No logic change; localfs copy/verify/hash tests exercise the new multi-read loop boundary.
- **DR-6 (doc) — correct the stale `chunk_landed` comment** on `DEFAULT_DRAIN_POLL`. There is no api NOTIFY / `chunk_landed` wake in the part model (the reconciler is the sole trigger, per `runtime.rs`); the poll is the period, not a backstop for a nonexistent trigger.

## Deferred (need owner sign-off or careful state-machine/store review — §5/§7 of the plan)
- **DR-1** (100% readback re-hash → optional sampling) and **DR-4** (per-part shared-root fsync): durability-critical, need the DR-1 durability-posture owner sign-off + a staging CephFS integration test.
- **DR-5** (drop the near-dead status SELECT) and **DR-78** (batch the post-MPU enqueue sweep): touch the store/state machine; want review against the commit-before-enqueue invariant + the DB-gated test tier (no local Postgres here).
- **DR-6 (the optional Redis wake)**: additive event trigger; deferred with the store work.
- **DR-2**: by-design (fsync-latency hiding); profile-gated only — confirm `sha2` `asm` first.
