### PR TITLE
ci: forward-port the hardened prod rollout gate to staging

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -300,31 +300,64 @@ jobs:
               echo "deployment/$1 absent — skipping"
             fi
           }
+          # Absolute size of the ingest tier, from the Node stanzas in the label file — the
+          # declarative source of truth for `s3-prod-local-ingest=true`. Both api-local and
+          # drain-agent are DaemonSets over that label, so a Ready count below it means the tier
+          # is serving degraded. This is deliberately an ABSOLUTE check: the drain-agent-vs-api-local
+          # test below only catches ASYMMETRY, and on 2026-07-22 the label was pulled from two nodes,
+          # shrinking BOTH DaemonSets to 3 together — that test passed (3==3, 3>=3) while the tier
+          # ran at 60% capacity for two hours with nothing alerting.
+          ingest_expected=$(grep -c '^kind: Node' k8s/production/ingest-node-labels-production.yaml 2>/dev/null || true)
+          ingest_expected=${ingest_expected:-0}
+          assert_ingest_tier() {
+            ready=$(kubectl get ds "$1" -n "$ns" -o jsonpath='{.status.numberReady}' 2>/dev/null || echo 0)
+            echo "$1 Ready=${ready:-0}/${ingest_expected} labelled ingest nodes"
+            if [ "${ingest_expected:-0}" -gt 0 ] && [ "${ready:-0}" -lt "${ingest_expected}" ]; then
+              echo "::error::$1 Ready ${ready:-0}/${ingest_expected} — ingest tier degraded. Verify every node in ingest-node-labels-production.yaml still carries s3-prod-local-ingest=true."
+              kubectl get nodes -l s3-prod-local-ingest=true || true
+              kubectl get pods -l app="$1" -n "$ns" -o wide || true
+              exit 1
+            fi
+          }
           kubectl rollout status deployment/gateway -n "$ns" --timeout=10m
           # api (monolith / hybrid base) and api-local (drain-direct) — whichever exist.
           wait_deploy api 10m
-          wait_deploy api-local 10m
+          # api-local is a DaemonSet (one pod per ingest node). Wait on it, then prune the
+          # pre-DaemonSet Deployment of the same name: kustomize can't change a resource's kind
+          # in place, so the old Deployment/api-local lingers after the first DaemonSet apply and
+          # both would serve behind app=api-local. Delete AFTER the DaemonSet is Ready (no capacity
+          # dip); idempotent — a no-op on every deploy after the conversion lands.
+          if kubectl get daemonset/api-local -n "$ns" >/dev/null 2>&1; then
+            kubectl rollout status daemonset/api-local -n "$ns" --timeout=10m
+            kubectl delete deployment/api-local -n "$ns" --ignore-not-found=true
+            assert_ingest_tier api-local
+          else
+            wait_deploy api-local 10m
+          fi
           kubectl rollout status deployment/arion-downloader -n "$ns" --timeout=10m
           kubectl rollout status deployment/arion-uploader -n "$ns" --timeout=10m
           # Drain stack (allocator-first: it applies the cephor_* migrations on startup). Present
           # only once the drain block is uncommented in kustomization.yaml (at cutover).
           wait_deploy drain-allocator 5m
           wait_deploy mpu-reaper 5m
-          # drain-agent is a DaemonSet: a labeled node at pod capacity legitimately can't host its
-          # pod, which must not fail the deploy. Require >= 1 Ready; warn on a partial roll, fail on
-          # zero. Skip entirely if the DaemonSet isn't deployed yet.
+          # drain-agent is a DaemonSet that MUST cover every node running api-local: a node with
+          # api-local but no drain-agent silently drops that node's uploads (never drained) — peer
+          # review B3. A partial roll is therefore a FAILURE, not a warning. The s3-ingest-priority
+          # class ensures the agent can preempt for a slot, so a partial roll is a real problem now.
+          # Require drain-agent numberReady == desiredNumberScheduled AND >= the api-local node count.
           if kubectl get ds/drain-agent -n "$ns" >/dev/null 2>&1; then
-            if ! kubectl rollout status daemonset/drain-agent -n "$ns" --timeout=5m; then
-              ready=$(kubectl get ds drain-agent -n "$ns" -o jsonpath='{.status.numberReady}' 2>/dev/null || echo 0)
-              desired=$(kubectl get ds drain-agent -n "$ns" -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo 0)
-              if [ "${ready:-0}" -ge 1 ]; then
-                echo "::warning::drain-agent rolled ${ready}/${desired} (a labeled node likely at pod capacity); proceeding"
-              else
-                echo "::error::drain-agent has 0 Ready pods after 5m — rollout genuinely failed"
-                kubectl get pods -l app=drain-agent -n "$ns" -o wide || true
-                exit 1
-              fi
+            kubectl rollout status daemonset/drain-agent -n "$ns" --timeout=10m || true
+            ready=$(kubectl get ds drain-agent -n "$ns" -o jsonpath='{.status.numberReady}' 2>/dev/null || echo 0)
+            desired=$(kubectl get ds drain-agent -n "$ns" -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo 0)
+            apiloc=$(kubectl get pods -l app=api-local -n "$ns" --field-selector=status.phase=Running -o json 2>/dev/null | jq -r '[.items[].spec.nodeName]|unique|length' 2>/dev/null || echo 0)
+            echo "drain-agent ready=${ready}/${desired}; api-local nodes=${apiloc}"
+            if [ "${ready:-0}" -lt "${desired:-1}" ] || [ "${ready:-0}" -lt "${apiloc:-0}" ]; then
+              echo "::error::drain-agent partial (${ready}/${desired}, api-local on ${apiloc} nodes) — a node runs api-local with NO drain-agent (dark uploads). FAILING the deploy."
+              kubectl get pods -l app=drain-agent -n "$ns" -o wide || true
+              exit 1
             fi
