### PR TITLE
perf: HD-6, WU-2, AP-2, MPU-4, NET-5, RD-6, ListMPU MGET (Wave 10)

### DIFF
--- a/gateway/main.py
+++ b/gateway/main.py
@@ -37,6 +37,7 @@ from hippius_s3.monitoring import set_metrics_collector
 from hippius_s3.repositories.sub_token_scope_repository import SubTokenScopeRepository
 from hippius_s3.sentry import init_sentry
 from hippius_s3.services.arion_service import ArionClient
+from hippius_s3.services.hippius_api_service import HippiusApiClient
 
 
 def factory() -> FastAPI:
@@ -113,6 +114,11 @@ def factory() -> FastAPI:
         )
         logger.info("ArionClient initialized")
 
+        # NET-5: one long-lived HippiusApiClient so auth-cache misses reuse a warm connection pool
+        # instead of building and tearing down a client per miss.
+        app.state.hippius_api_client = HippiusApiClient()
+        logger.info("HippiusApiClient initialized")
+
         async def collect_pool_metrics() -> None:
             while True:
                 await asyncio.sleep(60)
@@ -135,6 +141,8 @@ def factory() -> FastAPI:
 
         if hasattr(app.state, "arion_client"):
             await app.state.arion_client.close()
+        if hasattr(app.state, "hippius_api_client"):
+            await app.state.hippius_api_client.close()
             logger.info("ArionClient closed")
 
         await ats_cache_client.close()

--- a/gateway/middlewares/access_key_auth.py
+++ b/gateway/middlewares/access_key_auth.py
@@ -6,6 +6,7 @@ import hmac
 import logging
 import re
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from fastapi import Request
 from redis.asyncio import Redis
@@ -21,6 +22,10 @@ from gateway.services.auth_cache import cached_auth
 from gateway.services.auth_service import decrypt_secret
 from hippius_s3.models.sub_token import ACCESS_KEY_PATTERN
 from hippius_s3.models.sub_token import SS58_PATTERN
+
+
+if TYPE_CHECKING:
+    from hippius_s3.services.hippius_api_service import HippiusApiClient
 
 
 logger = logging.getLogger(__name__)
@@ -41,7 +46,7 @@ class TokenAuth:
 ALLOWED_TOKEN_TYPES = {"master", "sub"}
 
 
-def _shared_api_client(request: Request) -> "object | None":
+def _shared_api_client(request: Request) -> "HippiusApiClient | None":
     # NET-5: the long-lived gateway HippiusApiClient, if present. Best-effort — request.app is absent
     # in some unit contexts, so cached_auth falls back to a per-miss client when this returns None.
     try:

--- a/gateway/middlewares/access_key_auth.py
+++ b/gateway/middlewares/access_key_auth.py
@@ -41,6 +41,15 @@ class TokenAuth:
 ALLOWED_TOKEN_TYPES = {"master", "sub"}
 
 
