### PR TITLE
fix(stress): scope convergence/eviction to the ledger + fix nginx-414 SSD eviction

### DIFF
--- a/stress-test/harness/probes.py
+++ b/stress-test/harness/probes.py
@@ -95,26 +95,48 @@ class ClusterProbe:
         pods = self.api_pods()
         dirs = [f"{self.cfg.ssd_cache_dir.rstrip('/')}/{oid}" for oid in object_ids]
         ok_pods = 0
+        # `kubectl exec -- rm -rf <paths>` sends every path as a URL query param on the SPDY/exec
+        # upgrade request; the API ingress (nginx) rejects the request with `414 Request-URI Too Large`
+        # once the encoded URL crosses ~8 KiB. Each path is ~150 bytes URL-encoded, so a batch of 100
+        # (~15 KiB) always 414s — the durability gate silently downgraded to OBSERVED with 0/N evicted.
+        # 20 paths (~3 KiB) stays comfortably under the limit; the corpus is small so the extra round
+        # trips are cheap.
+        BATCH = 20
         for pod in pods:
             ok = True
-            # Bound the arg vector: chunk the rm so a large corpus can't blow the exec argv limit.
-            for i in range(0, len(dirs), 100):
-                try:
-                    proc = subprocess.run(  # noqa: S603 — fixed argv, oids are DB uuids
-                        ["kubectl", "-n", self.cfg.namespace, "exec", pod, "-c", "api",
-                         "--", "rm", "-rf", *dirs[i:i + 100]],
-                        capture_output=True, text=True, timeout=60,
-                    )
-                except (subprocess.TimeoutExpired, FileNotFoundError):
-                    # A kubectl hang / missing binary is an environment fault: mark this pod not-ok
-                    # so the gate downgrades to non-authoritative — same as a returncode!=0 failure —
-                    # rather than propagating and flipping the whole no-data-loss gate red.
+            for i in range(0, len(dirs), BATCH):
+                if not self._exec_rm_with_retry(pod, dirs[i:i + BATCH]):
                     ok = False
                     break
-                ok = ok and proc.returncode == 0
             if ok:
                 ok_pods += 1
         return (len(object_ids), ok_pods, len(pods))
+
+    def _exec_rm_with_retry(self, pod: str, dirs: list[str], attempts: int = 3) -> bool:
+        """rm a batch of dirs on one pod, retrying the transient `kubectl exec` flakes that show up when
+        the api pods are busy (right after the concurrency ramp). The rm itself is deterministic —
+        root, a 0777 cache dir, `-f` ignores absent paths — so a non-zero result is a kubectl-transport
+        blip, not a real failure; a short retry is what makes the durability gate authoritative instead
+        of flakily downgrading to OBSERVED. Returns True only if some attempt's rm returned 0.
+        The last failure's rc+stderr is printed so a persistent 0/N eviction is debuggable (the gate
+        used to swallow it and just report a non-authoritative count with no reason)."""
+        last = ""
+        for attempt in range(attempts):
+            try:
+                proc = subprocess.run(  # noqa: S603 — fixed argv, oids are DB uuids
+                    ["kubectl", "-n", self.cfg.namespace, "exec", pod, "-c", "api",
+                     "--", "rm", "-rf", *dirs],
+                    capture_output=True, text=True, timeout=90,
+                )
+            except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+                last = f"exec raised {type(e).__name__}"
+                continue  # a hang/missing-binary is transport-level — retry, then give up (non-authoritative)
+            if proc.returncode == 0:
+                return True
+            last = f"rc={proc.returncode} stderr={(proc.stderr or '').strip()[:300]!r}"
+            time.sleep(1.0 * (attempt + 1))
+        print(f"    [evict] {pod}: {len(dirs)} dirs FAILED after {attempts} attempts — {last}")
+        return False
 
     # ---------------------------------------------------------------- prometheus (port-forward)
     def start_prometheus(self) -> bool:

