### PR TITLE
feat(prod): SSD-ingest drain manifests + capacity plan for prod promotion

### DIFF
--- a/k8s/production/api-local-deployments-production.yaml
+++ b/k8s/production/api-local-deployments-production.yaml
@@ -1,0 +1,187 @@
+# Trial (s3-2.0 prototype): the entire staging api fleet on node-local SSD.
+#
+# A single `api-local` Deployment (2 replicas, one per ingest node) — the base (ceph) `api` deployment
+# is scaled to 0 in resource-limits.yaml, so ALL api pods run on local SSD. Each
+# pod writes to its node's local dir and read-falls-back to the shared CephFS
+# cache. All workers stay on ceph, untouched.
+#
+# Volume: a `hostPath` with `type: DirectoryOrCreate` — the kubelet creates the
+# node path on whatever node the pod lands on (NO manual node prep, so this deploys
+# cleanly via CI). A root initContainer chmods it so the api (which may run
+# non-root) can write. This replaces the earlier local-PV approach, which required
+# pre-creating the dir on each node (impossible in CI).
+#
+# The node path is /var/lib/hippius/local_ingest_STAGING (the `_staging` denominator
+# matters: staging + prod share the cluster, and prod uses /var/lib/hippius/local_ingest_prod
+# — so even if a staging and a prod pod land on the same node, their local disks
+# never collide).
+#
+# Scheduling: pinned to nodes labeled `s3-prod-local-ingest=true` (the ONE list
+# lives in ingest-node-labels-production.yaml). The drain-agent DaemonSet selects
+# the SAME label, so they stay in lockstep. Preferred pod anti-affinity spreads the
+# 2 replicas across the labeled nodes. A required nodeAffinity hostname allow-list
+# (node2/node3) is belt-and-suspenders WITH the label: a stray/mislabeled node alone
+# can't place ingest on a psql/cache node — the hostname must ALSO be on the list.
+#
+# Routing: the existing `api` Service (the gateway's GATEWAY_BACKEND_URL=
+# http://api:8000 upstream) is patched to select `app: api-local`
+# (kustomization.yaml), so the gateway routes here through the normal front door.
+#
+# IMPORTANT: with no ceph api pods, every upload stages locally and stays
+# `pending` until the replicator copies local->ceph. Install + test the replicator
+# when ready. See README-local-ingest-trial.md.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-local
+  labels:
+    app: api-local
+spec:
+  # One (or more) per prod ingest node — set to your prepared-node count (the capacity plan
+  # recommends 3–4). podAntiAffinity below spreads replicas across the labelled nodes.
+  replicas: 4
+  selector:
+    matchLabels:
+      app: api-local
+  template:
+    metadata:
+      labels:
+        app: api-local
+    spec:
+      nodeSelector:
+        s3-prod-local-ingest: "true"
+      affinity:
+        # Belt-and-suspenders with the nodeSelector label: even a mislabeled node
+        # can't host ingest unless its hostname is ALSO on this allow-list. Keep in
+        # sync with ingest-node-labels-production.yaml (the label list).
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      # PLACEHOLDER — the prod ingest nodes (repurposed local NVMe mounted at
+                      # /var/lib/hippius/local_ingest_prod + labeled s3-prod-local-ingest=true).
+                      # Keep in sync with ingest-node-labels-production.yaml + the drain-agent
+                      # DaemonSet. DISJOINT from staging's node2/node3. See s3-2.1-todo.md.
+                      - REPLACE-prod-ingest-node-a
+                      - REPLACE-prod-ingest-node-b
+                      - REPLACE-prod-ingest-node-c
+                      - REPLACE-prod-ingest-node-d
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: api-local
+                topologyKey: kubernetes.io/hostname
+      initContainers:
+        - name: wait-for-postgres
+          image: postgres:15
+          command:
+            - sh
+            - -c
+            - until pg_isready -h postgres-nvme-rw -p 5432 -U postgres; do echo waiting for postgres; sleep 5; done
+        - name: prepare-ingest-dir
+          image: busybox
+          command:
+            - sh
+            - -c
+            - mkdir -p /var/lib/hippius/local_object_cache && chmod 0777 /var/lib/hippius/local_object_cache
+          volumeMounts:
+            - name: local-ingest
+              mountPath: /var/lib/hippius/local_object_cache
+      containers:
+        - name: api
+          image: ghcr.io/thenervelab/hippius-s3/api:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - configMapRef:
+                name: hippius-s3-defaults
+            - configMapRef:
+                name: hippius-s3-environment
+            - secretRef:
+                name: hippius-s3-secrets
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment=$(ENVIRONMENT),service.namespace=$(K8S_NAMESPACE),service.instance.id=$(POD_NAME)"
+            - name: HIPPIUS_OBJECT_CACHE_DIR
+              value: /var/lib/hippius/local_object_cache
+            - name: HIPPIUS_OBJECT_CACHE_FALLBACK_DIR
+              value: /var/lib/hippius/object_cache
+          volumeMounts:
+            - name: local-ingest
+              mountPath: /var/lib/hippius/local_object_cache
+            - name: object-cache
+              mountPath: /var/lib/hippius/object_cache
+              readOnly: true
+            - name: persist
+              mountPath: /var/lib/hippius/persist
+            - name: dlq
+              mountPath: /tmp/hippius_dlq
+            - name: kms-certs
+              mountPath: /kms_certs
+              readOnly: true
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 120
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 20
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2Gi
+            limits:
+              cpu: 4000m
+              memory: 8Gi
+      volumes:
+        - name: local-ingest
+          hostPath:
+            # PLACEHOLDER PATH — the mount point of the repurposed local NVMe on each ingest node
+            # (see s3-2.1-todo.md → "Prod logistics"). type: Directory (not DirectoryOrCreate):
+            # if the NVMe is not mounted the pod won't start, rather than staging uploads onto the
+            # node root disk. The prepare-ingest-dir initContainer creates the subdir on the mount.
+            path: /var/lib/hippius/local_ingest_prod
+            type: Directory
+        - name: object-cache
+          persistentVolumeClaim:
+            claimName: object-cache-pvc
+        - name: persist
+          persistentVolumeClaim:
+            claimName: persist-pvc
+        - name: dlq
+          persistentVolumeClaim:
+            claimName: dlq-pvc
+        - name: kms-certs
+          secret:
+            secretName: ovh-kms-certs
+            defaultMode: 0400

