### PR TITLE
fix(k8s): staging api-local one-per-ingest-node via DaemonSet

### DIFF
--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -320,6 +320,15 @@ jobs:
         run: |
           kubectl rollout status deployment/gateway -n hippius-s3-staging --timeout=10m
           kubectl rollout status deployment/api -n hippius-s3-staging --timeout=10m
+          # api-local is a DaemonSet (one pod per ingest node). Wait on it, then prune the
+          # pre-DaemonSet Deployment of the same name: kustomize can't change a resource's kind
+          # in place, so the old Deployment/api-local lingers after the first DaemonSet apply and
+          # both would serve behind app=api-local. Delete AFTER the DaemonSet is Ready (no capacity
+          # dip); idempotent — a no-op on every deploy after the conversion lands.
+          if kubectl get daemonset/api-local -n hippius-s3-staging >/dev/null 2>&1; then
+            kubectl rollout status daemonset/api-local -n hippius-s3-staging --timeout=10m
+            kubectl delete deployment/api-local -n hippius-s3-staging --ignore-not-found=true
+          fi
           kubectl rollout status deployment/arion-downloader -n hippius-s3-staging --timeout=10m
           kubectl rollout status deployment/arion-uploader -n hippius-s3-staging --timeout=10m
           # Drain stack, allocator-first: the allocator applies the cephor_* migrations

