### PR TITLE
Apply prod ingest node labels server-side (forward-port of #309)

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -283,6 +283,18 @@ jobs:
         run: |
           kubectl apply -f k8s/redis-cluster/production.yaml
 
+      # Applied server-side in its own step — NOT folded into `apply -k` below — so prod
+      # and staging cannot prune each other's node label. Client-side apply does prune it:
+      # on 2026-07-22 a staging deploy stripped s3-prod-local-ingest from node2/node3 and
+      # stranded 243 prod parts, then a prod deploy stripped s3-staging-local-ingest back
+      # and took staging's ingest tier to 0. Full rationale + the retire-a-node checklist
+      # live in the manifest header.
+      - name: Label ingest nodes (server-side)
+        run: |
+          kubectl apply --server-side --force-conflicts \
+            --field-manager=hippius-s3-prod-ingest-labels \
+            -f k8s/production/ingest-node-labels-production.yaml
+
       - name: Deploy to production
         run: |
           kubectl apply -k k8s/production

--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -179,6 +179,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-images, build-drain]
     environment: production
+    # Serialize against the staging deploy: both target the SAME cluster and the same
+    # shared ingest nodes. On 2026-07-22 they ran simultaneously and collided twice — the
+    # ingest-label flap that stranded 243 parts, and a db-migrations "field is immutable"
+    # race when one run recreated the Job between the other's delete and apply. Server-side
+    # apply fixes the label symptom; this fixes the cause.
+    #
+    # The group string is REPO-SCOPED and must stay byte-identical to the one in
+    # staging-deploy.yaml — that shared string is the whole mechanism. Changing it in one
+    # file silently un-serializes the two environments.
+    #
+    # queue: max (GA 2026-05-07) is load-bearing, not decoration. The default queue:single
+    # allows only ONE pending run per group and CANCELS it when a third arrives — a prod
+    # deploy would be silently dropped. queue:max queues up to 100 FIFO instead. It cannot
+    # be combined with cancel-in-progress: true (workflow validation error).
+    #
+    # Cost: an urgent prod deploy can now wait behind a staging run. Keep deploys short.
+    concurrency:
+      group: hippius-s3-cluster-deploy
+      cancel-in-progress: false
+      queue: max
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -294,6 +314,13 @@ jobs:
           kubectl apply --server-side --force-conflicts \
             --field-manager=hippius-s3-prod-ingest-labels \
             -f k8s/production/ingest-node-labels-production.yaml
+          # Drop the pre-SSA client-side-apply record. Server-side apply does NOT clear it,
+          # and node1/node4/node5 still carry one listing s3-prod-local-ingest. While it
+          # survives, a stray `kubectl apply -f` on this file WITHOUT --server-side (old
+          # runbook, muscle memory) would resurrect the exact prune-on-apply behaviour this
+          # step exists to prevent. Idempotent: a no-op on every deploy once it is gone.
+          kubectl annotate node -l s3-prod-local-ingest=true \
+            kubectl.kubernetes.io/last-applied-configuration- 2>/dev/null || true
 
       - name: Deploy to production
         run: |
@@ -321,8 +348,21 @@ jobs:
           # ran at 60% capacity for two hours with nothing alerting.
           ingest_expected=$(grep -c '^kind: Node' k8s/production/ingest-node-labels-production.yaml 2>/dev/null || true)
           ingest_expected=${ingest_expected:-0}
