### PR TITLE
fix(read): re-poll the FS while waiting so a drain-landed chunk isn't a 35s hang

### DIFF
--- a/hippius_s3/cache/notifier.py
+++ b/hippius_s3/cache/notifier.py
@@ -25,6 +25,17 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 
 logger = logging.getLogger(__name__)
 
+# How often `wait_for_chunk` re-reads the FS while blocked, INDEPENDENT of pub/sub
+# notifications. A chunk can become readable from a producer that does NOT publish a
+# chunk-ready notification — notably the Rust drain, which lands a part in the CephFS pool
+# (making it readable via the pool fallback) WITHOUT publishing `notify:`. Without this
+# periodic re-read, a reader blocked on a fresh cross-node object waits out the whole caller
+# `timeout` (up to the 90s first-chunk bound → a client-visible ~35s+ hang) even though the
+# chunk is already in the pool. One poll interval bounds that to ~1s. The queues pub/sub
+# client is built without a socket_timeout, so the RedisTimeoutError re-poll path never fires
+# on its own — this tick is the primary FS re-read while waiting.
+_FS_REPOLL_INTERVAL_SECONDS = 1.0
+
 
 class ChunkNotReadyError(Exception):
     """A chunk is still absent after a pub/sub notification woke the waiter.
@@ -137,9 +148,19 @@ class ChunkNotifier:
                 remaining = deadline - loop.time()
                 if remaining <= 0:
                     raise asyncio.TimeoutError(f"timed out waiting for chunk {chunk_key}")
+                # Cap each listen to a short poll so we ALSO re-read the FS on every tick, not
+                # only when a notification arrives — see `_FS_REPOLL_INTERVAL_SECONDS`. This is
+                # what lets a reader pick up a chunk landed by a non-notifying producer (the
+                # drain) within ~1 poll interval instead of blocking to `timeout`.
                 try:
-                    await asyncio.wait_for(_listen(), timeout=remaining)
+                    await asyncio.wait_for(_listen(), timeout=min(_FS_REPOLL_INTERVAL_SECONDS, remaining))
                     break
+                except asyncio.TimeoutError:
+                    # Poll tick (no notification this interval): the chunk may have been landed
+                    # by the drain without a notify:. Re-read; keep waiting up to the deadline.
+                    data = await fetch_fn(object_id, int(object_version), int(part_number), int(chunk_index))
+                    if data is not None:
+                        return data
                 except (RedisTimeoutError, RedisConnectionError) as exc:
                     data = await fetch_fn(object_id, int(object_version), int(part_number), int(chunk_index))
                     if data is not None:

--- a/tests/unit/test_chunk_notifier.py
+++ b/tests/unit/test_chunk_notifier.py
@@ -233,6 +233,50 @@ async def test_wait_survives_transient_redis_read_timeout() -> None:
 
 
 @pytest.mark.asyncio
+async def test_wait_repolls_fs_for_a_chunk_landed_without_notification(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A chunk made readable by a NON-notifying producer must be picked up via the periodic FS
+    re-poll, not block until the caller `timeout`.
+
+    Reproduces the fresh-object cross-node read hang: the Rust drain lands a part in the CephFS
+    pool (readable via the pool fallback) WITHOUT publishing `notify:`, and the queues pub/sub
+    client has no socket read timeout. So no notification ever arrives and the socket-timeout
+    re-poll never fires — the wait is driven purely by the periodic FS re-read. Before the fix
+    (notification-only wait) this blocked the full `timeout` (up to the 90s first-chunk bound →
+    a client-visible ~35s hang) even though the chunk was already in the pool.
+    """
+    import hippius_s3.cache.notifier as notifier_mod
+
+    monkeypatch.setattr(notifier_mod, "_FS_REPOLL_INTERVAL_SECONDS", 0.02)
+
+    redis = FakeRedis()
+    notifier = ChunkNotifier(redis)
+
+    available = False
+
+    async def fetch(oid: str, v: int, pn: int, ci: int) -> bytes | None:
+        return b"drained-copy" if available else None
+
+    async def drain_lands_it_without_notifying() -> None:
+        await asyncio.sleep(0.1)  # the drain copies the part to the pool a bit later
+        nonlocal available
+        available = True
+        # DELIBERATELY no inject_message — the drain does not publish a chunk-ready notification.
+
+    worker = asyncio.create_task(drain_lands_it_without_notifying())
+    loop = asyncio.get_event_loop()
+    t0 = loop.time()
+    # A large timeout: without the re-poll this blocks the full 30s (nothing wakes the waiter),
+    # so returning quickly is the proof the FS re-poll works.
+    result = await notifier.wait_for_chunk(OBJ, 1, 1, 0, fetch_fn=fetch, timeout=30.0)
+    elapsed = loop.time() - t0
+    await worker
+
+    assert result == b"drained-copy"
+    assert elapsed < 2.0, f"re-poll should return ~1 interval after the chunk lands, not block; took {elapsed:.2f}s"
+    assert redis.published == [], "no notification was published — pickup was via the FS re-poll"
+
+
+@pytest.mark.asyncio
 async def test_wait_gives_up_if_retry_also_misses() -> None:
     """If even the retry fails, wait_for_chunk raises RuntimeError."""
     redis = FakeRedis()