--- a/k8s/production/drain-agent-daemonset.yaml
+++ b/k8s/production/drain-agent-daemonset.yaml
@@ -1,0 +1,256 @@
+# The hippius-drain agent: the per-node drain daemon.
+# One pod per ingest node, draining that node's local-SSD ingest dir to
+# the shared CephFS pool, path-preservingly per the api part layout
+# (<object_id>/v<version>/part_<n>/). The reconciler is the sole trigger — it scans the
+# SSD for complete parts (a meta.json marker) with no replication row and records them,
+# so the api needs no change.
+#
+# == Node alignment ==
+# Selects the SAME node label `s3-prod-local-ingest=true` as the api-local
+# Deployment (the one list lives in ingest-node-labels-production.yaml), so a DaemonSet
+# runs exactly one drain pod per node an api pod can land on — in lockstep, no
+# duplicated hostname list to drift, and off the cache/psql/master nodes.
+#
+# == Volumes ==
+#  * SSD source: the SAME hostPath the api pods write to,
+#    /var/lib/hippius/local_ingest_prod (the `_staging` suffix keeps it disjoint
+#    from prod on a shared node). RW so the agent can unlink a part after a verified,
+#    committed pool copy.
+#  * CephFS pool: object-cache-pvc — ReadWriteMany ceph-filesystem, mounted RW (the api
+#    pods mount it read-only; the agent is the writer into ceph).
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: drain-agent
+  labels:
+    app: drain-agent
+spec:
+  selector:
+    matchLabels:
+      app: drain-agent
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: drain-agent
+    spec:
+      # Same label as api-local — keeps them in lockstep (see header).
+      nodeSelector:
+        s3-prod-local-ingest: "true"
+      affinity:
+        # Belt-and-suspenders with the nodeSelector label, identical to api-local's
+        # allow-list: a drain-agent only runs where an api-local pod can land. Keep in
+        # sync with ingest-node-labels-production.yaml + api-local-deployments-production.yaml.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      # PLACEHOLDER — replace with the prod ingest nodes you prepared: each must
+                      # have a repurposed local NVMe mounted at /var/lib/hippius/local_ingest_prod
+                      # and be labeled s3-prod-local-ingest=true. Keep this list in sync with
+                      # ingest-node-labels-production.yaml + api-local-deployments-production.yaml.
+                      # MUST be DISJOINT from staging's ingest set (node2/node3) on this shared
+                      # cluster. See s3-2.1-todo.md → "Prod logistics" for the prep runbook.
+                      - REPLACE-prod-ingest-node-a
+                      - REPLACE-prod-ingest-node-b
+                      - REPLACE-prod-ingest-node-c
+                      - REPLACE-prod-ingest-node-d
+      # > the agent's shutdown grace (CEPHOR_GRACE_SECS default 30s): a burst winds
+      # down before the kubelet force-kills, so no in-flight part is stranded draining.
+      terminationGracePeriodSeconds: 40
+      initContainers:
+        - name: prepare-ingest-dir
+          image: busybox
+          command:
+            - sh
+            - -c
+            - mkdir -p /var/lib/hippius/local_object_cache && chmod 0777 /var/lib/hippius/local_object_cache
+          volumeMounts:
+            - name: local-ingest
+              mountPath: /var/lib/hippius/local_object_cache
+        # Block until the allocator has provisioned the cephor_* schema (it owns the
+        # migrations). Without this gate a fresh-namespace `apply` lets the agent start
+        # against missing tables and CrashLoop until the allocator catches up. Strengthens
+        # mpu-reaper's port-check to an actual schema check (to_regclass is NULL, not an
+        # error, for an absent table).
+        - name: wait-for-cephor-schema
+          image: postgres:16-alpine
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres-nvme-rw -p 5432; do echo "waiting for postgres"; sleep 3; done
+              until [ "$(psql "$CEPHOR_DATABASE_URL" -tAc "SELECT to_regclass('public.cephor_replication_status') IS NOT NULL")" = "t" ]; do
+                echo "waiting for the cephor schema (allocator migration)"; sleep 3
+              done
+          env:
+            - name: CEPHOR_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: DATABASE_URL
+      containers:
+        - name: agent
+          image: ghcr.io/thenervelab/hippius-s3/drain:latest
+          imagePullPolicy: Always
+          command: ["/usr/local/bin/hippius-drain-agent"]
+          env:
+            # NodeId keys this node's heartbeat in the fleet; the k8s node name is
+            # stable and unique per node.
+            - name: CEPHOR_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # Reuse the api's DATABASE_URL secret (cephor_* tables share the `hippius` DB).
+            - name: CEPHOR_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: DATABASE_URL
+            # Source (node-local SSD ingest) and destination (shared ceph pool) —
+            # mounted at the same paths the api uses, so the relative part dirs line up.
+            - name: CEPHOR_SSD_ROOT
+              value: /var/lib/hippius/local_object_cache
+            - name: CEPHOR_POOL_ROOT
+              value: /var/lib/hippius/object_cache
+            # The drain is the sole upload producer (s3-2.1 drain-direct): once a part is
+            # replicated to ceph it pushes an UploadChainRequest to {backend}_upload_requests
+            # for each configured backend. Reuse the api's queue-Redis + upload-backend list.
+            - name: REDIS_QUEUES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: REDIS_QUEUES_URL
+            # Sourced from the shared secret (like every Python worker), NOT a literal:
+            # the drain is the sole upload producer, so if a backup backend is added to the
+            # secret the drain must fan out to it too — a hardcoded "arion" would silently
+            # under-replicate (never enqueue the new backend, so the janitor replication gate
+            # never clears -> unbounded cache growth).
+            - name: HIPPIUS_UPLOAD_BACKENDS
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_UPLOAD_BACKENDS
+            # SSD-ingest reclaim worker: clean up broken/abandoned uploads (failed parts
+            # the drain skips forever) + orphan write-temps, once aged, so abandoned-upload
+            # junk does not accumulate on the node-local disk. Both have safe code defaults
+            # (300s poll / 1h grace); set here for visibility + per-node tuning.
+            - name: CEPHOR_RECLAIM_POLL_SECS
+              value: "300"
+            - name: CEPHOR_RECLAIM_GRACE_SECS
+              value: "3600"
+            # Max parts drained concurrently — the in-flight gate that lets the node
+            # overlap fsync latency across parts (the AIMD allocator only tunes bytes/s).
+            # Safe code default (4); set here for per-node tuning.
+            - name: CEPHOR_DRAIN_CONCURRENCY
+              value: "16"    # was 4 — overlap more per-part commit fsyncs (the drain is
+                             # commit-bound on the ceph-backed Postgres, ~0.68 parts/s at 4);
+                             # more concurrency is the main lever until the status DB moves off
+                             # ceph-backed storage. See drainer-optimisations.md.
+            # Replication-lag tuning (measured 2026-07-02: p50 4.6s / p99 5.9s under the old 5s
+            # poll). The lag was NOT the drain budget (unpinned to ~1 GB/s by the target_p99 fix)
+            # — it was the poll floor. Lower ONLY the poll:
+            #   the claim query is a partial-index (node_id, landed_at) WHERE status='pending'
+            #   lookup, so 1s polling scans only the small active-pending set, not the ~94M-row
+            #   parts table — unconditionally cheap even at prod scale.
+            # CEPHOR_DEFER_BACKOFF_SECS is deliberately left at its 5s code default: a
+            # not-yet-drainable part (MPU whose Complete hasn't written object_versions.address,
+            # or a stuck A21 orphan) re-parks for that long, so lowering it to 1s would make those
+            # parts retry the claim 5x more often — pure churn at prod cardinality with the A21
+            # orphan leak unfixed. It only affects the tail (MPU parts already wait for Complete),
+            # not the common simple-PUT case the poll cut covers.
+            - name: CEPHOR_DRAIN_POLL_SECS
+              value: "1"
+            # Reconciler scan period (was the 60s code default). The reconciler is the SOLE
+            # drain trigger — a freshly-landed part is invisible until the next scan records its
+            # `pending` row — so this interval, not the 1s drain poll, is the dominant, jittery
+            # replication-sync tail (0–60s at the old default; ~30s avg). 15s cuts it to ~7.5s avg.
+            # Safe to lower: a scan is a walk of the node-local SSD ingest tree (undrained parts
+            # only — drained parts are unlinked; the Ceph pool and the 94M-row parts table are
+            # never walked) + ONE batched UNNEST status read. record_landed writes fire only for
+            # genuinely-new parts (a known part is seen as already_pending and skipped), so a
+            # faster poll adds NO extra write load — just the cheap walk + one read, jittered per
+            # node. The real fix (an api landing fast-path + mtime-incremental scan) collapses
+            # this to ~1s; 15s is the zero-code interim. See drainer-optimisations.md Tier 1.
+            - name: CEPHOR_RECONCILE_POLL_SECS
+              value: "15"
+            - name: RUST_LOG
+              value: "info"
+            # OTLP metrics -> otel-collector -> Prometheus -> Grafana (feature `otel`, on by
+            # default). The collector turns these resource attrs into Prometheus labels; the
+            # dashboard's var-namespace filters on service_namespace, so drain_* series land
+            # under the staging namespace. Mirrors the janitor deployment's env.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ENVIRONMENT
+              value: "production"
+            - name: ENABLE_MONITORING
+              value: "true"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector:4317"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment=$(ENVIRONMENT),service.namespace=$(K8S_NAMESPACE),service.instance.id=$(POD_NAME)"
+          volumeMounts:
+            - name: local-ingest
+              mountPath: /var/lib/hippius/local_object_cache
+            - name: object-cache
+              mountPath: /var/lib/hippius/object_cache
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          # The agent touches this file each heartbeat tick (~10s); a stale file means a
+          # wedged (not crashed) runtime — e.g. a broken redis ConnectionManager — so k8s
+          # restarts the pod. The agent is the sole upload producer, so a silent hang would
+          # otherwise stop this node's uploads with no recovery.
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - 'f=/tmp/hippius-drain-agent.alive; test -f "$f" && [ $(( $(date +%s) - $(stat -c %Y "$f") )) -lt 40 ]'
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          # C8: NotReady when the drain is WEDGED — a hung CephFS write stalls draining while
+          # liveness (process-alive) stays fresh. The agent touches this file only while the drain
+          # is PROGRESSING (or idle); a wedged loop lets it go stale. Unlike liveness this does NOT
+          # restart the pod (a wedge is not a crash) — it marks the node NotReady so a rolling
+          # update does not step over stuck nodes and the wedge surfaces in pod status.
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - 'f=/tmp/hippius-drain-agent.ready; test -f "$f" && [ $(( $(date +%s) - $(stat -c %Y "$f") )) -lt 45 ]'
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: local-ingest
+          hostPath:
+            # PLACEHOLDER PATH — this MUST be the mount point of the repurposed local NVMe on
+            # each ingest node (see s3-2.1-todo.md → "Prod logistics"). type: Directory (NOT
+            # DirectoryOrCreate as on staging) is deliberate: if the NVMe is not mounted here the
+            # pod stays ContainerCreating instead of silently writing the ingest churn onto the
+            # node root disk and filling it. Prep the node (mount + label) before scheduling here.
+            path: /var/lib/hippius/local_ingest_prod
+            type: Directory
+        - name: object-cache
+          persistentVolumeClaim:
+            claimName: object-cache-pvc

