### PR TITLE
perf(mpu): reuse the endpoint's parts rows in CompleteMPU (MPU-3)

### DIFF
--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -1123,6 +1123,9 @@ async def complete_multipart_upload(
             # B1: the client's <Part> selection — the final object (bytes + ETag + size) reflects
             # only these; a strict subset is recorded so the reader excludes the unlisted parts.
             selected_parts=[pn for pn, _ in part_info],
+            # MPU-3: reuse the parts rows already fetched (and ETag-validated) above so mpu_complete
+            # doesn't re-read the parts table for the combined ETag and total size.
+            db_parts=db_parts,
         )
 
         # Drain-direct (s3-2.1 PR-11): the api does NOT enqueue the backend upload. It

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -912,9 +912,7 @@ class ObjectWriter:
 
         # Compute combined ETag from part etags for this version (client-selected subset only).
         etag_parts = (
-            [p for p in etag_rows if int(p["part_number"]) in selected_set]
-            if selected_set is not None
-            else etag_rows
+            [p for p in etag_rows if int(p["part_number"]) in selected_set] if selected_set is not None else etag_rows
         )
         etags = [p["etag"].split("-")[0] for p in etag_parts]
         binary = b"".join(bytes.fromhex(e) for e in etags) if etags else b""
@@ -923,9 +921,7 @@ class ObjectWriter:
         # Total size (client-selected subset only).
         all_pns = {int(p["part_number"]) for p in size_rows}
         size_parts = (
-            [p for p in size_rows if int(p["part_number"]) in selected_set]
-            if selected_set is not None
-            else size_rows
+            [p for p in size_rows if int(p["part_number"]) in selected_set] if selected_set is not None else size_rows
         )
         total_size = sum(int(p["size_bytes"]) for p in size_parts)
 

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -876,6 +876,7 @@ class ObjectWriter:
         object_version: int,
         address: str,
         selected_parts: list[int] | None = None,
+        db_parts: list[Any] | None = None,
     ) -> CompleteResult:
         # B1: S3 allows completing with a SUBSET of the uploaded parts. `selected_parts` is the
         # client's <Part> list (already validated exists+ETag-matches by the endpoint); the final
@@ -888,29 +889,45 @@ class ObjectWriter:
         # test `is not None` so a falsy-but-present empty list is not collapsed into the all-parts sentinel.
         selected = sorted({int(pn) for pn in selected_parts}) if selected_parts is not None else None
 
+        # MPU-3: `list_parts_for_version` (SELECT *) carries etag AND size_bytes ordered by
+        # part_number, so the endpoint's already-fetched rows serve both the combined ETag and the
+        # total size — no re-reads. When not supplied (migrate script), fall back to the original two
+        # queries so behaviour is byte-identical.
+        if db_parts is not None:
+            etag_rows: list[Any] = db_parts
+            size_rows: list[Any] = db_parts
+        else:
+            etag_rows = await self.pool.fetch(
+                get_query("get_parts_etags_for_version"),
+                object_id,
+                int(object_version),
+            )
+            size_rows = await self.pool.fetch(
+                get_query("list_parts_for_version"),
+                object_id,
+                int(object_version),
+            )
+
+        selected_set = set(selected) if selected is not None else None
+
         # Compute combined ETag from part etags for this version (client-selected subset only).