### PR DESCRIPTION
## The bug (reproduced live)

Running the stress harness against staging from the EU host, `func-acl-anon` failed. I reproduced it: **1 of 6 immediate-after-write anonymous public-read GETs hung for 35 s** (client ReadTimeout); the other 5 returned 200 in 0.2–0.7 s. Intermittent, but real.

## Root cause

`ChunkNotifier.wait_for_chunk` waits **purely on a pub/sub notification** (`notify:{chunk_key}`), re-reading the FS only on a notification or a Redis socket timeout. Two facts make that a trap for a fresh, cross-node object:

1. **The Rust drain lands a part in the CephFS pool without publishing `notify:`** — it only publishes the backend `UploadChainRequest`. So when the object becomes readable (~1 s after write), nothing wakes a waiting reader.
2. **The downloader does nothing** for it — there's no `chunk_backend` row yet (not uploaded), so it can't fetch/notify either.
3. **The queues pub/sub client is built with `async_redis.from_url(...)` — no `socket_timeout`** (unlike `create_redis_client`'s `socket_timeout=5`), so `pubsub.listen()` blocks indefinitely and the `RedisTimeoutError` re-poll branch never fires.

⇒ The reader blocks until the **90 s first-chunk bound** → `503` — even though the chunk is *already in the pool* ~1 s in. It just never looks again. The client gives up first (the 35 s hang).

## The fix

Cap each `listen()` to a short poll (`_FS_REPOLL_INTERVAL_SECONDS = 1 s`) and **re-read the FS on every tick, independent of notifications**. The reader picks up a drain-landed (or any non-notified) chunk within ~1 poll interval and **serves it** — no hang, no spurious 503. Pub/sub stays an optimization (immediate wake on notification); the FS re-poll is now the reliable path even if no producer notifies.

This is the graceful-retry fix: fresh cross-node reads now succeed in ~1–2 s instead of hanging, which also closes the read-after-write gap that gates the `api`/`api-local` parallel rollout.

## Test

`test_wait_repolls_fs_for_a_chunk_landed_without_notification` — a chunk that becomes readable with **no notification and no socket timeout** must return via the re-poll, not block the full `timeout`. It **fails on the pre-fix** notification-only wait and passes with the fix. All **10 notifier + 128 read-path tests** green; ruff + ty clean.

## Follow-ups (not in this PR)
- The 90 s first-chunk bound now only affects genuinely-missing objects; could be lowered for a faster clean 503 on true misses.
- The drain could publish `notify:` when it lands a part (event-driven wake) — an optimization on top of this reliable re-poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)