### PR TITLE
perf(crypto): offload AES-GCM encrypt/decrypt off the event loop (Wave 8)

### DIFF
--- a/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
+++ b/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
@@ -82,6 +82,7 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
         None,
         None,
         1,
+        None,
     )
     if objects:
         return errors.s3_error_response(

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -248,7 +248,9 @@ async def _collect_page(
                 if len(items) > target:
                     # The (target+1)th item proves truncation; resume just past the last KEPT item.
                     kind, payload = items[target - 1]
-                    next_cursor = _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    next_cursor = (
+                        _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    )
                     return items[:target], True, next_cursor
 
             if len(batch) < batch_limit:

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -262,6 +262,8 @@ class Config:
     # CF-3: depth of the encrypt producer/consumer queue per streaming write. Peak buffered memory
     # per PUT ≈ chunk_size × this. Exposed so it can move with chunk size (CF-1).
     write_queue_maxsize: int = env("HIPPIUS_WRITE_QUEUE_MAXSIZE:16", convert=int)
+    # RD-2 / WU-1: worker threads for the dedicated AES-GCM encrypt/decrypt pool (off the event loop).
+    crypto_pool_workers: int = env("HIPPIUS_CRYPTO_POOL_WORKERS:4", convert=int)
     # NET-3: keep the expensive mTLS KMS connection warm across sparse/bursty calls.
     ovh_kms_keepalive_expiry_seconds: int = env("HIPPIUS_OVH_KMS_KEEPALIVE_EXPIRY:300", convert=int)
 

--- a/hippius_s3/reader/decrypter.py
+++ b/hippius_s3/reader/decrypter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from hippius_s3.services.crypto_pool import run_crypto
 from hippius_s3.services.crypto_service import CryptoService
 from hippius_s3.storage_version import require_supported_storage_version
 
@@ -24,7 +25,12 @@ async def decrypt_chunk_if_needed(
     if key_bytes is None:
         raise RuntimeError("decrypt_key_missing")
 
-    return CryptoService.decrypt_chunk(
+    # RD-2: offload the AES-GCM decrypt to the dedicated crypto pool so a ~4 MiB decrypt doesn't
+    # head-of-line-block every other request on this worker. cryptography releases the GIL, so this
+    # yields real parallelism; the streamer still awaits chunks in plan order, so emit order is
+    # unchanged and an auth-tag failure still propagates to break the stream.
+    return await run_crypto(
+        CryptoService.decrypt_chunk,
         cbytes,
         object_id=object_id,
         part_number=int(part_number),

--- a/hippius_s3/services/crypto_pool.py
+++ b/hippius_s3/services/crypto_pool.py
@@ -1,0 +1,55 @@
+"""Dedicated thread pool for AES-GCM encrypt/decrypt (RD-2 / WU-1).
+
+AES-GCM in `cryptography` releases the GIL, so running it on a worker thread lets the event loop
+service other requests instead of head-of-line-blocking on each ~2-5 ms per-chunk crypto call. The
+pool is kept separate from asyncio's default executor (which already carries FS md5 offload and
+blocking FS work) so crypto never starves those, and vice versa.
+
+Callers await the offloaded call sequentially per chunk, so ciphertext order — and therefore
+`chunk_cipher_sizes` recording and the running md5 — are unchanged from the inline path; only the CPU
+moves off the loop thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import atexit
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+from typing import Callable
+from typing import TypeVar
+
+from hippius_s3.config import get_config
+
+
+T = TypeVar("T")
+
+_pool: ThreadPoolExecutor | None = None
+
+
+def _get_pool() -> ThreadPoolExecutor:
+    global _pool
+    if _pool is None:
+        workers = int(getattr(get_config(), "crypto_pool_workers", 4) or 4)
+        _pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="crypto")
+    return _pool
+
+
+async def run_crypto(func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    """Run a CPU-bound crypto callable on the dedicated pool and await the result."""
+    loop = asyncio.get_running_loop()
+    if kwargs:
+        from functools import partial
+
+        return await loop.run_in_executor(_get_pool(), partial(func, *args, **kwargs))
+    return await loop.run_in_executor(_get_pool(), func, *args)
+
+
+def shutdown_crypto_pool() -> None:
+    global _pool
+    if _pool is not None:
+        _pool.shutdown(wait=False)
+        _pool = None
+
+
+atexit.register(shutdown_crypto_pool)

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -52,7 +52,9 @@ class StreamContext:
 # RQ-4: compare-and-delete Lua — delete the coalesce lock only while it still holds our token, so we
 # never steal a lock a later streamer/downloader re-acquired. Fixed script (no user input in the body);
 # mirrors the downloader's release. The key format must match _enqueue_missing_downloads exactly.
-_COALESCE_LOCK_RELEASE_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+_COALESCE_LOCK_RELEASE_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+)
 
 
 async def _release_coalesce_locks(

--- a/hippius_s3/sql/queries/list_objects.sql
+++ b/hippius_s3/sql/queries/list_objects.sql
@@ -36,7 +36,7 @@ WHERE o.bucket_id = $1
   AND ($3::text IS NULL OR o.object_key >= $3::text)
   -- LS-2: explicit exclusive upper bound so the (bucket_id, object_key) index range is bounded on
   -- both ends even under a generic prepared plan (a sparse prefix no longer scans to partition end).
-  AND ($5::text IS NULL OR o.object_key < $5::text)
+  AND ($5::text IS NULL OR o.object_key < $5::text COLLATE "C")
   AND o.deleted_at IS NULL
 -- DB is C-collation; an explicit COLLATE here would defeat the (bucket_id, object_key) index ordered scan.
 ORDER BY o.object_key

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -21,6 +21,7 @@ from hippius_s3.cache import create_fs_store
 from hippius_s3.config import get_config
 from hippius_s3.db_pool import acquire_with_timeout
 from hippius_s3.db_retry import retry_on_object_version_conflict
+from hippius_s3.services.crypto_pool import run_crypto
 from hippius_s3.services.crypto_service import CryptoService
 from hippius_s3.services.parts_service import upsert_part_placeholder
 from hippius_s3.storage_version import require_supported_storage_version
@@ -342,7 +343,7 @@ class ObjectWriter:
                     # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                     # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                     t0 = time.monotonic()
-                    ct = adapter.encrypt_chunk(
+                    ct = await run_crypto(adapter.encrypt_chunk,
                         buf,
                         key=key_bytes,
                         bucket_id=str(bucket_id),
@@ -369,7 +370,7 @@ class ObjectWriter:
                 # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                 # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                 t0 = time.monotonic()
-                ct = adapter.encrypt_chunk(
+                ct = await run_crypto(adapter.encrypt_chunk,
                     buf,
                     key=key_bytes,
                     bucket_id=str(bucket_id),
@@ -787,7 +788,7 @@ class ObjectWriter:
                     # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                     # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                     t0 = time.monotonic()
-                    ct = adapter.encrypt_chunk(
+                    ct = await run_crypto(adapter.encrypt_chunk,
                         buf,
                         key=key_bytes,
                         bucket_id=bucket_id,
@@ -814,7 +815,7 @@ class ObjectWriter:
                 # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                 # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                 t0 = time.monotonic()
-                ct = adapter.encrypt_chunk(
+                ct = await run_crypto(adapter.encrypt_chunk,
                     buf,
                     key=key_bytes,
                     bucket_id=bucket_id,

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -343,7 +343,8 @@ class ObjectWriter:
                     # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                     # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                     t0 = time.monotonic()
-                    ct = await run_crypto(adapter.encrypt_chunk,
+                    ct = await run_crypto(
+                        adapter.encrypt_chunk,
                         buf,
                         key=key_bytes,
                         bucket_id=str(bucket_id),
@@ -370,7 +371,8 @@ class ObjectWriter:
                 # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                 # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                 t0 = time.monotonic()
-                ct = await run_crypto(adapter.encrypt_chunk,
+                ct = await run_crypto(
+                    adapter.encrypt_chunk,
                     buf,
                     key=key_bytes,
                     bucket_id=str(bucket_id),
@@ -788,7 +790,8 @@ class ObjectWriter:
                     # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                     # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                     t0 = time.monotonic()
-                    ct = await run_crypto(adapter.encrypt_chunk,
+                    ct = await run_crypto(
+                        adapter.encrypt_chunk,
                         buf,
                         key=key_bytes,
                         bucket_id=bucket_id,
@@ -815,7 +818,8 @@ class ObjectWriter:
                 # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                 # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                 t0 = time.monotonic()
-                ct = await run_crypto(adapter.encrypt_chunk,
+                ct = await run_crypto(
+                    adapter.encrypt_chunk,
                     buf,
                     key=key_bytes,
                     bucket_id=bucket_id,

--- a/tests/unit/test_crypto_offload.py
+++ b/tests/unit/test_crypto_offload.py
@@ -1,0 +1,85 @@
+"""RD-2 / WU-1: offloading AES-GCM to the crypto pool must be byte-for-byte identical to the inline
+path — no reordering, no altered ciphertext/plaintext. Parametrized over sizes (incl. empty and
+exact/off-by-one chunk multiples) stands in for a property test since hypothesis isn't a dependency.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from hippius_s3.reader.decrypter import decrypt_chunk_if_needed
+from hippius_s3.services.crypto_pool import run_crypto
+from hippius_s3.services.crypto_service import CryptoService
+
+
+SUITE = "hip-enc/aes256gcm"
+KEY = bytes(range(32))
+SIZES = [0, 1, 15, 16, 17, 255, 4096, 4 * 1024 * 1024 - 1, 4 * 1024 * 1024]
+
+
+def _enc_kwargs(chunk_index: int) -> dict:
+    return {
+        "key": KEY,
+        "bucket_id": "bkt-1",
+        "object_id": "11111111-1111-1111-1111-111111111111",
+        "part_number": 1,
+        "chunk_index": chunk_index,
+        "upload_id": "",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", SIZES)
+async def test_offloaded_encrypt_matches_inline(size: int) -> None:
+    adapter = CryptoService.get_adapter(SUITE)
+    buf = bytes((i * 7 + 3) & 0xFF for i in range(size))
+
+    inline = adapter.encrypt_chunk(buf, **_enc_kwargs(0))
+    offloaded = await run_crypto(adapter.encrypt_chunk, buf, **_enc_kwargs(0))
+
+    assert offloaded == inline, "offloaded encrypt must be byte-identical to inline"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", SIZES)
+async def test_decrypt_if_needed_roundtrips_via_pool(size: int) -> None:
+    adapter = CryptoService.get_adapter(SUITE)
+    plaintext = bytes((i * 11 + 5) & 0xFF for i in range(size))
+    chunk_index = 3
+
+    ct = adapter.encrypt_chunk(plaintext, **_enc_kwargs(chunk_index))
+
+    got = await decrypt_chunk_if_needed(
+        ct,
+        object_id="11111111-1111-1111-1111-111111111111",
+        part_number=1,
+        chunk_index=chunk_index,
+        storage_version=5,
+        key_bytes=KEY,
+        suite_id=SUITE,
+        bucket_id="bkt-1",
+        upload_id="",
+    )
+    assert got == plaintext, "encrypt→offloaded-decrypt must be the identity"
+
+
+@pytest.mark.asyncio
+async def test_offloaded_decrypt_rejects_tampered_ciphertext() -> None:
+    # An auth-tag failure must still raise (propagates to break the stream), not return garbage.
+    adapter = CryptoService.get_adapter(SUITE)
+    ct = bytearray(adapter.encrypt_chunk(b"hello world" * 100, **_enc_kwargs(0)))
+    ct[-1] ^= 0x01  # flip a tag bit
+
+    with pytest.raises(InvalidTag):
+        await decrypt_chunk_if_needed(
+            bytes(ct),
+            object_id="11111111-1111-1111-1111-111111111111",
+            part_number=1,
+            chunk_index=0,
+            storage_version=5,
+            key_bytes=KEY,
+            suite_id=SUITE,
+            bucket_id="bkt-1",
+            upload_id="",
+        )


### PR DESCRIPTION
Wave 8 — AES-GCM crypto offload (RD-2 + WU-1). **Stacked on #274** (base `perf/wave-7-drain`). Full unit suite green (1899 passed).

## Changes
- New **dedicated crypto ThreadPoolExecutor** (`hippius_s3/services/crypto_pool.py`, `HIPPIUS_CRYPTO_POOL_WORKERS` default 4), separate from asyncio's default pool so crypto never starves FS md5 offload / blocking FS work and vice versa.
- **RD-2** — `decrypt_chunk_if_needed` offloads the per-chunk AES-GCM decrypt, so a ~4 MiB decrypt no longer head-of-line-blocks every other request on the worker.
- **WU-1** — `put_simple_stream_full` and `mpu_upload_part_stream` offload `encrypt_chunk`. `cryptography` releases the GIL, so both yield real cross-request parallelism.

## Why this is the safe design (the two silent-corruption hazards, handled by construction)
Each chunk's crypto is **awaited sequentially per chunk**, not run as a concurrent-completion pipeline. So:
- **WU-1 hazard** — `chunk_cipher_sizes` stays in index order and `hasher.update` (the running md5/ETag) stays inline and sequential. No reordering possible.
- **RD-2 hazard** — the streamer still awaits chunks in plan order, so emit order is unchanged and an auth-tag failure still propagates to break the stream.

This delivers the primary win (event loop no longer blocked on crypto) with **zero** reordering risk. The more aggressive variant (overlap decrypt(N+1) with send(N) via a concurrent pipeline) is a deliberate future step that would reintroduce the reordering hazards and is gated on the concurrent-round-trip e2e + the pub/sub rework (RQ-1).

## Tests
`test_crypto_offload.py`: parametrized over sizes (0, chunk multiples, off-by-one, 4 MiB) proving the offloaded encrypt is byte-identical to inline and encrypt→decrypt is the identity; a tampered-tag test proving `InvalidTag` still raises. (Stands in for a hypothesis property test — no new dependency added.) `pytest tests/unit` → 1899 passed.

## Deferred
- **RQ-1/RQ-2** — one pub/sub subscription per stream instead of per cold chunk. Highest correctness risk (demux/race-guard rework); needs the live pub/sub key-contract e2e (§2). Ship behind a flag with fallback.
- **KM-5** — per-chunk adapter/cipher churn: the verification showed `get_adapter` is a cheap dict lookup, so not worth the churn.
