### PR TITLE
Stop prod and staging pruning each other's ingest node label

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -283,6 +283,18 @@ jobs:
         run: |
           kubectl apply -f k8s/redis-cluster/production.yaml
 
+      # Applied server-side in its own step — NOT folded into `apply -k` below — so prod
+      # and staging cannot prune each other's node label (client-side apply does; on
+      # 2026-07-22 that stranded 243 prod parts). Unconditional by design: the drain
+      # resources are still commented out of kustomization.yaml, but prod's drain stack
+      # already runs on these nodes, so the labels must be reasserted every deploy. Full
+      # rationale + the retire-a-node checklist: the manifest header.
+      - name: Label ingest nodes (server-side)
+        run: |
+          kubectl apply --server-side --force-conflicts \
+            --field-manager=hippius-s3-prod-ingest-labels \
+            -f k8s/production/ingest-node-labels-production.yaml
+
       - name: Deploy to production
         run: |
           kubectl apply -k k8s/production

--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -285,6 +285,17 @@ jobs:
         run: |
           kubectl apply -f k8s/redis-cluster/staging.yaml
 
+      # Applied server-side in its own step — NOT folded into `apply -k` below — so prod
+      # and staging cannot prune each other's node label (client-side apply does; on
+      # 2026-07-22 that stranded 243 prod parts). Must run BEFORE the overlay so
+      # api-local and drain-agent find labelled nodes on the first apply. Full rationale
+      # + the retire-a-node checklist: the manifest header.
+      - name: Label ingest nodes (server-side)
+        run: |
+          kubectl apply --server-side --force-conflicts \
+            --field-manager=hippius-s3-staging-ingest-labels \
+            -f k8s/staging/ingest-node-labels-staging.yaml
+
       - name: Deploy to staging
         run: |
           kubectl apply -k k8s/staging

--- a/k8s/production/ingest-node-labels-production.yaml
+++ b/k8s/production/ingest-node-labels-production.yaml
@@ -1,28 +1,52 @@
 # Declarative source of truth for the PROD local-ingest node set.
 #
-# This is the ONE list. `kubectl apply -k k8s/production` applies the
-# `s3-prod-local-ingest=true` label to these nodes; the api-local Deployment and the
-# drain-agent DaemonSet both select on that label, so they stay in lockstep. Both ALSO
-# carry a required nodeAffinity hostname allow-list — keep it in sync with the stanzas
-# below (edit the Node names here AND both allow-lists together).
+# This is the ONE list. The api-local Deployment and the drain-agent DaemonSet both
+# select `s3-prod-local-ingest=true`, so they stay in lockstep. Both ALSO carry a
+# required nodeAffinity hostname allow-list — keep it in sync with the stanzas below
+# (edit the Node names here AND both allow-lists together).
+#
+# APPLIED SEPARATELY, SERVER-SIDE — NOT via `kubectl apply -k k8s/production`.
+# This file is deliberately absent from kustomization.yaml's `resources:`. The deploy
+# runs it as its own step:
+#   kubectl apply --server-side --force-conflicts \
+#     --field-manager=hippius-s3-prod-ingest-labels -f <this file>
+#
+# WHY (incident 2026-07-22): prod and staging BOTH declare partial Node objects for
+# k8s-v3-node2/node3, each carrying its own label key. Client-side apply prunes any key
+# that was in the object's last-applied-configuration but is absent from the manifest
+# being applied — so each environment's deploy DELETED the other's label. Every push to
+# `staging` silently stripped `s3-prod-local-ingest` from node2/node3, which deleted
+# prod's drain-agent there and stranded 243 prod parts in `cephor_replication_status`
+# (node-scoped: a pending row for a node with no agent is unclaimable forever). Server-
+# side apply tracks ownership per field-manager, so each environment owns only the label
+# key it declares and cannot touch the other's. `--force-conflicts` is safe here
+# precisely because this manager declares exactly one label key and can never prune a
+# key it does not list.
 #
 # THE NODES: k8s-v3-node1..node5, each with a dedicated 3.84 TB enterprise NVMe (Gen4
 # datacenter U.2/U.3: WD Ultrastar DC / Micron 7450 PRO / Intel-Solidigm D7-P5520)
 # mounted at /var/lib/hippius/... via the host path /s3-data (ext4). The api-local +
 # drain-agent hostPath points at /s3-data.
 #
