### PR TITLE
chore(config): turn on HIPPIUS_STREAM_SINGLE_SUBSCRIPTION in staging + prod overlays

### DIFF
--- a/k8s/production/environment-patch.yaml
+++ b/k8s/production/environment-patch.yaml
@@ -6,3 +6,8 @@ data:
   ENVIRONMENT: "production"
   OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=hippius-s3-prod"
   SENTRY_DSN: "SENTRY_DSN_PLACEHOLDER"
+  # RQ-1 trial: one pub/sub subscription per stream instead of per-chunk (PR #279).
+  # Only the internal `api` pods read this (streamer/object_reader). No effect until
+  # #279's code lands. Rides to prod on the next staging->k8s-production promotion;
+  # flip to "false" here before promoting if the staging trial regresses.
+  HIPPIUS_STREAM_SINGLE_SUBSCRIPTION: "true"

--- a/k8s/staging/environment-patch.yaml
+++ b/k8s/staging/environment-patch.yaml
@@ -6,3 +6,8 @@ data:
   ENVIRONMENT: "staging"
   OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=staging,service.namespace=hippius-s3-staging"
   SENTRY_DSN: "SENTRY_DSN_PLACEHOLDER"
+  # RQ-1 trial: one pub/sub subscription per stream instead of per-chunk (PR #279).
+  # Only the internal `api` pods read this (streamer/object_reader). No effect until
+  # #279's code lands. Flip to "false" to disable before this promotes to prod if the
+  # staging trial regresses (see the lost fast-fail-503 caveat in the #279 review).
+  HIPPIUS_STREAM_SINGLE_SUBSCRIPTION: "true"


### PR DESCRIPTION
## Summary

Turns the RQ-1 flag **`HIPPIUS_STREAM_SINGLE_SUBSCRIPTION`** on in **both** environment overlays — one pub/sub subscription per read stream instead of one per chunk (cuts subscribe/unsubscribe churn on `redis-queues` for cold multi-chunk reads).

Set in the `hippius-s3-environment` configmap of each overlay:
- `k8s/staging/environment-patch.yaml`
- `k8s/production/environment-patch.yaml`

Both serving fleets load this configmap (`api-local` in staging, base `api` in prod), so the flag reaches the streamer/`object_reader` in each env.

## Rollout / control
- Branched off `staging`: merging enables it on **staging** immediately.
- It **rides to prod** on the next `staging` → `k8s-production` promotion.
- To back out: flip either value to `"false"` before promoting (per-env, independently).

## ⚠️ Dependencies / caveats
- **No runtime effect until PR #279 lands** — that's the code that reads the flag. Merge order: #279 first (dark), then this.
- Known tradeoff when enabled (from the #279 review): the single-subscription path loses the fast-fail **503 SlowDown** for notified-but-missing chunks — that case now polls up to the ~300s stream timeout instead. Validate cold multi-chunk reads + a forced downloader give-up on staging before promoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)