### PR TITLE
test(e2e): multipart-assembly, cold-read pub/sub, delimiter/pagination harness (§2)

### DIFF
--- a/tests/e2e/test_ColdReadPubSub.py
+++ b/tests/e2e/test_ColdReadPubSub.py
@@ -1,0 +1,82 @@
+"""E2E: multi-chunk cold reads round-trip byte-exact through the live pub/sub pipeline.
+
+Gate for RQ-1/RQ-2 (rework the per-chunk pub/sub subscription). Forces a cache miss on a multi-chunk
+object so the streamer waits on redis-queues notifications for each chunk as the downloader fills
+them; also exercises concurrent cold reads of the same object (the coalescing path). The existing
+resilience test only covers a single-chunk object.
+"""
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+from typing import Callable
+
+import pytest
+
+from .support.cache import clear_object_cache
+from .support.cache import get_object_id
+from .support.cache import wait_for_all_backends_ready
+from .support.compose import compose_exec
+
+
+# In CI the e2e Postgres is at localhost:5432 (the helpers' default). Locally it may be remapped off a
+# host Postgres — set HIPPIUS_E2E_DB_DSN to point the db-querying helpers at the e2e db.
+_E2E_DSN = os.environ.get("HIPPIUS_E2E_DB_DSN", "postgresql://postgres:postgres@localhost:5432/hippius")
+
+
+def _evict(object_id: str) -> None:
+    clear_object_cache(object_id, dsn=_E2E_DSN)
+    compose_exec("api", ["rm", "-rf", f"/var/lib/hippius/object_cache/{object_id}"])
+
+
+@pytest.mark.local
+def test_multichunk_cold_read_is_byte_exact(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket = unique_bucket_name("coldread-multichunk")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+
+    key = "multichunk.bin"
+    # 12 MiB => 3 chunks at the 4 MiB default, so the cold read notifies per chunk (not just one).
+    content = bytes((i * 31 + 7) & 0xFF for i in range(12 * 1024 * 1024))
+    boto3_client.put_object(Bucket=bucket, Key=key, Body=content)
+    assert wait_for_all_backends_ready(bucket, key, min_count=1, timeout_seconds=60.0, dsn=_E2E_DSN)
+
+    _evict(get_object_id(bucket, key, dsn=_E2E_DSN))
+
+    got = boto3_client.get_object(Bucket=bucket, Key=key)["Body"].read()
+    assert got == content, "cold multi-chunk read must reassemble byte-exact via the pub/sub pipeline"
+
+
+@pytest.mark.local
+def test_concurrent_cold_reads_coalesce_and_match(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket = unique_bucket_name("coldread-coalesce")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+
+    key = "coalesce.bin"
+    content = bytes((i * 17 + 3) & 0xFF for i in range(12 * 1024 * 1024))
+    boto3_client.put_object(Bucket=bucket, Key=key, Body=content)
+    assert wait_for_all_backends_ready(bucket, key, min_count=1, timeout_seconds=60.0, dsn=_E2E_DSN)
+
+    _evict(get_object_id(bucket, key, dsn=_E2E_DSN))
+
+    # Several readers hit the cold object at once: exactly one enqueues the download (coalesce lock),
+    # the rest wait on pub/sub. All must return identical, byte-exact content.
+    def _read() -> bytes:
+        return boto3_client.get_object(Bucket=bucket, Key=key)["Body"].read()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = [f.result() for f in [pool.submit(_read) for _ in range(4)]]
+
+    for r in results:
+        assert r == content, "every concurrent cold reader must get byte-exact content"

--- a/tests/e2e/test_ListObjects_Delimiter.py
+++ b/tests/e2e/test_ListObjects_Delimiter.py
@@ -1,0 +1,88 @@
+"""E2E: ListObjectsV2 delimiter + pagination contract over a wide/deep keyspace.
+
+Gate for LS-1 (push the distinct-common-prefix rollup into SQL). The CommonPrefixes / Contents /
+KeyCount / IsTruncated / NextContinuationToken semantics are a strict client contract; any SQL
+rollup must reproduce them exactly. The existing ListObjects e2e only covers a flat prefix.
+"""
+
+from typing import Any
+from typing import Callable
+
+
+def _seed(client: Any, bucket: str) -> None:
+    # Several sibling "folders", each with multiple keys, plus a couple of top-level keys.
+    keys = []
+    for folder in ("logs", "data", "images"):
+        for i in range(5):
+            keys.append(f"{folder}/{i:02d}.txt")
+    keys += ["root-a.txt", "root-b.txt"]
+    for k in keys:
+        client.put_object(Bucket=bucket, Key=k, Body=b"x", ContentType="application/octet-stream")
+
+
+def test_delimiter_rolls_up_common_prefixes(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket = unique_bucket_name("list-delim")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+    _seed(boto3_client, bucket)
+
+    resp = boto3_client.list_objects_v2(Bucket=bucket, Delimiter="/")
+    common = {p["Prefix"] for p in resp.get("CommonPrefixes", [])}
+    contents = {o["Key"] for o in resp.get("Contents", [])}
+
+    assert common == {"logs/", "data/", "images/"}, "each folder collapses to exactly one CommonPrefix"
+    assert contents == {"root-a.txt", "root-b.txt"}, "only top-level keys appear as Contents"
+    # KeyCount counts Contents + CommonPrefixes (AWS semantics).
+    assert resp["KeyCount"] == len(common) + len(contents)
+
+
+def test_delimiter_with_prefix_lists_one_level(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket = unique_bucket_name("list-delim-prefix")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+    _seed(boto3_client, bucket)
+
+    resp = boto3_client.list_objects_v2(Bucket=bucket, Prefix="logs/", Delimiter="/")
+    keys = {o["Key"] for o in resp.get("Contents", [])}
+    assert keys == {f"logs/{i:02d}.txt" for i in range(5)}
+    assert not resp.get("CommonPrefixes"), "a fully-listed folder has no nested CommonPrefixes"
+
+
+def test_pagination_is_stable_and_complete(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket = unique_bucket_name("list-paged")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+    _seed(boto3_client, bucket)  # 17 keys total
+
+    seen: list[str] = []
+    token: str | None = None
+    pages = 0
+    while True:
+        kwargs = {"Bucket": bucket, "MaxKeys": 4}
+        if token:
+            kwargs["ContinuationToken"] = token
+        resp = boto3_client.list_objects_v2(**kwargs)
+        seen.extend(o["Key"] for o in resp.get("Contents", []))
+        pages += 1
+        if not resp.get("IsTruncated"):
+            break
+        token = resp["NextContinuationToken"]
+        assert pages < 20, "pagination did not terminate"
+
+    assert sorted(seen) == seen, "keys must come back in sorted order across pages"
+    assert len(seen) == len(set(seen)) == 17, "every key returned exactly once across pages"

--- a/tests/e2e/test_MultipartAssembly.py
+++ b/tests/e2e/test_MultipartAssembly.py
@@ -1,0 +1,96 @@
+"""E2E: multi-part MPU assembly is byte-exact on GET (and Range), and HEAD headers match.
+
+Gate for MPU-3 (CompleteMPU reads the parts table 3× — must keep the combined ETag/size identical)
+and HD-4 (a lighter HEAD query — headers must stay byte-identical across multipart objects). The
+existing MPU e2e only checks the combined ETag; these download the assembled bytes and verify them.
+"""
+
+import hashlib
+from typing import Any
+from typing import Callable
+
+
+def _combined_etag(part_etags: list[str]) -> str:
+    raw = b"".join(bytes.fromhex(e.strip('"')) for e in part_etags)
+    return f"{hashlib.md5(raw).hexdigest()}-{len(part_etags)}"
+
+
+def test_multipart_get_is_byte_exact_and_head_matches(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket = unique_bucket_name("mpu-assembly")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+    key = "assembled.bin"
+
+    # 3 parts of distinct bytes. All but the last must be >= 5 MiB (S3 rule).
+    part_size = 5 * 1024 * 1024
+    bodies = [b"\x11" * part_size, b"\x22" * part_size, b"\x33" * (1024 * 1024)]
+    expected = b"".join(bodies)
+
+    create = boto3_client.create_multipart_upload(Bucket=bucket, Key=key, ContentType="application/octet-stream")
+    upload_id = create["UploadId"]
+
+    etags = []
+    for i, body in enumerate(bodies, start=1):
+        r = boto3_client.upload_part(Bucket=bucket, Key=key, UploadId=upload_id, PartNumber=i, Body=body)
+        etags.append(r["ETag"])
+
+    completed = boto3_client.complete_multipart_upload(
+        Bucket=bucket,
+        Key=key,
+        UploadId=upload_id,
+        MultipartUpload={"Parts": [{"ETag": e, "PartNumber": i} for i, e in enumerate(etags, start=1)]},
+    )
+    final_etag = completed["ETag"].strip('"')
+    assert final_etag == _combined_etag(etags), "combined ETag must be md5-of-part-md5s + -N"
+
+    # GET the whole object and assert byte-exact assembly.
+    got = boto3_client.get_object(Bucket=bucket, Key=key)["Body"].read()
+    assert got == expected, "assembled multipart object must be byte-identical to the concatenated parts"
+
+    # HEAD must expose the same size + ETag (the headers HD-4's lighter query must preserve).
+    head = boto3_client.head_object(Bucket=bucket, Key=key)
+    assert head["ContentLength"] == len(expected)
+    assert head["ETag"].strip('"') == final_etag
+
+
+def test_multipart_range_get_spans_part_boundary(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket = unique_bucket_name("mpu-range")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+    key = "ranged.bin"
+
+    part_size = 5 * 1024 * 1024
+    bodies = [b"\xa1" * part_size, b"\xb2" * part_size]
+    expected = b"".join(bodies)
+
+    create = boto3_client.create_multipart_upload(Bucket=bucket, Key=key)
+    upload_id = create["UploadId"]
+    etags = []
+    for i, body in enumerate(bodies, start=1):
+        etags.append(
+            boto3_client.upload_part(Bucket=bucket, Key=key, UploadId=upload_id, PartNumber=i, Body=body)["ETag"]
+        )
+    boto3_client.complete_multipart_upload(
+        Bucket=bucket,
+        Key=key,
+        UploadId=upload_id,
+        MultipartUpload={"Parts": [{"ETag": e, "PartNumber": i} for i, e in enumerate(etags, start=1)]},
+    )
+
+    # A range straddling the part-1/part-2 boundary must return the exact plaintext slice.
+    start = part_size - 100
+    end = part_size + 99  # inclusive
+    r = boto3_client.get_object(Bucket=bucket, Key=key, Range=f"bytes={start}-{end}")
+    got = r["Body"].read()
+    assert got == expected[start : end + 1], "cross-boundary range must be byte-exact"
+    assert len(got) == (end - start + 1)


### PR DESCRIPTION
The §2 e2e harness — the coverage gaps that gate the deferred perf findings. **Branches off `staging`** (test-only, independent of the perf-wave chain). All 7 tests verified passing against a real `docker-compose.e2e` stack.

## New e2e coverage
- **`test_MultipartAssembly.py`** (2 tests) — >2-part MPU, **byte-exact GET** of the assembled object, combined ETag, HEAD Content-Length/ETag, and a **cross-part-boundary range**. The existing MPU e2e only checked the combined ETag. → gates **MPU-3** (CompleteMPU parts-read reduction) and **HD-4** (lighter HEAD query must keep headers byte-identical).
- **`test_ColdReadPubSub.py`** (2 tests) — a **multi-chunk** object read cold (cache + FS evicted) reassembles byte-exact through the live redis-queues pub/sub pipeline; plus **concurrent** cold reads coalesce and all return identical bytes. The existing resilience test only covered a single-chunk object. → gates **RQ-1/RQ-2** (per-chunk pub/sub rework) and the prefetch>0 pipelined path (RD-2's e2e gate).
- **`test_ListObjects_Delimiter.py`** (3 tests) — CommonPrefixes rollup over sibling folders, prefix+delimiter one-level listing, and **stable/complete keyset pagination** (every key once, sorted, terminates). → gates **LS-1** (SQL delimiter rollup must reproduce the client contract exactly).

## Local-run note
The support helpers hardcode `localhost:5432`/`6379` (the e2e stack in CI). The cold-read tests accept `HIPPIUS_E2E_DB_DSN` so they run locally when the e2e Postgres is remapped off a host Postgres. No production or harness-config changes.

## Verified
`pytest tests/e2e/test_MultipartAssembly.py tests/e2e/test_ListObjects_Delimiter.py tests/e2e/test_ColdReadPubSub.py` → **7 passed** against the live stack (mock-arion/mock-kms/mock-hippius-api, real API+gateway+workers+drain).

Once merged, this unblocks implementing RD-3, MPU-3, HD-4, HD-1, RQ-1/RQ-2, and LS-1 — each now has an end-to-end gate.
