### PR TITLE
fix(netpol): allow monitoring to scrape CNPG :9187 metrics (staging back-port)

### DIFF
--- a/k8s/base/networkpolicy.yaml
+++ b/k8s/base/networkpolicy.yaml
@@ -24,12 +24,18 @@ spec:
       ports:
         - port: 8889
           protocol: TCP
+        # CNPG per-instance metrics exporter — scraped by the 'cnpg' Prometheus job
+        - port: 9187
+          protocol: TCP
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: monitoring
       ports:
         - port: 8889
+          protocol: TCP
+        # CNPG per-instance metrics exporter — scraped by the 'cnpg' Prometheus job
+        - port: 9187
           protocol: TCP
     - from:
         - namespaceSelector:


### PR DESCRIPTION
Back-port of #312 to `staging`, so `k8s/base/networkpolicy.yaml` stays in sync between `staging` and `k8s-production`.

Opens `:9187` alongside the existing `:8889` for the `monitoring` and `cattle-monitoring-system` namespaces, so the `cnpg` Prometheus scrape job can reach per-instance CNPG metrics on staging (currently `health=down`, same as prod was).

NetworkPolicy-only; no workload change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)