### PR TITLE
perf(head): light by-path HEAD query with LATERAL Arion hash (HD-4/HD-5)

### DIFF
--- a/hippius_s3/api/s3/objects/head_object_endpoint.py
+++ b/hippius_s3/api/s3/objects/head_object_endpoint.py
@@ -23,6 +23,11 @@ from hippius_s3.utils import get_query
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
+# Distinguishes "the light HEAD query returned a (possibly NULL) arion_file_hash" from "the column
+# isn't in this row" (the versioned path's heavy query) — asyncpg Record.get returns this only when
+# the key is absent.
+_MISSING = object()
+
 
 async def _get_object_with_permissions_min(
     bucket_name: str,
@@ -73,7 +78,9 @@ async def _get_object_with_permissions_min(
                 message=f"The specified key {object_key} does not exist",
             )
     else:
-        row = await ObjectRepository(db).get_for_download_with_permissions(bucket_name, object_key, main_account_id)
+        # HD-4: HEAD uses the light by-path query (no download_chunks/mpu joins; carries append_version
+        # and the Arion hash). The versioned path above keeps the heavy query.
+        row = await ObjectRepository(db).get_head_by_path(bucket_name, object_key, main_account_id)
         if not row:
             bucket_exists = await db.fetchval(
                 "SELECT 1 FROM buckets WHERE bucket_name = $1 AND deleted_at IS NULL",
@@ -222,15 +229,19 @@ async def handle_head_object(
         object_version = int(row.get("object_version") or 1)
         headers["x-amz-version-id"] = str(object_version)
 
-        # Add Arion file hash (first chunk of first part)
-        arion_hash = await db.fetchval(
-            get_query("get_chunk_backend_identifier"),
-            "arion",
-            row["object_id"],
-            object_version,
-            1,  # part_number (1-based)
-            0,  # chunk_index (0-based)
-        )
+        # Add Arion file hash (first chunk of first part). HD-5: the light HEAD query returns it via a
+        # LATERAL join, so skip the extra fetchval when present; the versioned path still fetches it.
+        # Sentinel (not `in row`) because asyncpg Record membership tests values, not column names.
+        arion_hash = row.get("arion_file_hash", _MISSING)
+        if arion_hash is _MISSING:
+            arion_hash = await db.fetchval(
+                get_query("get_chunk_backend_identifier"),
+                "arion",
+                row["object_id"],
+                object_version,
+                1,  # part_number (1-based)
+                0,  # chunk_index (0-based)
+            )
         headers["X-Hippius-Arion-File-Hash"] = arion_hash or "pending"
 
         # Append version header if present

--- a/hippius_s3/repositories/objects.py
+++ b/hippius_s3/repositories/objects.py
@@ -30,6 +30,14 @@ class ObjectRepository:
             version,
         )
 
+    async def get_head_by_path(self, bucket_name: str, object_key: str, main_account_id: Optional[str]) -> Any:
+        """HD-4: light HEAD metadata by path — no download_chunks/mpu joins; carries the Arion hash."""
+        return await self._db.fetchrow(
+            get_query("get_object_head_by_path"),
+            bucket_name,
+            object_key,
+        )
+
     async def get_by_path(self, bucket_id: str, object_key: str) -> Any:
         return await self._db.fetchrow(get_query("get_object_by_path"), bucket_id, object_key)
 

--- a/hippius_s3/sql/queries/get_object_head_by_path.sql
+++ b/hippius_s3/sql/queries/get_object_head_by_path.sql
@@ -1,0 +1,68 @@
+-- HD-4/HD-5: lightweight HEAD metadata by (bucket_name, object_key).
+-- Returns exactly the fields the HEAD endpoint needs plus the Arion first-chunk hash via LATERAL.
+-- Drops the download_chunks JSON_AGG and the mpu upload_id subquery of the download query, and
+-- projects append_version so the endpoint's per-request append-version fallback never fires.
+-- Uses the SAME incomplete-multipart-placeholder skip predicate as the download query so HEAD
+-- resolves the identical version.
+-- Parameters: $1: bucket_name, $2: object_key
+WITH object_info AS (
+    SELECT
+        o.object_id,
+        o.bucket_id,
+        o.object_key,
+        ov.size_bytes,
+        ov.multipart,
+        ov.status,
+        ov.content_type,
+        ov.metadata,
+        o.created_at,
+        ov.md5_hash,
+        ov.append_version,
+        b.bucket_name,
+        ov.object_version AS object_version
+    FROM objects o
+    JOIN object_versions ov ON ov.object_id = o.object_id AND ov.object_version = (
+        SELECT v.object_version
+        FROM object_versions v
+        WHERE v.object_id = o.object_id
+          AND v.object_version <= o.current_object_version
+          AND (v.size_bytes > 0 OR (v.md5_hash IS NOT NULL AND v.md5_hash != ''))
+        ORDER BY v.object_version DESC
+        LIMIT 1
+    )
+    JOIN buckets b ON o.bucket_id = b.bucket_id
+    WHERE b.bucket_name = $1
+      AND b.deleted_at IS NULL
+      AND o.object_key = $2
+      AND o.deleted_at IS NULL
+)
+SELECT
+    oi.object_id,
+    oi.bucket_id,
+    oi.object_key,
+    oi.size_bytes,
+    oi.multipart,
+    oi.status,
+    oi.content_type,
+    oi.metadata,
+    oi.created_at,
+    oi.md5_hash,
+    oi.append_version,
+    oi.bucket_name,
+    oi.object_version,
+    arion.backend_identifier AS arion_file_hash
+FROM object_info oi
+LEFT JOIN LATERAL (
+    SELECT cb.backend_identifier
+    FROM chunk_backend cb
+    JOIN part_chunks pc ON pc.id = cb.chunk_id
+    JOIN parts p ON pc.part_id = p.part_id
+    WHERE cb.backend = 'arion'
+      AND p.object_id = oi.object_id
+      AND p.object_version = oi.object_version
+      AND p.part_number = 1
+      AND pc.chunk_index = 0
+      AND NOT cb.deleted
+      AND cb.backend_identifier IS NOT NULL
+    LIMIT 1
+) arion ON TRUE;

--- a/tests/e2e/test_HeadObject_Contract.py
+++ b/tests/e2e/test_HeadObject_Contract.py
@@ -1,0 +1,90 @@
+"""E2E: HEAD header contract after the light by-path query (HD-4/HD-5).
+
+HD-4 repoints the common HEAD path at a lighter query (no download_chunks JSON_AGG / mpu subquery),
+projecting append_version (so the per-request fallback JOIN never fires) and the Arion first-chunk
+hash via LATERAL (HD-5). HEAD headers must stay byte-identical, so this pins the contract: size,
+ETag, content-type, x-amz-meta-*, x-amz-version-id, the append-version header, and that the Arion
+hash resolves to a real identifier (not just "pending") once the backend has the chunk.
+"""
+
+import hashlib
+import os
+import time
+from typing import Any
+from typing import Callable
+
+import pytest
+
+from .support.cache import wait_for_all_backends_ready
+
+
+_E2E_DSN = os.environ.get("HIPPIUS_E2E_DB_DSN", "postgresql://postgres:postgres@localhost:5432/hippius")
+
+
+@pytest.mark.local
+def test_head_simple_object_contract(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket = unique_bucket_name("head-simple")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+    key = "meta.bin"
+    body = b"\x5a" * 8192
+
+    boto3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body,
+        ContentType="application/octet-stream",
+        Metadata={"foo": "bar", "team": "hippius"},
+    )
+    assert wait_for_all_backends_ready(bucket, key, min_count=1, timeout_seconds=60.0, dsn=_E2E_DSN)
+
+    head = boto3_client.head_object(Bucket=bucket, Key=key)
+    hdrs = head["ResponseMetadata"]["HTTPHeaders"]
+
+    assert head["ContentLength"] == len(body)
+    assert head["ETag"].strip('"') == hashlib.md5(body).hexdigest()
+    assert hdrs["content-type"] == "application/octet-stream"
+    assert hdrs["accept-ranges"] == "bytes"
+    assert hdrs.get("x-amz-meta-foo") == "bar"
+    assert hdrs.get("x-amz-meta-team") == "hippius"
+    assert hdrs.get("x-amz-version-id") == "1"
+    # HD-5: the Arion hash comes from the LATERAL join and must resolve to a real identifier.
+    arion_hash = hdrs.get("x-hippius-arion-file-hash")
+    assert arion_hash and arion_hash != "pending", "LATERAL Arion hash must resolve once the chunk is on the backend"
+
+
+@pytest.mark.s4
+def test_head_appended_object_shows_append_version(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket = unique_bucket_name("head-append")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+    key = "log.txt"
+
+    boto3_client.put_object(Bucket=bucket, Key=key, Body=b"a\n", ContentType="text/plain")
+    head0 = boto3_client.head_object(Bucket=bucket, Key=key)
+    v0 = head0["ResponseMetadata"]["HTTPHeaders"].get("x-amz-meta-append-version", "0")
+    assert v0 == "0", "a fresh simple object reports append-version 0 (projected by the light query)"
+
+    boto3_client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=b"b\n",
+        ContentType="text/plain",
+        Metadata={"append": "true", "append-if-version": v0, "append-id": "head-contract-test"},
+    )
+    time.sleep(1)
+
+    head1 = boto3_client.head_object(Bucket=bucket, Key=key)
+    hdrs = head1["ResponseMetadata"]["HTTPHeaders"]
+    assert int(hdrs["x-amz-meta-append-version"]) == int(v0) + 1
+    assert head1["ContentLength"] == len(b"a\nb\n")


### PR DESCRIPTION
## What

HEAD used the full download query and then two more round trips:
- the download query builds `download_chunks` (a `JSON_AGG` over parts) and an mpu `upload_id` subquery — **neither used by HEAD**;
- it does **not** project `append_version`, so the endpoint's append-version fallback JOIN **always fired**;
- a separate `get_chunk_backend_identifier` fetchval for the Arion first-chunk hash.

New `get_object_head_by_path.sql` returns exactly the HEAD columns, projects `append_version`, and folds the Arion hash into a `LEFT JOIN LATERAL` (HD-5). The common (non-version) HEAD path is repointed to it; the append-version fallback and the Arion fetchval are now skipped.

## Blast radius

HEAD only, common path only. The **versioned** HEAD path (`?versionId=`) keeps the heavy query and both fallbacks — detected at runtime via a `Record.get` sentinel (asyncpg `Record` membership tests values, not column names, so `in row` would be wrong). GET is untouched (it still needs `download_chunks`/`is_public`). The light query reuses the **identical** incomplete-multipart-placeholder skip predicate, so HEAD resolves the same version.

## Breaking change

**LOW / none** — HEAD headers are byte-identical (Content-Length, ETag, Last-Modified, Content-Type, x-amz-meta-*, x-amz-version-id, x-amz-meta-append-version, X-Hippius-Arion-File-Hash). The multipart md5 fallback is retained.

## Tests

- e2e (gate): `tests/e2e/test_HeadObject_Contract.py` — simple object (size/ETag/content-type/x-amz-meta-*/version + LATERAL Arion hash resolves to a real identifier) and appended object (append-version increments). `test_MultipartAssembly.py` covers the multipart HEAD (ContentLength + combined ETag). All green against the live stack.

Full unit suite: 1856 passed. Sibling off the §2 harness (#278).