-# SHARED CLUSTER — no collision by design: staging's ingest also runs on node2/node3, but
-# on a DIFFERENT disk/path (`s3-staging-local-ingest` → /var/lib/hippius/local_ingest_staging
-# on the node root disk), while prod uses THIS label → the dedicated /s3-data NVMe. So a
-# staging and a prod ingest pod can co-reside on node2/node3 without sharing a disk. (If you
-# want the nodes prod-exclusive — nothing else scheduled — that needs a TAINT + tolerations,
+# SHARED CLUSTER: staging's ingest also runs on node2/node3, on a DIFFERENT disk/path
+# (`s3-staging-local-ingest` → /var/lib/hippius/local_ingest_staging on the node root
+# disk), while prod uses THIS label → the dedicated /s3-data NVMe. Both labels coexist
+# on node2/node3 and a staging and a prod ingest pod co-reside there without sharing a
+# disk. Watch pod-slot headroom: node1/2/4/5 run near the ~110-pod cap. (If you want the
+# nodes prod-exclusive — nothing else scheduled — that needs a TAINT + tolerations,
 # which would evict the general worker pool currently on node1-5; decide separately.)
 #
-# CAVEAT: `apply` adds labels but does not PRUNE them. To retire an ingest node, delete its
-# stanza here AND run: kubectl label node <name> s3-prod-local-ingest-
+# RETIRING A NODE — read this first. Under server-side apply, deleting a stanza here DOES
+# remove the label on the next deploy (unlike the old client-side behaviour). That deletes
+# the node's drain-agent, and any non-terminal `cephor_replication_status` row stamped
+# with that node_id becomes unclaimable — its parts sit on the node-local /s3-data NVMe,
+# unreplicated to CephFS and unreadable via GET. Always drain first:
+#   1. confirm 0 rows: SELECT count(*) FROM cephor_replication_status
+#        WHERE node_id = '<node>' AND status IN ('pending','draining');
+#   2. THEN delete the stanza here.
 #
-# (Partial Node objects: apply merges only metadata.labels, leaving all other node fields
-# untouched. Requires the deploy identity to be able to patch nodes.)
+# (Partial Node objects: the apply owns only metadata.labels.<our key>, leaving all other
+# node fields untouched. Requires the deploy identity to be able to patch nodes.)
 apiVersion: v1
 kind: Node
 metadata:

--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -11,12 +11,18 @@ resources:
   - gateway-nodeport.yaml
   # --- hippius-drain (s3-2.1) SSD-ingest tier — DELIBERATELY COMMENTED OUT. ---
   # Ingest nodes node1..node5 are prepared: each has a dedicated 3.84 TB NVMe mounted at
-  # /s3-data, and ingest-node-labels-production.yaml labels them s3-prod-local-ingest=true
-  # (both nodeAffinity allow-lists list node1..node5). Runbook: path-to-prod.md; sizing:
-  # s3-prod-drain-capacity-plan.md. Before uncommenting: confirm the label is applied on all
-  # five nodes, then also uncomment the `drain` image below, and (cutover) scale base `api`
-  # to 0 + point the `api` Service selector at app: api-local, as k8s/staging/kustomization.yaml does.
-  # - ingest-node-labels-production.yaml
+  # /s3-data (both nodeAffinity allow-lists list node1..node5). Runbook: path-to-prod.md;
+  # sizing: s3-prod-drain-capacity-plan.md. Before uncommenting: also uncomment the `drain`
+  # image below, and (cutover) scale base `api` to 0 + point the `api` Service selector at
+  # app: api-local, as k8s/staging/kustomization.yaml does.
+  #
+  # ingest-node-labels-production.yaml is NOT listed here and must not be added. This
+  # overlay is applied client-side, which prunes any label absent from the manifest — and
+  # staging declares the same Node objects (node2/node3), so the two deploys deleted each
+  # other's ingest label (2026-07-22: cost prod 243 stranded parts). The workflow applies
+  # that file in its own server-side step with a dedicated --field-manager, which scopes
+  # ownership to our label key. That step is UNCONDITIONAL: the labels are applied on every
+  # prod deploy regardless of whether the drain resources below are enabled.
   # - api-local-deployments-production.yaml
   # - drain-allocator-deployment.yaml   # singleton; owns the cephor_* schema (deploy first)
   # - drain-agent-daemonset.yaml        # one per labelled ingest node

--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -16,7 +16,14 @@ resources:
   # Ingest nodes node1..node5 are prepared (dedicated 3.84 TB /s3-data NVMe, labeled
   # s3-prod-local-ingest=true). allocator-first ordering is handled by the agent/reaper
   # initContainers. Routing is NOT flipped here — that's the full-swap overlay (3/3).
-  - ingest-node-labels-production.yaml
+  #
+  # ingest-node-labels-production.yaml is the declarative node list but is NOT listed here,
+  # and must not be added back. This overlay is applied client-side, which prunes any label
+  # absent from the manifest — and staging declares the same Node objects (node2/node3), so
+  # the two deploys deleted each other's ingest label (2026-07-22: cost prod 243 stranded
+  # parts). The workflow applies that file in its own server-side step with a dedicated
+  # --field-manager, which scopes ownership to our label key. That step is UNCONDITIONAL,
+  # so the labels land on every prod deploy independently of the resources below.
   - api-local-deployments-production.yaml
   - drain-allocator-deployment.yaml   # singleton; owns the cephor_* schema (deploy first)
   - drain-agent-daemonset.yaml        # one per labelled ingest node