--- a/k8s/staging/README-local-ingest-trial.md
+++ b/k8s/staging/README-local-ingest-trial.md
@@ -10,7 +10,7 @@ and draining local→ceph** — uploads complete e2e (see the drain-gating cavea
 
 | File | What |
 |---|---|
-| `api-local-deployments-staging.yaml` | `api-local` Deployment (**2 replicas**, one per ingest node) writing local (`HIPPIUS_OBJECT_CACHE_DIR=local_object_cache`) with ceph read-fallback. **This is the whole api fleet.** |
+| `api-local-deployments-staging.yaml` | `api-local` **DaemonSet** (exactly one pod per ingest node) writing local (`HIPPIUS_OBJECT_CACHE_DIR=local_object_cache`) with ceph read-fallback. **This is the whole api fleet.** |
 | `resource-limits.yaml` (modified) | Base (ceph) `api` deployment scaled to **0** — no ceph api pods. |
 | `kustomization.yaml` (inline patch) | `api` Service selector switched `app: api` → `app: api-local`, so the gateway routes to the local pods. |
 | `ingest-node-labels-staging.yaml` | **The ONE list** of staging ingest nodes — applying it labels them `s3-staging-local-ingest=true`. |
@@ -40,14 +40,14 @@ deploys cleanly via CI.**
 
 Ingest nodes are declared **once** in `ingest-node-labels-staging.yaml` (partial `Node` objects that
 carry `s3-staging-local-ingest=true`). Deploying applies that label; **both** the `api-local`
-Deployment and the `drain-agent` DaemonSet select on it (`nodeSelector`), so they always target
+DaemonSet and the `drain-agent` DaemonSet select on it (`nodeSelector`), so they always target
 the identical node set — no duplicated hostname list to drift. The DaemonSet (one pod per labeled
 node) therefore covers every node an api pod can land on. Current staging set: **node2, node3** (node1 is
 excluded — it runs at its pod cap, so the agent can't schedule there and would block the DaemonSet roll)
-(node4/5 are near pod-cap and left for prod). `api-local` also uses preferred pod anti-affinity to
-spread its 2 replicas across the labeled nodes.
+(node4/5 are near pod-cap and left for prod). Being a DaemonSet, `api-local` gets exactly one pod
+per labeled node — no soft anti-affinity that lets replicas cluster onto a subset of nodes.
 
-**Belt-and-suspenders:** both the `api-local` Deployment and the `drain-agent` DaemonSet ALSO carry a
+**Belt-and-suspenders:** both the `api-local` DaemonSet and the `drain-agent` DaemonSet ALSO carry a
 **required `nodeAffinity` hostname allow-list** (`kubernetes.io/hostname In [node2, node3]`) on top of
 the label. So a node that gets the ingest label by mistake still won't host ingest unless its hostname
 is on the allow-list — a single misconfiguration can't leak ingest onto a psql/cache node. The label
@@ -87,14 +87,14 @@ throughput (measured ~2.5 min for a 1GB / 128-part object on staging, fsync-boun
 ```bash
 kubectl kustomize k8s/staging | less          # review first
 kubectl apply -k k8s/staging                  # or via the staging-deploy pipeline
-kubectl -n hippius-s3-staging rollout status deploy/api-local --timeout=5m   # 2/2 Ready
+kubectl -n hippius-s3-staging rollout status ds/api-local --timeout=5m      # 2/2 Ready
 kubectl -n hippius-s3-staging get pods -l app=api-local -o wide              # 2 pods, one per ingest node
 kubectl -n hippius-s3-staging get deploy api                                 # base api 0/0
 kubectl -n hippius-s3-staging get endpoints api                              # 2 endpoint IPs (local pods)
 kubectl -n hippius-s3-staging get ds drain-agent                            # 2/2 ready (node2, node3)
 
 # watch a local pod's ingest dir fill on PUT; the object appears on ceph once the drain-agent copies it
-kubectl -n hippius-s3-staging exec deploy/api-local -c api -- sh -c 'ls -R /var/lib/hippius/local_object_cache | head'
+kubectl -n hippius-s3-staging exec ds/api-local -c api -- sh -c 'ls -R /var/lib/hippius/local_object_cache | head'
 # watch replication progress (pending→replicated) in the cephor table:
 kubectl -n hippius-s3-staging exec postgres-1 -c postgres -- psql -U postgres -d hippius -tAc \
   "SELECT status, node_id, count(*) FROM cephor_replication_status GROUP BY 1,2 ORDER BY 1;"

--- a/k8s/staging/api-local-deployments-staging.yaml
+++ b/k8s/staging/api-local-deployments-staging.yaml
@@ -1,6 +1,6 @@
 # Trial (s3-2.0 prototype): the entire staging api fleet on node-local SSD.
 #
-# A single `api-local` Deployment (2 replicas, one per ingest node) — the base (ceph) `api` deployment
+# A single `api-local` DaemonSet — exactly one pod per ingest node. The base (ceph) `api` deployment
 # is scaled to 0 in resource-limits.yaml, so ALL api pods run on local SSD. Each
 # pod writes to its node's local dir and read-falls-back to the shared CephFS
 # cache. All workers stay on ceph, untouched.
@@ -18,8 +18,10 @@
 #
 # Scheduling: pinned to nodes labeled `s3-staging-local-ingest=true` (the ONE list
 # lives in ingest-node-labels-staging.yaml). The drain-agent DaemonSet selects
-# the SAME label, so they stay in lockstep. Preferred pod anti-affinity spreads the
-# 2 replicas across the labeled nodes. A required nodeAffinity hostname allow-list
+# the SAME label, so they stay in lockstep. Being a DaemonSet, exactly one api-local
+# runs per labelled node — no soft anti-affinity that lets replicas cluster (in prod
+# the Deployment form left two nodes with an idle NVMe while two others ran two pods
+# on one SSD; see PR #302). A required nodeAffinity hostname allow-list
 # (node2/node3) is belt-and-suspenders WITH the label: a stray/mislabeled node alone
 # can't place ingest on a psql/cache node — the hostname must ALSO be on the list.
 #
@@ -31,13 +33,19 @@
 # `pending` until the replicator copies local->ceph. Install + test the replicator
 # when ready. See README-local-ingest-trial.md.
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: api-local
   labels:
     app: api-local
 spec:
-  replicas: 2
+  # DaemonSet: exactly one api-local per labelled ingest node, co-located with the drain-agent
+  # DaemonSet so every node's local writer has its sole drain producer on the same host.
+  # Auto-scales when an ingest node is added/removed (no replicas knob to keep in sync).
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: api-local
@@ -61,14 +69,6 @@ spec:
                     values:
                       - k8s-v3-node2
                       - k8s-v3-node3
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app: api-local
-                topologyKey: kubernetes.io/hostname
       initContainers:
         - name: wait-for-postgres
           image: postgres:15


### PR DESCRIPTION
Follow-up to #302 (the prod fix), which called this out explicitly:

> **Follow-up (not in this PR)** — Staging's `api-local` (`k8s/staging/api-local-deployments-staging.yaml`, Deployment replicas=2) has the same soft-affinity pattern — worth the same treatment in a separate staging change.

## Problem

Staging's `api-local` is a `Deployment(replicas=2)` whose "one per ingest node" claim rests on a **soft** (`preferredDuringScheduling`) pod anti-affinity. In prod the same pattern was observed clustering live post-cutover (node3=2, node5=2, node1=0, node4=0) — two pods sharing one SSD while two dedicated NVMes sat idle. Nothing stops staging from doing the same across its 2 ingest nodes (node2/node3).

Not a durability bug — every labelled node also runs a `drain-agent` (DaemonSet), so no dark uploads, and reads fall back to CephFS. This is a **placement / resilience** fix, and it keeps staging structurally identical to prod so the trial actually rehearses the prod topology.

## Fix

Convert `api-local` from Deployment → **DaemonSet**, mirroring the `drain-agent` DaemonSet it's designed to pair with:
- **exactly one api-local per labelled ingest node**, guaranteed
- **auto-scales** when an ingest node is added/removed (no `replicas` knob to keep in sync with `ingest-node-labels-staging.yaml`)
- **per-node rolling updates** (`updateStrategy: RollingUpdate, maxUnavailable: 1`)
- drops `replicas: 2` and the soft `podAntiAffinity`; keeps the `nodeSelector` + hostname allow-list (node2/node3) unchanged

## CI transition handling

kustomize can't change a resource's `kind` in place, so the pre-DaemonSet `Deployment/api-local` lingers after the first apply (both would serve behind `app=api-local`). The **Wait for rollout** step now waits on `daemonset/api-local` to be Ready, then prunes `Deployment/api-local` (`--ignore-not-found`, so it's a no-op on every deploy after the conversion lands). Deleting *after* the DaemonSet is Ready avoids a capacity dip. Note the staging workflow previously didn't wait on `api-local` at all — it does now.

Also refreshes `README-local-ingest-trial.md` (Deployment → DaemonSet wording, `rollout status ds/api-local`, `exec ds/api-local`).

## Verification
- `kubectl kustomize k8s/staging` renders `api-local` as `DaemonSet` with `updateStrategy` and **no** residual `replicas`/`podAntiAffinity`; build clean, `check yaml` passes.

## Conclusion
Small, mechanical parity change: staging now matches the prod topology fixed in #302, so both environments guarantee one ingest writer per local SSD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)