### PR TITLE
release(2/3): enable the drain-direct SSD-ingest tier

### DIFF
--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -30,10 +30,12 @@ patches:
   - path: ingress-patch.yaml
   - path: services-patch.yaml
   - path: postgres-nvme-initwait-patch.yaml
-  # Cutover full-swap routing: point the existing `api` Service (the gateway's
-  # GATEWAY_BACKEND_URL=http://api:8000 upstream) at the drain-direct api-local fleet.
-  # Base `api` is scaled to 0 in resource-limits.yaml. Mirrors k8s/staging/kustomization.yaml.
-  # (Gated/hybrid alternative: don't merge this overlay — drive the shift with rollout.sh.)
+  # Cutover routing: point the existing `api` Service (the gateway's GATEWAY_BACKEND_URL=
+  # http://api:8000 upstream) at the drain-direct api-local fleet. Base `api` is scaled to 0 in
+  # resource-limits.yaml. Mirrors k8s/staging/kustomization.yaml. This is a FULL SWAP — there is no
+  # safe incremental hybrid (peer review B2: a base-api pod on the new image writes to CephFS, which
+  # the drain never scans → dark uploads). The operator-driven `rollout.sh cutover` does the same
+  # full swap with gates + a dark-upload check; it is NOT an incremental base-api-serving alternative.
   - target:
       kind: Service
       name: api

--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -27,6 +27,18 @@ patches:
   - path: ingress-patch.yaml
   - path: services-patch.yaml
   - path: postgres-nvme-initwait-patch.yaml
+  # Cutover full-swap routing: point the existing `api` Service (the gateway's
+  # GATEWAY_BACKEND_URL=http://api:8000 upstream) at the drain-direct api-local fleet.
+  # Base `api` is scaled to 0 in resource-limits.yaml. Mirrors k8s/staging/kustomization.yaml.
+  # (Gated/hybrid alternative: don't merge this overlay — drive the shift with rollout.sh.)
+  - target:
+      kind: Service
+      name: api
+    patch: |-
+      - op: replace
+        path: /spec/selector
+        value:
+          app: api-local
 
 images:
   - name: ghcr.io/thenervelab/hippius-s3/api

--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -9,18 +9,15 @@ resources:
   - postgres-nvme-cluster.yaml
   - postgres-nvme-scheduledbackup.yaml
   - gateway-nodeport.yaml
-  # --- hippius-drain (s3-2.1) SSD-ingest tier — DELIBERATELY COMMENTED OUT. ---
-  # Ingest nodes node1..node5 are prepared: each has a dedicated 3.84 TB NVMe mounted at
-  # /s3-data, and ingest-node-labels-production.yaml labels them s3-prod-local-ingest=true
-  # (both nodeAffinity allow-lists list node1..node5). Runbook: path-to-prod.md; sizing:
-  # s3-prod-drain-capacity-plan.md. Before uncommenting: confirm the label is applied on all
-  # five nodes, then also uncomment the `drain` image below, and (cutover) scale base `api`
-  # to 0 + point the `api` Service selector at app: api-local, as k8s/staging/kustomization.yaml does.
-  # - ingest-node-labels-production.yaml
-  # - api-local-deployments-production.yaml
-  # - drain-allocator-deployment.yaml   # singleton; owns the cephor_* schema (deploy first)
-  # - drain-agent-daemonset.yaml        # one per labelled ingest node
-  # - mpu-reaper-deployment.yaml
+  # --- hippius-drain (s3-2.1) SSD-ingest tier — ENABLED (overlay 2/3). ---
+  # Ingest nodes node1..node5 are prepared (dedicated 3.84 TB /s3-data NVMe, labeled
+  # s3-prod-local-ingest=true). allocator-first ordering is handled by the agent/reaper
+  # initContainers. Routing is NOT flipped here — that's the full-swap overlay (3/3).
+  - ingest-node-labels-production.yaml
+  - api-local-deployments-production.yaml
+  - drain-allocator-deployment.yaml   # singleton; owns the cephor_* schema (deploy first)
+  - drain-agent-daemonset.yaml        # one per labelled ingest node
+  - mpu-reaper-deployment.yaml
 
 patches:
   - path: namespace-patch.yaml
@@ -38,6 +35,5 @@ images:
     newTag: latest
   - name: ghcr.io/thenervelab/hippius-s3/workers
     newTag: latest
-  # Uncomment with the drain resources above (the allocator + agent use the `drain` image):
-  # - name: ghcr.io/thenervelab/hippius-s3/drain
-  #   newTag: latest
+  - name: ghcr.io/thenervelab/hippius-s3/drain
+    newTag: latest

--- a/k8s/production/resource-limits.yaml
+++ b/k8s/production/resource-limits.yaml
@@ -21,7 +21,10 @@ kind: Deployment
 metadata:
   name: api
 spec:
-  replicas: 5
+  # Cutover full-swap: base ceph `api` scaled to 0 — the drain-direct `api-local` fleet
+  # (replicas=5) serves all traffic via the `api` Service selector patch in kustomization.yaml.
+  # Rollback = scale back to 5 + repoint the Service to app: api.
+  replicas: 0
   template:
     spec:
       containers:


### PR DESCRIPTION
**DRAFT — PR 2 of 3, stacked on #296.** Diff shows *only* the drain-enable change.

Uncomments the SSD-ingest tier in `k8s/production/kustomization.yaml`: `ingest-node-labels` + `api-local` (5) + `drain-allocator` + `drain-agent` + `mpu-reaper` + the `drain` image, and pulls in the `s3-ingest-priority` PriorityClass. Brings the drain stack up on node1–5.

⚠️ **NOT durability-safe on its own** (peer review B2). Base `api` still serves all traffic here, and on the new image it writes to CephFS — which the drain never scans (the drain only triggers on a node-local SSD scan) — so those uploads go **dark** (never replicated). This overlay must land **together with #298** (which flips routing to api-local and scales base api to 0). The three PRs are one atomic change; no intermediate state is safe.

Verified: renders the drain stack + api-local + PriorityClass; base api replicas=5, api Service → `app: api` (routing unchanged here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)