--- a/k8s/production/drain-allocator-deployment.yaml
+++ b/k8s/production/drain-allocator-deployment.yaml
@@ -1,0 +1,116 @@
+# The hippius-drain allocator: the singleton, leader-elected budget allocator.
+#
+# One replica. The allocator does NOT need the SSD/CephFS mounts — it only reads the
+# fleet's heartbeats and writes per-node write-budgets. Leadership, heartbeats, and
+# budgets are TTL-keyed in redis-queues (epoch-fenced via Lua), NOT Postgres, so the
+# ~2s leader tick never touches the WAL. It is still the schema owner: on startup it
+# applies the hippius-drain-core migrations (the durable cephor_* tables) before
+# contending for leadership, so the agents come up against a ready schema
+# (allocator-first deploy). A Redis leader-lease (monotonic epoch) fences any accidental
+# second instance, so even a brief rollout overlap allocates from exactly one leader.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: drain-allocator
+  labels:
+    app: drain-allocator
+spec:
+  replicas: 1
+  # One leader at a time: never run an old and a new allocator pod concurrently.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: drain-allocator
+  template:
+    metadata:
+      labels:
+        app: drain-allocator
+    spec:
+      # > the allocator tick + lease-relinquish on SIGTERM (graceful handoff).
+      terminationGracePeriodSeconds: 40
+      containers:
+        - name: allocator
+          image: ghcr.io/thenervelab/hippius-s3/drain:latest
+          imagePullPolicy: Always
+          command: ["/usr/local/bin/hippius-drain-allocator"]
+          env:
+            # The lease holder id — the pod name makes a restart a distinct holder.
+            - name: CEPHOR_ALLOCATOR_INSTANCE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # Reuse the api's DATABASE_URL secret; the cephor_* tables live in the
+            # same `hippius` database (distinct table names, no collision).
+            - name: CEPHOR_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: DATABASE_URL
+            # Coordination state (leader lease / fleet heartbeats / per-node budgets) lives
+            # here, TTL-keyed — the same redis-queues instance the agents use. Reuse the
+            # api's secret.
+            - name: REDIS_QUEUES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: REDIS_QUEUES_URL
+            - name: RUST_LOG
+              value: "info"
+            # OTLP metrics -> otel-collector -> Prometheus -> Grafana (feature `otel`, on by
+            # default). service_namespace is what the dashboard's var-namespace filters on.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ENVIRONMENT
+              value: "production"
+            - name: ENABLE_MONITORING
+              value: "true"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector:4317"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment=$(ENVIRONMENT),service.namespace=$(K8S_NAMESPACE),service.instance.id=$(POD_NAME)"
+            # AIMD write-budget tuning (2026-07-14). The former defaults deadlocked the
+            # drain: target_p99=2000ms is compared against a WHOLE-part copy+fsync+verify,
+            # which for a 64 MiB part needs >=~41 MB/s/node to stay under 2s — so any dip
+            # collapsed the budget to the 1 MB/s min_total floor, and at 0.5 MB/s/node a
+            # 64 MiB part takes ~130s, keeping p99 above target permanently (self-reinforcing).
+            # Measured live: budget pinned at 1 MB/s, drain fully stalled. Raising the floor
+            # above the stability threshold and the p99 target above the real per-part copy
+            # time lets the AIMD ramp back up (validated live: budget 0.5 -> 100 MB/s, drain
+            # resumed). See drainer-optimisations.md.
+            - name: CEPHOR_ALLOC_MIN_TOTAL_BPS
+              value: "50000000"    # 50 MB/s floor (was 1 MB/s) — above the collapse threshold
+            - name: CEPHOR_ALLOC_TARGET_P99_MS
+              value: "8000"        # 8s (was 2s) — headroom over per-part copy under load
+            # Live ceph-mgr ceiling probe. Left unset for first bring-up so the
+            # allocator uses its static ceiling; enable once cross-namespace reach to
+            # rook-ceph is confirmed:
+            # - name: CEPHOR_CEPH_MGR_METRICS_URL
+            #   value: "http://rook-ceph-mgr.rook-ceph.svc:9283/metrics"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          # The allocator touches this file each tick (~2s); a stale file means a wedged
+          # (not crashed) tick loop — e.g. blocked on a hung Redis — so k8s restarts it. A
+          # hung leader stops refreshing per-node budgets and the whole fleet decays to
+          # floor, so a silent hang must not persist. initialDelay covers startup migrations.
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - 'f=/tmp/hippius-drain-allocator.alive; test -f "$f" && [ $(( $(date +%s) - $(stat -c %Y "$f") )) -lt 30 ]'
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/k8s/production/ingest-node-labels-production.yaml
+++ b/k8s/production/ingest-node-labels-production.yaml
@@ -1,0 +1,52 @@
+# Declarative source of truth for the PROD local-ingest node set.
+#
+# This is the ONE list. `kubectl apply -k k8s/production` applies the
+# `s3-prod-local-ingest=true` label to these nodes; the api-local Deployment and the
+# drain-agent DaemonSet both select on that label, so they stay in lockstep. Both ALSO
+# carry a required nodeAffinity hostname allow-list — keep it in sync with the stanzas
+# below (edit the Node names here AND both allow-lists together).
+#
+# SHARED CLUSTER: staging and prod run on the same physical nodes, so their ingest sets
+# MUST be DISJOINT. Staging uses `s3-staging-local-ingest` on node2/node3 writing to
+# /var/lib/hippius/local_ingest_staging; prod uses THIS label on DIFFERENT nodes writing
+# to /var/lib/hippius/local_ingest_prod. Never put a prod ingest label on a staging
+# ingest node (or vice-versa).
+#
+# ⚠️ PLACEHOLDERS. The names below are placeholders — replace them with the actual prod
+# ingest nodes you prepared. Preparing a node = repurpose one Ceph OSD's NVMe into a local
+# ingest disk (the cluster's OSD disks are 3.84 TB enterprise NVMe; Ceph is only ~29% full
+# so it can spare a few). Full runbook: s3-2.1-todo.md → "Prod logistics". The capacity
+# plan (s3-prod-drain-capacity-plan.md) recommends 3–4 such nodes.
+#
+# CAVEAT: `apply` adds labels but does not PRUNE them. To retire an ingest node, delete its
+# stanza here AND run: kubectl label node <name> s3-prod-local-ingest-
+#
+# (Partial Node objects: apply merges only metadata.labels, leaving all other node fields
+# untouched. Requires the deploy identity to be able to patch nodes.)
+apiVersion: v1
+kind: Node
+metadata:
+  name: REPLACE-prod-ingest-node-a
+  labels:
+    s3-prod-local-ingest: "true"
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: REPLACE-prod-ingest-node-b
+  labels:
+    s3-prod-local-ingest: "true"
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: REPLACE-prod-ingest-node-c
+  labels:
+    s3-prod-local-ingest: "true"
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: REPLACE-prod-ingest-node-d
+  labels:
+    s3-prod-local-ingest: "true"

