### PR TITLE
feat(prod): pin SSD-ingest tier to node1-5 on the dedicated /s3-data NVMe

### DIFF
--- a/k8s/production/api-local-deployments-production.yaml
+++ b/k8s/production/api-local-deployments-production.yaml
@@ -1,35 +1,31 @@
-# Trial (s3-2.0 prototype): the entire staging api fleet on node-local SSD.
+# PROD api-local fleet: the api on node-local SSD ingest (s3-2.1 drain-direct).
 #
-# A single `api-local` Deployment (2 replicas, one per ingest node) — the base (ceph) `api` deployment
-# is scaled to 0 in resource-limits.yaml, so ALL api pods run on local SSD. Each
-# pod writes to its node's local dir and read-falls-back to the shared CephFS
-# cache. All workers stay on ceph, untouched.
+# One `api-local` Deployment, 5 replicas (one per ingest node, node1..node5). At cutover the
+# base (ceph) `api` deployment scales to 0 and the `api` Service selector points here, so ALL
+# api pods run on local SSD. Each pod writes to its node's /s3-data NVMe and read-falls-back
+# to the shared CephFS pool. Workers run on ceph. The drain-agent DaemonSet (sole upload
+# producer) replicates each node's /s3-data → CephFS and enqueues the backend upload.
 #
-# Volume: a `hostPath` with `type: DirectoryOrCreate` — the kubelet creates the
-# node path on whatever node the pod lands on (NO manual node prep, so this deploys
-# cleanly via CI). A root initContainer chmods it so the api (which may run
-# non-root) can write. This replaces the earlier local-PV approach, which required
-# pre-creating the dir on each node (impossible in CI).
+# Volume: a `hostPath` at /s3-data with `type: Directory` — the dedicated 3.84 TB NVMe is
+# mounted there out-of-band (node prep, not CI). Directory (not DirectoryOrCreate) is the
+# safety latch: if the NVMe isn't mounted the pod won't start, rather than staging uploads
+# onto the node root disk. A root initContainer chmods the mount so the (non-root) api can write.
 #
-# The node path is /var/lib/hippius/local_ingest_STAGING (the `_staging` denominator
-# matters: staging + prod share the cluster, and prod uses /var/lib/hippius/local_ingest_prod
-# — so even if a staging and a prod pod land on the same node, their local disks
-# never collide).
+# staging + prod share nodes node2/node3, but prod uses this dedicated /s3-data disk while
+# staging uses the node-root local_ingest_staging path — different disks, no collision.
 #
-# Scheduling: pinned to nodes labeled `s3-prod-local-ingest=true` (the ONE list
-# lives in ingest-node-labels-production.yaml). The drain-agent DaemonSet selects
-# the SAME label, so they stay in lockstep. Preferred pod anti-affinity spreads the
-# 2 replicas across the labeled nodes. A required nodeAffinity hostname allow-list
-# (node2/node3) is belt-and-suspenders WITH the label: a stray/mislabeled node alone
-# can't place ingest on a psql/cache node — the hostname must ALSO be on the list.
+# Scheduling: pinned to nodes labeled `s3-prod-local-ingest=true` (the ONE list lives in
+# ingest-node-labels-production.yaml). The drain-agent DaemonSet selects the SAME label, so
+# they stay in lockstep. Preferred pod anti-affinity spreads the replicas one-per-node. A
+# required nodeAffinity hostname allow-list (node1..node5) is belt-and-suspenders WITH the
+# label: a stray/mislabeled node alone can't place ingest on a psql/cache node.
 #
-# Routing: the existing `api` Service (the gateway's GATEWAY_BACKEND_URL=
-# http://api:8000 upstream) is patched to select `app: api-local`
-# (kustomization.yaml), so the gateway routes here through the normal front door.
+# Routing: the existing `api` Service (the gateway's GATEWAY_BACKEND_URL=http://api:8000
+# upstream) is patched to select `app: api-local` (kustomization.yaml), so the gateway routes
+# here through the normal front door.
 #
-# IMPORTANT: with no ceph api pods, every upload stages locally and stays
-# `pending` until the replicator copies local->ceph. Install + test the replicator
-# when ready. See README-local-ingest-trial.md.
+# IMPORTANT: with no ceph api pods, every upload stages locally and stays `pending` until the
+# drain replicates local->ceph. The drain stack (allocator + agent) MUST be up first.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -37,9 +33,9 @@ metadata:
   labels:
     app: api-local
 spec:
-  # One (or more) per prod ingest node — set to your prepared-node count (the capacity plan
-  # recommends 3–4). podAntiAffinity below spreads replicas across the labelled nodes.
-  replicas: 4
+  # One per prod ingest node — node1..node5 each have a dedicated /s3-data NVMe.
+  # podAntiAffinity below spreads replicas one-per-node across the labelled nodes.
+  replicas: 5
   selector:
     matchLabels:
       app: api-local
@@ -61,14 +57,16 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      # PLACEHOLDER — the prod ingest nodes (repurposed local NVMe mounted at
-                      # /var/lib/hippius/local_ingest_prod + labeled s3-prod-local-ingest=true).
-                      # Keep in sync with ingest-node-labels-production.yaml + the drain-agent
-                      # DaemonSet. DISJOINT from staging's node2/node3. See s3-2.1-todo.md.
-                      - REPLACE-prod-ingest-node-a
-                      - REPLACE-prod-ingest-node-b
-                      - REPLACE-prod-ingest-node-c
-                      - REPLACE-prod-ingest-node-d
+                      # The prod ingest nodes: dedicated /s3-data NVMe, labeled
+                      # s3-prod-local-ingest=true. Keep in sync with
+                      # ingest-node-labels-production.yaml + the drain-agent DaemonSet.
+                      # Overlaps staging's node2/node3 but on a different disk (staging uses
+                      # the node-root local_ingest_staging path). See s3-2.1-todo.md.
+                      - k8s-v3-node1
+                      - k8s-v3-node2
+                      - k8s-v3-node3
+                      - k8s-v3-node4
+                      - k8s-v3-node5
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -166,11 +164,11 @@ spec:
       volumes:
         - name: local-ingest
           hostPath:
-            # PLACEHOLDER PATH — the mount point of the repurposed local NVMe on each ingest node
-            # (see s3-2.1-todo.md → "Prod logistics"). type: Directory (not DirectoryOrCreate):
-            # if the NVMe is not mounted the pod won't start, rather than staging uploads onto the
-            # node root disk. The prepare-ingest-dir initContainer creates the subdir on the mount.
-            path: /var/lib/hippius/local_ingest_prod
+            # The dedicated 3.84 TB NVMe mounted at /s3-data on each ingest node (node1..node5).
+            # type: Directory (not DirectoryOrCreate): if the NVMe is not mounted at /s3-data the
+            # pod won't start, rather than staging uploads onto the node root disk. The
+            # prepare-ingest-dir initContainer chmods the mount so the (non-root) api can write.
+            path: /s3-data
             type: Directory
         - name: object-cache
           persistentVolumeClaim:

--- a/k8s/production/drain-agent-daemonset.yaml
+++ b/k8s/production/drain-agent-daemonset.yaml
@@ -12,10 +12,10 @@
 # duplicated hostname list to drift, and off the cache/psql/master nodes.
 #
 # == Volumes ==
-#  * SSD source: the SAME hostPath the api pods write to,
-#    /var/lib/hippius/local_ingest_prod (the `_staging` suffix keeps it disjoint
-#    from prod on a shared node). RW so the agent can unlink a part after a verified,
-#    committed pool copy.
+#  * SSD source: the SAME hostPath the api pods write to — the dedicated /s3-data NVMe
+#    on each ingest node (staging uses a different path/disk, local_ingest_staging on the
+#    node root, so they don't collide on shared node2/node3). RW so the agent can unlink a
+#    part after a verified, committed pool copy.
 #  * CephFS pool: object-cache-pvc — ReadWriteMany ceph-filesystem, mounted RW (the api
 #    pods mount it read-only; the agent is the writer into ceph).
 apiVersion: apps/v1
@@ -49,16 +49,16 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      # PLACEHOLDER — replace with the prod ingest nodes you prepared: each must
-                      # have a repurposed local NVMe mounted at /var/lib/hippius/local_ingest_prod
-                      # and be labeled s3-prod-local-ingest=true. Keep this list in sync with
+                      # The prod ingest nodes: dedicated /s3-data NVMe, labeled
+                      # s3-prod-local-ingest=true. Keep in sync with
                       # ingest-node-labels-production.yaml + api-local-deployments-production.yaml.
