### PR TITLE
fix(k8s): api-local one-per-ingest-node via DaemonSet (was clustered)

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -303,7 +303,17 @@ jobs:
           kubectl rollout status deployment/gateway -n "$ns" --timeout=10m
           # api (monolith / hybrid base) and api-local (drain-direct) — whichever exist.
           wait_deploy api 10m
-          wait_deploy api-local 10m
+          # api-local is a DaemonSet (one pod per ingest node). Wait on it, then prune the
+          # pre-DaemonSet Deployment of the same name: kustomize can't change a resource's kind
+          # in place, so the old Deployment/api-local lingers after the first DaemonSet apply and
+          # both would serve behind app=api-local. Delete AFTER the DaemonSet is Ready (no capacity
+          # dip); idempotent — a no-op on every deploy after the conversion lands.
+          if kubectl get daemonset/api-local -n "$ns" >/dev/null 2>&1; then
+            kubectl rollout status daemonset/api-local -n "$ns" --timeout=10m
+            kubectl delete deployment/api-local -n "$ns" --ignore-not-found=true
+          else
+            wait_deploy api-local 10m
+          fi
           kubectl rollout status deployment/arion-downloader -n "$ns" --timeout=10m
           kubectl rollout status deployment/arion-uploader -n "$ns" --timeout=10m
           # Drain stack (allocator-first: it applies the cephor_* migrations on startup). Present

--- a/k8s/production/api-local-deployments-production.yaml
+++ b/k8s/production/api-local-deployments-production.yaml
@@ -1,6 +1,6 @@
 # PROD api-local fleet: the api on node-local SSD ingest (s3-2.1 drain-direct).
 #
-# One `api-local` Deployment, 5 replicas (one per ingest node, node1..node5). At cutover the
+# One `api-local` DaemonSet — exactly one pod per ingest node (node1..node5). At cutover the
 # base (ceph) `api` deployment scales to 0 and the `api` Service selector points here, so ALL
 # api pods run on local SSD. Each pod writes to its node's /s3-data NVMe and read-falls-back
 # to the shared CephFS pool. Workers run on ceph. The drain-agent DaemonSet (sole upload
@@ -16,9 +16,11 @@
 #
 # Scheduling: pinned to nodes labeled `s3-prod-local-ingest=true` (the ONE list lives in
 # ingest-node-labels-production.yaml). The drain-agent DaemonSet selects the SAME label, so
-# they stay in lockstep. Preferred pod anti-affinity spreads the replicas one-per-node. A
-# required nodeAffinity hostname allow-list (node1..node5) is belt-and-suspenders WITH the
-# label: a stray/mislabeled node alone can't place ingest on a psql/cache node.
+# they stay in lockstep. Being a DaemonSet, exactly one api-local runs per labelled node — no
+# soft anti-affinity that lets replicas cluster (the Deployment form left node1/node4 with an
+# idle NVMe while node3/node5 ran two pods on one SSD). A required nodeAffinity hostname
+# allow-list (node1..node5) is belt-and-suspenders WITH the label: a stray/mislabeled node
+# alone can't place ingest on a psql/cache node.
 #
 # Routing: the existing `api` Service (the gateway's GATEWAY_BACKEND_URL=http://api:8000
 # upstream) is patched to select `app: api-local` (kustomization.yaml), so the gateway routes
@@ -27,15 +29,19 @@
 # IMPORTANT: with no ceph api pods, every upload stages locally and stays `pending` until the
 # drain replicates local->ceph. The drain stack (allocator + agent) MUST be up first.
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: api-local
   labels:
     app: api-local
 spec:
-  # One per prod ingest node — node1..node5 each have a dedicated /s3-data NVMe.
-  # podAntiAffinity below spreads replicas one-per-node across the labelled nodes.
-  replicas: 5
+  # DaemonSet: exactly one api-local per labelled ingest node (node1..node5), co-located with the
+  # drain-agent DaemonSet so every node's /s3-data writer has its sole drain producer on the same
+  # host. Auto-scales when an ingest node is added/removed (no replicas knob to keep in sync).
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: api-local
@@ -70,14 +76,6 @@ spec:
                       - k8s-v3-node3
                       - k8s-v3-node4
                       - k8s-v3-node5
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app: api-local
-                topologyKey: kubernetes.io/hostname
       initContainers:
         - name: wait-for-postgres
           image: postgres:15


### PR DESCRIPTION
## Problem (found live, post-cutover)

`api-local` (the node-local SSD ingest tier) was a `Deployment(replicas=5)` with only a **soft** (`preferredDuringScheduling`) pod anti-affinity. The manifest comment claimed "one-per-node", but soft affinity doesn't guarantee it — the scheduler clustered the pods:

```
node1=0   node2=1   node3=2   node4=0   node5=2      (drain-agent DaemonSet: 1 on every node)
```

**Consequence:** node1 + node4 each ran a `drain-agent` and a dedicated 3.5 TB NVMe **with no api-local writing to it**, while node3 + node5 ran **two api-local pods sharing one SSD** (doubled write pressure).

**Not a durability bug** — every node that runs api-local also runs a drain-agent (it's a DaemonSet), so no dark uploads; reads fall back to CephFS. This is a **placement / efficiency / resilience** fix: use all five ingest SSDs evenly and keep the writer co-located with its sole drain producer on every node.

## Fix

Convert `api-local` from Deployment → **DaemonSet**, mirroring the `drain-agent` DaemonSet it's designed to pair with:
- **exactly one api-local per labelled ingest node**, guaranteed
- **auto-scales** when an ingest node is added/removed (no `replicas` knob to keep in sync with the node count)
- **correct per-node rolling updates** (`updateStrategy: RollingUpdate, maxUnavailable: 1`)
- drops `replicas: 5` and the soft `podAntiAffinity`; keeps the `nodeSelector` + hostname allow-list unchanged

## CI transition handling

kustomize can't change a resource's `kind` in place, so the pre-DaemonSet `Deployment/api-local` lingers after the first apply (both would serve behind `app=api-local`). The **Wait for rollout** step now:
1. waits on `daemonset/api-local` to be Ready, then
2. prunes `Deployment/api-local` (`--ignore-not-found`, so it's a no-op on every deploy after the conversion lands).

Deleting *after* the DaemonSet is Ready avoids any capacity dip.

## Verification
- `kubectl kustomize k8s/production` renders `api-local` as `DaemonSet`, no residual `replicas`/`podAntiAffinity`, build clean.
- Live evidence of the clustering (node2=1/node3=2/node5=2/node1=0/node4=0) captured post-cutover.

## Follow-up (not in this PR)
Staging's `api-local` (`k8s/staging/api-local-deployments-staging.yaml`, Deployment replicas=2) has the same soft-affinity pattern — worth the same treatment in a separate staging change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