--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -11,6 +11,19 @@ resources:
   - gateway-nodeport.yaml
   - pv-local-cache.yaml
   - pvc-local-cache.yaml
+  # --- hippius-drain (s3-2.1) SSD-ingest tier — DELIBERATELY COMMENTED OUT. ---
+  # Do NOT uncomment until the prod ingest nodes are prepared: repurpose one Ceph OSD's
+  # NVMe per node -> mount it at /var/lib/hippius/local_ingest_prod -> label the node
+  # s3-prod-local-ingest=true, and replace the REPLACE-prod-ingest-node-* placeholders in
+  # ingest-node-labels-production.yaml + both nodeAffinity allow-lists. Runbook:
+  # s3-2.1-todo.md -> "Prod logistics"; sizing: s3-prod-drain-capacity-plan.md.
+  # Also uncomment the `drain` image below, and (cutover) scale base `api` to 0 + point the
+  # `api` Service selector at app: api-local, as k8s/staging/kustomization.yaml does.
+  # - ingest-node-labels-production.yaml
+  # - api-local-deployments-production.yaml
+  # - drain-allocator-deployment.yaml   # singleton; owns the cephor_* schema (deploy first)
+  # - drain-agent-daemonset.yaml        # one per labelled ingest node
+  # - mpu-reaper-deployment.yaml
 
 patches:
   - path: namespace-patch.yaml
@@ -30,3 +43,6 @@ images:
     newTag: latest
   - name: ghcr.io/thenervelab/hippius-s3/workers
     newTag: latest
+  # Uncomment with the drain resources above (the allocator + agent use the `drain` image):
+  # - name: ghcr.io/thenervelab/hippius-s3/drain
+  #   newTag: latest

--- a/k8s/production/mpu-reaper-deployment.yaml
+++ b/k8s/production/mpu-reaper-deployment.yaml
@@ -1,0 +1,172 @@
+# The abandoned-multipart-upload reaper: a singleton worker that auto-aborts uploads
+# whose object_versions.address was never written (client crashed / never completed)
+# past HIPPIUS_MPU_STALE_SECONDS, marking their drain replication rows terminal so the
+# per-node drain stops re-copying + re-deferring them fleet-wide. Pure DB + redis-queues
+# work (the node-local SSD is unreachable here — reclaiming those bytes is the orphan
+# GC's job), so a single replica and no object-cache mount. Staging-only for now,
+# alongside the drain-agent DaemonSet that owns cephor_replication_status.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mpu-reaper
+  labels:
+    app: mpu-reaper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mpu-reaper
+  template:
+    metadata:
+      labels:
+        app: mpu-reaper
+        worker-type: mpu-reaper
+    spec:
+      initContainers:
+        - name: wait-for-services
+          image: busybox:1.35
+          command:
+            - sh
+            - -c
+            - until nc -z postgres-nvme-rw 5432 && nc -z redis-queues 6379; do echo waiting for services; sleep 5; done
+        # D1/A18: the reaper writes cephor_replication_status (Rust-owned, NOT in the Python
+        # migrations — the drain allocator owns those tables). The port-check above only proves
+        # postgres is reachable, so on a fresh-namespace `apply` the reaper would start against a
+        # missing table and CrashLoop until the allocator catches up. Gate on the actual schema,
+        # mirroring the drain-agent DaemonSet's initContainer (to_regclass is NULL, not an error,
+        # for an absent table).
+        - name: wait-for-cephor-schema
+          image: postgres:16-alpine
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres-nvme-rw -p 5432; do echo "waiting for postgres"; sleep 3; done
+              until [ "$(psql "$CEPHOR_DATABASE_URL" -tAc "SELECT to_regclass('public.cephor_replication_status') IS NOT NULL")" = "t" ]; do
+                echo "waiting for the cephor schema (allocator migration)"; sleep 3
+              done
+          env:
+            - name: CEPHOR_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: DATABASE_URL
+        # D2: the cephor gate above covers only the Rust-owned schema; the reaper also reads the
+        # Python-migrated object_versions/parts/multipart_uploads. Wait for those migrations too.
+        - name: wait-for-migrations
+          image: ghcr.io/thenervelab/hippius-s3/workers:latest
+          command:
+            - python
+            - scripts/wait_for_migrations.py
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: DATABASE_URL
+      containers:
+        - name: mpu-reaper
+          image: ghcr.io/thenervelab/hippius-s3/workers:latest
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: hippius-s3-defaults
+            - configMapRef:
+                name: hippius-s3-environment
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment=$(ENVIRONMENT),service.namespace=$(K8S_NAMESPACE),service.instance.id=$(POD_NAME)"
+            - name: OTEL_SERVICE_NAME
+              value: "hippius-s3-mpu-reaper"
+            - name: WORKER_SCRIPT
+              value: "workers/run_mpu_reaper_in_loop.py"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: DATABASE_URL
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: REDIS_URL
+            - name: REDIS_QUEUES_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: REDIS_QUEUES_URL
+            - name: HIPPIUS_SERVICE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_SERVICE_KEY
+            - name: ARION_SERVICE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: ARION_SERVICE_KEY
+            - name: ARION_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: ARION_BEARER_TOKEN
+            - name: HIPPIUS_AUTH_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_AUTH_ENCRYPTION_KEY
+            - name: FRONTEND_HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: FRONTEND_HMAC_SECRET
+            - name: DISCORD_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: DISCORD_WEBHOOK_URL
+            - name: HIPPIUS_OVH_KMS_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_OVH_KMS_ENDPOINT
+            - name: HIPPIUS_OVH_KMS_DEFAULT_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_OVH_KMS_DEFAULT_KEY_ID
+            - name: HIPPIUS_OVH_KMS_OKMS_ID
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_OVH_KMS_OKMS_ID
+            - name: HIPPIUS_UPLOAD_BACKENDS
+              valueFrom:
+                secretKeyRef:
+                  name: hippius-s3-secrets
+                  key: HIPPIUS_UPLOAD_BACKENDS
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "test -d /proc/1 && grep -q python /proc/1/cmdline"
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/s3-2.1-todo.md
+++ b/s3-2.1-todo.md
@@ -215,3 +215,68 @@ logical-decode slot vs log-tail + keep polling.
 [*edge] **Edge auto-caching.** EC-1 must authorize *every* request including cache hits and demote visibility to
 `private, no-store` on egress; verify on staging before EC-2/EC-3. Future: edge-validated signed tokens/URLs if per-hit
 auth costs too much.