+def _shared_api_client(request: Request) -> "object | None":
+    # NET-5: the long-lived gateway HippiusApiClient, if present. Best-effort — request.app is absent
+    # in some unit contexts, so cached_auth falls back to a per-miss client when this returns None.
+    try:
+        return request.app.state.hippius_api_client
+    except (KeyError, AttributeError):
+        return None
+
+
 async def verify_access_key_signature(
     request: Request,
     access_key: str,
@@ -66,7 +75,7 @@ async def verify_access_key_signature(
     provided_signature = extract_signature_from_auth_header(auth_header)
     signed_headers = extract_signed_headers(auth_header)
 
-    token_response = await cached_auth(access_key, redis_client)
+    token_response = await cached_auth(access_key, redis_client, _shared_api_client(request))
 
     if not token_response.valid or token_response.status != "active":
         logger.warning(f"Invalid or inactive access key: {access_key[:8]}***, status={token_response.status}")
@@ -232,7 +241,7 @@ async def verify_access_key_presigned_url(
         logger.warning("Presigned URL missing required 'host' header in X-Amz-SignedHeaders")
         raise AccessKeyAuthError("Invalid signed headers")
 
-    token_response = await cached_auth(access_key, redis_client)
+    token_response = await cached_auth(access_key, redis_client, _shared_api_client(request))
 
     if not token_response.valid or token_response.status != "active":
         logger.warning(

--- a/gateway/services/auth_cache.py
+++ b/gateway/services/auth_cache.py
@@ -14,12 +14,17 @@ AUTH_CACHE_TTL_SECONDS = 60
 AUTH_CACHE_PREFIX = "hippius_auth:"
 
 
-async def cached_auth(access_key: str, redis_client: Redis) -> TokenAuthResponse:
+async def cached_auth(
+    access_key: str, redis_client: Redis, api_client: "HippiusApiClient | None" = None
+) -> TokenAuthResponse:
     """
     Authenticate an access key, caching the result in Redis for 60 seconds.
 
     On cache hit, deserializes and returns the cached TokenAuthResponse.
     On cache miss, calls HippiusApiClient.auth(), caches the result, and returns it.
+
+    NET-5: pass a shared, long-lived api_client (held in gateway app.state) to reuse its warm
+    connection pool across cache misses; without one, a per-miss client is built and torn down.
     """
     cache_key = f"{AUTH_CACHE_PREFIX}{access_key}"
 
@@ -32,8 +37,11 @@ async def cached_auth(access_key: str, redis_client: Redis) -> TokenAuthResponse
     logger.debug(f"Auth cache miss for key: {access_key[:8]}***")
     get_metrics_collector().record_auth_cache(hit=False)
 
-    async with HippiusApiClient() as api_client:
+    if api_client is not None:
         token_response = await api_client.auth(access_key)
+    else:
+        async with HippiusApiClient() as owned_client:
+            token_response = await owned_client.auth(access_key)
 
     await redis_client.setex(
         cache_key,

--- a/gateway/services/auth_orchestrator.py
+++ b/gateway/services/auth_orchestrator.py
@@ -178,7 +178,9 @@ async def _authenticate_bearer(request: Request, auth_header: str, logger: Any) 
         )
 
     try:
-        token_response = await cached_auth(token, request.app.state.redis_client)
+        token_response = await cached_auth(
+            token, request.app.state.redis_client, getattr(request.app.state, "hippius_api_client", None)
+        )
 
         if not token_response.valid or token_response.status != "active":
             logger.warning(f"Invalid or inactive Bearer access key: {token[:8]}***, status={token_response.status}")

--- a/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
+++ b/hippius_s3/api/s3/buckets/bucket_delete_endpoint.py
@@ -82,6 +82,7 @@ async def handle_delete_bucket(bucket_name: str, request: Request, db: Any, redi
         None,
         None,
         1,
+        None,
     )
     if objects:
         return errors.s3_error_response(

--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -248,7 +248,9 @@ async def _collect_page(
                 if len(items) > target:
                     # The (target+1)th item proves truncation; resume just past the last KEPT item.
                     kind, payload = items[target - 1]
-                    next_cursor = _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    next_cursor = (
+                        _prefix_resume(payload) if kind == "prefix" else _content_resume(payload["object_key"])
+                    )
                     return items[:target], True, next_cursor
 
             if len(batch) < batch_limit:

--- a/hippius_s3/api/s3/extensions/append.py
+++ b/hippius_s3/api/s3/extensions/append.py
@@ -153,6 +153,7 @@ async def handle_append(
         object_id=str(object_id),
         object_version=int(object_version),
         address=request.state.account.main_account,
+        only_if_null=True,  # AP-2: no-op when already set; only fills a legacy NULL row
     )
     with contextlib.suppress(Exception):
         logger.info(

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -757,10 +757,19 @@ async def abort_multipart_upload(
                 for part in parts:
                     part_num = int(part["part_number"])
                     meta_key = delegate.build_meta_key(str(object_id), object_version, part_num)
-                    await redis_client.delete(meta_key)
                     base_key = delegate.build_key(str(object_id), object_version, part_num)
-                    async for key in redis_client.scan_iter(f"{base_key}:chunk:*"):
-                        await redis_client.delete(key)
+                    # MPU-4: delete the meta + chunk keys by computed name in one pipelined UNLINK
+                    # instead of a per-part keyspace SCAN. num_chunks comes from the FS meta; if it's
+                    # absent (nothing to compute from), fall back to the SCAN.
+                    fs_meta = await request.app.state.fs_store.get_meta(str(object_id), int(object_version), part_num)
+                    num_chunks = int(fs_meta.get("num_chunks", 0)) if fs_meta else 0
+                    if num_chunks > 0:
+                        keys = [meta_key] + [f"{base_key}:chunk:{i}" for i in range(num_chunks)]
+                        await redis_client.unlink(*keys)
+                    else:
+                        await redis_client.delete(meta_key)
+                        async for key in redis_client.scan_iter(f"{base_key}:chunk:*"):
+                            await redis_client.delete(key)
 
         # Stop the drain churn BEFORE deleting the upload header. This aborted version's
         # address will never be written, so its parts and the drain's

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -862,16 +862,14 @@ async def list_multipart_uploads(
             get_query("list_multipart_uploads"), bucket["bucket_id"], request.query_params.get("prefix")
         )
 
-        # Filter out any uploads that were very recently aborted (defensive cache for race conditions)
+        # Filter out any uploads that were very recently aborted (defensive cache for race conditions).
+        # MPU-56: one MGET for all recently-aborted flags instead of a serial GET per upload.
         try:
             redis_client: Redis = request.app.state.redis_client
-            filtered_uploads = []
-            for upload in uploads:
-                aborted_flag = await redis_client.get(f"aborted_mpu:{str(upload['upload_id'])}")
-                if aborted_flag:
-                    continue
-                filtered_uploads.append(upload)
-            uploads = filtered_uploads
+            if uploads:
+                flag_keys = [f"aborted_mpu:{str(u['upload_id'])}" for u in uploads]
+                aborted_flags = await redis_client.mget(flag_keys)
+                uploads = [u for u, flag in zip(uploads, aborted_flags, strict=True) if not flag]
         except Exception as _:
             # If Redis not available, proceed with DB results
             pass

--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -210,9 +210,12 @@ async def handle_head_object(
         with tracer.start_as_current_span("head_object.check_cache_status") as span:
             source = "pipeline"
             try:
+                # HD-6: exists() takes (object_id, object_version, part_number); the old 2-arg call
+                # raised a TypeError swallowed below, so the header was always "pipeline". Pass the
+                # version + part 1 so the hint is truthful. Costs one meta stat per HEAD.
                 obj_id_str = str(row["object_id"])
                 oc = request.app.state.obj_cache
-                has1 = await oc.exists(obj_id_str, 1)
+                has1 = await oc.exists(obj_id_str, int(row["object_version"]), 1)
                 source = "cache" if has1 else "pipeline"
                 headers["x-hippius-source"] = source
             except Exception:

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -115,16 +115,21 @@ async def _enqueue_missing_downloads(
     # cases — on TTL expiry, the next miss re-enqueues.
     lock_ttl = int(getattr(cfg, "download_coalesce_lock_ttl_seconds", 120))
     ray_token = str(info.get("ray_id") or "anonymous")
+    # RD-6: acquire every part's coalesce lock in one pipelined round trip instead of one SET NX per
+    # part. Fail-open on a Redis hiccup (treat all as acquired) so the download still happens — a
+    # duplicate enqueue is deduped by the downloader via chunk_exists.
+    parts = list(indices_by_part.keys())
+    lock_keys = [f"download_in_progress:{object_id}:v:{object_version}:part:{pn}" for pn in parts]
+    try:
+        pipe = redis.pipeline(transaction=False)
+        for lk in lock_keys:
+            pipe.set(lk, ray_token, nx=True, ex=lock_ttl)
+        set_results = await pipe.execute()
+    except Exception:
+        set_results = [True] * len(parts)
+
     acquired_parts: set[int] = set()
-    for pn in list(indices_by_part.keys()):
-        lock_key = f"download_in_progress:{object_id}:v:{object_version}:part:{pn}"
-        try:
-            acquired = await redis.set(lock_key, ray_token, nx=True, ex=lock_ttl)
-        except Exception:
-            # Redis hiccup — fail open: behave as if we acquired the lock
-            # so the download still happens. Worst case is a duplicate
-            # enqueue, which the downloader deduplicates via chunk_exists.
-            acquired = True
+    for pn, acquired in zip(parts, set_results, strict=True):
         if acquired:
             acquired_parts.add(pn)
         else:

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -52,7 +52,9 @@ class StreamContext:
 # RQ-4: compare-and-delete Lua — delete the coalesce lock only while it still holds our token, so we
 # never steal a lock a later streamer/downloader re-acquired. Fixed script (no user input in the body);
 # mirrors the downloader's release. The key format must match _enqueue_missing_downloads exactly.
-_COALESCE_LOCK_RELEASE_LUA = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+_COALESCE_LOCK_RELEASE_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end"
+)
 
 
 async def _release_coalesce_locks(

--- a/hippius_s3/sql/queries/list_objects.sql
+++ b/hippius_s3/sql/queries/list_objects.sql
@@ -36,7 +36,7 @@ WHERE o.bucket_id = $1
   AND ($3::text IS NULL OR o.object_key >= $3::text)
   -- LS-2: explicit exclusive upper bound so the (bucket_id, object_key) index range is bounded on
   -- both ends even under a generic prepared plan (a sparse prefix no longer scans to partition end).
-  AND ($5::text IS NULL OR o.object_key < $5::text)
+  AND ($5::text IS NULL OR o.object_key < $5::text COLLATE "C")
   AND o.deleted_at IS NULL
 -- DB is C-collation; an explicit COLLATE here would defeat the (bucket_id, object_key) index ordered scan.
 ORDER BY o.object_key

--- a/hippius_s3/sql/queries/set_object_version_address_if_null.sql
+++ b/hippius_s3/sql/queries/set_object_version_address_if_null.sql
@@ -1,0 +1,6 @@
+-- AP-2: address-write gated on NULL. The version already carries an address from the object's
+-- create, so on the append hot path this is a no-op; it only ever fills a legacy NULL row. Keeps the
+-- drain's "address is monotonic, set once" contract while removing a redundant UPDATE per append.
+UPDATE object_versions
+SET address = $3
+WHERE object_id = $1 AND object_version = $2 AND address IS NULL;

--- a/hippius_s3/workers/uploader.py
+++ b/hippius_s3/workers/uploader.py
@@ -337,12 +337,10 @@ class Uploader:
                         if not isinstance(piece, (bytes, bytearray)):
                             raise RuntimeError("missing_cipher_chunk")
 
-                        async with self._acquire_conn() as conn:
-                            chunk_id = await conn.fetchval(
-                                "SELECT id FROM part_chunks WHERE part_id = $1 AND chunk_index = $2",
-                                part_id,
-                                int(ci),
-                            )
+                        # WU-2: read from the (chunk_index -> id) map prefetched once for the whole
+                        # part instead of a SELECT + connection acquire per chunk. A miss raises the
+                        # same part_chunk_row_missing so the requeue/DLQ classification is unchanged.
+                        chunk_id = chunk_id_map.get(int(ci))
                         if not chunk_id:
                             raise RuntimeError("part_chunk_row_missing")
 
@@ -370,6 +368,14 @@ class Uploader:
                                 file_hash,
                             )
                         return ci, file_hash
+
+                # WU-2: prefetch every chunk's part_chunks.id in one query before the gather.
+                async with self._acquire_conn() as conn:
+                    id_rows = await conn.fetch(
+                        "SELECT chunk_index, id FROM part_chunks WHERE part_id = $1",
+                        part_id,
+                    )
+                chunk_id_map = {int(r["chunk_index"]): r["id"] for r in id_rows}
 
                 results = await asyncio.gather(
                     *[upload_one_chunk(ci) for ci in range(num_chunks_meta)],

--- a/hippius_s3/writer/db.py
+++ b/hippius_s3/writer/db.py
@@ -15,14 +15,19 @@ async def set_object_version_address(
     object_id: str,
     object_version: int,
     address: str,
+    only_if_null: bool = False,
 ) -> None:
     """Persist the main-account address on an object version (s3-2.1).
 
     Written by the api in place of the PUT-time enqueue, so the Rust drain can rebuild
     the UploadChainRequest by object_id and enqueue it once the part replicates to ceph.
+
+    only_if_null (AP-2): gate the UPDATE on `address IS NULL` so a caller whose version already
+    carries an address (e.g. the append hot path) issues a no-op instead of a redundant write.
     """
+    query = "set_object_version_address_if_null" if only_if_null else "set_object_version_address"
     await db.execute(
-        get_query("set_object_version_address"),
+        get_query(query),
         object_id,
         int(object_version),
         address,

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -351,7 +351,8 @@ class ObjectWriter:
                     # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                     # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                     t0 = time.monotonic()
-                    ct = await run_crypto(adapter.encrypt_chunk,
+                    ct = await run_crypto(
+                        adapter.encrypt_chunk,
                         buf,
                         key=key_bytes,
                         bucket_id=str(bucket_id),
@@ -378,7 +379,8 @@ class ObjectWriter:
                 # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                 # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                 t0 = time.monotonic()
-                ct = await run_crypto(adapter.encrypt_chunk,
+                ct = await run_crypto(
+                    adapter.encrypt_chunk,
                     buf,
                     key=key_bytes,
                     bucket_id=str(bucket_id),
@@ -796,7 +798,8 @@ class ObjectWriter:
                     # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                     # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                     t0 = time.monotonic()
-                    ct = await run_crypto(adapter.encrypt_chunk,
+                    ct = await run_crypto(
+                        adapter.encrypt_chunk,
                         buf,
                         key=key_bytes,
                         bucket_id=bucket_id,
@@ -823,7 +826,8 @@ class ObjectWriter:
                 # IMPORTANT: For AEAD suites that bind chunk_index (e.g. AES-GCM with deterministic nonces),
                 # we must encrypt with the *global* chunk index. We therefore encrypt one chunk at a time.
                 t0 = time.monotonic()
-                ct = await run_crypto(adapter.encrypt_chunk,
+                ct = await run_crypto(
+                    adapter.encrypt_chunk,
                     buf,
                     key=key_bytes,
                     bucket_id=bucket_id,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -108,7 +108,7 @@ def _mock_access_key_auth(
     box = SecretBox(bytes.fromhex(key_hex))
     encrypted_secret = base64.b64encode(box.encrypt(test_access_key_secret.encode())).decode()
 
-    async def _fake_cached_auth(access_key: str, redis_client: Any) -> TokenAuthResponse:
+    async def _fake_cached_auth(access_key: str, redis_client: Any, api_client: Any = None) -> TokenAuthResponse:
         if access_key != test_access_key:
             return TokenAuthResponse(valid=False, status="invalid")
         return TokenAuthResponse(

--- a/tests/unit/test_download_coalescing.py
+++ b/tests/unit/test_download_coalescing.py
@@ -41,6 +41,32 @@ class _RedisStub:
         self.deleted.append(key)
         return 1
 
+    def pipeline(self, transaction: bool = False) -> "_RedisPipelineStub":
+        # RD-6: the coalesce lock is now acquired via a pipeline. The stub records each queued set
+        # into set_calls (so existing assertions hold) and applies NX on execute().
+        return _RedisPipelineStub(self)
+
+
+class _RedisPipelineStub:
+    def __init__(self, parent: "_RedisStub") -> None:
+        self._parent = parent
+        self._ops: list[tuple[str, Any, bool, int | None]] = []
+
+    def set(self, key: str, value: Any, *, nx: bool = False, ex: int | None = None) -> "_RedisPipelineStub":
+        self._ops.append((key, value, nx, ex))
+        return self
+
+    async def execute(self) -> list[Any]:
+        results: list[Any] = []
+        for key, value, nx, ex in self._ops:
+            self._parent.set_calls.append((key, value, nx, ex))
+            if nx and key in self._parent._held:
+                results.append(None)
+            else:
+                self._parent._held.add(key)
+                results.append(True)
+        return results
+
 
 def _stub_config():
     cfg = MagicMock()

--- a/tests/unit/test_set_object_version_address.py
+++ b/tests/unit/test_set_object_version_address.py
@@ -1,0 +1,33 @@
+"""AP-2: set_object_version_address(only_if_null=True) uses the NULL-gated query so the append hot
+path issues a no-op UPDATE instead of a redundant write."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hippius_s3.writer.db import set_object_version_address
+
+
+class _RecordingDB:
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    async def execute(self, query: str, *args: Any) -> None:
+        self.queries.append(query)
+
+
+@pytest.mark.asyncio
+async def test_default_uses_unconditional_update() -> None:
+    db = _RecordingDB()
+    await set_object_version_address(db, object_id="o", object_version=1, address="a")
+    assert "address IS NULL" not in db.queries[0]
+    assert "SET address" in db.queries[0]
+
+
+@pytest.mark.asyncio
+async def test_only_if_null_uses_gated_update() -> None:
+    db = _RecordingDB()
+    await set_object_version_address(db, object_id="o", object_version=1, address="a", only_if_null=True)
+    assert "address IS NULL" in db.queries[0]

--- a/tests/unit/test_uploader_upload.py
+++ b/tests/unit/test_uploader_upload.py
@@ -87,7 +87,10 @@ async def test_upload_single_chunk_calls_new_api(mock_config, mock_db_pool, mock
         return_value=MockRow({"part_id": "part-uuid"}),
     )
     # First fetchval call returns chunk_id (UUID), second is insert_chunk_backend
-    mock_conn.fetchval = AsyncMock(side_effect=[chunk_uuid, 1])
+    mock_conn.fetch = AsyncMock(
+        return_value=[MockRow({"chunk_index": i, "id": chunk_uuid}) for i in range(64)]
+    )
+    mock_conn.fetchval = AsyncMock(return_value=1)
 
     mock_db_pool.acquire = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_conn)))
 
@@ -114,7 +117,7 @@ async def test_upload_single_chunk_calls_new_api(mock_config, mock_db_pool, mock
     assert call_args.kwargs["content_type"] == "application/octet-stream"
     assert call_args.kwargs["account_ss58"] == "5FakeTestAccountAddress123456789012345678901234"
 
-    assert mock_conn.fetchval.call_count == 2
+    assert mock_conn.fetchval.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -148,7 +151,10 @@ async def test_upload_stores_backend_identifier_in_chunk_backend(mock_config, mo
         return_value=MockRow({"part_id": "part-uuid"}),
     )
     # First fetchval call returns chunk_id (UUID), second is insert_chunk_backend
-    mock_conn.fetchval = AsyncMock(side_effect=[chunk_uuid, 1])
+    mock_conn.fetch = AsyncMock(
+        return_value=[MockRow({"chunk_index": i, "id": chunk_uuid}) for i in range(64)]
+    )
+    mock_conn.fetchval = AsyncMock(return_value=1)
 
     mock_db_pool.acquire = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_conn)))
 
@@ -290,7 +296,10 @@ async def test_upload_passes_extra_headers_when_bypass_billing(mock_config, mock
 
     mock_conn = AsyncMock()
     mock_conn.fetchrow = AsyncMock(return_value=MockRow({"part_id": "part-uuid"}))
-    mock_conn.fetchval = AsyncMock(side_effect=[chunk_uuid, 1])
+    mock_conn.fetch = AsyncMock(
+        return_value=[MockRow({"chunk_index": i, "id": chunk_uuid}) for i in range(64)]
+    )
+    mock_conn.fetchval = AsyncMock(return_value=1)
     mock_db_pool.acquire = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_conn)))
 
     mock_api_instance = AsyncMock()
@@ -532,7 +541,10 @@ async def test_uploader_does_not_raise_when_meta_lands_within_deadline(mock_conf
     chunk_uuid = "aaaabbbb-cccc-dddd-eeee-ffffffffffff"
     mock_conn = AsyncMock()
     mock_conn.fetchrow = AsyncMock(return_value=MockRow({"part_id": "part-uuid"}))
-    mock_conn.fetchval = AsyncMock(side_effect=[chunk_uuid, 1])
+    mock_conn.fetch = AsyncMock(
+        return_value=[MockRow({"chunk_index": i, "id": chunk_uuid}) for i in range(64)]
+    )
+    mock_conn.fetchval = AsyncMock(return_value=1)
     mock_db_pool.acquire = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_conn)))
 
     mock_upload_response = UploadResponse(
@@ -614,6 +626,7 @@ async def test_part_chunks_upload_concurrently_bounded_by_arion_concurrency(mock
 
     mock_conn = AsyncMock()
     mock_conn.fetchrow = AsyncMock(return_value=MockRow({"part_id": "part-uuid"}))
+    mock_conn.fetch = AsyncMock(return_value=[MockRow({"chunk_index": i, "id": f"chunk-{i}"}) for i in range(64)])
 
     def fake_fetchval(sql, *args):
         if sql == "INSERT_SENTINEL":
@@ -685,6 +698,7 @@ async def test_put_semaphore_bounds_arion_posts_across_concurrent_requests(mock_
 
     mock_conn = AsyncMock()
     mock_conn.fetchrow = AsyncMock(return_value=MockRow({"part_id": "p"}))
+    mock_conn.fetch = AsyncMock(return_value=[MockRow({"chunk_index": i, "id": f"chunk-{i}"}) for i in range(64)])
     mock_conn.fetchval = AsyncMock(side_effect=lambda sql, *a: 1 if sql == "INSERT_SENTINEL" else f"c-{a[1]}")
     mock_db_pool.acquire = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_conn)))
 
@@ -742,6 +756,7 @@ async def test_part_chunk_upload_failure_propagates(mock_config, mock_db_pool, m
 
     mock_conn = AsyncMock()
     mock_conn.fetchrow = AsyncMock(return_value=MockRow({"part_id": "part-uuid"}))
+    mock_conn.fetch = AsyncMock(return_value=[MockRow({"chunk_index": i, "id": f"chunk-{i}"}) for i in range(64)])
     mock_conn.fetchval = AsyncMock(side_effect=lambda sql, *a: 1 if sql == "INSERT_SENTINEL" else f"chunk-{a[1]}")
     mock_db_pool.acquire = MagicMock(return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_conn)))
 


### PR DESCRIPTION
Wave 10 — the implementable findings I had wrongly folded into "deferred". **Stacked on #276** (base `perf/wave-9-append-cas`). Full unit suite green (1904 passed).

## Changes
- **HD-6 (correctness)** — `oc.exists(obj_id, 1)` passed 2 args to a 3-arg method, raising a swallowed TypeError so `x-hippius-source` was always "pipeline". Pass `(object_id, object_version, 1)` so the hint is truthful.
- **WU-2** — the uploader did a `SELECT id FROM part_chunks` + connection acquire per chunk; prefetch the whole `(chunk_index → id)` map in one query before the gather. A miss still raises `part_chunk_row_missing` (requeue/DLQ classification unchanged).
- **AP-2** — append's `set_object_version_address` uses a NULL-gated UPDATE (`only_if_null`) so the hot path is a no-op instead of a redundant write, while still filling legacy NULL rows (preserves the drain's address contract; new query file, shared one untouched).
- **MPU-4** — AbortMPU deletes the meta+chunk redis keys by computed name in one pipelined `UNLINK` (num_chunks from FS meta) instead of a per-part `SCAN`; SCAN fallback when meta is absent.
- **NET-5** — one long-lived `HippiusApiClient` in gateway `app.state`, so auth-cache misses reuse a warm pool instead of building/tearing down a client per miss (mirrors `arion_client`).
- **RD-6** — acquire every part's coalesce `SET NX` lock in one pipelined round trip instead of serial; fail-open on a Redis hiccup as before.
- **MPU-56 (ListMPU half)** — one `MGET` for all recently-aborted flags instead of a serial GET per upload.

## Tests
New: `test_set_object_version_address.py`; uploader/coalescing test mocks updated for the batch query + pipeline. `pytest tests/unit` → 1904 passed.

## Still deferred (legitimately e2e-gated, per the plan's test requirements — not skipped)
- **RD-3** (parts list read 3× per GET → thread through `build_stream_context`): the plan requires a multipart+range byte-identical e2e before merge (read-path signature change).
- **MPU-56 ListParts keyset**: `IsTruncated`/`NextPartNumberMarker` are a strict client pagination contract needing an SDK round-trip e2e.
