### PR TITLE
docs(todo): release PR-stack + merge-order section

### DIFF
--- a/s3-2.1-todo.md
+++ b/s3-2.1-todo.md
@@ -23,6 +23,46 @@ fix (one ingest pod per node + Ceph read-fallback → lose a node, degrade not b
 
 ---
 
+# RELEASE — PR stack & merge order
+
+The staging→prod cutover ships as a **stacked PR set** (reviewed layer-by-layer, merged together in one
+window). Prod deploys from the `k8s-production` branch — **only the final merge into `k8s-production`
+triggers the deploy.** Companion runbook: `path-to-prod.md`. A gated/hybrid alternative to the big-bang
+merge is the **`rollout.sh`** operator script (`status` / `preflight` / `cutover` / `rollback`, with a
+signal check + confirmation at each step) — **team-internal, kept out of this repo; shared out-of-band.**
+
+### hippius-s3 — merge **bottom-up** (3 → 2 → 1)
+| Order | PR | Branch → base | Effect |
+|---|---|---|---|
+| 3rd | [#298](https://github.com/thenervelab/hippius-s3/pull/298) | `release/full-swap` → `release/enable-drain` | Routing flip: base `api`→0, `api` Service → `app: api-local` |
+| 2nd | [#297](https://github.com/thenervelab/hippius-s3/pull/297) | `release/enable-drain` → `release/promote-staging` | Enable the SSD-ingest tier (api-local + drain allocator/agent/reaper + drain image) |
+| 1st | [#296](https://github.com/thenervelab/hippius-s3/pull/296) | `release/promote-staging` → `k8s-production` | The ~396-commit code promotion (conflicts resolved) |
+
+Merge #298 into its base, then #297, then **#296 into `k8s-production`** — that last merge is the single
+event that deploys the whole cutover (CI builds images incl. `drain` and applies the overlay). Merging the
+overlay PRs into their feature bases does **not** deploy.
+
+### s3-backup — same window
+| PR | Branch → base | Effect |
+|---|---|---|
+| [s3-backup#18](https://github.com/thenervelab/s3-backup/pull/18) | `release/prod-promotion` → `k8s-production` | Promote the monolith removal — un-pin `backup`/`hydrator` onto CephFS |
+
+Merge **together with** the hippius-s3 cutover: the un-pin is only safe once hippius-s3 is drain-direct
+(chunks in the CephFS pool). `backup` is already drain-gated, so it only reads pool copies that exist.
+
+### Before merging (pre-flight — all in "TO SHIP" below)
+- [ ] Node pod-slot cleanup on the ingest nodes ([*podcap]) — the ingest tier adds +2 pods/node.
+- [ ] Run the DB migrations ([*initgates]).
+- [ ] `redis-queues` = `noeviction` + restart ([*noeviction]).
+- [ ] Grow `object-cache-pvc` → 20 TiB ([*cachegrow], #294).
+- [ ] Drain the old upload queue (so the deploy doesn't abandon un-uploaded node6 cache data).
+
+### Rollback
+Revert the routing (Service → `app: api`, base `api` → 5) or `rollout.sh rollback`. Acked bytes on the
+ingest disk are never lost — the janitor's replication gate never evicts an un-replicated chunk.
+
+---
+
 # TO SHIP (critical path)
 
 ### Deploy steps (with the rollout) [*deployorder] — full ordered runbook now in `path-to-prod.md`


### PR DESCRIPTION
Adds a **RELEASE — PR stack & merge order** section to `s3-2.1-todo.md` so the cutover execution is documented in the plan.

Includes:
- The stacked hippius-s3 PRs (#296 promotion → #297 enable-drain → #298 full-swap) with the **bottom-up merge order**, and that only the final merge into `k8s-production` triggers the deploy.
- The s3-backup sibling PR (s3-backup#18), to merge in the same window.
- Pre-flight gates + rollback.
- A reference to the **team-internal `rollout.sh`** operator script (gated/hybrid alternative) — noted as kept out of the repo / shared out-of-band, per team preference. The script itself is **not committed**.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)