+
+---
+
+# PROD LOGISTICS — provisioning the SSD-ingest tier on the existing cluster
+
+Full analysis + formulas + references live in **`s3-prod-drain-capacity-plan.md`**. Manifests are in
+**`k8s/production/`** (created here, **commented out** in `kustomization.yaml` until nodes are prepped).
+
+### Sizing (measured from prod `object_versions` + Loki, NOT the metrics — those are inflated pre-#265)
+- Real ingest: **avg 32 MB/s, peak-5min 470 MB/s, peak-1min 573 MB/s, ~2.5 TB/day (peak day 5.2 TB)**;
+  objects avg 21/s, peak 150/s; **bimodal** — 91% of objects <64 KB, 92% of bytes are 1–10 MB.
+- Verdict: **light on bytes, heavy on count, very bursty (~18×).** Binding constraint = **drain
+  throughput**; SSD is sized for **endurance/headroom**, not capacity (resident backlog ~10–25 GB).
+- **Recommendation: 3–4 ingest nodes**, each `api-local` + `drain-agent`, with **1–2 TB
+  write-intensive NVMe (≥3 DWPD)**. Drainers are a DaemonSet on those nodes — no separate hosts.
+
+### No new hardware needed — repurpose a Ceph OSD disk
+The cluster's worker nodes (`node1–5`) each have **6 × 3.84 TB enterprise NVMe, all Ceph OSDs**
+(`rook-ceph` is `useAllDevices:true` → no free spare). **Ceph is only ~29% used (75 TiB free)**, so we
+pull **one OSD per chosen node** and hand that 3.84 TB NVMe to local ingest. Cost: ~5 TiB of unused Ceph
+usable capacity for 4 nodes; Ceph stays ~33% used. Pick nodes **disjoint from staging's ingest set**
+(staging = `node2/node3`); `node1` is at its pod cap (skip it); `node6-cache` has no OSDs but is a single
+shared cache node. Candidates: **node4, node5 + two of node1/2/3** (mind the staging overlap + node1 cap).
+
+### ⚠️ TL;DR — how to create the ingest paths (per chosen node, ONE at a time)
+```bash
+TB=deploy/rook-ceph-tools; OSD=<id-on-this-node>; DEV=<nvmeXn1 of that OSD>; NODE=<k8s node name>
+# 0. FIRST exclude the disk in the CephCluster CR (deviceFilter / explicit devices, or
+#    useAllDevices:false) so rook does NOT re-adopt it after wipe. (The one real gotcha.)
+kubectl -n rook-ceph exec $TB -- ceph osd out $OSD                 # drain the OSD
+kubectl -n rook-ceph exec $TB -- ceph -s                          # WAIT: active+clean / HEALTH_OK
+kubectl -n rook-ceph scale deploy rook-ceph-osd-$OSD --replicas=0
+kubectl -n rook-ceph exec $TB -- ceph osd purge $OSD --yes-i-really-mean-it
+# on the NODE (privileged debug pod / node shell):
+wipefs -a /dev/$DEV && mkfs.xfs -f /dev/$DEV
+mkdir -p /var/lib/hippius/local_ingest_prod
+# persist the mount (fstab or a systemd .mount unit), noatime:
+echo "/dev/$DEV /var/lib/hippius/local_ingest_prod xfs defaults,noatime 0 0" >> /etc/fstab && mount -a
+# label the node so api-local + drain-agent schedule here:
+kubectl label node $NODE s3-prod-local-ingest=true
+```
+The manifests use `hostPath type: Directory` (not `DirectoryOrCreate`) at
+`/var/lib/hippius/local_ingest_prod` **on purpose**: if the NVMe isn't mounted there the pod won't start,
+rather than silently staging uploads onto the node root disk and filling it.
+
+### Deploy (after ≥1 node is prepped)
+1. Edit `k8s/production/ingest-node-labels-production.yaml` + BOTH nodeAffinity allow-lists
+   (`drain-agent-daemonset.yaml`, `api-local-deployments-production.yaml`) — replace the four
+   `REPLACE-prod-ingest-node-*` placeholders with the real node names; set `api-local` `replicas` to the
+   node count.
+2. Uncomment the drain block **and** the `drain` image in `k8s/production/kustomization.yaml`.
+3. Follow the standard deploy order ([*deployorder]): migrations → allocator (owns `cephor_*` schema,
+   deploy first) → api-local + agent + reaper. The prod app image must be **≥ #265** (metrics fix; see
+   PR #284) so the OTel metrics are trustworthy again.
+4. **Cutover routing** (as `k8s/staging/kustomization.yaml` does): scale the base ceph `api` to 0 and
+   patch the `api` Service selector to `app: api-local`, so the gateway routes through the ingest tier.
+   Rollback = revert (re-point the Service + scale base api back up); acked bytes on SSD are never lost
+   (the janitor never evicts an un-replicated chunk).
+
+### Prod deltas already baked into `k8s/production/*` (vs the staging copies)
+`s3-prod-local-ingest` label · `/var/lib/hippius/local_ingest_prod` path · `postgres-nvme-rw` (prod's NVMe
+PG) · `ENVIRONMENT=production` · `hostPath type: Directory` · placeholder node allow-lists · the tuned
+drain knobs carried over (AIMD floor 50 MB/s / target 8 s, `DRAIN_CONCURRENCY=16`, `RECONCILE_POLL=15`,
+`DRAIN_POLL=1`). Consider raising `CEPHOR_MAX_DRAIN_RATE_BPS` (default 100 MB/s/node) toward 150–200 if
+going with only 3 nodes — validate against the Ceph pool first.