--- a/stress-test/harness/scenarios.py
+++ b/stress-test/harness/scenarios.py
@@ -247,19 +247,36 @@ _PREFIX_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 
 
 def _safe_prefix(prefix: str) -> str:
-    """Constrain the bucket prefix before it goes into a SQL LIKE — it's operator-set, but we build
+    """Constrain a bucket prefix/name before it goes into a SQL LIKE/IN — it's ours, but we build
     raw SQL from it, so reject anything outside the S3 bucket-name charset rather than interpolate it."""
     if not _PREFIX_RE.match(prefix):
-        raise ValueError(f"unsafe bucket prefix for SQL LIKE: {prefix!r}")
+        raise ValueError(f"unsafe bucket name for SQL: {prefix!r}")
     return prefix
 
 
-def _our_repl_counts(probe: ClusterProbe, prefix: str) -> dict[str, int] | None:
+def _ledger_buckets(ledger: Ledger) -> list[str]:
+    """The distinct buckets that hold acked, should-fully-replicate objects (the durability corpus +
+    the concurrency-ramp load bucket). The functional/adversarial objects (aborted MPU, wrong-ETag
+    parts) are NEVER recorded to the ledger, so scoping to these buckets excludes exactly the objects
+    the harness deliberately breaks — which must not count against drain convergence or the durability gate."""
+    return sorted({a.bucket for a in ledger.all()})
+
+
+def _bucket_filter(prefix: str, buckets: list[str] | None) -> str:
+    """SQL predicate for 'our objects': an exact-bucket IN-list when given (the ledger's clean set),
+    else the prefix LIKE (whole-run scope). Every name is charset-validated before it hits raw SQL."""
+    if buckets:
+        names = ", ".join("'" + _safe_prefix(b) + "'" for b in buckets)
+        return f"b.bucket_name in ({names})"
+    return f"b.bucket_name like '{_safe_prefix(prefix)}-%'"
+
+
+def _our_repl_counts(probe: ClusterProbe, prefix: str, buckets: list[str] | None = None) -> dict[str, int] | None:
     rows = probe.pg(
         "select crs.status, count(*) from cephor_replication_status crs "
         "join objects o on o.object_id::text = crs.object_id::text "
         "join buckets b on b.bucket_id = o.bucket_id "
-        f"where b.bucket_name like '{_safe_prefix(prefix)}-%' group by crs.status")
+        f"where {_bucket_filter(prefix, buckets)} group by crs.status")
     if rows is None:
         return None
     return {r[0]: int(r[1]) for r in rows}
@@ -279,13 +296,14 @@ def _our_repl_rows(probe: ClusterProbe, prefix: str) -> dict[tuple[str, str, str
     return {(r[0], r[1], r[2]): r[3] for r in rows}
 
 
-def _our_object_ids(probe: ClusterProbe, prefix: str) -> list[str] | None:
+def _our_object_ids(probe: ClusterProbe, prefix: str, buckets: list[str] | None = None) -> list[str] | None:
     """object_ids of every object in our test buckets — the set the durability gate must force off
-    the SSD ingest cache before re-GETting. None if Postgres is unreachable."""
+    the SSD ingest cache before re-GETting. Pass `buckets` (the ledger set) to scope to the objects the
+    gate actually re-verifies, which also keeps the eviction arg-vector small. None if Postgres is unreachable."""
     rows = probe.pg(
         "select distinct o.object_id::text from objects o "
         "join buckets b on b.bucket_id = o.bucket_id "
-        f"where b.bucket_name like '{_safe_prefix(prefix)}-%'")
+        f"where {_bucket_filter(prefix, buckets)}")
     if rows is None:
         return None
     return [r[0] for r in rows]
