### PR TITLE
fix(deploy): serialize staging against production deploys

### DIFF
--- a/.github/workflows/staging-deploy.yaml
+++ b/.github/workflows/staging-deploy.yaml
@@ -178,6 +178,24 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-images, build-drain]
     environment: staging
+    # Serialize against the production deploy: both target the SAME cluster and share
+    # ingest nodes node2/node3. On 2026-07-22 they ran simultaneously and collided twice —
+    # the ingest-label flap that stranded 243 prod parts, and a db-migrations "field is
+    # immutable" race when one run recreated the Job between the other's delete and apply.
+    # Server-side apply fixes the label symptom; this fixes the cause.
+    #
+    # The group string is REPO-SCOPED and must stay byte-identical to the one in
+    # production-deploy.yaml — that shared string is the whole mechanism. Changing it in
+    # one file silently un-serializes the two environments.
+    #
+    # queue: max (GA 2026-05-07) is load-bearing, not decoration. The default queue:single
+    # allows only ONE pending run per group and CANCELS it when a third arrives — a deploy
+    # would be silently dropped. queue:max queues up to 100 FIFO instead. It cannot be
+    # combined with cancel-in-progress: true (workflow validation error).
+    concurrency:
+      group: hippius-s3-cluster-deploy
+      cancel-in-progress: false
+      queue: max
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -301,6 +319,13 @@ jobs:
           kubectl apply --server-side --force-conflicts \
             --field-manager=hippius-s3-staging-ingest-labels \
             -f k8s/staging/ingest-node-labels-staging.yaml
+          # Drop any pre-SSA client-side-apply record. Server-side apply does NOT clear it,
+          # and while one survives, a stray `kubectl apply -f` on this file WITHOUT
+          # --server-side (old runbook, muscle memory) would resurrect the prune-on-apply
+          # behaviour this step exists to prevent. Currently a no-op on node2/node3 — kept
+          # for symmetry with production-deploy.yaml and to stay safe if one reappears.
+          kubectl annotate node -l s3-staging-local-ingest=true \
+            kubectl.kubernetes.io/last-applied-configuration- 2>/dev/null || true
 
       - name: Deploy to staging
         run: |


### PR DESCRIPTION
## Summary

Companion to **#311**. That PR stops prod and staging pruning each other's ingest node label via server-side apply; this one stops the two deploys running against the shared cluster at the same time in the first place.

**This half is required for the fix to work at all.** GitHub concurrency groups are repository-scoped, so serialization only engages once *both* workflows declare the same group string. #311 alone leaves staging free to deploy concurrently exactly as it does today.

## Changes

- **Job-level `concurrency` on `deploy-staging`**, group `hippius-s3-cluster-deploy` — byte-identical to the string in `production-deploy.yaml` (verified by hash). Placed on the deploy job rather than the workflow so builds still run in parallel; only the cluster-touching phase serializes.
- **`queue: max`** — this is load-bearing, not decoration. The default `queue: single` permits only ONE pending run per group and *cancels* it when a third arrives, which would silently drop a deploy. `queue: max` queues up to 100 FIFO. It cannot be combined with `cancel-in-progress: true` (workflow validation error). [GA 2026-05-07](https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/).
- **Strip any pre-SSA `last-applied-configuration` annotation** after the label apply. Server-side apply does not clear it, and while one survives a `kubectl apply -f` without `--server-side` would resurrect prune-on-apply. A no-op on node2/node3 today; kept for symmetry with prod and safety if one reappears.

## Verification

`queue: max` was validated against **GitHub's own workflow parser** on a throwaway branch — a workflow carrying this exact concurrency block ran to success. This matters because `actionlint`'s bundled schema predates the feature and reports `unexpected key "queue"`; that is a false positive from stale tooling, not a real error. actionlint is not wired into CI here.

Group string match confirmed:
```
staging = 897b10cce3af34218d0faa00e9c53ccc
prod    = 897b10cce3af34218d0faa00e9c53ccc   MATCH
```

## Also fixed by this

The `db-migrations` "field is immutable" failure on 2026-07-22 was two runs interleaving delete/apply on the Job. Serializing the deploys removes that race — no manifest change needed, since `k8s/base/migration-job.yaml` already carries `ttlSecondsAfterFinished: 7200`.

## Tradeoff

An urgent prod deploy can now wait behind a staging run. Worth pairing with #310, which cuts the `api-local` rollout from ~12m to ~2.5m and makes the queue cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)