--- a/k8s/staging/ingest-node-labels-staging.yaml
+++ b/k8s/staging/ingest-node-labels-staging.yaml
@@ -1,25 +1,48 @@
 # Declarative source of truth for the STAGING local-ingest node set.
 #
-# This is the ONE list. `kubectl apply -k k8s/staging` (the deploy) applies the
-# `s3-staging-local-ingest=true` label to these nodes; the api-local Deployment and
-# the drain-agent DaemonSet both select on that label, so they stay in lockstep
-# automatically. Both ALSO carry a required nodeAffinity hostname allow-list (node2,
-# node3) — keep that allow-list in sync with the stanzas below. To change the set,
-# edit the Node stanzas here AND both allow-lists.
+# This is the ONE list. The api-local DaemonSet and the drain-agent DaemonSet both
+# select `s3-staging-local-ingest=true`, so they stay in lockstep automatically. Both
+# ALSO carry a required nodeAffinity hostname allow-list (node2, node3) — keep that
+# allow-list in sync with the stanzas below. To change the set, edit the Node stanzas
+# here AND both allow-lists.
 #
-# SHARED CLUSTER: staging and prod run on the same physical nodes, so their ingest
-# sets MUST be disjoint — prod uses a different label (s3-local-ingest) on DIFFERENT
-# nodes, so a staging and a prod api pod never share a node's /var/lib/hippius/local_ingest.
+# APPLIED SEPARATELY, SERVER-SIDE — NOT via `kubectl apply -k k8s/staging`.
+# This file is deliberately absent from kustomization.yaml's `resources:`. The deploy
+# runs it as its own step:
+#   kubectl apply --server-side --force-conflicts \
+#     --field-manager=hippius-s3-staging-ingest-labels -f <this file>
 #
-# CAVEAT: `apply` adds labels but does not PRUNE them. Removing a node here does not
-# clear its label — to retire an ingest node, delete its stanza AND run:
-#   kubectl label node <name> s3-staging-local-ingest-
+# WHY (incident 2026-07-22): staging and prod BOTH declare partial Node objects for
+# k8s-v3-node2/node3, each carrying its own label key. Client-side apply prunes any
+# key that was in the object's last-applied-configuration but is absent from the
+# manifest being applied — so each environment's deploy DELETED the other's label.
+# Every push to `staging` silently stripped `s3-prod-local-ingest` from node2/node3,
+# which deleted prod's drain-agent there and stranded 243 prod parts in
+# `cephor_replication_status` (node-scoped: a pending row for a node with no agent is
+# unclaimable forever). Server-side apply tracks ownership per field-manager, so each
+# environment owns only the label key it declares and cannot touch the other's.
+# `--force-conflicts` is safe here precisely because this manager declares exactly one
+# label key and can never prune a key it does not list.
 #
-# (These are partial Node objects: apply merges only metadata.labels and leaves all
-# other node fields untouched. Requires the deploy identity to be able to patch nodes.)
-# node1 is intentionally NOT an ingest node: it runs at its ~110-pod cap, so the
+# SHARED CLUSTER: staging and prod ingest sets OVERLAP on node2/node3 by design. Both
+# labels coexist on those nodes; the two stacks use different disks (staging →
+# /var/lib/hippius/local_ingest_staging on the root disk, prod → the dedicated /s3-data
+# NVMe), so co-resident ingest pods never share storage.
+#
+# RETIRING A NODE — read this first. Under server-side apply, deleting a stanza here
+# DOES remove the label on the next deploy (unlike the old client-side behaviour). That
+# deletes the node's drain-agent, and any non-terminal `cephor_replication_status` row
+# stamped with that node_id becomes unclaimable — its parts sit on the node-local SSD,
+# unreplicated and unreadable. Always drain first:
+#   1. confirm 0 rows: SELECT count(*) FROM cephor_replication_status
+#        WHERE node_id = '<node>' AND status IN ('pending','draining');
+#   2. THEN delete the stanza here.
+#
+# (These are partial Node objects: the apply owns only metadata.labels.<our key> and
+# leaves all other node fields untouched. Requires the deploy identity to patch nodes.)
+# node1 is intentionally NOT a staging ingest node: it runs at its ~110-pod cap, so the
 # per-node drain-agent can't schedule there (Pending), which blocks the DaemonSet's
-# rolling update of the other nodes. Ingest set = node2, node3.
+# rolling update of the other nodes. Staging ingest set = node2, node3.
 apiVersion: v1
 kind: Node
 metadata:

--- a/k8s/staging/kustomization.yaml
+++ b/k8s/staging/kustomization.yaml
@@ -11,9 +11,13 @@ resources:
   - postgres-objectstore.yaml
   # s3-2.0 trial: node-local-SSD ingest tier (see README-local-ingest-trial.md).
   # Uses a hostPath (DirectoryOrCreate) volume — no PV/PVC, no manual node prep.
-  # ingest-node-labels-staging.yaml is the ONE list of ingest nodes: applying it
-  # labels them s3-staging-local-ingest=true, which api-local + the drain agent select.
-  - ingest-node-labels-staging.yaml
+  #
+  # ingest-node-labels-staging.yaml is the ONE list of ingest nodes, but it is
+  # DELIBERATELY NOT listed here. This overlay is applied client-side, which prunes any
+  # label absent from the manifest — and prod declares the same Node objects, so the two
+  # deploys deleted each other's ingest label (2026-07-22: cost prod 243 stranded parts).
+  # The workflow applies that file in its own server-side step with a dedicated
+  # --field-manager, which scopes ownership to our label key. Do not re-add it here.
   - api-local-deployments-staging.yaml
   # The hippius-drain stack: the singleton allocator (also the cephor_* schema owner)
   # and the per-ingest-node drain agent DaemonSet. Both use the `drain` image.


### PR DESCRIPTION
Prod and staging each declare partial `Node` objects for **k8s-v3-node2** and **k8s-v3-node3**, carrying different label keys (`s3-prod-local-ingest` / `s3-staging-local-ingest`). Client-side `kubectl apply` prunes any key present in `last-applied-configuration` but absent from the manifest being applied — so each environment's deploy deleted the other's label.

Because `ingest-node-labels-staging.yaml` was in the staging kustomization, **every push to `staging`** stripped `s3-prod-local-ingest` from node2/node3. On 2026-07-22 that deleted prod's `drain-agent` on those nodes; `cephor_replication_status` is node-scoped (`claim_part` filters `node_id`), so **243 pending parts across 243 objects became unclaimable** — sitting on the node-local NVMe, unreplicated to CephFS and unreadable via GET — until the label was restored by hand.

The reverse direction was live too: `k8s/production/kustomization.yaml` now has the ingest tier enabled and listed `ingest-node-labels-production.yaml`, so the next prod deploy would have pruned **staging's** label the same way.

## Changes

- **Both `ingest-node-labels-*.yaml` removed from their kustomization `resources:`** — `apply -k` no longer touches `Node` objects in either overlay.
- **New workflow step in both pipelines**, before the overlay apply:
  ```
  kubectl apply --server-side --force-conflicts \
    --field-manager=hippius-s3-<env>-ingest-labels \
    -f k8s/<env>/ingest-node-labels-<env>.yaml
  ```
  Server-side apply tracks ownership per field-manager, so each environment owns only the key it declares. `--force-conflicts` is bounded: a manager can only take keys its own manifest lists.
- **Both manifest headers rewritten.** They asserted *"SHARED CLUSTER — no collision by design"* and *"apply adds labels but does not PRUNE them"* — both false, and the reason this shipped. They now carry the mechanism plus a drain-before-retire checklist, because under server-side apply deleting a stanza **does** remove the label.

## Relationship to the ingest-tier gate

Complementary, not overlapping. `assert_ingest_tier` (d6041e9) and the Grafana rule (6ca670b) **detect** a shrunken tier after the fact; this PR **prevents** the shrink. The gate derives its expected count from `grep -c '^kind: Node'` on the label file, which this PR leaves at 5 (prod) / 2 (staging) — verified unchanged.

## Verification

- `kubectl kustomize` on both overlays: builds clean, **0 `Node` objects** in output.
- **Server dry-run, both directions**: applying either environment's manifest leaves node2/node3 carrying **both** labels.
- `actionlint`: 10 findings per file before and after — no new warnings; all pre-existing, none near the new steps.
- Both workflows use the same `secrets.KUBE_CONFIG`, and staging already patches `Node` objects today, so the prod step's permission is proven rather than assumed.

## Notes

- The first `--server-side` apply removes the `last-applied-configuration` annotation, permanently disarming client-side prune logic on those objects. Merging this **stops the recurrence immediately**, without waiting on the prod pipeline.
- The production workflow change does not execute from this merge — prod deploys from `k8s-production`. It activates on the next prod promotion.
- Prod's node set stays node1–node5, co-residing with staging on node2/node3 (different disks: `/s3-data` NVMe vs the root-disk staging path).
- Not addressed here: nothing blocks a de-label that strands a node's queue. The gate catches it after the deploy, but there is no pre-flight check that a node being removed has zero non-terminal `cephor_replication_status` rows.
