### PR TITLE
ci: fail prod deploy when the ingest tier is undersized

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -300,6 +300,25 @@ jobs:
               echo "deployment/$1 absent — skipping"
             fi
           }
+          # Absolute size of the ingest tier, from the Node stanzas in the label file — the
+          # declarative source of truth for `s3-prod-local-ingest=true`. Both api-local and
+          # drain-agent are DaemonSets over that label, so a Ready count below it means the tier
+          # is serving degraded. This is deliberately an ABSOLUTE check: the drain-agent-vs-api-local
+          # test below only catches ASYMMETRY, and on 2026-07-22 the label was pulled from two nodes,
+          # shrinking BOTH DaemonSets to 3 together — that test passed (3==3, 3>=3) while the tier
+          # ran at 60% capacity for two hours with nothing alerting.
+          ingest_expected=$(grep -c '^kind: Node' k8s/production/ingest-node-labels-production.yaml 2>/dev/null || true)
+          ingest_expected=${ingest_expected:-0}
+          assert_ingest_tier() {
+            ready=$(kubectl get ds "$1" -n "$ns" -o jsonpath='{.status.numberReady}' 2>/dev/null || echo 0)
+            echo "$1 Ready=${ready:-0}/${ingest_expected} labelled ingest nodes"
+            if [ "${ingest_expected:-0}" -gt 0 ] && [ "${ready:-0}" -lt "${ingest_expected}" ]; then
+              echo "::error::$1 Ready ${ready:-0}/${ingest_expected} — ingest tier degraded. Verify every node in ingest-node-labels-production.yaml still carries s3-prod-local-ingest=true."
+              kubectl get nodes -l s3-prod-local-ingest=true || true
+              kubectl get pods -l app="$1" -n "$ns" -o wide || true
+              exit 1
+            fi
+          }
           kubectl rollout status deployment/gateway -n "$ns" --timeout=10m
           # api (monolith / hybrid base) and api-local (drain-direct) — whichever exist.
           wait_deploy api 10m
@@ -311,6 +330,7 @@ jobs:
           if kubectl get daemonset/api-local -n "$ns" >/dev/null 2>&1; then
             kubectl rollout status daemonset/api-local -n "$ns" --timeout=10m
             kubectl delete deployment/api-local -n "$ns" --ignore-not-found=true
+            assert_ingest_tier api-local
           else
             wait_deploy api-local 10m
           fi
@@ -337,6 +357,7 @@ jobs:
               exit 1
             fi
             echo "drain-agent covers every api-local node ✅"
+            assert_ingest_tier drain-agent
           else
             echo "daemonset/drain-agent absent — drain block not yet enabled; skipping"
           fi

--- a/monitoring/grafana/provisioning/alerting/alert-rules.yml
+++ b/monitoring/grafana/provisioning/alerting/alert-rules.yml
@@ -453,6 +453,63 @@ groups:
     folder: Hippius S3 Alerts
     interval: 1m
     rules:
