### PR TITLE
fix(ci/staging): wait for db-migrations Job deletion before apply

### DIFF
--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -279,7 +279,13 @@ jobs:
 
       - name: Delete old migration job
         run: |
-          kubectl delete job db-migrations -n hippius-s3-staging --ignore-not-found=true
+          # A Job's spec.template is immutable, so `apply -k` re-creating db-migrations with a new image
+          # tag over an existing (or still-terminating) Job fails with "spec.template ... field is
+          # immutable". Plain `kubectl delete` can return while the Job is still terminating (its pods
+          # carry the batch.kubernetes.io/job-tracking finalizer), so the very next `apply` races it.
+          # Delete AND wait for the object to be fully gone before applying.
+          kubectl delete job db-migrations -n hippius-s3-staging --ignore-not-found=true --wait=true --timeout=120s
+          kubectl wait --for=delete job/db-migrations -n hippius-s3-staging --timeout=120s 2>/dev/null || true
 
       - name: Deploy Redis cluster
         run: |


### PR DESCRIPTION
## Problem
The staging deploy (PR #305 merge) failed at **Deploy to staging**:
```
The Job "db-migrations" is invalid: spec.template: Invalid value: ... field is immutable
```
A Job's `spec.template` is immutable, and every deploy bumps the image tag → the template always changes. The "Delete old migration job" step exists and ran (✓), but `kubectl delete` returns while the Job is still **terminating** (its pods carry the `batch.kubernetes.io/job-tracking` finalizer), so the immediately-following `kubectl apply -k` **races** it and tries to *update* the still-present Job → immutable error.

## Fix
Make the delete block until the Job is fully gone before the apply re-creates it:
```
kubectl delete job db-migrations ... --wait=true --timeout=120s
kubectl wait --for=delete job/db-migrations ... --timeout=120s || true
```

Also cleared the currently-stuck completed job in `hippius-s3-staging` so the deploy re-runs cleanly.

**Note:** `production-deploy.yaml` has the same delete-then-apply pattern and the same latent race — worth the identical fix in a k8s-production PR (it got lucky on timing this time).