### PR TITLE
fix(metrics): stop double-counting s3_operations_total

### DIFF
--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -672,6 +672,11 @@ async def upload_part(
         total_time = time.time() - start_time
         logger.debug(f"Part {part_number}: TOTAL processing time: {total_time:.3f}s")
 
+        get_metrics_collector().record_s3_operation(
+            operation="upload_part",
+            bucket_name=ongoing_multipart_upload.get("bucket_name", ""),
+            success=True,
+        )
         get_metrics_collector().record_data_transfer(
             operation="upload_part",
             bytes_transferred=file_size,

--- a/hippius_s3/monitoring.py
+++ b/hippius_s3/monitoring.py
@@ -351,6 +351,11 @@ class MetricsCollector:
         bytes_transferred: int,
         bucket_name: str,
     ) -> None:
+        # BYTES ONLY. The operation COUNT is owned solely by record_s3_operation — this
+        # method must not also bump s3_operations_total, or every data op (put_object,
+        # get_object, upload_part, CompleteMPU calls BOTH) double-counts, split across two
+        # label shapes ({operation} here vs {operation, success} there). That inflated
+        # s3_operations_total 2x. Any op that should be counted calls record_s3_operation.
         attributes = {
             "operation": operation,
         }
@@ -359,8 +364,6 @@ class MetricsCollector:
             self.s3_bytes_uploaded.add(bytes_transferred, attributes=attributes)
         elif operation in ["download", "get_object"]:
             self.s3_bytes_downloaded.add(bytes_transferred, attributes=attributes)
-
-        self.s3_operations_total.add(1, attributes=attributes)
 
     def record_error(
         self,

--- a/tests/unit/test_metrics_cardinality.py
+++ b/tests/unit/test_metrics_cardinality.py
@@ -226,3 +226,43 @@ class TestNoUnboundedLabels:
         assert called, "no record_* methods were exercised — the reflection broke"
         assert emitted, "no attributes captured — the instrument mocking broke"
         assert emitted <= BOUNDED_LABELS, f"unbounded label(s) emitted: {sorted(emitted - BOUNDED_LABELS)}"
+
+
+class TestOperationCountedExactlyOnce:
+    """s3_operations_total is owned by record_s3_operation ALONE.
+
+    Every data op (put_object, get_object, upload_part, CompleteMPU) calls BOTH
+    record_s3_operation and record_data_transfer. When record_data_transfer also bumped
+    s3_operations_total, each such op counted twice — split across two label shapes
+    ({operation} vs {operation, success}) — inflating the counter 2x. Lock the split of
+    responsibilities: record_data_transfer records BYTES ONLY.
+    """
+
+    def _counting_collector(self) -> tuple[MetricsCollector, MagicMock, MagicMock, MagicMock]:
+        c = MetricsCollector(redis_client=MagicMock())
+        c.s3_operations_total = MagicMock()
+        c.s3_bytes_uploaded = MagicMock()
+        c.s3_bytes_downloaded = MagicMock()
+        return c, c.s3_operations_total, c.s3_bytes_uploaded, c.s3_bytes_downloaded
+
+    def test_record_data_transfer_records_bytes_only_not_the_op_count(self) -> None:
+        c, ops, up, _down = self._counting_collector()
+        c.record_data_transfer(operation="put_object", bytes_transferred=1234, bucket_name="b")
+
+        ops.add.assert_not_called()  # the double-count that inflated s3_operations_total 2x
+        up.add.assert_called_once()
+        assert up.add.call_args.args[0] == 1234
+
+    def test_record_s3_operation_is_the_sole_counter(self) -> None:
+        c, ops, _up, _down = self._counting_collector()
+        c.record_s3_operation(operation="put_object", bucket_name="b", success=True)
+
+        ops.add.assert_called_once_with(1, attributes={"operation": "put_object", "success": "true"})
+
+    def test_a_data_op_calling_both_increments_the_count_exactly_once(self) -> None:
+        # Mirrors the put_object/get_object/upload_part/CompleteMPU call pattern.
+        c, ops, _up, _down = self._counting_collector()
+        c.record_s3_operation(operation="get_object", bucket_name="b", success=True)
+        c.record_data_transfer(operation="get_object", bytes_transferred=10, bucket_name="b")
+
+        assert ops.add.call_count == 1, "a data op must count once, not twice"


### PR DESCRIPTION
## Summary

`s3_operations_total` is **2× inflated** for every data-transfer operation on `main`. `record_data_transfer` bumps the counter *in addition to* `record_s3_operation`, and every data op calls **both**:

| op | `record_s3_operation` | `record_data_transfer` | counted |
|---|:-:|:-:|:-:|
| `put_object` | ✅ | ✅ | **2×** |
| `get_object` | ✅ | ✅ | **2×** |
| CompleteMultipartUpload | ✅ | ✅ | **2×** |
| `upload_part` | ❌ | ✅ | 1× (only via data_transfer) |
| CreateBucket | ✅ | ❌ | 1× |

Worse, the two adds use **different label shapes** — `{operation}` (data_transfer) vs `{operation, success}` (s3_operation) — so the count is split across two series per op.

This survived #265 (which fixed the per-worker series-collision inflation, the ~8× cardinality, and the `handler`→`unknown` fallback) — it never touched this double-add.

## Fix
- **`record_data_transfer` records BYTES ONLY** — drops its `s3_operations_total.add`. The op count is owned solely by `record_s3_operation`.
- **`upload_part`** counted only via `record_data_transfer`, so it now also calls `record_s3_operation` (the other data ops already call both). Count preserved, no longer doubled.
- **Test:** `TestOperationCountedExactlyOnce` locks the split — `record_data_transfer` must not touch `s3_operations_total`, and a data op calling both counts exactly once.

## How it was found
Measuring prod ingest for a capacity-planning exercise, `rate(s3_operations_total{...put_object})` read **~30,700/s** against a true **~53 ops/s** in the gateway audit log (Loki). Most of that gap is prod still running a **pre-#265 image `07b1fb1`** (per-worker cumulative-counter collision → constant resets → ~100–650× inflation). Deploying a ≥#265 image fixes that part; **this PR fixes the residual 2× that remains on current main.**

## Tests
`tests/unit/test_metrics_cardinality.py` — 13 pass (incl. 3 new); ruff + ty clean. No dashboards/alerts reference `s3_operations_total` (checked `monitoring/`, `k8s/`), so halving it to the correct value has no downstream break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)