### PR TITLE
release(3/3): full-swap routing (base api→0, Service→api-local)

### DIFF
--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -30,10 +30,12 @@ patches:
   - path: ingress-patch.yaml
   - path: services-patch.yaml
   - path: postgres-nvme-initwait-patch.yaml
-  # Cutover full-swap routing: point the existing `api` Service (the gateway's
-  # GATEWAY_BACKEND_URL=http://api:8000 upstream) at the drain-direct api-local fleet.
-  # Base `api` is scaled to 0 in resource-limits.yaml. Mirrors k8s/staging/kustomization.yaml.
-  # (Gated/hybrid alternative: don't merge this overlay — drive the shift with rollout.sh.)
+  # Cutover routing: point the existing `api` Service (the gateway's GATEWAY_BACKEND_URL=
+  # http://api:8000 upstream) at the drain-direct api-local fleet. Base `api` is scaled to 0 in
+  # resource-limits.yaml. Mirrors k8s/staging/kustomization.yaml. This is a FULL SWAP — there is no
+  # safe incremental hybrid (peer review B2: a base-api pod on the new image writes to CephFS, which
+  # the drain never scans → dark uploads). The operator-driven `rollout.sh cutover` does the same
+  # full swap with gates + a dark-upload check; it is NOT an incremental base-api-serving alternative.
   - target:
       kind: Service
       name: api

--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -27,6 +27,18 @@ patches:
   - path: ingress-patch.yaml
   - path: services-patch.yaml
   - path: postgres-nvme-initwait-patch.yaml
+  # Cutover full-swap routing: point the existing `api` Service (the gateway's
+  # GATEWAY_BACKEND_URL=http://api:8000 upstream) at the drain-direct api-local fleet.
+  # Base `api` is scaled to 0 in resource-limits.yaml. Mirrors k8s/staging/kustomization.yaml.
+  # (Gated/hybrid alternative: don't merge this overlay — drive the shift with rollout.sh.)
+  - target:
+      kind: Service
+      name: api
+    patch: |-
+      - op: replace
+        path: /spec/selector
+        value:
+          app: api-local
 
 images:
   - name: ghcr.io/thenervelab/hippius-s3/api

--- a/k8s/production/resource-limits.yaml
+++ b/k8s/production/resource-limits.yaml
@@ -21,7 +21,10 @@ kind: Deployment
 metadata:
   name: api
 spec:
-  replicas: 5
+  # Cutover full-swap: base ceph `api` scaled to 0 — the drain-direct `api-local` fleet
+  # (replicas=5) serves all traffic via the `api` Service selector patch in kustomization.yaml.
+  # Rollback = scale back to 5 + repoint the Service to app: api.
+  replicas: 0
   template:
     spec:
       containers:


### PR DESCRIPTION
**DRAFT — PR 3 of 3, stacked on #297.** The routing **full swap**.

- `resource-limits.yaml`: base `api` → **0**.
- `kustomization.yaml`: `api` Service selector → **`app: api-local`**.

This is a **full swap, not an incremental hybrid** — peer review B2 showed there is no safe base-`api`-serving window (a base-`api` pod on the new image writes to CephFS, which the drain never scans → dark uploads). `rollout.sh cutover` does the same full swap with gates + a `darkcheck`; it is NOT an incremental base-api-serving alternative.

Merging all three (this → #297 → #296) deploys the drain-direct architecture in one CI run — in a window after the pre-flight (see `s3-2.1-todo.md` → REVIEW BLOCKERS), together with **s3-backup#18**. Rollback: revert (Service → `app: api`, base `api` → 5) or `rollout.sh rollback`, **and revert the deploy commit**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)