### PR TITLE
fix(otel): hash-generate collector ConfigMap so config changes roll the pod (prod back-port)

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -17,3 +17,18 @@ resources:
   - networkpolicy.yaml
   - otel-collector.yaml
   - servicemonitor.yaml
+
+# Generated, not a plain resource, so the name carries a content hash. The collector reads
+# its config once at startup: under a fixed name, `kubectl apply -k` updates the ConfigMap
+# and the running pod keeps the old copy indefinitely. Prod ran 37 days that way (pod
+# started 2026-06-15, ConfigMap last applied 2026-07-22) still applying `action: upsert` to
+# service.name, which stamped service.name=hippius-s3 over drain-agent, drain-allocator and
+# every worker — making them indistinguishable in Prometheus. The hash renames the ConfigMap
+# on any content change, which changes the Deployment's volume reference, which rolls the pod.
+#
+# The key MUST stay otel-config.yaml: the container runs
+# --config=/etc/otelcol-contrib/otel-config.yaml against this volume.
+configMapGenerator:
+  - name: otel-collector-config
+    files:
+      - otel-config.yaml

--- a/k8s/base/otel-collector.yaml
+++ b/k8s/base/otel-collector.yaml
@@ -1,75 +1,12 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: otel-collector-config
-data:
-  otel-config.yaml: |
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-
-    processors:
-      resource:
-        attributes:
-          # insert (not upsert) so a producer's own service.name (api/gateway via
-          # configure_otel, workers via OTEL_SERVICE_NAME, the Rust drain) survives;
-          # this only labels telemetry that arrives without a service.name.
-          - key: service.name
-            value: "hippius-s3"
-            action: insert
-      batch:
-        timeout: 1s
-        send_batch_size: 1024
-      memory_limiter:
-        limit_mib: 768
-        spike_limit_mib: 128
-        check_interval: 1s
-
-    exporters:
-      prometheus:
-        endpoint: "0.0.0.0:8889"
-        send_timestamps: true
-        metric_expiration: 180m
-        enable_open_metrics: true
-        resource_to_telemetry_conversion:
-          enabled: true
-      otlp/tempo:
-        endpoint: tempo.monitoring.svc.cluster.local:4317
-        tls:
-          insecure: true
-        retry_on_failure:
-          enabled: true
-          max_elapsed_time: 300s
-        sending_queue:
-          enabled: true
-          num_consumers: 4
-          queue_size: 100
-      loki:
-        endpoint: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
-
-    extensions:
-      health_check:
-        endpoint: 0.0.0.0:13133
-
-    service:
-      extensions: [health_check]
-      pipelines:
-        metrics:
-          receivers: [otlp]
-          processors: [memory_limiter, resource, batch]
-          exporters: [prometheus]
-        traces:
-          receivers: [otlp]
-          processors: [memory_limiter, batch]
-          exporters: [otlp/tempo]
-        logs:
-          receivers: [otlp]
-          processors: [memory_limiter, resource, batch]
-          exporters: [loki]
+# The otel-collector ConfigMap is NOT here — it is generated from otel-config.yaml by the
+# configMapGenerator in kustomization.yaml, which appends a content hash to its name.
+# That hash is what makes a config change actually take effect: the collector reads its
+# config ONCE at startup, and with a fixed ConfigMap name `kubectl apply -k` updates the
+# ConfigMap while leaving the running pod untouched. Prod sat 37 days on a stale config
+# that way (pod started 2026-06-15, ConfigMap last applied 2026-07-22), silently forcing
+# service.name=hippius-s3 onto every workload because the loaded copy still said `upsert`.
+# With the hash in the name, changing otel-config.yaml renames the ConfigMap, which changes
+# the volume reference, which rolls the pod. Do not pin the name back.
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/base/otel-config.yaml
+++ b/k8s/base/otel-config.yaml
@@ -1,0 +1,66 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  resource:
+    attributes:
+      # insert (not upsert) so a producer's own service.name (api/gateway via
+      # configure_otel, workers via OTEL_SERVICE_NAME, the Rust drain) survives;
+      # this only labels telemetry that arrives without a service.name.
+      - key: service.name
+        value: "hippius-s3"
+        action: insert
+  batch:
+    timeout: 1s
+    send_batch_size: 1024
+  memory_limiter:
+    limit_mib: 768
+    spike_limit_mib: 128
+    check_interval: 1s
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+    send_timestamps: true
+    metric_expiration: 180m
+    enable_open_metrics: true
+    resource_to_telemetry_conversion:
+      enabled: true
+  otlp/tempo:
+    endpoint: tempo.monitoring.svc.cluster.local:4317
+    tls:
+      insecure: true
+    retry_on_failure:
+      enabled: true
+      max_elapsed_time: 300s
+    sending_queue:
+      enabled: true
+      num_consumers: 4
+      queue_size: 100
+  loki:
+    endpoint: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp/tempo]
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, resource, batch]
+      exporters: [loki]


### PR DESCRIPTION
Back-port of #314 to `k8s-production`, keeping `k8s/base` in sync between `staging` and `k8s-production`.

## What
Generate the otel-collector ConfigMap via `configMapGenerator` (content-hashed name) so a config change renames it → changes the Deployment volume ref → rolls the pod. Kustomize's native mechanism for config reload; no checksum annotation to hand-maintain.

## Verification
- `kubectl kustomize k8s/production` and `k8s/staging` both build (45 resources in prod).
- Generated name matches #314: `otel-collector-config-86tcmd4hkk`.
- Rendered config is byte-identical to what's live in prod — only effect on first apply is the rename + one collector restart (`OtelCollectorDown` is `for: 15m`, won't page).

## Post-deploy cleanup
The old fixed-name ConfigMap is orphaned (apply doesn't prune):
`kubectl -n hippius-s3-prod delete cm otel-collector-config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)