### PR TITLE
fix(netpol): allow monitoring to scrape CNPG :9187 metrics

### DIFF
--- a/k8s/base/networkpolicy.yaml
+++ b/k8s/base/networkpolicy.yaml
@@ -24,12 +24,18 @@ spec:
       ports:
         - port: 8889
           protocol: TCP
+        # CNPG per-instance metrics exporter — scraped by the 'cnpg' Prometheus job
+        - port: 9187
+          protocol: TCP
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: monitoring
       ports:
         - port: 8889
+          protocol: TCP
+        # CNPG per-instance metrics exporter — scraped by the 'cnpg' Prometheus job
+        - port: 9187
           protocol: TCP
     - from:
         - namespaceSelector:


### PR DESCRIPTION
## Summary

The `cnpg` Prometheus scrape job (defined in `thenervelab/hippius-otel` `values/prometheus.yaml`) discovers every CNPG instance pod by the `cnpg.io/cluster` label and scrapes `:9187`. But the `allow-internal` NetworkPolicy only permits the `monitoring` and `cattle-monitoring-system` namespaces to reach `:8889` (the otel-collector). **`:9187` was never opened**, so every CNPG target is `health=down` (`context deadline exceeded`) and **no `cnpg_*` metrics reach Prometheus from prod**.

Verified live:
- `monitoring` ns → `postgres-nvme-2:9187` = timeout (blocked)
- same-namespace → `:9187` = 48 metric lines (endpoint healthy)
- Prometheus `/api/v1/targets` for the `cnpg` pool: all 6 targets `health=down`, `0` `cnpg_` series present.

This is one root cause of why the `postgres-nvme-4` replica could sit **23 days stale** while CNPG/kube-state reported it "ready": there were no per-instance replication metrics to alert on.

## Change

Add `:9187` alongside the existing `:8889` for both the `monitoring` and `cattle-monitoring-system` ingress rules in `k8s/base/networkpolicy.yaml`.

## Blast radius

- NetworkPolicy-only; no workload change. Purely *widens* ingress by one port from two trusted monitoring namespaces.
- `k8s/base` is shared, so staging gets the same fix when this is forward-ported to the `staging` branch (follow-up).

## Note / follow-up (not in this PR)

Even with this merged, `cnpg_pg_replication_*` will still be empty: the CNPG exporter's replication collectors query database `app`, which does not exist (the real DB is `hippius`) — every `pg_stat_replication`/`pg_replication` query errors. That exporter-target fix + the per-instance replication-staleness **alert** (in hippius-otel) are separate, dependent follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)