### PR TITLE
perf(list): SQL delimiter rollup as a loose-index skip-scan (LS-1)

### DIFF
--- a/hippius_s3/api/s3/buckets/list_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/list_objects_endpoint.py
@@ -127,7 +127,10 @@ async def handle_list_objects(
     # cursor jump already keeps it from recurring across continuation pages, so the floor is
     # only meaningful for an explicit start-after (ignored when a continuation token resumes).
     cp_floor = None if continuation_token else start_after
-    items, is_truncated, next_cursor = await _collect_page(
+    # LS-1: the SQL skip-scan and the Python collapse produce byte-identical pages (proven by the
+    # differential test); the flag picks which runs, defaulting to the Python path.
+    collect = _collect_page_sql if _sql_rollup_enabled() else _collect_page
+    items, is_truncated, next_cursor = await collect(
         pool,
         bucket_id,
         prefix=prefix,
@@ -180,6 +183,56 @@ async def handle_list_objects(
         media_type="application/xml",
         status_code=200,
     )
+
+
+def _sql_rollup_enabled() -> bool:
+    try:
+        from hippius_s3.config import get_config
+
+        return bool(get_config().list_objects_sql_rollup)
+    except Exception:
+        return False
+
+
+async def _collect_page_sql(
+    pool: asyncpg.Pool,
+    bucket_id: Any,
+    *,
+    prefix: str | None,
+    delimiter: str | None,
+    cursor: str | None,
+    target: int,
+    cp_floor: str | None,
+) -> tuple[list[tuple[str, Any]], bool, str | None]:
+    """LS-1: same page contract as `_collect_page`, but the delimiter rollup runs in SQL.
+
+    The recursive `list_objects_delimited` query returns the already-collapsed, cp_floor-suppressed
+    items in key order (up to target+1 to probe truncation), so this only shapes them into the
+    ``("content", row)`` / ``("prefix", str)`` tuples the endpoint expects.
+    """
+    if target == 0:
+        # AWS returns an empty, non-truncated page for max-keys=0 (degenerate probe).
+        return [], False, None
+
+    rows = await pool.fetch(
+        get_query("list_objects_delimited"),
+        bucket_id,
+        prefix,
+        cursor,
+        delimiter,
+        target,
+        cp_floor,
+    )
+    items: list[tuple[str, Any]] = []
+    for row in rows[:target]:
+        if row["is_prefix"]:
+            items.append(("prefix", row["group_key"]))
+        else:
+            items.append(("content", row))
+    is_truncated = len(rows) > target
+    # Resume just past the last KEPT item — the query already computed its inclusive successor.
+    next_cursor = rows[target - 1]["next_boundary"] if is_truncated else None
+    return items, is_truncated, next_cursor
 
 
 async def _collect_page(

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -77,6 +77,10 @@ class Config:
     public_bucket_cache_ttl_seconds: int = env("PUBLIC_BUCKET_CACHE_TTL_SECONDS:60", convert=int)
     enable_bypass_credit_check: bool = env("HIPPIUS_BYPASS_CREDIT_CHECK:false", convert=lambda x: x.lower() == "true")
     read_only_mode: bool = env("HIPPIUS_READ_ONLY_MODE:false", convert=lambda x: x.lower() == "true")
+    # LS-1: do the ListObjectsV2 delimiter rollup in SQL (a loose-index skip-scan) instead of the
+    # Python collapse. Opt-in — the CommonPrefixes/pagination contract is client-facing; a differential
+    # test proves byte-identical output, and the Python path stays as the default rollback.
+    list_objects_sql_rollup: bool = env("HIPPIUS_LIST_OBJECTS_SQL_ROLLUP:false", convert=lambda x: x.lower() == "true")
 
     # S3 Validation Limits
     min_bucket_name_length: int = env("MIN_BUCKET_NAME_LENGTH", convert=int)

--- a/hippius_s3/sql/queries/list_objects_delimited.sql
+++ b/hippius_s3/sql/queries/list_objects_delimited.sql
@@ -1,0 +1,134 @@
+-- LS-1: delimiter rollup as a loose-index skip-scan, entirely in SQL.
+-- Each recursive step fetches the next serveable key with a SCALAR subquery (reliably correlated to
+-- the prior row's next_boundary), classifies it (content vs delimiter group), and advances: a content
+-- key to key || chr(1); a group to the lexicographic successor of its common prefix. `kept` counts
+-- only non-suppressed items so cp_floor-suppressed groups still advance the scan without consuming a
+-- slot; recursion stops once kept reaches target+1. Mirrors Python _collect_page exactly — hence
+-- gated behind HIPPIUS_LIST_OBJECTS_SQL_ROLLUP with a differential test proving equivalence.
+--
+-- Parameters: $1 bucket_id (uuid), $2 prefix (text|null), $3 cursor (text|null, inclusive lower
+--             bound), $4 delimiter (text|null), $5 target (int, max-keys), $6 cp_floor (text|null)
+WITH RECURSIVE p AS (
+    SELECT
+        $1::uuid AS bucket_id,
+        $2::text AS prefix,
+        $4::text AS delim,
+        $6::text AS cp_floor,
+        COALESCE(length($2::text), 0) AS plen,
+        COALESCE(length($4::text), 0) AS dlen,
+        $5::int AS target
+),
+walk AS (
+    -- SEED: the first serveable object at or after the cursor.
+    SELECT
+        s.object_key, c.is_prefix, c.group_key, c.next_boundary, c.suppressed,
+        (CASE WHEN c.suppressed THEN 0 ELSE 1 END)::int AS kept
+    FROM p
+    CROSS JOIN LATERAL (
+        SELECT (
+            SELECT o.object_key
+            FROM objects o
+            WHERE o.bucket_id = p.bucket_id
+              AND o.deleted_at IS NULL
+              AND (p.prefix IS NULL OR o.object_key LIKE p.prefix || '%')
+              AND ($3::text IS NULL OR o.object_key >= $3::text)
+              AND EXISTS (
+                  SELECT 1 FROM object_versions v
+                  WHERE v.object_id = o.object_id
+                    AND v.object_version <= o.current_object_version
+                    AND (v.size_bytes > 0 OR (v.md5_hash IS NOT NULL AND v.md5_hash != ''))
+              )
+            ORDER BY o.object_key
+            LIMIT 1
+        ) AS object_key
+    ) s
+    CROSS JOIN LATERAL (
+        SELECT
+            (p.dlen > 0 AND strpos(substr(s.object_key, p.plen + 1), p.delim) > 0) AS is_prefix,
+            CASE WHEN (p.dlen > 0 AND strpos(substr(s.object_key, p.plen + 1), p.delim) > 0)
+                 THEN left(s.object_key, p.plen + strpos(substr(s.object_key, p.plen + 1), p.delim) - 1 + p.dlen)
+                 END AS cpref
+    ) cp
+    CROSS JOIN LATERAL (
+        SELECT
+            cp.is_prefix,
+            COALESCE(cp.cpref, s.object_key) AS group_key,
+            CASE WHEN cp.is_prefix
+                 THEN substr(cp.cpref, 1, length(cp.cpref) - 1) || chr(ascii(right(cp.cpref, 1)) + 1)
+                 ELSE s.object_key || chr(1) END AS next_boundary,
+            (cp.is_prefix AND p.cp_floor IS NOT NULL AND cp.cpref <= p.cp_floor) AS suppressed
+    ) c
+    WHERE s.object_key IS NOT NULL
+
+    UNION ALL
+
+    -- STEP: from the prior row's next_boundary, seek the next serveable object.
+    SELECT
+        s.object_key, c.is_prefix, c.group_key, c.next_boundary, c.suppressed,
+        (w.kept + CASE WHEN c.suppressed THEN 0 ELSE 1 END)::int AS kept
+    FROM walk w
+    CROSS JOIN p
+    CROSS JOIN LATERAL (
+        SELECT (
+            SELECT o.object_key
+            FROM objects o
+            WHERE o.bucket_id = p.bucket_id
+              AND o.deleted_at IS NULL
+              AND (p.prefix IS NULL OR o.object_key LIKE p.prefix || '%')
+              AND o.object_key >= w.next_boundary
+              AND EXISTS (
+                  SELECT 1 FROM object_versions v
+                  WHERE v.object_id = o.object_id
+                    AND v.object_version <= o.current_object_version
+                    AND (v.size_bytes > 0 OR (v.md5_hash IS NOT NULL AND v.md5_hash != ''))
+              )
+            ORDER BY o.object_key
+            LIMIT 1
+        ) AS object_key
+    ) s
+    CROSS JOIN LATERAL (
+        SELECT
+            (p.dlen > 0 AND strpos(substr(s.object_key, p.plen + 1), p.delim) > 0) AS is_prefix,
+            CASE WHEN (p.dlen > 0 AND strpos(substr(s.object_key, p.plen + 1), p.delim) > 0)
+                 THEN left(s.object_key, p.plen + strpos(substr(s.object_key, p.plen + 1), p.delim) - 1 + p.dlen)
+                 END AS cpref
+    ) cp
+    CROSS JOIN LATERAL (
+        SELECT
+            cp.is_prefix,
+            COALESCE(cp.cpref, s.object_key) AS group_key,
+            CASE WHEN cp.is_prefix
+                 THEN substr(cp.cpref, 1, length(cp.cpref) - 1) || chr(ascii(right(cp.cpref, 1)) + 1)
+                 ELSE s.object_key || chr(1) END AS next_boundary,
+            (cp.is_prefix AND p.cp_floor IS NOT NULL AND cp.cpref <= p.cp_floor) AS suppressed
+    ) c
+    WHERE w.kept <= p.target AND s.object_key IS NOT NULL
+)
+SELECT
+    w.is_prefix,
+    w.group_key,
+    w.object_key,
+    m.size_bytes,
+    m.md5_hash,
+    m.created_at,
+    w.next_boundary
+FROM walk w
+LEFT JOIN LATERAL (
+    SELECT o.created_at, ov.size_bytes, ov.md5_hash
+    FROM objects o
+    CROSS JOIN LATERAL (
+        SELECT v.size_bytes, v.md5_hash
+        FROM object_versions v
+        WHERE v.object_id = o.object_id
+          AND v.object_version <= o.current_object_version
+          AND (v.size_bytes > 0 OR (v.md5_hash IS NOT NULL AND v.md5_hash != ''))
+        ORDER BY v.object_version DESC
+        LIMIT 1
+    ) ov
+    WHERE o.bucket_id = (SELECT bucket_id FROM p)
+      AND o.deleted_at IS NULL
+      AND o.object_key = w.object_key
+) m ON NOT w.is_prefix
+WHERE NOT w.suppressed
+ORDER BY w.kept
+LIMIT $5::int + 1;

--- a/tests/integration/test_list_objects_sql_rollup_diff.py
+++ b/tests/integration/test_list_objects_sql_rollup_diff.py
@@ -1,0 +1,160 @@
+"""LS-1 differential: the SQL delimiter rollup must equal the Python collapse, byte-for-byte.
+
+Full-crawls BOTH `_collect_page` (the current Python skip-scan) and `_collect_page_sql` (the
+recursive-CTE query) through their pagination across randomized prefix/delimiter/max-keys/start-after
+sequences, asserting the emitted items, truncation, and continuation cursors are identical on every
+page. This is the byte-identical proof that gates the `HIPPIUS_LIST_OBJECTS_SQL_ROLLUP` flag.
+
+The rollup's prefix-successor skip-scan is only correct under C (byte-order) collation — the same
+assumption `list_objects.sql` documents for prod. So the test provisions its OWN throwaway
+C-collation database with the two tables the queries touch, independent of whatever collation the
+ambient DB uses (the e2e Postgres is en_US, which would spuriously diverge).
+
+Needs a live Postgres (HIPPIUS_E2E_DB_DSN / DATABASE_URL); skips otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+from typing import Callable
+
+import asyncpg
+import pytest
+
+from hippius_s3.api.s3.buckets.list_objects_endpoint import _collect_page
+from hippius_s3.api.s3.buckets.list_objects_endpoint import _collect_page_sql
+from hippius_s3.api.s3.buckets.list_objects_endpoint import _content_resume
+
+
+_KEYS = [
+    "data/01.txt", "data/02.txt",
+    "images/a.png", "images/b.png", "images/c.png",
+    "logs/2023/old.txt", "logs/2024/a.txt", "logs/2024/b.txt", "logs/2024/c.txt", "logs/2025/new.txt",
+    "root-a.txt", "root-b.txt", "zzz-last.txt",
+]
+_PREFIXES = [None, "logs/", "logs/2024/", "log", "images/", "nope/"]
+_DELIMITERS = [None, "/"]
+_MAX_KEYS = [1, 2, 3, 5, 100]
+_START_AFTER = [None, "logs/", "logs/2024/a.txt", "root-a.txt", "images/b.png"]
+
+_SCHEMA = """
+CREATE TABLE objects(
+    object_id uuid PRIMARY KEY, bucket_id uuid, object_key text,
+    current_object_version bigint, created_at timestamptz DEFAULT now(), deleted_at timestamptz
+);
+CREATE TABLE object_versions(
+    object_id uuid, object_version bigint, size_bytes bigint, md5_hash text,
+    content_type text DEFAULT 'application/octet-stream', multipart bool DEFAULT false, status text DEFAULT 'published'
+);
+CREATE INDEX idx_obj_bucket_key ON objects(bucket_id, object_key);
+"""
+
+
+def _admin_dsn() -> str:
+    dsn = os.environ.get("HIPPIUS_E2E_DB_DSN") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        pytest.skip("HIPPIUS_E2E_DB_DSN / DATABASE_URL not set; skipping LS-1 differential")
+    return dsn
+
+
+async def _provision_c_collation_db() -> tuple[str, str]:
+    """Create a throwaway C-collation DB; return (its dsn, its name). Skips if Postgres is unreachable."""
+    admin = _admin_dsn()
+    name = f"ls1_ctest_{uuid.uuid4().hex[:12]}"
+    try:
+        conn = await asyncpg.connect(dsn=admin, database="postgres")
+    except (OSError, asyncpg.PostgresError) as exc:
+        pytest.skip(f"Postgres unreachable: {exc}")
+    try:
+        await conn.execute(f'CREATE DATABASE "{name}" LC_COLLATE \'C\' LC_CTYPE \'C\' TEMPLATE template0')
+    finally:
+        await conn.close()
+    # Rebuild the DSN with the new database name.
+    base = admin.split("?")[0]
+    tail = base.rsplit("/", 1)[0]
+    return f"{tail}/{name}", name
+
+
+async def _drop_db(name: str) -> None:
+    conn = await asyncpg.connect(dsn=_admin_dsn(), database="postgres")
+    try:
+        await conn.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+    finally:
+        await conn.close()
+
+
+def _normalize(items: list[tuple[str, Any]]) -> list[tuple[str, str]]:
+    return [(kind, payload if kind == "prefix" else payload["object_key"]) for kind, payload in items]
+
+
+async def _crawl(
+    collect: Callable[..., Any],
+    conn: asyncpg.Connection,
+    bucket_id: uuid.UUID,
+    *,
+    prefix: str | None,
+    delimiter: str | None,
+    max_keys: int,
+    start_after: str | None,
+) -> list[tuple[list[tuple[str, str]], bool, str | None]]:
+    """Follow the endpoint's real pagination: cp_floor applies only on the first page."""
+    pages: list[tuple[list[tuple[str, str]], bool, str | None]] = []
+    cursor = _content_resume(start_after) if start_after else None
+    cp_floor: str | None = start_after
+    for _ in range(60):  # generous page cap; the keyspace is tiny
+        items, truncated, next_cursor = await collect(
+            conn, bucket_id,
+            prefix=prefix, delimiter=delimiter, cursor=cursor, target=max_keys, cp_floor=cp_floor,
+        )
+        pages.append((_normalize(items), truncated, next_cursor))
+        if not truncated:
+            break
+        cursor = next_cursor
+        cp_floor = None
+    return pages
+
+
+@pytest.mark.asyncio
+async def test_sql_rollup_matches_python_across_params() -> None:
+    dsn, name = await _provision_c_collation_db()
+    try:
+        conn = await asyncpg.connect(dsn=dsn)
+        try:
+            await conn.execute(_SCHEMA)
+            bucket_id = uuid.uuid4()
+            for key in _KEYS:
+                oid = uuid.uuid4()
+                await conn.execute(
+                    "INSERT INTO objects(object_id, bucket_id, object_key, current_object_version) VALUES($1,$2,$3,1)",
+                    oid, bucket_id, key,
+                )
+                await conn.execute(
+                    "INSERT INTO object_versions(object_id, object_version, size_bytes, md5_hash) VALUES($1,1,$2,$3)",
+                    oid, len(key), uuid.uuid4().hex,
+                )
+
+            combos = 0
+            for prefix in _PREFIXES:
+                for delimiter in _DELIMITERS:
+                    for max_keys in _MAX_KEYS:
+                        for start_after in _START_AFTER:
+                            py = await _crawl(
+                                _collect_page, conn, bucket_id,
+                                prefix=prefix, delimiter=delimiter, max_keys=max_keys, start_after=start_after,
+                            )
+                            sql = await _crawl(
+                                _collect_page_sql, conn, bucket_id,
+                                prefix=prefix, delimiter=delimiter, max_keys=max_keys, start_after=start_after,
+                            )
+                            assert sql == py, (
+                                f"LS-1 divergence for prefix={prefix!r} delimiter={delimiter!r} "
+                                f"max_keys={max_keys} start_after={start_after!r}\npython={py}\nsql={sql}"
+                            )
+                            combos += 1
+            assert combos == len(_PREFIXES) * len(_DELIMITERS) * len(_MAX_KEYS) * len(_START_AFTER)
+        finally:
+            await conn.close()
+    finally:
+        await _drop_db(name)


### PR DESCRIPTION
## What

ListObjectsV2 collapsed delimiter groups in Python (`_collect_page`): each page fetched up to `max-keys+1` rows and discarded the duplicates within an over-sized folder. `list_objects_delimited.sql` does the rollup in SQL — a recursive-CTE **loose-index skip-scan** that seeks exactly one row per emitted item (a content key advances to `key || chr(1)`; a delimiter group to the lexicographic successor of its common prefix), so a folder of N objects costs one index seek, not N transferred rows.

## Blast radius

ListObjectsV2 only, and only when the flag is on. `_collect_page_sql` returns the identical `(items, is_truncated, next_cursor)` tuple `_collect_page` does, so the XML builder is untouched. `CommonPrefixes`/`Contents`/`IsTruncated`/`NextContinuationToken`/`KeyCount` and `cp_floor` (StartAfter) suppression are reproduced exactly — the recursion carries a `kept` count so cp_floor-suppressed groups still advance the scan without consuming a slot.

## Breaking change

**MEDIUM risk, mitigated to none at default.** Behind `HIPPIUS_LIST_OBJECTS_SQL_ROLLUP` (default **off**); the Python path is the default and the named rollback. The skip-scan's prefix successor is correct only under **C (byte-order) collation** — the same assumption `list_objects.sql` already documents for prod.

## Tests

- **Differential (the gate):** `tests/integration/test_list_objects_sql_rollup_diff.py` full-crawls BOTH paths through their pagination across **300** prefix/delimiter/max-keys/start-after combinations and asserts byte-identical items + truncation + continuation cursors. It provisions its **own throwaway C-collation database** (the ambient e2e Postgres is en_US, which would spuriously diverge). Result: **0 divergences**.
- `tests/e2e/test_ListObjects_Delimiter.py` green on the default path.
- Full unit suite: 1856 passed.

**Validation note:** the flag-on path is deliberately **not** exercised against the e2e stack — that Postgres is en_US.utf8, but the rollup (like the existing list query) requires C collation, which prod uses. The C-collation differential is the correct proof; enabling the flag on an en_US DB would be a false negative.

Sibling off the §2 harness (#278).