### PR TITLE
Make otel-collector config changes actually take effect

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -17,3 +17,18 @@ resources:
   - networkpolicy.yaml
   - otel-collector.yaml
   - servicemonitor.yaml
+
+# Generated, not a plain resource, so the name carries a content hash. The collector reads
+# its config once at startup: under a fixed name, `kubectl apply -k` updates the ConfigMap
+# and the running pod keeps the old copy indefinitely. Prod ran 37 days that way (pod
+# started 2026-06-15, ConfigMap last applied 2026-07-22) still applying `action: upsert` to
+# service.name, which stamped service.name=hippius-s3 over drain-agent, drain-allocator and
+# every worker — making them indistinguishable in Prometheus. The hash renames the ConfigMap
+# on any content change, which changes the Deployment's volume reference, which rolls the pod.
+#
+# The key MUST stay otel-config.yaml: the container runs
+# --config=/etc/otelcol-contrib/otel-config.yaml against this volume.
+configMapGenerator:
+  - name: otel-collector-config
+    files:
+      - otel-config.yaml

--- a/k8s/base/otel-collector.yaml
+++ b/k8s/base/otel-collector.yaml
@@ -1,75 +1,12 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: otel-collector-config
-data:
-  otel-config.yaml: |
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-
-    processors:
-      resource:
-        attributes:
-          # insert (not upsert) so a producer's own service.name (api/gateway via
-          # configure_otel, workers via OTEL_SERVICE_NAME, the Rust drain) survives;
-          # this only labels telemetry that arrives without a service.name.
-          - key: service.name
-            value: "hippius-s3"
-            action: insert
-      batch:
-        timeout: 1s
-        send_batch_size: 1024
-      memory_limiter:
-        limit_mib: 768
-        spike_limit_mib: 128
-        check_interval: 1s
-
-    exporters:
-      prometheus:
-        endpoint: "0.0.0.0:8889"
-        send_timestamps: true
-        metric_expiration: 180m
-        enable_open_metrics: true
-        resource_to_telemetry_conversion:
-          enabled: true
-      otlp/tempo:
-        endpoint: tempo.monitoring.svc.cluster.local:4317
-        tls:
-          insecure: true
-        retry_on_failure:
-          enabled: true
-          max_elapsed_time: 300s
-        sending_queue:
-          enabled: true
-          num_consumers: 4
-          queue_size: 100
-      loki:
-        endpoint: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
-
-    extensions:
-      health_check:
-        endpoint: 0.0.0.0:13133
-
-    service:
-      extensions: [health_check]
-      pipelines:
-        metrics:
-          receivers: [otlp]
-          processors: [memory_limiter, resource, batch]
-          exporters: [prometheus]
-        traces:
-          receivers: [otlp]
-          processors: [memory_limiter, batch]
-          exporters: [otlp/tempo]
-        logs:
-          receivers: [otlp]
-          processors: [memory_limiter, resource, batch]
-          exporters: [loki]
+# The otel-collector ConfigMap is NOT here — it is generated from otel-config.yaml by the
+# configMapGenerator in kustomization.yaml, which appends a content hash to its name.
+# That hash is what makes a config change actually take effect: the collector reads its
+# config ONCE at startup, and with a fixed ConfigMap name `kubectl apply -k` updates the
+# ConfigMap while leaving the running pod untouched. Prod sat 37 days on a stale config
+# that way (pod started 2026-06-15, ConfigMap last applied 2026-07-22), silently forcing
+# service.name=hippius-s3 onto every workload because the loaded copy still said `upsert`.
+# With the hash in the name, changing otel-config.yaml renames the ConfigMap, which changes
+# the volume reference, which rolls the pod. Do not pin the name back.
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/base/otel-config.yaml
+++ b/k8s/base/otel-config.yaml
@@ -1,0 +1,66 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  resource:
+    attributes:
+      # insert (not upsert) so a producer's own service.name (api/gateway via
+      # configure_otel, workers via OTEL_SERVICE_NAME, the Rust drain) survives;
+      # this only labels telemetry that arrives without a service.name.
+      - key: service.name
+        value: "hippius-s3"
+        action: insert
+  batch:
+    timeout: 1s
+    send_batch_size: 1024
+  memory_limiter:
+    limit_mib: 768
+    spike_limit_mib: 128
+    check_interval: 1s
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+    send_timestamps: true
+    metric_expiration: 180m
+    enable_open_metrics: true
+    resource_to_telemetry_conversion:
+      enabled: true
+  otlp/tempo:
+    endpoint: tempo.monitoring.svc.cluster.local:4317
+    tls:
+      insecure: true
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 300s
+    sending_queue:
+      enabled: true
+      num_consumers: 4
+      queue_size: 100
+  loki:
+    endpoint: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/tempo]
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [loki]