+          # Poll, don't sample once: `rollout status` can return before the final pod flips
+          # Ready, and a single instantaneous read would then fail an otherwise-good deploy.
+          # This is NOT a weakening — the absolute threshold below is unchanged, the check
+          # just gets up to 60s to be satisfied. (For the record: this guard has never
+          # false-positived. On 2026-07-22 it correctly caught a real 3/5 after staging's
+          # deploy stripped the label from two nodes. Do not relax the threshold itself.)
           assert_ingest_tier() {
             ready=$(kubectl get ds "$1" -n "$ns" -o jsonpath='{.status.numberReady}' 2>/dev/null || echo 0)
+            if [ "${ingest_expected:-0}" -gt 0 ]; then
+              for _ in $(seq 1 12); do
+                [ "${ready:-0}" -ge "${ingest_expected}" ] && break
+                sleep 5
+                ready=$(kubectl get ds "$1" -n "$ns" -o jsonpath='{.status.numberReady}' 2>/dev/null || echo 0)
+              done
+            fi
             echo "$1 Ready=${ready:-0}/${ingest_expected} labelled ingest nodes"
             if [ "${ingest_expected:-0}" -gt 0 ] && [ "${ready:-0}" -lt "${ingest_expected}" ]; then
               echo "::error::$1 Ready ${ready:-0}/${ingest_expected} — ingest tier degraded. Verify every node in ingest-node-labels-production.yaml still carries s3-prod-local-ingest=true."

--- a/k8s/production/ingest-node-labels-production.yaml
+++ b/k8s/production/ingest-node-labels-production.yaml
@@ -1,28 +1,52 @@
 # Declarative source of truth for the PROD local-ingest node set.
 #
-# This is the ONE list. `kubectl apply -k k8s/production` applies the
-# `s3-prod-local-ingest=true` label to these nodes; the api-local Deployment and the
-# drain-agent DaemonSet both select on that label, so they stay in lockstep. Both ALSO
-# carry a required nodeAffinity hostname allow-list — keep it in sync with the stanzas
-# below (edit the Node names here AND both allow-lists together).
+# This is the ONE list. The api-local Deployment and the drain-agent DaemonSet both
+# select `s3-prod-local-ingest=true`, so they stay in lockstep. Both ALSO carry a
+# required nodeAffinity hostname allow-list — keep it in sync with the stanzas below
+# (edit the Node names here AND both allow-lists together).
+#
+# APPLIED SEPARATELY, SERVER-SIDE — NOT via `kubectl apply -k k8s/production`.
+# This file is deliberately absent from kustomization.yaml's `resources:`. The deploy
+# runs it as its own step:
+#   kubectl apply --server-side --force-conflicts \
+#     --field-manager=hippius-s3-prod-ingest-labels -f <this file>
+#
+# WHY (incident 2026-07-22): prod and staging BOTH declare partial Node objects for
+# k8s-v3-node2/node3, each carrying its own label key. Client-side apply prunes any key
+# that was in the object's last-applied-configuration but is absent from the manifest
+# being applied — so each environment's deploy DELETED the other's label. Every push to
+# `staging` silently stripped `s3-prod-local-ingest` from node2/node3, which deleted
+# prod's drain-agent there and stranded 243 prod parts in `cephor_replication_status`
+# (node-scoped: a pending row for a node with no agent is unclaimable forever). Server-
+# side apply tracks ownership per field-manager, so each environment owns only the label
+# key it declares and cannot touch the other's. `--force-conflicts` is safe here
+# precisely because this manager declares exactly one label key and can never prune a
+# key it does not list.
 #
 # THE NODES: k8s-v3-node1..node5, each with a dedicated 3.84 TB enterprise NVMe (Gen4
 # datacenter U.2/U.3: WD Ultrastar DC / Micron 7450 PRO / Intel-Solidigm D7-P5520)
 # mounted at /var/lib/hippius/... via the host path /s3-data (ext4). The api-local +
 # drain-agent hostPath points at /s3-data.
 #
-# SHARED CLUSTER — no collision by design: staging's ingest also runs on node2/node3, but
-# on a DIFFERENT disk/path (`s3-staging-local-ingest` → /var/lib/hippius/local_ingest_staging
-# on the node root disk), while prod uses THIS label → the dedicated /s3-data NVMe. So a
-# staging and a prod ingest pod can co-reside on node2/node3 without sharing a disk. (If you
-# want the nodes prod-exclusive — nothing else scheduled — that needs a TAINT + tolerations,
+# SHARED CLUSTER: staging's ingest also runs on node2/node3, on a DIFFERENT disk/path
+# (`s3-staging-local-ingest` → /var/lib/hippius/local_ingest_staging on the node root
+# disk), while prod uses THIS label → the dedicated /s3-data NVMe. Both labels coexist
+# on node2/node3 and a staging and a prod ingest pod co-reside there without sharing a
+# disk. Watch pod-slot headroom: node1/2/4/5 run near the ~110-pod cap. (If you want the
+# nodes prod-exclusive — nothing else scheduled — that needs a TAINT + tolerations,
 # which would evict the general worker pool currently on node1-5; decide separately.)
 #
-# CAVEAT: `apply` adds labels but does not PRUNE them. To retire an ingest node, delete its
-# stanza here AND run: kubectl label node <name> s3-prod-local-ingest-
+# RETIRING A NODE — read this first. Under server-side apply, deleting a stanza here DOES
+# remove the label on the next deploy (unlike the old client-side behaviour). That deletes
+# the node's drain-agent, and any non-terminal `cephor_replication_status` row stamped
+# with that node_id becomes unclaimable — its parts sit on the node-local /s3-data NVMe,
+# unreplicated to CephFS and unreadable via GET. Always drain first:
+#   1. confirm 0 rows: SELECT count(*) FROM cephor_replication_status
+#        WHERE node_id = '<node>' AND status IN ('pending','draining');
+#   2. THEN delete the stanza here.
 #
-# (Partial Node objects: apply merges only metadata.labels, leaving all other node fields
-# untouched. Requires the deploy identity to be able to patch nodes.)
+# (Partial Node objects: the apply owns only metadata.labels.<our key>, leaving all other
+# node fields untouched. Requires the deploy identity to be able to patch nodes.)
 apiVersion: v1
 kind: Node
 metadata:

--- a/k8s/production/kustomization.yaml
+++ b/k8s/production/kustomization.yaml
@@ -16,7 +16,14 @@ resources:
   # Ingest nodes node1..node5 are prepared (dedicated 3.84 TB /s3-data NVMe, labeled
   # s3-prod-local-ingest=true). allocator-first ordering is handled by the agent/reaper
   # initContainers. Routing is NOT flipped here — that's the full-swap overlay (3/3).
-  - ingest-node-labels-production.yaml
+  #
+  # ingest-node-labels-production.yaml is the declarative node list but is NOT listed here,
+  # and must not be added back. This overlay is applied client-side, which prunes any label
+  # absent from the manifest — and staging declares the same Node objects (node2/node3), so
+  # the two deploys deleted each other's ingest label (2026-07-22: cost prod 243 stranded
+  # parts). The workflow applies that file in its own server-side step with a dedicated
+  # --field-manager, which scopes ownership to our label key. That step is UNCONDITIONAL,
+  # so the labels land on every prod deploy independently of the resources below.
   - api-local-deployments-production.yaml
   - drain-allocator-deployment.yaml   # singleton; owns the cephor_* schema (deploy first)
   - drain-agent-daemonset.yaml        # one per labelled ingest node


### PR DESCRIPTION
Forward-port of the **production half** of #309, which merged to `staging` but is not on this branch.

**This is a live exposure.** Until it lands, every production deploy strips `s3-staging-local-ingest` from k8s-v3-node2 and node3 — it already happened today at 14:4x, taking staging's ingest tier to **0 ready pods**.

## Mechanism

Both overlays declare partial `Node` objects for node2/node3, each with its own label key (`s3-prod-local-ingest` / `s3-staging-local-ingest`). Client-side `kubectl apply` prunes any key present in `last-applied-configuration` but absent from the manifest being applied — so each environment's deploy deletes the other's label.

It has now fired in **both** directions on 2026-07-22:

| Time | Deploy | Effect |
|---|---|---|
| 13:41 | staging | stripped `s3-prod-local-ingest` → prod's drain-agent deleted on node2/node3 → **243 prod parts stranded** |
| 14:4x | production | stripped `s3-staging-local-ingest` → **staging ingest tier to 0/0** |

`cephor_replication_status` is node-scoped (`claim_part` filters `node_id`), so a pending row for a node with no agent is unclaimable forever. The parts sit on that node's local NVMe — unreplicated to CephFS, unreadable via GET. Recovery is only possible while the node's `/s3-data` is intact.

## Changes

- **`ingest-node-labels-production.yaml` removed from the overlay `resources:`** — `apply -k k8s/production` no longer touches `Node` objects.
- **New step before the overlay apply:**
  ```
  kubectl apply --server-side --force-conflicts \
    --field-manager=hippius-s3-prod-ingest-labels \
    -f k8s/production/ingest-node-labels-production.yaml
  ```
  Server-side apply tracks ownership per field-manager, so prod owns only its own key. `--force-conflicts` is bounded: a manager can only take keys its manifest lists.
- **Manifest header corrected.** It asserted *"SHARED CLUSTER — no collision by design"* and *"apply adds labels but does not PRUNE them"* — both false, and the reason this shipped. It now documents the mechanism and a drain-before-retire checklist, because under server-side apply deleting a stanza **does** remove the label.

## Verification

- `kubectl kustomize k8s/production`: builds clean, **0 `Node` objects** in output.
- **Server dry-run against the live cluster**: applying this manifest server-side leaves node2/node3 carrying **both** labels.
- The staging counterpart already ran this exact command in CI today and succeeded.
- `actionlint`: 10 findings before and after — no new warnings.
- `grep -c '^kind: Node'` still returns **5**, so `assert_ingest_tier`'s expected count is unchanged.

## Scope

Deliberately limited to the three production files. The staging-side counterpart is already on `staging` and will arrive here through the normal branch merge — `staging-deploy.yaml` has unrelated divergence between the branches, so pulling it in here would widen the blast radius.

## Not fixed here

- **No `concurrency:` group on either deploy workflow.** Today's staging and production deploys ran simultaneously and collided twice: the label flap above, and a `db-migrations` "field is immutable" failure when one run recreated the Job between the other's delete and apply.
- **`assert_ingest_tier` false-positives on rollouts.** It failed today's production deploy because an `api-local` pod was inside its 120s startup-probe grace. It asserts an absolute Ready count immediately after `rollout status`.
- **Nothing detects stranded rows directly.** Both existing guards measure tier size, not harm, so they cannot distinguish a de-label with an empty queue from one with 243 parts at risk.