-                      # MUST be DISJOINT from staging's ingest set (node2/node3) on this shared
-                      # cluster. See s3-2.1-todo.md → "Prod logistics" for the prep runbook.
-                      - REPLACE-prod-ingest-node-a
-                      - REPLACE-prod-ingest-node-b
-                      - REPLACE-prod-ingest-node-c
-                      - REPLACE-prod-ingest-node-d
+                      # Overlaps staging's node2/node3 but on a different disk (staging uses the
+                      # node-root local_ingest_staging path). See s3-2.1-todo.md.
+                      - k8s-v3-node1
+                      - k8s-v3-node2
+                      - k8s-v3-node3
+                      - k8s-v3-node4
+                      - k8s-v3-node5
       # > the agent's shutdown grace (CEPHOR_GRACE_SECS default 30s): a burst winds
       # down before the kubelet force-kills, so no in-flight part is stranded draining.
       terminationGracePeriodSeconds: 40
@@ -244,12 +244,11 @@ spec:
       volumes:
         - name: local-ingest
           hostPath:
-            # PLACEHOLDER PATH — this MUST be the mount point of the repurposed local NVMe on
-            # each ingest node (see s3-2.1-todo.md → "Prod logistics"). type: Directory (NOT
-            # DirectoryOrCreate as on staging) is deliberate: if the NVMe is not mounted here the
-            # pod stays ContainerCreating instead of silently writing the ingest churn onto the
-            # node root disk and filling it. Prep the node (mount + label) before scheduling here.
-            path: /var/lib/hippius/local_ingest_prod
+            # The dedicated 3.84 TB NVMe mounted at /s3-data on each ingest node (node1..node5).
+            # type: Directory (NOT DirectoryOrCreate as on staging) is deliberate: if the NVMe is
+            # not mounted at /s3-data the pod stays ContainerCreating instead of silently writing
+            # the ingest churn onto the node root disk and filling it.
+            path: /s3-data
             type: Directory
         - name: object-cache
           persistentVolumeClaim:

--- a/k8s/production/ingest-node-labels-production.yaml
+++ b/k8s/production/ingest-node-labels-production.yaml
@@ -6,17 +6,17 @@
 # carry a required nodeAffinity hostname allow-list — keep it in sync with the stanzas
 # below (edit the Node names here AND both allow-lists together).
 #
-# SHARED CLUSTER: staging and prod run on the same physical nodes, so their ingest sets
-# MUST be DISJOINT. Staging uses `s3-staging-local-ingest` on node2/node3 writing to
-# /var/lib/hippius/local_ingest_staging; prod uses THIS label on DIFFERENT nodes writing
-# to /var/lib/hippius/local_ingest_prod. Never put a prod ingest label on a staging
-# ingest node (or vice-versa).
+# THE NODES: k8s-v3-node1..node5, each with a dedicated 3.84 TB enterprise NVMe (Gen4
+# datacenter U.2/U.3: WD Ultrastar DC / Micron 7450 PRO / Intel-Solidigm D7-P5520)
+# mounted at /var/lib/hippius/... via the host path /s3-data (ext4). The api-local +
+# drain-agent hostPath points at /s3-data.
 #
-# ⚠️ PLACEHOLDERS. The names below are placeholders — replace them with the actual prod
-# ingest nodes you prepared. Preparing a node = repurpose one Ceph OSD's NVMe into a local
-# ingest disk (the cluster's OSD disks are 3.84 TB enterprise NVMe; Ceph is only ~29% full
-# so it can spare a few). Full runbook: s3-2.1-todo.md → "Prod logistics". The capacity
-# plan (s3-prod-drain-capacity-plan.md) recommends 3–4 such nodes.
+# SHARED CLUSTER — no collision by design: staging's ingest also runs on node2/node3, but
+# on a DIFFERENT disk/path (`s3-staging-local-ingest` → /var/lib/hippius/local_ingest_staging
+# on the node root disk), while prod uses THIS label → the dedicated /s3-data NVMe. So a
+# staging and a prod ingest pod can co-reside on node2/node3 without sharing a disk. (If you
+# want the nodes prod-exclusive — nothing else scheduled — that needs a TAINT + tolerations,
+# which would evict the general worker pool currently on node1-5; decide separately.)
 #
 # CAVEAT: `apply` adds labels but does not PRUNE them. To retire an ingest node, delete its
 # stanza here AND run: kubectl label node <name> s3-prod-local-ingest-
@@ -26,27 +26,34 @@
 apiVersion: v1
 kind: Node
 metadata:
-  name: REPLACE-prod-ingest-node-a
+  name: k8s-v3-node1
   labels:
     s3-prod-local-ingest: "true"
 ---
 apiVersion: v1
 kind: Node
 metadata:
-  name: REPLACE-prod-ingest-node-b
+  name: k8s-v3-node2
   labels:
     s3-prod-local-ingest: "true"
 ---
 apiVersion: v1
 kind: Node
 metadata:
-  name: REPLACE-prod-ingest-node-c
+  name: k8s-v3-node3
   labels:
     s3-prod-local-ingest: "true"
 ---
 apiVersion: v1
 kind: Node
 metadata:
-  name: REPLACE-prod-ingest-node-d
+  name: k8s-v3-node4
+  labels:
+    s3-prod-local-ingest: "true"
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: k8s-v3-node5
   labels:
     s3-prod-local-ingest: "true"

--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -12,13 +12,12 @@ resources:
   - pv-local-cache.yaml
   - pvc-local-cache.yaml
   # --- hippius-drain (s3-2.1) SSD-ingest tier — DELIBERATELY COMMENTED OUT. ---
-  # Do NOT uncomment until the prod ingest nodes are prepared: repurpose one Ceph OSD's
-  # NVMe per node -> mount it at /var/lib/hippius/local_ingest_prod -> label the node
-  # s3-prod-local-ingest=true, and replace the REPLACE-prod-ingest-node-* placeholders in
-  # ingest-node-labels-production.yaml + both nodeAffinity allow-lists. Runbook:
-  # s3-2.1-todo.md -> "Prod logistics"; sizing: s3-prod-drain-capacity-plan.md.
-  # Also uncomment the `drain` image below, and (cutover) scale base `api` to 0 + point the
-  # `api` Service selector at app: api-local, as k8s/staging/kustomization.yaml does.
+  # Ingest nodes node1..node5 are prepared: each has a dedicated 3.84 TB NVMe mounted at
+  # /s3-data, and ingest-node-labels-production.yaml labels them s3-prod-local-ingest=true
+  # (both nodeAffinity allow-lists list node1..node5). Runbook: path-to-prod.md; sizing:
+  # s3-prod-drain-capacity-plan.md. Before uncommenting: confirm the label is applied on all
+  # five nodes, then also uncomment the `drain` image below, and (cutover) scale base `api`
+  # to 0 + point the `api` Service selector at app: api-local, as k8s/staging/kustomization.yaml does.
   # - ingest-node-labels-production.yaml
   # - api-local-deployments-production.yaml
   # - drain-allocator-deployment.yaml   # singleton; owns the cephor_* schema (deploy first)


### PR DESCRIPTION
Wires the prod hippius-drain SSD-ingest manifests to the real ingest nodes now that node1–5 each have a dedicated NVMe mounted at `/s3-data`. Manifests only; the drain block stays commented out in the prod kustomization until cutover.

## Node sweep (what confirmed this)
All five worker nodes have `/s3-data` mounted on a dedicated **3.84 TB Gen4 datacenter NVMe** (ext4, ~empty, SSD): WD Ultrastar DC (node1/3/5), Micron 7450 PRO (node2), Intel/Solidigm D7-P5520 (node4). Each drive does ~2.5–3.4 GB/s write vs a ~115 MB/s/node ingest demand — ~20× headroom; endurance need ≈0.13 DWPD, comfortably under the drives' rating.

## Changes
- **ingest-node-labels** — the five real nodes, labeled `s3-prod-local-ingest=true`.
- **api-local + drain-agent** — nodeAffinity allow-list → `k8s-v3-node1..5`; hostPath → `/s3-data` (`type: Directory` kept as the "NVMe must be mounted or the pod won't start" latch); api-local `replicas` 4 → 5.
- Corrected the stale staging-copied comments: prod and staging share node2/node3 but on **different disks** (prod `/s3-data` vs staging node-root `local_ingest_staging`), so no collision — the earlier "must be disjoint" note no longer applies.
- kustomization drain block unchanged (still commented; uncomment at cutover).

## Notes for review
- The nodes are **already labeled** on the live cluster (`s3-prod-local-ingest=true` on node1–5); this PR is the declarative source of truth for that. The drain stack is **not** deployed.
- **Exclusivity is intentionally not done here.** The label only makes prod ingest land *only* on node1–5; making the nodes prod-*exclusive* would need a taint, which would evict the general worker pool — a separate capacity decision.
- node4/node5 sit near the pod cap; adding api-local + drain-agent (+2/node) may want the terminal-pod cleanup first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)