### PR TITLE
perf(append): pre-write append-version re-check (Wave 9)

### DIFF
--- a/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
+++ b/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
@@ -82,6 +82,7 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
         None,
         None,
         1,
+        None,
     )
     if objects:
         return errors.s3_error_response(

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -248,7 +248,9 @@ async def _collect_page(
                 if len(items) > target:
                     # The (target+1)th item proves truncation; resume just past the last KEPT item.
                     kind, payload = items[target - 1]
-                    next_cursor = _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    next_cursor = (
+                        _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    )
                     return items[:target], True, next_cursor
 
             if len(batch) < batch_limit:

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -52,7 +52,9 @@ class StreamContext:
 # RQ-4: compare-and-delete Lua — delete the coalesce lock only while it still holds our token, so we
 # never steal a lock a later streamer/downloader re-acquired. Fixed script (no user input in the body);
 # mirrors the downloader's release. The key format must match _enqueue_missing_downloads exactly.
-_COALESCE_LOCK_RELEASE_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+_COALESCE_LOCK_RELEASE_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+)
 
 
 async def _release_coalesce_locks(

--- a/hippius_s3/sql/queries/list_objects.sql
+++ b/hippius_s3/sql/queries/list_objects.sql
@@ -36,7 +36,7 @@ WHERE o.bucket_id = $1
   AND ($3::text IS NULL OR o.object_key >= $3::text)
   -- LS-2: explicit exclusive upper bound so the (bucket_id, object_key) index range is bounded on
   -- both ends even under a generic prepared plan (a sparse prefix no longer scans to partition end).
-  AND ($5::text IS NULL OR o.object_key < $5::text)
+  AND ($5::text IS NULL OR o.object_key < $5::text COLLATE "C")
   AND o.deleted_at IS NULL
 -- DB is C-collation; an explicit COLLATE here would defeat the (bucket_id, object_key) index ordered scan.
 ORDER BY o.object_key

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -41,6 +41,14 @@ tracer = trace.get_tracer(__name__)
 logger = logging.getLogger(__name__)
 
 
+def _append_version_conflict(current: int | None, expected: int) -> bool:
+    """AP-1: True when a re-read append_version proves a concurrent append already advanced it.
+
+    A missing row (None) is not a conflict here — the reservation/finalize path handles that case.
+    """
+    return current is not None and int(current) != int(expected)
+
+
 class ObjectWriter:
     def __init__(self, *, pool: asyncpg.Pool, redis_client: Any, fs_store: FileSystemPartsStore | None = None) -> None:
         self.pool = pool
@@ -1113,6 +1121,19 @@ class ObjectWriter:
                     int(cov),
                     int(next_part),
                 )
+
+        # AP-1 (cheap interim): re-check the append version right before the expensive encrypt+FS
+        # write. When K appends share an expected_version, whichever finalizes first bumps it; any
+        # loser that hasn't started its write yet is rejected here instead of wasting the full write.
+        # The finalize CAS below remains the authoritative guard for writes that fully overlap.
+        precheck = await self.pool.fetchval(
+            "SELECT append_version FROM object_versions WHERE object_id = $1 AND object_version = $2",
+            object_id,
+            int(cov),
+        )
+        if _append_version_conflict(precheck, expected_version):
+            await _delete_part_row()
+            raise AppendPreconditionFailed(int(precheck))
 
         try:
             part_res = await self.mpu_upload_part_stream(

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -351,7 +351,8 @@ class ObjectWriter:
                     # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                     # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                     t0 = time.monotonic()
-                    ct = await run_crypto(adapter.encrypt_chunk,
+                    ct = await run_crypto(
+                        adapter.encrypt_chunk,
                         buf,
                         key=key_bytes,
                         bucket_id=str(bucket_id),
@@ -378,7 +379,8 @@ class ObjectWriter:
                 # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                 # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                 t0 = time.monotonic()
-                ct = await run_crypto(adapter.encrypt_chunk,
+                ct = await run_crypto(
+                    adapter.encrypt_chunk,
                     buf,
                     key=key_bytes,
                     bucket_id=str(bucket_id),
@@ -796,7 +798,8 @@ class ObjectWriter:
                     # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                     # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                     t0 = time.monotonic()
-                    ct = await run_crypto(adapter.encrypt_chunk,
+                    ct = await run_crypto(
+                        adapter.encrypt_chunk,
                         buf,
                         key=key_bytes,
                         bucket_id=bucket_id,
@@ -823,7 +826,8 @@ class ObjectWriter:
                 # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                 # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                 t0 = time.monotonic()
-                ct = await run_crypto(adapter.encrypt_chunk,
+                ct = await run_crypto(
+                    adapter.encrypt_chunk,
                     buf,
                     key=key_bytes,
                     bucket_id=bucket_id,

--- a/tests/unit/test_append_version_conflict.py
+++ b/tests/unit/test_append_version_conflict.py
@@ -1,0 +1,22 @@
+"""AP-1: the pre-write append-version conflict predicate.
+
+Before the expensive encrypt+FS write, append re-reads append_version and rejects fast if a concurrent
+append already changed it — instead of paying the full write only to fail the finalize CAS.
+"""
+
+from __future__ import annotations
+
+from hippius_s3.writer.object_writer import _append_version_conflict
+
+
+def test_matching_version_is_not_a_conflict() -> None:
+    assert _append_version_conflict(5, 5) is False
+
+
+def test_changed_version_is_a_conflict() -> None:
+    assert _append_version_conflict(6, 5) is True
+
+
+def test_missing_row_is_not_a_conflict() -> None:
+    # No row yet (None) → defer to the downstream reservation/finalize path, don't reject here.
+    assert _append_version_conflict(None, 5) is False


### PR DESCRIPTION
Wave 9 — append CAS cheap interim (AP-1). **Stacked on #275** (base `perf/wave-8-crypto-offload`). Full unit suite green (1902 passed).

## Change
- **AP-1 (cheap interim)** — `append_version` was only re-checked in the finalize CAS, so K concurrent appends sharing an `expected_version` each performed the full encrypt+FS write and all but one lost at finalize (K-1 wasted writes). Re-read `append_version` right before the write and reject fast (same `AppendPreconditionFailed`) when a concurrent append already advanced it. The finalize CAS stays authoritative for fully-overlapping writes.
- **Breaking-change: none** — it only rejects earlier what the finalize CAS would reject anyway; identical exception and semantics.

## Tests
Extracted the decision into a pure `_append_version_conflict(current, expected)` and unit-tested it (match → no conflict, changed → conflict, missing row → defer). `pytest tests/unit` → 1902 passed.

## Deferred (design sign-off MANDATORY, per §Design-track of the plan — not implemented unilaterally)
- **AP-1 optimistic** (reserve-and-bump `append_version` in the reservation txn): eliminates the wasted write entirely for overlapping appends, but splits the counter from the atomic size/md5/etag update and strands it on a crash-between-reserve-and-finalize — needs a reaper for orphaned reserved parts. Also flagged: `append_stream` never validates `objects.current_object_version` (a concurrent plain PUT can silently supersede an append). Both are design decisions.
- **CP-1 → v6 copy** (make server-side copy O(1)): needs a copy-stable crypto binding (`content_key_id` AAD, frozen-immutable copied ciphertext, new-DEK-on-mutation to avoid nonce reuse), a storage-version bump, `object_versions.content_key_id`, and unpin/janitor shared-CID dedup. New storage/suite version + crypto invariant → design sign-off. **CP-3** (batch the dead `copy_chunk_cids` loop) lands with it.
