### PR TITLE
perf(read): thread the parts catalog through GET (RD-3)

### DIFF
--- a/hippius_s3/api/s3/objects/get_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/get_object_endpoint.py
@@ -358,6 +358,10 @@ async def handle_get_object(
                 rng=v2_rng,
                 address=resolved_address,
                 range_was_invalid=range_was_invalid,
+                # RD-3: reuse the parts catalog built above only when it came from the DB (carries
+                # chunk_size_bytes + the completed-parts filter). "cached"/fallback → None so the
+                # reader re-reads authoritatively.
+                parts=download_chunks if parts_source == "db" else None,
             )
             set_span_attributes(span, {"http.status_code": int(response.status_code)})
 

--- a/hippius_s3/reader/planner.py
+++ b/hippius_s3/reader/planner.py
@@ -29,9 +29,14 @@ async def build_chunk_plan(
     # Normalize and sort parts
     ordered = sorted(parts, key=lambda x: int(x.get("part_number", 0)))
 
-    # Batch-load all part sizes in a single DB query instead of N sequential calls
     part_numbers = [int(p.get("part_number", 0)) for p in ordered]
-    size_map = await read_parts_plain_and_chunk_sizes_batch(db, object_id, part_numbers, int(object_version))
+    # RD-3: the GET path already carries size_bytes + chunk_size_bytes on each part (from the parts
+    # catalog), so size the plan from them and skip the query. Fall back to the batch query when any
+    # part lacks them — copy/UploadPartCopy callers and the envelope-race re-read pass thinner lists.
+    if ordered and all("size_bytes" in p and int(p.get("chunk_size_bytes") or 0) > 0 for p in ordered):
+        size_map = {int(p["part_number"]): (int(p.get("size_bytes") or 0), int(p["chunk_size_bytes"])) for p in ordered}
+    else:
+        size_map = await read_parts_plain_and_chunk_sizes_batch(db, object_id, part_numbers, int(object_version))
 
     sizes: list[tuple[int, int, int]] = []  # (part_number, plain_size, chunk_size)
     for pn in part_numbers:

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -177,13 +177,17 @@ async def build_stream_context(
     *,
     rng: RangeRequest | None,
     address: str,
+    parts: list[dict] | None = None,
 ) -> StreamContext:
     cfg = get_config()
     storage_version = require_supported_storage_version(int(info["storage_version"]))
     # v4-only policy: always decrypt at read time.
 
     ov = int(info.get("object_version") or info.get("current_object_version") or 1)
-    parts = await read_parts_list(db, info["object_id"], ov)
+    # RD-3: the GET endpoint already built the parts catalog; reuse it instead of re-reading. HEAD and
+    # copy callers pass nothing and keep the DB read.
+    if parts is None:
+        parts = await read_parts_list(db, info["object_id"], ov)
     plan = await build_chunk_plan(db, info["object_id"], parts, rng, object_version=ov)
 
     # Batch check all chunks in a single Redis pipeline round trip
@@ -308,8 +312,11 @@ async def read_response(
     rng: RangeRequest | None,
     address: str,
     range_was_invalid: bool = False,
+    parts: list[dict] | None = None,
 ) -> Response:
     cfg = get_config()
+    # RD-3: the endpoint already built the parts catalog; pass it through so build_stream_context and
+    # the planner don't re-read `parts`. None → they read it themselves (unchanged).
     ctx = await build_stream_context(
         db,
         redis,
@@ -317,6 +324,7 @@ async def read_response(
         info,
         rng=rng,
         address=address,
+        parts=parts,
     )
     gen = stream_plan(
         obj_cache=obj_cache,

--- a/hippius_s3/services/parts_catalog.py
+++ b/hippius_s3/services/parts_catalog.py
@@ -34,7 +34,8 @@ class PartsCatalog:
                 """
                 SELECT p.part_number,
                        COALESCE(c.cid, p.ipfs_cid) AS cid,
-                       p.size_bytes::bigint AS size_bytes
+                       p.size_bytes::bigint AS size_bytes,
+                       p.chunk_size_bytes::bigint AS chunk_size_bytes
                 FROM objects o
                 JOIN parts p
                   ON p.object_id = o.object_id
@@ -71,7 +72,12 @@ class PartsCatalog:
                         cid = cid_str
 
                 size = int(r[2] or 0)
-                parts.append({"part_number": pn, "cid": cid, "size_bytes": size})
+                # RD-3: carry chunk_size_bytes so the read-path planner can size chunks without a
+                # second `parts` query. 0 when the row lacks it (legacy) → planner falls back.
+                chunk_size = int(r[3] or 0)
+                parts.append(
+                    {"part_number": pn, "cid": cid, "size_bytes": size, "chunk_size_bytes": chunk_size}
+                )
 
             logger.debug(f"Built parts catalog: {parts}")
             return parts

--- a/hippius_s3/services/parts_catalog.py
+++ b/hippius_s3/services/parts_catalog.py
@@ -75,9 +75,7 @@ class PartsCatalog:
                 # RD-3: carry chunk_size_bytes so the read-path planner can size chunks without a
                 # second `parts` query. 0 when the row lacks it (legacy) → planner falls back.
                 chunk_size = int(r[3] or 0)
-                parts.append(
-                    {"part_number": pn, "cid": cid, "size_bytes": size, "chunk_size_bytes": chunk_size}
-                )
+                parts.append({"part_number": pn, "cid": cid, "size_bytes": size, "chunk_size_bytes": chunk_size})
 
             logger.debug(f"Built parts catalog: {parts}")
             return parts

--- a/tests/unit/reader/test_planner_inline_sizes.py
+++ b/tests/unit/reader/test_planner_inline_sizes.py
@@ -1,0 +1,64 @@
+"""RD-3: `build_chunk_plan` uses sizes already carried on the parts list, avoiding a size query.
+
+The GET path builds the parts catalog once (now including `chunk_size_bytes`). When those sizes are
+present the planner must NOT re-query `parts`; when they're absent (legacy/copy callers) it must fall
+back to the batch query so the plan is still correct.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+
+from hippius_s3.reader.planner import build_chunk_plan
+
+
+@pytest.mark.asyncio
+async def test_inline_sizes_skip_the_size_query() -> None:
+    db = AsyncMock()  # .fetch must never be awaited
+    parts = [
+        {"part_number": 1, "size_bytes": 8192, "chunk_size_bytes": 4096},
+        {"part_number": 2, "size_bytes": 4096, "chunk_size_bytes": 4096},
+    ]
+
+    plan = await build_chunk_plan(db, "obj-1", parts, None, object_version=1)
+
+    # 8192/4096=2 chunks for part 1, 4096/4096=1 for part 2.
+    assert [(i.part_number, i.chunk_index) for i in plan] == [(1, 0), (1, 1), (2, 0)]
+    db.fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_inline_sizes_fall_back_to_query() -> None:
+    db = AsyncMock()
+    parts = [{"part_number": 1, "cid": "x"}]  # no size fields
+
+    with patch(
+        "hippius_s3.reader.planner.read_parts_plain_and_chunk_sizes_batch",
+        AsyncMock(return_value={1: (8192, 4096)}),
+    ) as m:
+        plan = await build_chunk_plan(db, "obj-1", parts, None, object_version=1)
+
+    assert len(plan) == 2
+    m.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_inline_sizes_fall_back_to_query() -> None:
+    """If any part lacks the sizes, fall back rather than plan a truncated response."""
+    db = AsyncMock()
+    parts = [
+        {"part_number": 1, "size_bytes": 8192, "chunk_size_bytes": 4096},
+        {"part_number": 2, "cid": "x"},  # missing sizes
+    ]
+
+    with patch(
+        "hippius_s3.reader.planner.read_parts_plain_and_chunk_sizes_batch",
+        AsyncMock(return_value={1: (8192, 4096), 2: (4096, 4096)}),
+    ) as m:
+        plan = await build_chunk_plan(db, "obj-1", parts, None, object_version=1)
+
+    assert len(plan) == 3
+    m.assert_awaited_once()

--- a/tests/unit/test_stream_context_batch.py
+++ b/tests/unit/test_stream_context_batch.py
@@ -172,6 +172,66 @@ async def test_none_cached_sets_source_pipeline(
 @patch("hippius_s3.services.object_reader.unwrap_dek", return_value=b"\x01" * 32)
 @patch("hippius_s3.services.object_reader.get_bucket_kek_bytes", new_callable=AsyncMock, return_value=b"\x02" * 32)
 @patch("hippius_s3.services.object_reader.CryptoService")
+async def test_supplied_parts_skip_read_parts_list(
+    mock_crypto, mock_kek, mock_unwrap, mock_config, mock_storage, mock_read_parts, mock_plan
+):
+    """RD-3: a parts list passed by the caller is used directly — no second read_parts_list."""
+    plan_items = _make_plan_items(2)
+    mock_plan.return_value = plan_items
+    mock_crypto.is_supported_suite_id.return_value = True
+    mock_config.return_value = MagicMock()
+    supplied = [{"part_number": 1, "cid": None, "size_bytes": 8000, "chunk_size_bytes": 4096}]
+
+    obj_cache = FakeObjCache([True, True])
+    db = FakeDB()
+
+    from hippius_s3.services.object_reader import build_stream_context
+
+    ctx = await build_stream_context(
+        db, None, obj_cache, _make_info(), rng=None, address="addr1", parts=supplied
+    )
+
+    assert ctx.source == "cache"
+    mock_read_parts.assert_not_awaited()
+    # build_chunk_plan(db, object_id, parts, rng, object_version=...) — 3rd positional is parts.
+    assert mock_plan.call_args.args[2] is supplied
+
+
+@pytest.mark.asyncio
+@patch("hippius_s3.services.object_reader.build_chunk_plan")
+@patch("hippius_s3.services.object_reader.read_parts_list")
+@patch("hippius_s3.services.object_reader.require_supported_storage_version", return_value=5)
+@patch("hippius_s3.services.object_reader.get_config")
+@patch("hippius_s3.services.object_reader.unwrap_dek", return_value=b"\x01" * 32)
+@patch("hippius_s3.services.object_reader.get_bucket_kek_bytes", new_callable=AsyncMock, return_value=b"\x02" * 32)
+@patch("hippius_s3.services.object_reader.CryptoService")
+async def test_no_parts_supplied_reads_parts_list(
+    mock_crypto, mock_kek, mock_unwrap, mock_config, mock_storage, mock_read_parts, mock_plan
+):
+    """Default (parts=None) still reads the parts list — HEAD/copy callers are unchanged."""
+    mock_plan.return_value = _make_plan_items(1)
+    mock_read_parts.return_value = [{"part_number": 1, "cid": "cid1"}]
+    mock_crypto.is_supported_suite_id.return_value = True
+    mock_config.return_value = MagicMock()
+
+    obj_cache = FakeObjCache([True])
+    db = FakeDB()
+
+    from hippius_s3.services.object_reader import build_stream_context
+
+    await build_stream_context(db, None, obj_cache, _make_info(), rng=None, address="addr1")
+
+    mock_read_parts.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("hippius_s3.services.object_reader.build_chunk_plan")
+@patch("hippius_s3.services.object_reader.read_parts_list")
+@patch("hippius_s3.services.object_reader.require_supported_storage_version", return_value=5)
+@patch("hippius_s3.services.object_reader.get_config")
+@patch("hippius_s3.services.object_reader.unwrap_dek", return_value=b"\x01" * 32)
+@patch("hippius_s3.services.object_reader.get_bucket_kek_bytes", new_callable=AsyncMock, return_value=b"\x02" * 32)
+@patch("hippius_s3.services.object_reader.CryptoService")
 async def test_empty_plan_is_cache_source(
     mock_crypto, mock_kek, mock_unwrap, mock_config, mock_storage, mock_read_parts, mock_plan
 ):


### PR DESCRIPTION
## What

A single GET read the `parts` table **three times**: the endpoint's `build_initial_download_chunks`, then `build_stream_context`'s `read_parts_list`, then the planner's `read_parts_plain_and_chunk_sizes_batch`. This threads the endpoint's catalog through so a GET reads parts **once**.

- `build_initial_download_chunks` SELECT now returns `chunk_size_bytes` (added last; positional reads unchanged), so each catalog row carries `size_bytes` + `chunk_size_bytes`.
- `build_chunk_plan` sizes the plan from those inline values when every part has them, else falls back to the batch query.
- `build_stream_context`/`read_response` accept an optional `parts` list and skip `read_parts_list` when supplied.
- The GET endpoint passes its catalog **only when `parts_source == 'db'`** — that list carries `chunk_size_bytes` and the `completed_part_numbers` (MPU) filter. `cached`/fallback → `None` (authoritative re-read).

## Blast radius

GET read path only. HEAD and copy callers pass nothing and are unchanged (still read parts). Response bytes, headers, and DB are untouched. The planner's fallback guarantees a correct plan even if a caller passes a thin list.

## Breaking change

**No.** Behavior identical; only the number of parts reads drops (3 → 1 on the hot GET path).

## Tests

- Unit: `tests/unit/reader/test_planner_inline_sizes.py` (inline sizes skip the query; partial/missing sizes fall back).
- Unit: `tests/unit/test_stream_context_batch.py` (supplied parts skip `read_parts_list`; `None` still reads).
- e2e (gate): `test_MultipartAssembly.py` (multipart GET + cross-boundary range byte-exact) and `test_ColdReadPubSub.py` (cold multi-chunk + concurrent) — validated green against the live stack.

Full unit suite: 1861 passed. Sibling of #279, off the §2 harness (#278).