+      # Ingest-tier size. api-local and drain-agent are DaemonSets over the
+      # s3-prod-local-ingest=true label, so Ready == the number of labelled nodes (5, per
+      # k8s/production/ingest-node-labels-production.yaml). This exists because on 2026-07-22
+      # the label was pulled from two nodes and BOTH DaemonSets shrank to 3 together: the
+      # deploy-time check compares drain-agent against the api-local node count, so a
+      # symmetric shrink passes it, and the tier ran at 60% capacity for two hours with
+      # nothing firing. min() so either DaemonSet falling behind trips it. Threshold is the
+      # absolute node count, not a ratio — resizing the tier must be a conscious edit here
+      # AND in the label file. Node labels themselves aren't alertable: kube_node_labels is
+      # not exposed by this kube-state-metrics (no --metric-labels-allowlist), so the
+      # DaemonSet Ready count is the observable proxy for the label going missing.
+      - uid: ingest-tier-degraded
+        title: Ingest Tier Degraded - Fewer Ingest Nodes Than Configured
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'min(kube_daemonset_status_number_ready{namespace="hippius-s3-prod",daemonset=~"api-local|drain-agent"})'
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator:
+                    params:
+                      - 5
+                    type: lt
+                  type: query
+              refId: C
+        noDataState: NoData
+        execErrState: Error
+        for: 10m
+        annotations:
+          description: 'Only {{ if $values.B }}{{ printf "%.0f" $values.B.Value }}{{ else }}N/A{{ end }} of 5 ingest nodes are running the tier. Check `kubectl get nodes -l s3-prod-local-ingest=true` — a missing label silently shrinks both DaemonSets and cuts ingest throughput headroom (5 nodes x 100 MB/s = 500 MB/s; below 4 an N-1 loss drops under the 257 MB/s p99 sustained peak).'
+          summary: Ingest tier is running on fewer nodes than configured
+        labels:
+          severity: critical
+
       # Pages BEFORE the api's fs_cache_pressure 90% cutoff (which 503s every PUT on the
       # node), leaving runway to drain or reclaim. drain_ssd_pressure is a 0..1 fill
       # fraction per node; max() catches the worst node. Unlike drain_ssd_backlog_bytes


### PR DESCRIPTION
Closes the detection gap that let the prod ingest tier run at 60% capacity for two hours on 2026-07-22 with nothing failing or firing.

## What happened

`s3-prod-local-ingest=true` was removed from `k8s-v3-node2` and `k8s-v3-node3` during pod-slot cleanup. `api-local` and `drain-agent` are both DaemonSets over that label, so **both shrank from 5 to 3 together**. The existing deploy check compares `drain-agent` Ready against the `api-local` node count — a symmetric shrink evaluates `3 == 3 AND 3 >= 3` and passes. Nothing in `alert-rules.yml` watches DaemonSet size, so nothing paged either.

## Changes

- **`production-deploy.yaml`** — adds `assert_ingest_tier`, called after both DaemonSet rollout waits. Expected size is read from the `kind: Node` stanzas in `k8s/production/ingest-node-labels-production.yaml` (currently 5), so the gate tracks the declared node set rather than a hardcoded number. The existing relative check stays: it catches asymmetry (a node with `api-local` and no `drain-agent` → dark uploads), which is a different failure.
- **`alert-rules.yml`** — adds `ingest-tier-degraded` to the `hippius-s3-drain` group: `min(kube_daemonset_status_number_ready{namespace="hippius-s3-prod",daemonset=~"api-local|drain-agent"}) < 5`, `for: 10m`, critical. CI only sees tier size at deploy time; this covers the between-deploys window.

## Verification

Gate logic exercised against a stubbed `kubectl`:

| `numberReady` | Result |
|---|---|
| 5 | PASS |
| 3 | FAIL — the case that slipped through |
| 0 | FAIL |
| label file absent | PASS — pre-cutover overlay shapes still deploy |

The alert expression was run against live Prometheus before being written: `kube_daemonset_status_number_ready` is present for both DaemonSets (`job=kubernetes-service-endpoints`) and the exact query returns 5. This check was prompted by a recorded gotcha on this file — a rule once shipped with a matcher that silently matched nothing because PromQL `=~` is fully anchored.

`actionlint` finding set is byte-identical to baseline (4 pre-existing SC2086 infos at lines 58/92/190/269; none in new code).

## Notes

- Threshold is the absolute node count, not a ratio — resizing the tier requires a conscious edit in both the alert and the label file.
- `noDataState: NoData` rather than `OK` like its neighbours: if kube-state-metrics dies, `OK` means silence, and silence is the failure mode this rule exists to catch.
- Alerting on node labels directly is not possible here — `kube_node_labels` is not exposed by this kube-state-metrics (no `--metric-labels-allowlist`), so DaemonSet Ready count is the observable proxy.