### PR TITLE
fix(redis): set prod redis-queues to noeviction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ Five separate services for blast-radius isolation:
 |---|---|---|---|
 | `redis` | 6379 | General cache / short-lived state | Ephemeral |
 | `redis-accounts` | 6380 | Account credit cache | Persistent (AOF) |
-| `redis-queues` | 6382 | Work queues + chunk pub/sub notifications + drain coordination (`cephor:*`) | Persistent, 2GB, **noeviction** (holds queue + coordination data — must not evict; a full instance fails writes loudly) |
+| `redis-queues` | 6382 | Work queues + chunk pub/sub notifications + drain coordination (`cephor:*`) | Persistent, 4GB, **noeviction** (holds queue + coordination data — must not evict; a full instance fails writes loudly. Pod mem limit 6Gi > maxmemory so Redis rejects writes before k8s OOM-kills) |
 | `redis-rate-limiting` | 6383 | Rate limit counters | Ephemeral, 1GB |
 | `redis-acl` | 6384 | ACL cache | Ephemeral, 2GB, LRU |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ Five separate services for blast-radius isolation:
 |---|---|---|---|
 | `redis` | 6379 | General cache / short-lived state | Ephemeral |
 | `redis-accounts` | 6380 | Account credit cache | Persistent (AOF) |
-| `redis-queues` | 6382 | Work queues + chunk pub/sub notifications | Persistent, 2GB, LRU |
+| `redis-queues` | 6382 | Work queues + chunk pub/sub notifications + drain coordination (`cephor:*`) | Persistent, 2GB, **noeviction** (holds queue + coordination data — must not evict; a full instance fails writes loudly) |
 | `redis-rate-limiting` | 6383 | Rate limit counters | Ephemeral, 1GB |
 | `redis-acl` | 6384 | ACL cache | Ephemeral, 2GB, LRU |
 

--- a/k8s/base/redis-statefulsets.yaml
+++ b/k8s/base/redis-statefulsets.yaml
@@ -129,7 +129,7 @@ spec:
           command:
             - redis-server
             - --maxmemory
-            - 2gb
+            - 4gb
             # noeviction (NOT allkeys-lru): redis-queues holds the drain's coordination
             # keys (the cephor:* leader lease + epoch fence) AND the upload work queues.
             # Evicting either is data loss — a reset epoch deadlocks the allocator (drain
@@ -138,6 +138,10 @@ spec:
             # alerted on, not silently drop data. Alert on redis-queues memory usage.
             - --maxmemory-policy
             - noeviction
+            # Pod memory limit (6Gi) is kept above --maxmemory (4gb) so Redis rejects writes
+            # at its own limit FIRST (the intended loud OOM under noeviction); the headroom
+            # absorbs AOF rewrite copy-on-write + client/replication buffers so k8s does not
+            # OOM-kill the pod before Redis can fail writes. Keep limit > maxmemory on any bump.
             - --appendonly
             - "yes"
             - --appendfsync
@@ -168,10 +172,10 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 2Gi
+              memory: 4Gi
             limits:
               cpu: 1000m
-              memory: 4Gi
+              memory: 6Gi
   volumeClaimTemplates:
     - metadata:
         name: redis-data

--- a/k8s/base/redis-statefulsets.yaml
+++ b/k8s/base/redis-statefulsets.yaml
@@ -130,8 +130,14 @@ spec:
             - redis-server
             - --maxmemory
             - 2gb
+            # noeviction (NOT allkeys-lru): redis-queues holds the drain's coordination
+            # keys (the cephor:* leader lease + epoch fence) AND the upload work queues.
+            # Evicting either is data loss — a reset epoch deadlocks the allocator (drain
+            # audit F3), and a dropped UploadChainRequest is a lost upload (the drain is the
+            # sole producer). A genuinely-full queue must fail writes LOUDLY (OOM) so it is
+            # alerted on, not silently drop data. Alert on redis-queues memory usage.
             - --maxmemory-policy
-            - allkeys-lru
+            - noeviction
             - --appendonly
             - "yes"
             - --appendfsync


### PR DESCRIPTION
Cherry-picks `ba7c445` (already on `staging`) onto `k8s-production`.

## Why

Prod `redis-queues-0` is running `allkeys-lru` right now. Measured on the live instance:

- `maxmemory-policy` = `allkeys-lru`
- `evicted_keys` = 3
- `used_memory_peak` = 2,147,502,968 (within ~19 kB of the 2G cap)

That instance holds the upload work queues, the retry ZSET, the DLQs, and the drain's
`cephor:*` leader-lease/epoch keys. Under LRU, Redis may silently evict any of them:
a dropped `UploadChainRequest` is a lost upload (the drain is the sole producer), and a
reset epoch deadlocks the allocator. At the time of measurement the only two resident keys
were the DLQs, holding 393 + 1,519 entries of unrecoverable work.

`ba7c445` fixed this on `staging` on 2026-07-01. It never reached `k8s-production` or `main`,
so production has been running the unfixed policy since.

## Changes

- `k8s/base/redis-statefulsets.yaml` — `redis-queues` `--maxmemory-policy`: `allkeys-lru` → `noeviction`
- `CLAUDE.md` — corrects the redis table row to match

The CLAUDE.md hunk conflicted on cherry-pick because the branches' docs diverged; resolved by
updating only the `redis-queues` row, keeping this branch's table structure.

## Deploy notes

- **Requires a `redis-queues` restart to take effect.** `maxmemory-policy` is not re-read live.
- Separately, the running instance reports `maxmemory` = 3G while the StatefulSet spec says 2gb —
  an out-of-band `CONFIG SET` with `config_file:` empty, so it is not persisted. **A restart
  reverts it to 2G**, which is the level where `used_memory_peak` already sat and where the 3
  evictions occurred. Confirm 2G is enough headroom before restarting, or raise the spec.
- With `noeviction`, a full instance fails writes loudly instead of dropping data. Alerting on
  `redis-queues` memory should land alongside this.