+            echo "drain-agent covers every api-local node ✅"
+            assert_ingest_tier drain-agent
           else
             echo "daemonset/drain-agent absent — drain block not yet enabled; skipping"
           fi

--- a/monitoring/grafana/provisioning/alerting/alert-rules.yml
+++ b/monitoring/grafana/provisioning/alerting/alert-rules.yml
@@ -453,6 +453,63 @@ groups:
     folder: Hippius S3 Alerts
     interval: 1m
     rules:
+      # Ingest-tier size. api-local and drain-agent are DaemonSets over the
+      # s3-prod-local-ingest=true label, so Ready == the number of labelled nodes (5, per
+      # k8s/production/ingest-node-labels-production.yaml). This exists because on 2026-07-22
+      # the label was pulled from two nodes and BOTH DaemonSets shrank to 3 together: the
+      # deploy-time check compares drain-agent against the api-local node count, so a
+      # symmetric shrink passes it, and the tier ran at 60% capacity for two hours with
+      # nothing firing. min() so either DaemonSet falling behind trips it. Threshold is the
+      # absolute node count, not a ratio — resizing the tier must be a conscious edit here
+      # AND in the label file. Node labels themselves aren't alertable: kube_node_labels is
+      # not exposed by this kube-state-metrics (no --metric-labels-allowlist), so the
+      # DaemonSet Ready count is the observable proxy for the label going missing.
+      - uid: ingest-tier-degraded
+        title: Ingest Tier Degraded - Fewer Ingest Nodes Than Configured
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              expr: 'min(kube_daemonset_status_number_ready{namespace="hippius-s3-prod",daemonset=~"api-local|drain-agent"})'
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              expression: A
+              reducer: last
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator:
+                    params:
+                      - 5
+                    type: lt
+                  type: query
+              refId: C
+        noDataState: NoData
+        execErrState: Error
+        for: 10m
+        annotations:
+          description: 'Only {{ if $values.B }}{{ printf "%.0f" $values.B.Value }}{{ else }}N/A{{ end }} of 5 ingest nodes are running the tier. Check `kubectl get nodes -l s3-prod-local-ingest=true` — a missing label silently shrinks both DaemonSets and cuts ingest throughput headroom (5 nodes x 100 MB/s = 500 MB/s; below 4 an N-1 loss drops under the 257 MB/s p99 sustained peak).'
+          summary: Ingest tier is running on fewer nodes than configured
+        labels:
+          severity: critical
+
       # Pages BEFORE the api's fs_cache_pressure 90% cutoff (which 503s every PUT on the
       # node), leaving runway to drain or reclaim. drain_ssd_pressure is a 0..1 fill
       # fraction per node; max() catches the worst node. Unlike drain_ssd_backlog_bytes


### PR DESCRIPTION
Stops `staging` from reverting the prod deploy gate on its next promotion, and brings across the ingest-tier size check from #304.

## Why

`staging` carries the **pre-hardening** version of `production-deploy.yaml`. `k8s-production` has since diverged on a single hunk in the rollout step, and promoting `staging` as-is would revert two things:

- **The drain-agent hard failure.** staging still downgrades a partial roll to `::warning::drain-agent rolled N/M … proceeding`. Peer review called this the most dangerous line in the cutover diff: because `api-local` selects the same node label, a node can end up running `api-local` with no `drain-agent`, silently dropping that node's uploads while CI reports green.
- **The DaemonSet handling.** staging waits on `api-local` as a Deployment. It is a DaemonSet in `k8s/production`, and the prod branch also prunes the leftover Deployment of the same name (kustomize cannot change a resource's kind in place).

Same class of regression as the `ff9b537` unpinner fixes that staging reverted and had to be cherry-picked back.

## Changes

- **`production-deploy.yaml`** — syncs the rollout step to `k8s-production`, including `assert_ingest_tier` from #304. After this the file is byte-identical across both branches.
- **`alert-rules.yml`** — adds the `ingest-tier-degraded` rule, matching #304. The file was previously identical across branches and stays so.

## Verification

- Both files confirmed byte-identical to the `fix/ingest-tier-size-gate` branch after the port.
- staging already carries `k8s/production/ingest-node-labels-production.yaml` with 5 `kind: Node` stanzas, so the gate reads the correct expected size here too.
- `actionlint` finding set identical to the pre-change `origin/staging` baseline.
- YAML parses; the drain alert group holds 8 rules with `ingest-tier-degraded` present.

Merge order does not matter — the two PRs converge on the same content.