@@ -342,14 +360,25 @@ def invariant_assert(probe: ClusterProbe, cfg: Config, report: Report, prom_ok: 
 
 
 # ---------------------------------------------------------------- 5. REPLICATION CONVERGENCE (cluster)
-def replication_convergence(probe: ClusterProbe, cfg: Config, report: Report, prom_ok: bool) -> None:
+def replication_convergence(probe: ClusterProbe, cfg: Config, report: Report, prom_ok: bool, ledger: Ledger) -> None:
+    # Scope to the ledger's buckets (durability corpus + concurrency-ramp load) — the objects that are
+    # SUPPOSED to fully replicate. The functional/adversarial scenario deliberately leaves objects
+    # non-terminal (an aborted MPU strands a `pending` cephor orphan; a rejected wrong-ETag MPU leaves
+    # `failed` parts) and never records them to the ledger — counting those against the drain is a
+    # false NO-GO, not a real lag signal.
+    corpus_buckets = _ledger_buckets(ledger)
+    # Floor: how many replicated rows we must SEE before "0 non-terminal" means converged rather than
+    # "the drain hasn't created our rows yet". Each non-empty acked object contributes ≥1 chunk/part, so
+    # our replicated-part count must reach at least the non-empty object count — otherwise a poll taken
+    # before the reconciler has recorded our objects would read 0 pending and declare a false convergence.
+    expected = sum(1 for a in ledger.all() if a.size > 0)
     before = probe.prom_scalar(
         'sum(drain_parts_replicated_total{service_namespace="hippius-s3-staging"})') if prom_ok else None
     deadline = time.time() + cfg.drain_convergence_timeout_s
     converged = False
     last: dict[str, int] | None = None
     while time.time() < deadline:
-        our = _our_repl_counts(probe, cfg.bucket_prefix)
+        our = _our_repl_counts(probe, cfg.bucket_prefix, buckets=corpus_buckets)
         if our is None:
             report.add(Result("drain-convergence", "drain replicates", passed=True, skipped=True,
                               detail="Postgres not reachable — skipped",
@@ -357,7 +386,10 @@ def replication_convergence(probe: ClusterProbe, cfg: Config, report: Report, pr
             return
         last = our
         non_terminal = our.get("pending", 0) + our.get("draining", 0)
-        if non_terminal == 0:
+        replicated = our.get("replicated", 0)
+        # Converged only when NONE of our parts are still draining AND we have actually seen our objects
+        # replicate (guards against declaring victory before the reconciler recorded them).
+        if non_terminal == 0 and replicated >= expected:
             converged = True
             break
         time.sleep(5)
@@ -369,14 +401,16 @@ def replication_convergence(probe: ClusterProbe, cfg: Config, report: Report, pr
         name="drain-convergence",
         invariant="drain actually replicates (lag proxy)",
         passed=converged,
-        detail=f"our repl rows={last}; drain_parts_replicated Δ={delta}; "
-               f"{'converged' if converged else 'STILL non-terminal'} in ≤{elapsed:.0f}s",
-        criteria=f"0 pending/draining rows for our objects within {cfg.drain_convergence_timeout_s}s",
+        detail=f"corpus repl rows={last} (buckets={len(corpus_buckets)}, expected≥{expected} replicated); "
+               f"drain_parts_replicated Δ={delta}; {'converged' if converged else 'STILL non-terminal/incomplete'} "
+               f"in ≤{elapsed:.0f}s",
+        criteria=f"0 pending/draining AND ≥{expected} replicated for our durability/load objects "
+                 f"within {cfg.drain_convergence_timeout_s}s",
     ))
 
 
 # ---------------------------------------------------------------- 6. DURABILITY RE-VERIFY (the gate)
-def _evict_ssd_before_reverify(probe: ClusterProbe | None, cfg: Config) -> tuple[bool, str]:
+def _evict_ssd_before_reverify(probe: ClusterProbe | None, cfg: Config, ledger: Ledger) -> tuple[bool, str]:
     """Force the re-GETs off the SSD ingest cache and onto the drained copy.
 
     THIS is the whole point of the no-data-loss gate: a re-GET that reads the node-local SSD ingest
@@ -399,7 +433,9 @@ def _evict_ssd_before_reverify(probe: ClusterProbe | None, cfg: Config) -> tuple
     if probe is None:
         return (False, "no cluster access — SSD not evicted; reads may be served from the ingest cache "
                        "(NOT an authoritative drained-copy proof)")
-    oids = _our_object_ids(probe, cfg.bucket_prefix)
+    # Scope to the ledger's objects (the ones we re-verify) rather than every prodgate object — this is
+    # both correct (we only need to force THESE off the cache) and keeps the eviction arg-vector small.
+    oids = _our_object_ids(probe, cfg.bucket_prefix, buckets=_ledger_buckets(ledger))
     if oids is None:
         return (False, "Postgres unreachable — could not resolve object_ids to evict; reads may be cache-served")
     targeted, ok_pods, total_pods = probe.evict_ssd_parts(oids)
@@ -415,7 +451,7 @@ def _evict_ssd_before_reverify(probe: ClusterProbe | None, cfg: Config) -> tuple
 def durability_reverify(client, cfg: Config, ledger: Ledger, report: Report,
                         probe: ClusterProbe | None = None) -> None:
     items = ledger.all()
-    authoritative, evict_note = _evict_ssd_before_reverify(probe, cfg)
+    authoritative, evict_note = _evict_ssd_before_reverify(probe, cfg, ledger)
     mismatches: list[str] = []
     missing: list[str] = []
 

--- a/stress-test/run.py
+++ b/stress-test/run.py
@@ -76,7 +76,7 @@ def main() -> int:
         with probe.prometheus() as prom_ok:
             guarded("invariants (cluster)", lambda: scenarios.invariant_assert(probe, cfg, report, prom_ok))
             guarded(f"drain convergence (≤{cfg.drain_convergence_timeout_s}s)",
-                    lambda: scenarios.replication_convergence(probe, cfg, report, prom_ok))
+                    lambda: scenarios.replication_convergence(probe, cfg, report, prom_ok, ledger))
     else:
         print("-- invariants + convergence: skipped (no cluster) --")
         # give the drain a moment before the durability re-verify even without cluster probes


### PR DESCRIPTION
Forward-ports the harness fix (orig `5c5ae0b`, stranded 181 commits behind staging) onto current staging. Two **harness** bugs — neither a drain defect — that made a clean staging run report a false `go=False`:

## 1. `drain-convergence` false NO-GO
It graded the drain on the harness's *own adversarial* objects: the bucket-prefix scope swept in the `func-mpu-abort` orphan (a deliberately-stuck `pending` cephor row) and the wrong-ETag `failed` parts → false non-convergence. **Fix:** scope to the **ledger's buckets** (durability corpus + load); adversarial objects are never recorded to the ledger. Adds a floor (`replicated >= expected`) so a poll taken before the reconciler recorded our objects can't declare false convergence.

## 2. `durability-reverify` could never run authoritatively (the S8 gap)
SSD eviction batched 100 dirs per `kubectl exec` recursive-delete, whose paths ride the exec URL → the API ingress (nginx) returned **414 Request-URI Too Large**, silently swallowed as 0/N evicted → the durability gate downgraded to non-authoritative. **Fix:** batch of 20 (~3 KB URL), retry transient exec flakes, surface stderr on persistent failure, scope eviction to ledger objects.

## Result (re-run against s3-staging, this branch)
- **`GO: True` — 12 pass, 0 fail, 0 skip, 2 observed** (was `go=False`, 1 fail).
- `durability-reverify`: evicted 105 obj on **2/2 api pods** → re-GET reads a drained copy → **105/105 byte-identical, 0 corrupt, 0 missing, authoritative=True**.
- `drain-convergence`: 109 replicated (≥104 expected), converged ≤1s.
- Ship-gate SLOs (S8 durability, S10/S11 single-leader) now certifiable GREEN on a clean baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