### PR DESCRIPTION
## The bug

The collector reads its config **once at startup**, and `otel-collector-config` had a fixed name. So `kubectl apply -k` updates the ConfigMap and leaves the running pod on the old copy — indefinitely. There is no reload sidecar and no checksum annotation.

Prod sat **37 days** in that state:

| | collector pod started | its ConfigMap last applied |
|---|---|---|
| **prod** | 2026-06-15 15:21 | **2026-07-22 08:18** |
| staging | 2026-07-02 11:41:34 | 2026-07-02 11:41:31 |

Staging was correct purely by accident — its pod happened to start 3 seconds *after* its ConfigMap.

## Why it mattered

The stale copy still had `action: upsert` on `service.name`. `upsert` overwrites each producer's own name, so the collector stamped `service.name=hippius-s3` onto **everything** — `drain-agent`, `drain-allocator`, `api`, all workers — leaving them indistinguishable in Prometheus. The current on-disk config uses `insert` (fallback only) and has since 2026-07-22, but nothing had loaded it.

That is why no drain alert rule could name the component it was firing about: in prod, agent vs allocator was only separable by regexing `exported_instance`.

Already remediated by hand (`rollout restart deploy/otel-collector` in `hippius-s3-prod`); the drain metrics now report `hippius-drain-agent` / `hippius-drain-allocator` correctly. **This PR stops it recurring** — the manual restart fixed the instance, not the class.

## The fix

Move the config to `k8s/base/otel-config.yaml` and generate the ConfigMap with `configMapGenerator`, so its name carries a content hash. A config change renames the ConfigMap → changes the Deployment's volume reference → rolls the pod. Kustomize's own mechanism for exactly this; no annotation to keep in sync by hand.

## Verification

- `kubectl kustomize k8s/production` and `k8s/staging` both build.
- Deployment volume reference matches the generated name in both overlays (`otel-collector-config-86tcmd4hkk`).
- **Rendered config is byte-identical to what is live in prod** — so the only effect is the rename plus one pod roll, not a config change riding along.
- `hippius-s3-defaults` and `hippius-s3-environment` keep fixed names and are unaffected; only the collector ConfigMap is generated.

## Two things to know when this deploys

1. **One collector restart per environment**, on the first apply, as the volume reference moves to the hashed name. Brief metrics gap; `OtelCollectorDown` is `for: 15m` so it will not page.
2. **The old `otel-collector-config` ConfigMap is orphaned.** `kubectl apply -k` does not prune, so it lingers until deleted by hand:
   `kubectl -n <ns> delete cm otel-collector-config`
   Worth doing, because a runbook or a human reaching for `kubectl edit cm otel-collector-config` would otherwise be editing an object nothing mounts — the same silent-no-op this PR exists to remove.

## Diagnostic worth keeping

If the collector pod is older than its ConfigMap, the running config is not what the repo says:

```bash
kubectl -n <ns> get pods -l app=otel-collector -o jsonpath='{.items[0].status.startTime}'
kubectl -n <ns> get cm otel-collector-config -o jsonpath='{.metadata.managedFields[*].time}'
```