### PR TITLE
fix(deploy): stop api-local rollout timing out the production deploy

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -327,8 +327,12 @@ jobs:
           # in place, so the old Deployment/api-local lingers after the first DaemonSet apply and
           # both would serve behind app=api-local. Delete AFTER the DaemonSet is Ready (no capacity
           # dip); idempotent — a no-op on every deploy after the conversion lands.
+          # 20m, not 10m: this DaemonSet rolls one node at a time (maxSurge 0), so the wall clock
+          # is per-pod startup x ingest node count and grows every time the tier does. 10m was
+          # already marginal at 5 nodes and timed out mid-roll on 2026-07-22 with the deploy
+          # otherwise healthy.
           if kubectl get daemonset/api-local -n "$ns" >/dev/null 2>&1; then
-            kubectl rollout status daemonset/api-local -n "$ns" --timeout=10m
+            kubectl rollout status daemonset/api-local -n "$ns" --timeout=20m
             kubectl delete deployment/api-local -n "$ns" --ignore-not-found=true
             assert_ingest_tier api-local
           else
@@ -346,7 +350,10 @@ jobs:
           # class ensures the agent can preempt for a slot, so a partial roll is a real problem now.
           # Require drain-agent numberReady == desiredNumberScheduled AND >= the api-local node count.
           if kubectl get ds/drain-agent -n "$ns" >/dev/null 2>&1; then
-            kubectl rollout status daemonset/drain-agent -n "$ns" --timeout=10m || true
+            # 20m for the same per-node-serial reason as api-local. The `|| true` means a timeout
+            # here does not fail directly — it falls through to the ready-count check below, which
+            # would then report a "partial roll" that is really just a roll still in progress.
+            kubectl rollout status daemonset/drain-agent -n "$ns" --timeout=20m || true
             ready=$(kubectl get ds drain-agent -n "$ns" -o jsonpath='{.status.numberReady}' 2>/dev/null || echo 0)
             desired=$(kubectl get ds drain-agent -n "$ns" -o jsonpath='{.status.desiredNumberScheduled}' 2>/dev/null || echo 0)
             apiloc=$(kubectl get pods -l app=api-local -n "$ns" --field-selector=status.phase=Running -o json 2>/dev/null | jq -r '[.items[].spec.nodeName]|unique|length' 2>/dev/null || echo 0)

--- a/k8s/production/api-local-deployments-production.yaml
+++ b/k8s/production/api-local-deployments-production.yaml
@@ -133,11 +133,15 @@ spec:
             - name: kms-certs
               mountPath: /kms_certs
               readOnly: true
+          # This DaemonSet rolls strictly serially (maxSurge 0 / maxUnavailable 1), so every
+          # second of startup gating is multiplied by the ingest node count. failureThreshold
+          # x periodSeconds already grants 200s for a slow start; a long initialDelay adds
+          # nothing but dead time and blew the deploy's rollout timeout at 5 nodes.
           startupProbe:
             httpGet:
               path: /health
               port: 8000
-            initialDelaySeconds: 120
+            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 20

--- a/k8s/staging/api-local-deployments-staging.yaml
+++ b/k8s/staging/api-local-deployments-staging.yaml
@@ -126,11 +126,13 @@ spec:
             - name: kms-certs
               mountPath: /kms_certs
               readOnly: true
+          # Kept in step with production: failureThreshold x periodSeconds already grants 200s
+          # for a slow start, so a long initialDelay only adds dead time to every rollout.
           startupProbe:
             httpGet:
               path: /health
               port: 8000
-            initialDelaySeconds: 120
+            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 20


### PR DESCRIPTION
## Summary

Production deploy [run 29929848049](https://github.com/thenervelab/hippius-s3/actions/runs/29929848049/job/88957344853) failed at `Wait for rollout` with `error: timed out waiting for the condition`, 4 of 5 `api-local` pods updated. Nothing was actually wrong with the release — the rollout simply needed ~12 minutes and the gate allowed 10. The tier finished rolling on its own a few seconds after the job gave up.

**Root cause.** `api-local` is a DaemonSet with `maxSurge: 0` / `maxUnavailable: 1`, so it rolls strictly one node at a time. Each pod was gated behind `startupProbe.initialDelaySeconds: 120`, meaning kubelet withheld the first probe for two full minutes on a process that logs `Application startup complete` about 5 seconds after container start. Cost per node was ~145s (120s delay + image pull + 30s grace on the outgoing pod).

The run's timestamps show it exactly — pods went Ready at 14:49:59, 14:52:40 and 14:55:21, each ~2m41s apart, and the 10m deadline expired at 14:57:55, roughly 30 seconds short of the fifth.

This was not a flake. It would fail on **every** production deploy from here, and get worse with each node added to the ingest tier.

## Changes

- **`k8s/production/api-local-deployments-production.yaml`** — `startupProbe.initialDelaySeconds` 120 → 10 on the `api-local` DaemonSet. `failureThreshold: 20` x `periodSeconds: 10` already budgets 200s for a genuinely slow start, so the initial delay bought no safety; it only added dead time, multiplied by the node count. Serial rollout drops from ~12m to ~2.5m.
- **`.github/workflows/production-deploy.yaml`** — `daemonset/api-local` rollout wait 10m → 20m. Headroom so tier growth alone can't reintroduce this.
- **`.github/workflows/production-deploy.yaml`** — `daemonset/drain-agent` rollout wait 10m → 20m. Same serial-rollout exposure, and its `|| true` means a timeout there falls through to the ready-count assertion, which would then report a "partial roll — dark uploads" failure for what is really just a roll still in progress. That's a misleading error on an otherwise-fine deploy.
- **`k8s/staging/api-local-deployments-staging.yaml`** — same probe change, to keep the overlays in step. Staging's `api-local` is still a Deployment so it wasn't hitting the timeout, but the 2m of dead startup time was pure waste there too.

Left deliberately alone: `k8s/base/api-deployment.yaml` still carries `initialDelaySeconds: 120`. That's the `api` Deployment, which rolls with surge rather than serially, so it isn't on this failure path — worth revisiting separately, but out of scope here.

## Verification

`kubectl kustomize k8s/production` renders as intended, with only the DaemonSet affected:

```
Deployment/api        container=api      initialDelay=120   (unchanged)
Deployment/gateway    container=gateway  initialDelay=30    (unchanged)
DaemonSet/api-local   container=api      initialDelay=10    (changed)
```

Current prod state, for the record — the tier did converge on `api:365d714` after the job failed, so this PR fixes the gate rather than a broken deployment:

```
api-local     5/5 ready, 5 up-to-date
drain-agent   5/5 ready, 5 up-to-date
```

## Conclusion

Two-line behavioural fix to a CI gate that was mis-tuned rather than a code defect. The probe change is the real fix; the timeout bumps are margin. Worth watching the next deploy's `Wait for rollout` duration to confirm it lands near ~2.5m for `api-local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)