### PR TITLE
fix(unpinner): forward-port ff9b537 (batch soft-delete guards) to staging

### DIFF
--- a/hippius_s3/workers/unpinner.py
+++ b/hippius_s3/workers/unpinner.py
@@ -231,6 +231,10 @@ async def process_unpin_batch(
 
         seen: set[str] = set()
         for item in result.deleted:
+            # Ignore a file_id HCFS echoes that we did NOT send (defensive: avoids a KeyError in the
+            # fan-out and never soft-deletes a chunk we don't own).
+            if item.file_id not in group.file_id_chunk_ids:
+                continue
             resolved_ok.add(item.file_id)
             seen.add(item.file_id)
         for err in result.errors:
@@ -248,22 +252,26 @@ async def process_unpin_batch(
     # A9 gate: soft-delete only file_ids whose backend delete succeeded. A file_id counts as fully
     # cleared only if EVERY one of its chunk_ids soft-deleted without a DB error.
     soft_deleted_ok: set[str] = set()
+    # Bound concurrent soft-deletes to the DB pool size: a large batch (up to 1000 file_ids) would
+    # otherwise spawn that many gather tasks all contending for the ~pool_max connections at once.
+    soft_delete_sem = asyncio.Semaphore(max(1, int(config.unpinner_db_pool_max)))
 
     async def _soft_delete_file(file_id: str) -> None:
         ok = True
-        for chunk_id in group.file_id_chunk_ids[file_id]:
-            try:
-                async with db_pool.acquire() as conn:
-                    await conn.fetchval(
-                        get_query("soft_delete_chunk_backend_by_chunk_id"),
-                        backend_name,
-                        chunk_id,
+        for chunk_id in group.file_id_chunk_ids.get(file_id, set()):
+            async with soft_delete_sem:
+                try:
+                    async with db_pool.acquire() as conn:
+                        await conn.fetchval(
+                            get_query("soft_delete_chunk_backend_by_chunk_id"),
+                            backend_name,
+                            chunk_id,
+                        )
+                except Exception as db_err:
+                    ok = False
+                    worker_logger.warning(
+                        f"Failed to soft-delete chunk_backend row chunk_id={chunk_id} (file_id={file_id}): {db_err}"
                     )
-            except Exception as db_err:
-                ok = False
-                worker_logger.warning(
-                    f"Failed to soft-delete chunk_backend row chunk_id={chunk_id} (file_id={file_id}): {db_err}"
-                )
         if ok:
             soft_deleted_ok.add(file_id)
 
@@ -634,22 +642,42 @@ async def run_unpinner_loop(
         while req is not None:
             ray_id = req.ray_id or "no-ray-id"
             req_logger = get_logger_with_ray_id(__name__, ray_id)
-            async with db_pool.acquire() as conn:
-                rows = await conn.fetch(
-                    get_query("get_chunk_backend_identifiers"),
-                    backend_name,
-                    req.object_id,
-                    req.object_version,
-                )
-            if not rows:
-                await _handle_no_identifiers(req, req_logger)
-            else:
-                key = (req.address, folder_hash)
-                group = groups.get(key)
-                if group is None:
-                    group = _BatchGroup(req.address, folder_hash)
-                    groups[key] = group
-                group.add(req, rows)
+            # The request is already destructively brpop'd off Redis, so it must never be lost: any
+            # error handling it here (a DB blip on the identifier fetch, a redis hiccup enqueuing a
+            # no-rows retry) routes it to retry instead of propagating out and crashing the loop —
+            # matching the per-file path's resilience. Losing the whole in-flight assembly window on
+            # a transient DB error would strand those pins forever.
+            try:
+                async with db_pool.acquire() as conn:
+                    rows = await conn.fetch(
+                        get_query("get_chunk_backend_identifiers"),
+                        backend_name,
+                        req.object_id,
+                        req.object_version,
+                    )
+                if not rows:
+                    await _handle_no_identifiers(req, req_logger)
+                else:
+                    key = (req.address, folder_hash)
+                    group = groups.get(key)
+                    if group is None:
+                        group = _BatchGroup(req.address, folder_hash)
+                        groups[key] = group
+                    group.add(req, rows)
+            except Exception as assemble_err:
+                req_logger.warning(f"Error assembling unpin {req.name}, routing to retry: {assemble_err}")
+                try:
+                    await _route_failed_request(
+                        req,
+                        backend_name=backend_name,
+                        error_class="transient",
+                        last_error=f"assembly error: {assemble_err}",
+                        worker_logger=req_logger,
+                        dlq_manager=dlq_manager,
+                        config=config,
+                    )
+                except Exception as route_err:
+                    req_logger.error(f"Failed to route unpin {req.name} after assembly error: {route_err}")
 
             if any(len(g.file_id_chunk_ids) >= batch_max_files for g in groups.values()):
                 break

--- a/tests/unit/test_unpinner_batch.py
+++ b/tests/unit/test_unpinner_batch.py
@@ -501,11 +501,14 @@ class _LoopClient:
 
 
 class _BatchHarness:
-    def __init__(self, *, config, client=None, rows_by_object=None, fail_chunk_ids=frozenset()) -> None:
+    def __init__(
+        self, *, config, client=None, rows_by_object=None, fail_chunk_ids=frozenset(), fail_fetch_objects=frozenset()
+    ) -> None:
         self.config = config
         self.client = client or _LoopClient()
         self.rows_by_object = rows_by_object or {}
         self.fail_chunk_ids = fail_chunk_ids
+        self.fail_fetch_objects = fail_fetch_objects
         self.dequeue_sequence: list = []
         self.softdeleted: list[int] = []
         self.retry_calls: list = []
@@ -526,6 +529,8 @@ class _BatchHarness:
         conn = AsyncMock()
 
         async def _fetch(query, backend, object_id, object_version):
+            if object_id in self.fail_fetch_objects:
+                raise RuntimeError("db down during assembly")
             return self.rows_by_object.get(object_id, [])
 
         async def _fetchval(query, backend, chunk_id):
@@ -684,3 +689,51 @@ async def test_configured_folder_hash_threaded_into_payload():
 
     assert len(h.client.batch_calls) == 1
     assert h.client.batch_calls[0][2] == "abcdef0123456789"
+
+
+# --------------------------------------------------------------------------- #
+# Review findings (PR #260) — regression tests
+# --------------------------------------------------------------------------- #
+
+
+# P1. A DB blip while assembling a batch must NOT crash the loop, and the already-brpop'd request
+# must be routed to retry (never silently lost -> stranded pin).
+@pytest.mark.asyncio
+async def test_assembly_db_error_routes_request_to_retry_and_loop_survives():
+    cfg = _loop_config(batch_enabled=True)
+    h = _BatchHarness(config=cfg, fail_fetch_objects={"obj-bad"})
+    h.dequeue_sequence = [_ureq("obj-bad")]  # then dequeue raises KeyboardInterrupt (clean stop)
+
+    # Must NOT propagate the RuntimeError — the loop survives the assembly-phase DB error.
+    await asyncio.wait_for(h.run(), timeout=5.0)
+
+    assert len(h.retry_calls) == 1, "the destructively-popped request must be re-enqueued, not lost"
+    assert h.retry_calls[0][0].object_id == "obj-bad"
+
+
+# P2. HCFS echoing back a file_id we did NOT send must not KeyError / drop the whole group.
+@pytest.mark.asyncio
+async def test_unknown_echoed_file_id_is_ignored_not_crashing_group():
+    req = _ureq("o1")
+    g = _group([(req, [("fid-real", 1)])])
+
+    def resp(_fids):
+        return BatchDeleteResult(
+            deleted=[
+                BatchDeleteItem(file_id="fid-real", status="deleted"),
+                BatchDeleteItem(file_id="fid-UNKNOWN-not-sent", status="deleted"),
+            ],
+            errors=[],
+            files_deleted=2,
+        )
+
+    client = _BatchClient(resp_fn=resp)
+    pool = _pool()
+
+    # Must NOT raise KeyError on the unknown file_id.
+    retry, dlq, metrics = await _run_batch(g, client, pool)
+
+    assert _softdeleted(pool) == {1}, "only the real chunk soft-deleted; unknown echoed id ignored"
+    retry.assert_not_called()
+    dlq.push.assert_not_called()
+    assert _success_count(metrics) == 1, "the request is acked; unknown echoed id does not affect it"


### PR DESCRIPTION
Forward-ports **ff9b537** ("resolve code review findings for PR #260") from `k8s-production` to `staging`. These three batch-delete-unpinner fixes lived only on the prod release branch and were never back-merged — so the s3-2.1 promotion (#296) had to cherry-pick them, and without this they'd regress on the *next* promotion.

## Fixes restored
- **Unguarded `KeyError` fails a whole batch group** → `group.file_id_chunk_ids.get(file_id, set())` (an echoed-but-unsent `file_id` no longer crashes a batch of up to 1000 deletes in a bare `gather`).
- **Unbounded DB-pool fan-out** → `soft_delete_sem = asyncio.Semaphore(config.unpinner_db_pool_max)` bounds the concurrent `db_pool.acquire()`.
- **Destructively-popped unpin request lost on a transient DB blip** → wrapped + routed to retry (the `brpop`'d request is re-enqueued, not stranded).

Plus the two regression tests (`test_unknown_echoed_file_id_is_ignored_not_crashing_group`, `test_assembly_db_error_routes_request_to_retry_and_loop_survives`).

Clean cherry-pick onto staging; `pytest tests/unit/test_unpinner_batch.py` → **20 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)