--- a/s3-prod-drain-capacity-plan.md
+++ b/s3-prod-drain-capacity-plan.md
@@ -1,0 +1,296 @@
+# hippius-s3 prod — SSD-drain architecture capacity plan
+
+**Question:** to run the staging "SSD-draining cache" S3 stack in `hippius-s3-prod`, how many
+API/ingest nodes with local NVMe do we need, and how big should the SSDs be, to keep up with
+daily traffic + bursts?
+
+**Answer (TL;DR):** the workload is **light on bytes, heavy on object count, and very bursty**
+(~18× peak/avg). It is trivially served on CPU/RAM; the only real sizing levers are (1) enough
+**drain throughput** to clear the sustained peak, and (2) an SSD sized for **endurance**, not
+capacity (the resident backlog is ~10–25 GB, but you write 2.5–5 TB/day of churn to it).
+
+> **Recommendation:** **3–4 ingest nodes**, each running `api-local` + a `drain-agent`, pinned by
+> a `s3-prod-local-ingest=true` label, with **1–2 TB write-intensive NVMe (≥3 DWPD)** local disk.
+> 4 nodes at the default 100 MB/s/node drain budget = 400 MB/s fleet (covers the p99 sustained
+> peak with headroom, N+1 redundancy, and absorbs the rare 470–573 MB/s bursts on the SSD).
+> 3 nodes work if you raise `CEPHOR_MAX_DRAIN_RATE_BPS` to ~150–200 MB/s/node (validate against
+> the Ceph pool first). Drainers are a DaemonSet on those same nodes — **no separate drain hosts.**
+
+---
+
+## 1. Measured demand (ground truth)
+
+⚠️ **The OTel byte/op metrics are NOT usable on prod today.** `rate(s3_operations_total{...put_object})`
+reads **~30,700 put/s** and `s3_bytes_uploaded_total` reads **~13 GB/s** — vs a true **~53 ops/s**
+and **~32 MB/s**. Prod runs a pre-#265 image (`api:07b1fb1`); every uvicorn worker shares one
+`service.instance.id`, so N cumulative counters collide in one collector slot and each scrape reads
+as a counter reset → ~100–650× inflated rates (see the incident behind PR #265, and PR #284 for a
+residual 2× double-count). **All numbers below come from ground truth instead:** the
+`object_versions` table (authoritative bytes/objects) and the gateway audit log in Loki
+(authoritative request rate).
+
+Measured over **2026-07-12 → 07-19** (`object_versions.size_bytes` by `created_at`):
+
+| Metric | Value |
+|---|---|
+| Daily ingest | **1.3 – 5.2 TB/day** (peak day 07-13 = 5.2 TB; typical 2–3 TB) |
+| Avg ingest rate | **31.8 MB/s** (≈ 2.7 TB/day) |
+| Peak 5-min sustained | **470 MB/s** (p99 = 257 MB/s) |
+| Peak 1-min burst | **573 MB/s** (p99 = 284, p99.9 = 494 MB/s) |
+| Burstiness (peak/avg) | **~15× (5-min), ~18× (1-min)** |
+| Object create rate | avg **21/s**, peak-hour 61/s, **peak-1-min 150/s** |
+| Request mix (Loki) | PUT 18/s, GET 13.5/s, HEAD 22.5/s, DELETE 0.9/s |
+| Current API CPU | **< 1 core total** across all 5 pods (75–202 mCPU each) |
+| Reads (GET+HEAD) | light; served from the Ceph pool, **not** the local SSD ingest |
+
+### Workload shape — bimodal, and it matters
+
+| Size band | % of object **count** | % of **bytes** |
+|---|---|---|
+| < 64 KB | **91 %** | 0.3 % |
+| 64 KB – 1 MB | 4 % | 1.3 % |
+| **1 – 10 MB** | 5 % | **92 %** |
+| > 10 MB | 0.1 % | 6 % (max seen 50 MB) |
+
+p50 object = **496 bytes**, avg ≈ 116 KB–1.5 MB, p99 = 2 MB. This is an M365 mail-backup pattern
+(`tora-m365/.../*.enc`): a flood of tiny manifests (drives **op/DB/part rate**) plus a smaller
+population of 1–10 MB blobs (drives **SSD byte throughput**). **Neither dimension is large**, but
+they stress different resources, so size for both.
+
+---
+
+## 2. How the drain architecture consumes this (the supply side)
+
+Per the staging design (`crates/hippius-drain-*`, `k8s/staging/drain-*`):
+
+- A client PUT lands on `api-local`, which writes the encrypted, chunked object to the **node-local
+  SSD** (`/var/lib/hippius/local_ingest_*`) and returns 200. The SSD therefore holds only the
+  **not-yet-drained** working set.
+- A **`drain-agent`** (DaemonSet, one per ingest node) copies each complete part SSD → CephFS pool,
+  commits `replicated` to `cephor_replication_status`, enqueues the backend upload, and unlinks the
+  SSD copy. The singleton **`drain-allocator`** hands each node an AIMD write-budget; the
+  **`mpu-reaper`** cleans abandoned MPUs.
+- **Two throughput ceilings:** the AIMD **byte budget** (`CEPHOR_MAX_DRAIN_RATE_BPS`, default
+  **100 MB/s/node**) and the per-part **commit** (`mark_replicated` = a WAL fsync on the app
+  Postgres). On staging (Ceph-backed PG) this was commit-bound at ~0.68 parts/s; **prod's PG is
+  NVMe (`postgres-nvme`)** so the commit is ~ms → the part rate ceiling is hundreds–thousands/s,
+  far above the 150 parts/s peak. **On prod the drain is byte-budget-bound, not commit-bound.**
+
+---
+
+## 3. Sizing model
+
+Formulas (see references): the SSD is a write-back staging buffer; backlog = `max_t(A(t) − D(t))`;
+burst backlog ≈ `(R_in_peak − R_drain) × τ_burst`; **if sustained `R_drain ≥ R_in_sustained`, the
+backlog is bounded and small — otherwise no SSD is big enough.** Size the drain first.
+
+### 3a. Drain fleet (the binding constraint)
+
+Must sustain the **5-min sustained peak** so backlog can't grow unboundedly:
+- p99 5-min = **257 MB/s**; worst 5-min = **470 MB/s**.
+- Target with headroom (keep utilisation ≤ ~65 %, per SRE): `257 / 0.65 ≈ 395 MB/s`, and be able
+  to ride the worst 470 MB/s.
+- At the default **100 MB/s/node** budget → **4 nodes = 400 MB/s** (covers p99 + headroom; the rare
+  470–573 MB/s 1-min bursts are absorbed by the SSD buffer). Or **3 nodes** with the budget raised
+  to ~150–200 MB/s/node (Ceph pool can take it; validate) = 450–600 MB/s.
+
+### 3b. SSD size per node — driven by ENDURANCE, not capacity
+
+**Resident backlog is tiny.** With drain ≈ sustained peak, the SSD only holds the trigger/dwell
+window (reconciler poll 15 s + copy) times the burst rate:
+`573 MB/s × ~45 s ≈ 26 GB total`, spread across nodes ≈ **~10 GB/node**; under the worst 5-min peak
+with a 400 MB/s drain: `(470−400) × 300 s ≈ 21 GB total`. **Round to ~50 GB/node of usable backlog
+even pessimistically.**
+
+**Endurance is the real driver.** Every uploaded byte is written to SSD once, then deleted — a
+high-churn logging pattern. Daily host writes/node (3-node fleet, WAF ≈ 2×):
+- typical `2.7 TB/day ÷ 3 × 2 ≈ 1.8 TB/day/node`; peak-day `5.2 ÷ 3 × 2 ≈ 3.5 TB/day/node`.
+- On a **1 TB** drive → **1.8–3.5 DWPD**; on **2 TB** → **0.9–1.8 DWPD**.
+- 3-yr TBW: peak 3.5 TB/day ⇒ ~3.8 PBW. A **1 TB @ 5 DWPD** (5.5 PBW) or **2 TB @ 3 DWPD**
+  (6.6 PBW) both clear it with margin; a read-intensive/consumer drive (≤1 DWPD) would **not**.
+
+→ **1–2 TB write-intensive enterprise NVMe, ≥3 DWPD (prefer 5).** Capacity is irrelevant (only
+~10–50 GB is ever used); you're buying **endurance + sustained-write bandwidth + burst headroom**.
+
+### 3c. Node count = max of the bounds, + redundancy
+
+| Bound | Requirement | Nodes |
+|---|---|---|
+| Ingress bandwidth | 573 MB/s peak ÷ ~1 GB/s (NVMe write) or 1.25 GB/s (10 GbE) | 1 |
+| **Drain throughput** | ≥ ~400 MB/s (p99 5-min + headroom) @ 100 MB/s/node | **~4** |
+| SSD resident set | ~26 GB total | 1 |
+| Part/commit rate | 150 parts/s ≪ NVMe-PG capacity | 1 |
+| CPU / RAM | < 1 core, ~1.4 GB/pod today | 1 |
+| **Redundancy (N+1)** | survive 1 node down at peak | +1 already folded in |
+
+**Binding bound = drain throughput → 3–4 ingest nodes.** The average load needs *one* node; the
+**bursts + N+1 redundancy** are what justify 3–4.
+
+### Host spec for a new ingest node
+- **CPU:** 16–32 cores (huge headroom vs the <1 core used; covers AES-256-GCM + chunking + reads).
+- **RAM:** 32–64 GB (api pods ~1.5 GB each + streaming buffers + page cache).
+- **Local disk:** **1–2 TB write-intensive NVMe, ≥3 DWPD**, dedicated to `local_ingest_prod`.
+- **NIC:** 10 GbE (peak 573 MB/s ≈ 4.6 Gbps ingress + read egress).
+- (The existing `node1–5` are 96–128 core / 263–395 GB — already ample **if** local NVMe is added.)
+
+---
+
+## 4. Provisioning on kubectl in `hippius-s3-prod`
+
+Mirror the staging manifests (`k8s/staging/drain-*`, `api-local-*`, `ingest-node-labels-*`) into a
+prod overlay. Prod already has `postgres-nvme` (for `cephor_*`), `object-cache-pvc` (CephFS pool),
+and `redis-queues` — the drain reuses all three.
+
+1. **Attach + mount local NVMe** on the 3–4 chosen nodes at `/var/lib/hippius/local_ingest_prod`
+   (a dedicated disk, `xfs`/`ext4`, `noatime`). Prefer a **Local PersistentVolume**
+   (`volumeBindingMode: WaitForFirstConsumer`) or a `hostPath` with an app-level `sizeLimit` — **not**
+   a bare hostPath with no limit (the scheduler ignores its size; a full disk causes node
+   disk-pressure eviction).
+2. **Label the ingest nodes:**
+   ```bash
+   kubectl label node <node> s3-prod-local-ingest=true    # x3–4 nodes
+   ```
+3. **Deploy the drain control plane + agents** (prod copies of the staging YAML, namespace
+   `hippius-s3-prod`, `CEPHOR_DATABASE_URL` → `postgres-nvme`, `CEPHOR_POOL_ROOT` → the CephFS pool,
+   `CEPHOR_SSD_ROOT` → `local_ingest_prod`):
+   ```bash
+   kubectl -n hippius-s3-prod apply -f k8s/production/drain-allocator-deployment.yaml   # singleton
+   kubectl -n hippius-s3-prod apply -f k8s/production/drain-agent-daemonset.yaml         # nodeSelector s3-prod-local-ingest
+   kubectl -n hippius-s3-prod apply -f k8s/production/mpu-reaper-deployment.yaml
+   ```
+   Carry over the tuned knobs already validated on staging (PR #250 + the Tier-2 decouple in #264):
+   `CEPHOR_ALLOC_MIN_TOTAL_BPS=50MB/s`, `CEPHOR_ALLOC_TARGET_P99_MS=8000`,
+   `CEPHOR_DRAIN_CONCURRENCY=16`, `CEPHOR_RECONCILE_POLL_SECS=15`, `CEPHOR_ENQUEUE_POLL_SECS=5`, and
+   **raise `CEPHOR_MAX_DRAIN_RATE_BPS` toward 150–200 MB/s/node** if you go with 3 nodes.
+4. **Deploy `api-local`** pinned to the labelled nodes (nodeSelector `s3-prod-local-ingest=true`),
+   writing to `local_ingest_prod`; keep the classic `api` (Ceph-backed) as fallback during cutover.
+5. **Set the 503 back-pressure below the kubelet eviction threshold** so
+   `fs_cache_pressure_middleware` sheds load (503 + Retry-After) *before* the node evicts pods —
+   with ~50 GB of real use on a 1–2 TB disk this is a non-issue in steady state, but keep the margin.
+6. **Redeploy the API image ≥ #265** (`main` today) as part of cutover so the metrics stop lying
+   (the inflation above is purely the old image; PR #284 removes the residual 2×).
+
+---
+
+## 5. Caveats & what to validate before cutover
+
+- **Drain byte-budget vs Ceph:** the default 100 MB/s/node is a floor; going to 3 nodes needs
+  ~150–200 MB/s/node — load-test the SSD→CephFS copy against the live pool before trusting it.
+- **Node-loss exposure:** a client gets 200 once data is on one node's SSD. If that node dies before
+  the part drains, the undrained bytes are stranded until it recovers (not lost — but not yet on
+  Ceph). Keep the drain fast (it is, on NVMe-PG) and N+1 so a failure is absorbed; the exposure
+  window is seconds.
+- **Growth:** peak day was 5.2 TB (2× the median). If ingest doubles, the model is linear — add a
+  node (drain-bound) rather than bigger SSDs (endurance-bound; bump DWPD/size).
+- **Re-measure after #265/#284 deploy:** once prod runs a fixed image, `s3_bytes_uploaded_total` /
+  `s3_operations_total` become trustworthy and you can drive this off Grafana directly instead of
+  the DB.
+
+---
+
+## 6. Promoting to prod on EXISTING hardware (no new hosts)
+
+We do not need to order hosts. The cluster already has the right disks — they're just all
+inside Ceph. Full inventory of schedulable worker nodes:
+
+| Node | CPU | RAM | Local NVMe | Ceph OSDs | Current role |
+|---|---|---|---|---|---|
+| **k8s-v3-node1** | 96 | 263 GB | 8× NVMe (6 data + 2 OS) | **6 × 3.84 TB** | Ceph |
+| **k8s-v3-node2** | 96 | 263 GB | 8× NVMe | 6 × 3.84 TB | Ceph |
+| **k8s-v3-node3** | 96 | 263 GB | 8× NVMe | 6 × 3.84 TB | Ceph |
+| **k8s-v3-node4** | 128 | 395 GB | 8× NVMe | 6 × 3.84 TB | Ceph |
+| **k8s-v3-node5** | 96 | 263 GB | 8× NVMe | 6 × 3.84 TB | Ceph |
+| k8s-v3-node6-cache | 96 | 197 GB | OS disk only | 0 | api + redis cache |
+| psql-s3-1/2/3 | 12 | 65 GB | — | 0 | Postgres (dedicated) |
+
+- Disks are **enterprise datacenter NVMe, 3.84 TB each** (WD Ultrastar DC SN840 on node1–3/5,
+  Intel/Solidigm D7-P5520 on node4). `bluestore_bdev_type=ssd`, `rotational=0`.
+- **`rook-ceph` is `useAllDevices:true`** → every one of the 6 data NVMe per node is already an OSD;
+  the 2 leftover NVMe (`nvme1n1`/`nvme2n1`) are the OS/boot pair. **There is no free NVMe to grab.**
+- Ceph today: **30 OSDs, 105 TiB raw, 29 % used (30 TiB), 75 TiB free, size=3** (all PGs `active+clean`).
+
+### The move: repurpose one OSD per node into a local-ingest disk
+
+Pick **4 of node1–5** (they're identical; e.g. **node1, node2, node3, node5** — leave node4, the
+fattest, whole). On each, **pull one OSD out of Ceph** and dedicate that 3.84 TB NVMe to
+`local_ingest_prod`. That is 4 × 3.84 TB of enterprise NVMe reclaimed for free — **far more than
+the 1–2 TB target** (only ~20 GB is ever used; the size buys endurance headroom).
+
+**Ceph impact (safe):** 30 → 26 OSDs, raw 105 → ~91 TiB, usable (size 3) 35 → 30 TiB against
+~10 TiB used → **~33 % used**, still far below the 85 % nearfull line. Each removal backfills ~1 TB
+onto the remaining OSDs — **do it one OSD at a time, waiting for `HEALTH_OK` between each.**
+
+**⚠️ Label, don't hard-taint.** These nodes keep running their other 5 OSDs, so a `NoSchedule`/
+`NoExecute` taint would evict the co-located `rook-ceph` OSD pods (and everything else). Use a
+**nodeSelector label** exactly like staging (`s3-prod-local-ingest=true`) to pin `api-local` +
+`drain-agent` there while OSDs keep running. (A hard taint is only appropriate if you fully
+evacuate Ceph from a node — not worth it here, it would remove 6 OSDs at once.)
+
+### Per-node runbook (repeat on each of the 4 chosen nodes, one at a time)
+
+```bash
+# 1. Pick the OSD on this node to sacrifice (from: ceph osd df tree). Say osd.8 on node1.
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd out osd.8
+#    wait for rebalance to finish:
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph -s   # until active+clean, HEALTH_OK
+
+# 2. Stop + purge the OSD (rook: scale its deployment to 0, then purge)
+kubectl -n rook-ceph scale deploy rook-ceph-osd-8 --replicas=0
+kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd purge 8 --yes-i-really-mean-it
+#    remove the OSD from rook's device list so it isn't re-consumed (useAllDevices=true will
+#    otherwise re-adopt the wiped disk!): pin the node's devices explicitly OR set the disk in
+#    the CephCluster `storage.nodes[].devices`/`deviceFilter` to EXCLUDE nvmeXn1. This is the
+#    one gotcha — without it rook re-creates the OSD on the freed disk.
+
+# 3. Wipe the freed disk and mount it for ingest (nvmeXn1 = the purged OSD's device)
+#    (run on the node via a privileged debug pod / node shell)
+wipefs -a /dev/nvmeXn1 && mkfs.xfs -f /dev/nvmeXn1
+mkdir -p /var/lib/hippius/local_ingest_prod
+#    persistent mount (noatime) via /etc/fstab or a systemd mount unit:
+mount -o noatime /dev/nvmeXn1 /var/lib/hippius/local_ingest_prod
+
+# 4. Label the node for the s3 ingest role
+kubectl label node k8s-v3-node1 s3-prod-local-ingest=true
+```
+
+Then deploy the drain stack + `api-local` pinned to `s3-prod-local-ingest=true` (see §4).
+
+**Net for 4 nodes:** reclaim 4 × 3.84 TB dedicated NVMe (endurance to spare), cost Ceph ~5 TiB of
+usable capacity it isn't using, add zero hardware. The chosen nodes then run 5 Ceph OSDs +
+`api-local` + `drain-agent` side-by-side — trivially within their 96–128 cores / 263–395 GB.
+
+### The one real gotcha
+
+`useAllDevices:true` will **re-adopt the wiped disk as a new OSD** unless you first change the
+`CephCluster` CR to exclude that device on that node (`deviceFilter` / explicit `devices` list, or
+`useAllDevices:false` with an enumerated set). Do that **before** wiping, or rook will fight you for
+the disk. This is the only step that needs care; everything else is standard drain/ceph ops.
+
+---
+
+## References
+
+- **Google SRE Book — Capacity Planning / Provisioning** — provision to peak, never 100 %, N+1/N+2:
+  https://sre.google/sre-book/software-engineering-in-sre/ ,
+  https://research.google/pubs/sre-best-practices-for-capacity-management/
+- **Brendan Gregg — USE Method / Thinking Methodically about Performance** — utilisation vs
+  saturation; averages hide sub-minute spikes: https://www.brendangregg.com/usemethod.html ,
+  https://queue.acm.org/detail.cfm?id=2413037
+- **Little's Law for buffer/cache sizing** (`L = λ·W`): https://sookocheff.com/post/modeling/littles-law/
+- **Token/leaky-bucket burst math** (bucket depth = `(fill−leak)·τ`):
+  https://intronetworks.cs.luc.edu/current/html/tokenbucket.html
+- **NERSC / Cray DataWarp burst buffer** — the closest architectural prior art (per-node building
+  block fronting a ~100× slower durable tier):
+  http://www.cs.umd.edu/class/fall2022/cmsc714/Readings/Bhimji-burst-buffer.pdf
+- **Kubernetes Local Persistent Volumes (KEP-121)** — Local PV vs hostPath, ephemerality,
+  `WaitForFirstConsumer`:
+  https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/121-local-persistent-volumes/README.md
+- **GKE local SSD / AKS ephemeral NVMe** — NVMe-backed scratch guidance:
+  https://docs.cloud.google.com/kubernetes-engine/docs/concepts/local-ssd ,
+  https://learn.microsoft.com/en-us/azure/aks/best-practices-storage-nvme
+- **SSD endurance (DWPD / TBW / write amplification)** — why a churn workload needs write-intensive
+  NVMe: https://techcommunity.microsoft.com/blog/filecab/understanding-ssd-endurance-drive-writes-per-day-dwpd-terabytes-written-tbw-and-/426024 ,
+  https://www.atpinc.com/blog/ssd-tbw-dwpd-endurance
+
+*Generated 2026-07-19 from live prod telemetry (object_versions + Loki audit) — metric-derived
+numbers deliberately avoided due to the pre-#265 inflation.*


### PR DESCRIPTION
## Summary

Everything needed to promote the staging SSD-drain architecture to `hippius-s3-prod` — the prod k8s manifests + a measured capacity plan + the ops runbook. **No new hardware required.**

## What's here

**`k8s/production/` drain manifests** (prod copies of the staging stack, wired **commented-out** in `kustomization.yaml` so a routine prod apply doesn't deploy them before nodes are prepped):
- `api-local-deployments-production.yaml`, `drain-agent-daemonset.yaml`, `drain-allocator-deployment.yaml`, `mpu-reaper-deployment.yaml`, `ingest-node-labels-production.yaml`

**Prod deltas vs the staging copies:** `s3-prod-local-ingest` label · `/var/lib/hippius/local_ingest_prod` path · `postgres-nvme-rw` · `ENVIRONMENT=production` · **`hostPath type: Directory`** (fail-loud if the NVMe isn't mounted, instead of staging's `DirectoryOrCreate` that would silently stage uploads onto the node root disk) · placeholder node allow-lists · the tuned drain knobs carried over (AIMD 50 MB/s / 8 s, concurrency 16, reconcile 15 s, drain-poll 1 s).

**`s3-prod-drain-capacity-plan.md`** — sizing from **ground truth** (`object_versions` + Loki audit), because prod's OTel byte/op metrics are ~600× inflated on the pre-#265 image:
- Real ingest: **~2.5 TB/day, avg 32 MB/s, peak-1min 573 MB/s**; bimodal (91% of objects <64 KB, 92% of bytes 1–10 MB); very bursty (~18×). Current API: <1 CPU core total.
- Verdict: **3–4 ingest nodes**, **1–2 TB write-intensive NVMe (≥3 DWPD)**; drain throughput is the binding constraint, SSD is endurance-sized (resident backlog only ~10–25 GB).

**`s3-2.1-todo.md` → "Prod logistics"** — the ops runbook + the path-creation TL;DR.

## The key insight: repurpose, don't buy

`node1–5` each have **6 × 3.84 TB enterprise NVMe, all consumed by Ceph OSDs** (`useAllDevices:true`, no free spare). But **Ceph is only ~29% used (75 TiB free)**, so we **pull one OSD per chosen node** and hand that 3.84 TB NVMe to local ingest — 2–4× bigger than needed, for free. Cost: ~5 TiB of unused Ceph capacity across 4 nodes (Ceph → ~33% used).

## To deploy (not in this PR — needs ops)
1. Prep ≥1 node (pull OSD → mount NVMe at the path → label) per the todo TL;DR.
2. Replace the `REPLACE-prod-ingest-node-*` placeholders in the labels file + both allow-lists; set `api-local` replicas.
3. Uncomment the drain block + `drain` image in `kustomization.yaml`; deploy allocator-first.
4. Ship the app image **≥ #265** (metrics) — see the companion double-count fix PR #284.

**Validation:** all 5 manifests pass `kubectl apply --dry-run=client`; `kubectl kustomize k8s/production` still builds (drain block commented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)