-        parts = await self.pool.fetch(
-            get_query("get_parts_etags_for_version"),
-            object_id,
-            int(object_version),
+        etag_parts = (
+            [p for p in etag_rows if int(p["part_number"]) in selected_set]
+            if selected_set is not None
+            else etag_rows
         )
-        if selected is not None:
-            selected_set = set(selected)
-            parts = [p for p in parts if int(p["part_number"]) in selected_set]
-        etags = [p["etag"].split("-")[0] for p in parts]
+        etags = [p["etag"].split("-")[0] for p in etag_parts]
         binary = b"".join(bytes.fromhex(e) for e in etags) if etags else b""
         final_md5 = hashlib.md5(binary).hexdigest() + f"-{len(etags)}"
 
         # Total size (client-selected subset only).
-        all_parts = await self.pool.fetch(
-            get_query("list_parts_for_version"),
-            object_id,
-            int(object_version),
+        all_pns = {int(p["part_number"]) for p in size_rows}
+        size_parts = (
+            [p for p in size_rows if int(p["part_number"]) in selected_set]
+            if selected_set is not None
+            else size_rows
         )
-        all_pns = {int(p["part_number"]) for p in all_parts}
-        if selected is not None:
-            all_parts = [p for p in all_parts if int(p["part_number"]) in set(selected)]
-        total_size = sum(int(p["size_bytes"]) for p in all_parts)
+        total_size = sum(int(p["size_bytes"]) for p in size_parts)
 
         # Only persist the filter when the client named a STRICT subset — a full-set completion
         # (the overwhelming common case) leaves the column NULL so no per-read filter/array is

--- a/tests/unit/test_mpu_complete_selected_parts.py
+++ b/tests/unit/test_mpu_complete_selected_parts.py
@@ -33,6 +33,13 @@ _SIZE_ROWS = [
 ]
 _FULL_SIZE = 300  # 100 + 200: the size an accidental "all parts" completion would produce.
 
+# MPU-3: `list_parts_for_version` is SELECT * — the endpoint's already-fetched rows carry BOTH etag
+# and size_bytes (ordered by part_number). Passing them lets mpu_complete skip its two re-reads.
+_DB_PARTS = [
+    {"etag": "aabbccdd-1", "part_number": 1, "size_bytes": 100},
+    {"etag": "11223344-1", "part_number": 2, "size_bytes": 200},
+]
+
 
 class _FakeTxn:
     async def __aenter__(self) -> None:
@@ -70,8 +77,10 @@ class _FakePool:
 
     def __init__(self) -> None:
         self.conn = _FakeConn()
+        self.fetch_calls = 0
 
     async def fetch(self, query: str, *_args: Any) -> list[dict[str, Any]]:
+        self.fetch_calls += 1
         if query == get_query("get_parts_etags_for_version"):
             return _ETAG_ROWS
         if query == get_query("list_parts_for_version"):
@@ -145,4 +154,41 @@ async def test_strict_subset_selects_only_named_parts(tmp_path: Any) -> None:
 
     assert res.size_bytes == 100
     assert res.etag.endswith("-1")
+    assert _persisted_completed_part_numbers(pool) == [1]
+
+
+@pytest.mark.asyncio
+async def test_db_parts_passthrough_skips_both_reads(tmp_path: Any) -> None:
+    """MPU-3: when the endpoint's parts rows are passed, mpu_complete issues zero parts fetches."""
+    writer, pool = _writer(tmp_path)
+
+    res = await _complete(writer, db_parts=_DB_PARTS)
+
+    assert res.size_bytes == _FULL_SIZE
+    assert res.etag.endswith("-2")
+    assert pool.fetch_calls == 0, "db_parts supplied — mpu_complete must not re-read the parts table"
+
+
+@pytest.mark.asyncio
+async def test_db_parts_result_matches_fallback(tmp_path: Any) -> None:
+    """The ETag/size computed from db_parts must be byte-identical to the DB-read fallback."""
+    w_fb, _ = _writer(tmp_path)
+    fallback = await _complete(w_fb)  # reads the two queries
+
+    w_db, _ = _writer(tmp_path)
+    passthrough = await _complete(w_db, db_parts=_DB_PARTS)
+
+    assert (passthrough.etag, passthrough.size_bytes) == (fallback.etag, fallback.size_bytes)
+
+
+@pytest.mark.asyncio
+async def test_db_parts_strict_subset(tmp_path: Any) -> None:
+    """Subset filtering works off db_parts too — only the named part's bytes/ETag/filter."""
+    writer, pool = _writer(tmp_path)
+
+    res = await _complete(writer, selected_parts=[1], db_parts=_DB_PARTS)
+
+    assert res.size_bytes == 100
+    assert res.etag.endswith("-1")
+    assert pool.fetch_calls == 0
     assert _persisted_completed_part_numbers(pool) == [1]


### PR DESCRIPTION
## What

`CompleteMultipartUpload` read the parts table **three times**: the endpoint's `list_parts_for_version` (validation), then inside `mpu_complete` a `get_parts_etags_for_version` (combined ETag) and another `list_parts_for_version` (total size).

`list_parts_for_version` is `SELECT *` — it already carries `etag` and `size_bytes` ordered by `part_number` — so the endpoint's already-fetched, ETag-validated `db_parts` covers both. `mpu_complete` now derives the combined ETag and total size from `db_parts` when supplied.

## Blast radius

CompleteMPU only. `db_parts=None` (the `migrate_objects` script) keeps the original two-query path, so the ETag/size are byte-identical there. Ordering (part_number ASC) is preserved, so the combined ETag hash is unchanged. The `completed_part_numbers` subset logic and the UPDATE txn are untouched.

## Breaking change

**No.** ETag, size, and persisted subset are identical; only the number of parts reads drops (3 → 1 on the hot complete path).

## Tests

- Unit: `tests/unit/test_mpu_complete_selected_parts.py` — db_parts pass-through issues zero fetches; result byte-identical to the fallback; strict-subset filtering off db_parts.
- e2e (gate): `tests/e2e/test_MultipartAssembly.py` — combined ETag == md5-of-part-md5s + -N and assembled bytes byte-exact, validated green against the live stack.

Full unit suite: 1859 passed. Sibling off the §2 harness (#278).