### PR TITLE
fix(drain): reclaim replicated crash-orphans from the ingest SSD

### DIFF
--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -73,6 +73,13 @@ const DEFAULT_ORPHAN_RECLAIM_GRACE: Duration = Duration::from_hours(24);
 /// (abandoned-upload) part — and an orphan write-temp — is kept on SSD before
 /// eviction (a diagnosis / abort-settle window).
 const DEFAULT_RECLAIM_GRACE: Duration = Duration::from_hours(1);
+/// Replicated crash-orphan grace when `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS` is unset: how
+/// long a `replicated` part may linger on SSD before the reclaim treats it as a drain
+/// crash-orphan (a crash between the `mark_replicated` commit and the drain's own unlink) and
+/// re-drives that unlink. The happy-path unlink runs milliseconds after the commit, so this
+/// need only clear the in-flight-unlink window; a conservative hour also absorbs reclaim-poll
+/// skew. Keyed on the row's `updated_at` (store clock), so no agent-clock dependence.
+const DEFAULT_REPLICATED_RECLAIM_GRACE: Duration = Duration::from_hours(1);
 
 /// Default path of the liveness file the runtime touches each heartbeat tick; the
 /// k8s `livenessProbe` checks its freshness. Container-local `/tmp` is always writable.
@@ -141,6 +148,10 @@ pub struct Config {
     /// How long a no-DB-backing part (its object hard-deleted) is kept on SSD before the
     /// orphan reclaim evicts it. Keyed on the part's FS `meta.json` age, so set generously.
     pub orphan_reclaim_grace: Duration,
+    /// How long a `replicated` part may linger on SSD before the reclaim re-drives the drain's
+    /// own unlink (treating it as a crash-orphan). Keyed on the row's `updated_at`, so set only
+    /// to clear the in-flight-unlink window.
+    pub replicated_reclaim_grace: Duration,
     /// Maximum parts the drain worker processes concurrently — the in-flight gate
     /// that lets the node overlap fsync latency across parts.
     pub drain_concurrency: u32,
@@ -224,6 +235,7 @@ impl Config {
             reclaim_poll: self.reclaim_poll,
             reclaim_grace: self.reclaim_grace,
             orphan_reclaim_grace: self.orphan_reclaim_grace,
+            replicated_reclaim_grace: self.replicated_reclaim_grace,
             grace: self.grace,
             drain_concurrency: self.drain_concurrency,
             redrive_max_attempts: self.redrive_max_attempts,
@@ -295,6 +307,7 @@ impl Config {
             reclaim_poll: duration_secs(&get, "CEPHOR_RECLAIM_POLL_SECS", DEFAULT_RECLAIM_POLL)?,
             reclaim_grace: duration_secs(&get, "CEPHOR_RECLAIM_GRACE_SECS", DEFAULT_RECLAIM_GRACE)?,
             orphan_reclaim_grace: duration_secs(&get, "CEPHOR_ORPHAN_RECLAIM_GRACE_SECS", DEFAULT_ORPHAN_RECLAIM_GRACE)?,
+            replicated_reclaim_grace: duration_secs(&get, "CEPHOR_REPLICATED_RECLAIM_GRACE_SECS", DEFAULT_REPLICATED_RECLAIM_GRACE)?,
             drain_concurrency: positive_u32_or(&get, "CEPHOR_DRAIN_CONCURRENCY", DEFAULT_DRAIN_CONCURRENCY)?,
             redrive_max_attempts: positive_u32_or(&get, "CEPHOR_REDRIVE_MAX_ATTEMPTS", DEFAULT_REDRIVE_MAX_ATTEMPTS)?,
             liveness_file: path_or(&get, "CEPHOR_LIVENESS_FILE", DEFAULT_LIVENESS_FILE),
@@ -403,7 +416,7 @@ mod tests {
     use super::{
         Config, ConfigError, DEFAULT_ALLOCATION_POLL, DEFAULT_CLAIM_LEASE, DEFAULT_DECAY_HALF_LIFE, DEFAULT_DRAIN_CONCURRENCY, DEFAULT_DRAIN_POLL,
         DEFAULT_FLOOR_RATE_BPS, DEFAULT_HEARTBEAT_POLL, DEFAULT_HEARTBEAT_TTL, DEFAULT_MAX_DRAIN_RATE_BPS, DEFAULT_ORPHAN_RECLAIM_GRACE,
-        DEFAULT_RECLAIM_GRACE, DEFAULT_RECLAIM_POLL,
+        DEFAULT_RECLAIM_GRACE, DEFAULT_RECLAIM_POLL, DEFAULT_REPLICATED_RECLAIM_GRACE,
     };
     use core::str::FromStr;
     use hippius_drain_core::{ByteRate, NodeId};
@@ -537,6 +550,7 @@ mod tests {
         assert_eq!(config.reclaim_poll, DEFAULT_RECLAIM_POLL);
         assert_eq!(config.reclaim_grace, DEFAULT_RECLAIM_GRACE);
         assert_eq!(config.orphan_reclaim_grace, DEFAULT_ORPHAN_RECLAIM_GRACE);
+        assert_eq!(config.replicated_reclaim_grace, DEFAULT_REPLICATED_RECLAIM_GRACE);
     }
 
     #[test]
@@ -545,10 +559,12 @@ mod tests {
         pairs.push(("CEPHOR_RECLAIM_POLL_SECS", "120"));
         pairs.push(("CEPHOR_RECLAIM_GRACE_SECS", "600"));
         pairs.push(("CEPHOR_ORPHAN_RECLAIM_GRACE_SECS", "7200"));
+        pairs.push(("CEPHOR_REPLICATED_RECLAIM_GRACE_SECS", "1800"));
         let config = Config::from_lookup(lookup(&pairs)).unwrap();
         assert_eq!(config.reclaim_poll, Duration::from_mins(2));
         assert_eq!(config.reclaim_grace, Duration::from_mins(10));
         assert_eq!(config.orphan_reclaim_grace, Duration::from_hours(2));
+        assert_eq!(config.replicated_reclaim_grace, Duration::from_mins(30));
     }
 
     #[test]

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -97,6 +97,10 @@ pub struct RuntimeConfig {
     /// How long a no-DB-backing part (its object hard-deleted) is kept before the orphan
     /// reclaim unlinks it. Keyed on the part's FS `meta.json` age, so set generously.
     pub orphan_reclaim_grace: Duration,
+    /// How long a `replicated` part may linger on SSD before the reclaim re-drives the drain's
+    /// own unlink (a crash-orphan between the `mark_replicated` commit and the unlink). Keyed
+    /// on the row's `updated_at`.
+    pub replicated_reclaim_grace: Duration,
     /// How long workers get to finish an in-flight tick after cancellation
     /// before the supervisor force-aborts them.
     pub grace: Duration,
@@ -283,11 +287,11 @@ async fn heartbeat_once(ssd: &LocalSsd, store: &Store, coord: &Coordinator, node
 /// Reclaim and sweep errors are logged and skipped; the next tick retries, and no part
 /// is ever removed without a successful status read (fail-safe). The store is both the
 /// replication log and the object-backing log for the reclaim.
-async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, grace: Duration, orphan_grace: Duration) {
-    match reclaim_ssd(ssd, ssd, store, store, grace, orphan_grace).await {
+async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, grace: Duration, orphan_grace: Duration, replicated_grace: Duration) {
+    match reclaim_ssd(ssd, ssd, store, store, grace, orphan_grace, replicated_grace).await {
         Ok(report) => {
-            // Both dispositions free SSD bytes, so the reclaimed gauge counts their sum.
-            snapshot.record_reclaimed(report.reclaimed + report.reclaimed_orphan);
+            // All three dispositions free SSD bytes, so the reclaimed gauge counts their sum.
+            snapshot.record_reclaimed(report.reclaimed + report.reclaimed_orphan + report.reclaimed_replicated);
             if report.reclaimed > 0 {
                 // Aggregate, not per-part: an abandoned MPU reclaims many parts at once,
                 // so a per-part line would spam.
@@ -299,12 +303,19 @@ async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, gr
                     "reclaimed no-DB-backing (deleted-object) SSD orphans"
                 );
             }
-            // The one signal that the (deliberately un-handled) replicated crash-orphan
-            // leak is actually occurring — otherwise invisible. Warn so it surfaces.
+            if report.reclaimed_replicated > 0 {
+                tracing::info!(
+                    reclaimed_replicated = report.reclaimed_replicated,
+                    "reclaimed replicated crash-orphan SSD parts — re-drove the drain's skipped unlink"
+                );
+            }
+            // Replicated parts still on SSD but within the reclaim grace: a just-committed part
+            // whose happy-path unlink may not have run yet. Transient and self-clearing — aged
+            // ones are reclaimed above — so this is DEBUG, not the old un-reclaimable-leak WARN.
             if report.skipped_replicated > 0 {
-                tracing::warn!(
+                tracing::debug!(
                     skipped_replicated = report.skipped_replicated,
-                    "replicated parts still on SSD — drain crash-orphans nothing currently reclaims"
+                    "replicated parts on SSD within grace — reclaimed once they age past it"
                 );
             }
             // Parts held this cycle because their live object's pool copy is corrupt (R4): a
@@ -638,12 +649,13 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
         let reclaim_poll = self.config.reclaim_poll;
         let reclaim_grace = self.config.reclaim_grace;
         let orphan_reclaim_grace = self.config.orphan_reclaim_grace;
+        let replicated_reclaim_grace = self.config.replicated_reclaim_grace;
         let redrive_max_attempts = self.config.redrive_max_attempts;
         supervisor.spawn(WorkerName::new("ssd_reclaim"), move |token| {
             run_periodic(token, reclaim_poll, move || {
                 let (ssd, store, snapshot) = (Arc::clone(&ssd), Arc::clone(&store), Arc::clone(&snapshot));
                 async move {
-                    reclaim_once(&ssd, &store, &snapshot, reclaim_grace, orphan_reclaim_grace).await;
+                    reclaim_once(&ssd, &store, &snapshot, reclaim_grace, orphan_reclaim_grace, replicated_reclaim_grace).await;
                     // R4 re-drive: reset bounded `corrupt` parts to `pending` for a fresh copy,
                     // then publish the held-corrupt gauge. Same cadence as reclaim (both are the
                     // node-local SSD lifecycle); errors log and retry next poll (fail-safe).
@@ -949,6 +961,7 @@ mod tests {
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
+                replicated_reclaim_grace: Duration::from_hours(1),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
                 redrive_max_attempts: 3,
@@ -1023,6 +1036,7 @@ mod tests {
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
+                replicated_reclaim_grace: Duration::from_hours(1),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
                 redrive_max_attempts: 3,
@@ -1115,6 +1129,7 @@ mod tests {
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
+                replicated_reclaim_grace: Duration::from_hours(1),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
                 redrive_max_attempts: 3,
@@ -1180,6 +1195,7 @@ mod tests {
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
+                replicated_reclaim_grace: Duration::from_hours(1),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
                 redrive_max_attempts: 3,
@@ -1228,6 +1244,7 @@ mod tests {
                 reclaim_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
+                replicated_reclaim_grace: Duration::from_hours(1),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
                 redrive_max_attempts: 3,
@@ -1277,14 +1294,23 @@ mod tests {
         force_terminal_2h(&pool, &failed, "failed").await;
         seed_object_version(&pool, &failed, None, Some(0), Some("")).await;
 
-        // A replicated part -> the drain's own to clean up; the reclaimer leaves it.
+        // A replicated part within the replicated grace -> left for the drain's own in-flight
+        // unlink (the 24h grace below keeps this 2h-aged part inside the window).
         let replicated = part_at(5, 2);
         seed_ssd_dir(ssd_dir.path(), &replicated);
         store.record_landed_part(&replicated).await.unwrap();
         force_terminal_2h(&pool, &replicated, "replicated").await;
 
         let ssd = LocalSsd::new(ssd_dir.path());
-        super::reclaim_once(&ssd, &store, &snapshot, Duration::from_secs(1), Duration::from_secs(1)).await;
+        super::reclaim_once(
+            &ssd,
+            &store,
+            &snapshot,
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_hours(24),
+        )
+        .await;
 
         assert!(
             !ssd_dir.path().join(failed.relative_dir()).exists(),
@@ -1292,7 +1318,7 @@ mod tests {
         );
         assert!(
             ssd_dir.path().join(replicated.relative_dir()).exists(),
-            "a replicated part is left for the drain, never reclaimed here",
+            "a replicated part within the replicated grace is left for the drain's own unlink",
         );
         assert_eq!(snapshot.load().reclaimed, 1, "exactly the failed part was counted");
         // Reclaim only unlinks the SSD copy; the DB row is left intact.
@@ -1300,6 +1326,45 @@ mod tests {
             <Store as PartReplicationStore>::status(&store, &failed).await.unwrap(),
             Some(ReplicationState::Failed),
             "reclaim does not touch the replication row",
+        );
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn reclaim_once_evicts_an_aged_replicated_crash_orphan(pool: PgPool) {
+        // The ssd-leak fix end-to-end through reclaim_once against real Postgres: a `replicated`
+        // part still on SSD past the replicated grace is a drain crash-orphan (the drain committed
+        // mark_replicated but crashed before its own unlink). It is evicted, counted, and its
+        // replication row is left intact — the pool copy remains authoritative.
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let store = Store::from_pool(pool.clone());
+        let snapshot = SnapshotCell::new();
+
+        let orphan = part_at(5, 1);
+        seed_ssd_dir(ssd_dir.path(), &orphan);
+        store.record_landed_part(&orphan).await.unwrap();
+        force_terminal_2h(&pool, &orphan, "replicated").await;
+
+        let ssd = LocalSsd::new(ssd_dir.path());
+        // Short replicated grace so the 2h-aged crash-orphan is past the window.
+        super::reclaim_once(
+            &ssd,
+            &store,
+            &snapshot,
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert!(
+            !ssd_dir.path().join(orphan.relative_dir()).exists(),
+            "the aged replicated crash-orphan was evicted from the SSD",
+        );
+        assert_eq!(snapshot.load().reclaimed, 1, "the replicated crash-orphan counts toward reclaimed");
+        assert_eq!(
+            <Store as PartReplicationStore>::status(&store, &orphan).await.unwrap(),
+            Some(ReplicationState::Replicated),
+            "reclaim only unlinks the SSD copy; the replicated row is left intact",
         );
     }
 
@@ -1320,7 +1385,7 @@ mod tests {
 
         let ssd = LocalSsd::new(ssd_dir.path());
         // Zero grace so the just-written temp is past the (no-)window.
-        super::reclaim_once(&ssd, &store, &snapshot, Duration::ZERO, Duration::ZERO).await;
+        super::reclaim_once(&ssd, &store, &snapshot, Duration::ZERO, Duration::ZERO, Duration::from_hours(24)).await;
 
         assert!(!orphan.exists(), "reclaim_once swept the orphan temp");
         assert_eq!(snapshot.load().reclaimed, 0, "no failed part -> nothing reclaimed, only the temp swept");
@@ -1350,7 +1415,15 @@ mod tests {
         seed_object_version(&pool, &live, Some("5Flive"), Some(4096), None).await;
 
         let ssd = LocalSsd::new(ssd_dir.path());
-        super::reclaim_once(&ssd, &store, &snapshot, Duration::from_secs(1), Duration::from_hours(1)).await;
+        super::reclaim_once(
+            &ssd,
+            &store,
+            &snapshot,
+            Duration::from_secs(1),
+            Duration::from_hours(1),
+            Duration::from_hours(24),
+        )
+        .await;
 
         assert!(
             !ssd_dir.path().join(orphan.relative_dir()).exists(),
@@ -1382,7 +1455,15 @@ mod tests {
         seed_object_version(&pool, &corrupt_live, Some("5Fserve"), Some(4096), None).await;
 
         let ssd = LocalSsd::new(ssd_dir.path());
-        super::reclaim_once(&ssd, &store, &snapshot, Duration::from_secs(1), Duration::from_secs(1)).await;
+        super::reclaim_once(
+            &ssd,
+            &store,
+            &snapshot,
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_hours(24),
+        )
+        .await;
 
         assert!(
             ssd_dir.path().join(corrupt_live.relative_dir()).exists(),
@@ -1410,7 +1491,15 @@ mod tests {
         force_terminal_2h(&pool, &failed, "failed").await;
 
         let ssd = LocalSsd::new(ssd_dir.path());
-        super::reclaim_once(&ssd, &store, &snapshot, Duration::from_secs(1), Duration::from_secs(1)).await;
+        super::reclaim_once(
+            &ssd,
+            &store,
+            &snapshot,
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            Duration::from_hours(24),
+        )
+        .await;
 
         assert!(
             ssd_dir.path().join(failed.relative_dir()).exists(),

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -23,8 +23,8 @@ use crate::supervisor::{RunReport, Supervisor, WorkerName};
 use crate::worker::drain_until_empty;
 use hippius_drain_core::{
     BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, CoordError, Coordinator, Enforcer, NodeId, NodeObservation,
-    PartReplicationStore, ReclaimError, SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket, UploadEnqueuer, decay_rate, jittered,
-    reclaim_ssd, reconcile_parts,
+    PartReplicationStore, ReclaimError, ReclaimGraces, SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket, UploadEnqueuer, decay_rate,
+    jittered, reclaim_ssd, reconcile_parts,
 };
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -287,8 +287,8 @@ async fn heartbeat_once(ssd: &LocalSsd, store: &Store, coord: &Coordinator, node
 /// Reclaim and sweep errors are logged and skipped; the next tick retries, and no part
 /// is ever removed without a successful status read (fail-safe). The store is both the
 /// replication log and the object-backing log for the reclaim.
-async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, grace: Duration, orphan_grace: Duration, replicated_grace: Duration) {
-    match reclaim_ssd(ssd, ssd, store, store, grace, orphan_grace, replicated_grace).await {
+async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, graces: ReclaimGraces) {
+    match reclaim_ssd(ssd, ssd, store, store, graces).await {
         Ok(report) => {
             // All three dispositions free SSD bytes, so the reclaimed gauge counts their sum.
             snapshot.record_reclaimed(report.reclaimed + report.reclaimed_orphan + report.reclaimed_replicated);
@@ -346,7 +346,7 @@ async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, gr
         Err(err) => tracing::warn!(error = ?err, "ssd reclaim cycle failed; will retry next poll"),
     }
 
-    match ssd.sweep_orphan_tmp(grace).await {
+    match ssd.sweep_orphan_tmp(graces.failed).await {
         Ok(0) => {}
         Ok(removed) => tracing::info!(removed, "swept orphan SSD write-temps"),
         Err(err) => tracing::warn!(error = %err, "orphan-temp sweep failed; will retry next poll"),
@@ -647,15 +647,17 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
         // abandoned-upload junk does not accumulate on the node-local disk.
         let (ssd, store, snapshot) = (Arc::clone(&self.ssd), Arc::clone(&self.store), Arc::clone(&self.snapshot));
         let reclaim_poll = self.config.reclaim_poll;
-        let reclaim_grace = self.config.reclaim_grace;
-        let orphan_reclaim_grace = self.config.orphan_reclaim_grace;
-        let replicated_reclaim_grace = self.config.replicated_reclaim_grace;
+        let reclaim_graces = ReclaimGraces {
+            failed: self.config.reclaim_grace,
+            orphan: self.config.orphan_reclaim_grace,
+            replicated: self.config.replicated_reclaim_grace,
+        };
         let redrive_max_attempts = self.config.redrive_max_attempts;
         supervisor.spawn(WorkerName::new("ssd_reclaim"), move |token| {
             run_periodic(token, reclaim_poll, move || {
                 let (ssd, store, snapshot) = (Arc::clone(&ssd), Arc::clone(&store), Arc::clone(&snapshot));
                 async move {
-                    reclaim_once(&ssd, &store, &snapshot, reclaim_grace, orphan_reclaim_grace, replicated_reclaim_grace).await;
+                    reclaim_once(&ssd, &store, &snapshot, reclaim_graces).await;
                     // R4 re-drive: reset bounded `corrupt` parts to `pending` for a fresh copy,
                     // then publish the held-corrupt gauge. Same cadence as reclaim (both are the
                     // node-local SSD lifecycle); errors log and retry next poll (fail-safe).
@@ -769,8 +771,8 @@ mod tests {
     use crate::supervisor::ShutdownTrigger;
     use core::str::FromStr;
     use hippius_drain_core::{
-        Allocation, ByteRate, Bytes, Clock, CoordError, Coordinator, NodeId, ObjectId, PartKey, PartNumber, PartReplicationStore, ReplicationState,
-        SnapshotCell, Store, StoredAllocation, TestClock, UploadEnqueuer, Version,
+        Allocation, ByteRate, Bytes, Clock, CoordError, Coordinator, NodeId, ObjectId, PartKey, PartNumber, PartReplicationStore, ReclaimGraces,
+        ReplicationState, SnapshotCell, Store, StoredAllocation, TestClock, UploadEnqueuer, Version,
     };
 
     /// A coordinator on the test Redis under a per-test prefix, or `None` to skip the
@@ -1306,9 +1308,11 @@ mod tests {
             &ssd,
             &store,
             &snapshot,
-            Duration::from_secs(1),
-            Duration::from_secs(1),
-            Duration::from_hours(24),
+            ReclaimGraces {
+                failed: Duration::from_secs(1),
+                orphan: Duration::from_secs(1),
+                replicated: Duration::from_hours(24),
+            },
         )
         .await;
 
@@ -1350,9 +1354,11 @@ mod tests {
             &ssd,
             &store,
             &snapshot,
-            Duration::from_secs(1),
-            Duration::from_secs(1),
-            Duration::from_secs(1),
+            ReclaimGraces {
+                failed: Duration::from_secs(1),
+                orphan: Duration::from_secs(1),
+                replicated: Duration::from_secs(1),
+            },
         )
         .await;
 
@@ -1385,7 +1391,17 @@ mod tests {
 
         let ssd = LocalSsd::new(ssd_dir.path());
         // Zero grace so the just-written temp is past the (no-)window.
-        super::reclaim_once(&ssd, &store, &snapshot, Duration::ZERO, Duration::ZERO, Duration::from_hours(24)).await;
+        super::reclaim_once(
+            &ssd,
+            &store,
+            &snapshot,
+            ReclaimGraces {
+                failed: Duration::ZERO,
+                orphan: Duration::ZERO,
+                replicated: Duration::from_hours(24),
+            },
+        )
+        .await;
 
         assert!(!orphan.exists(), "reclaim_once swept the orphan temp");
         assert_eq!(snapshot.load().reclaimed, 0, "no failed part -> nothing reclaimed, only the temp swept");
@@ -1419,9 +1435,11 @@ mod tests {
             &ssd,
             &store,
             &snapshot,
-            Duration::from_secs(1),
-            Duration::from_hours(1),
-            Duration::from_hours(24),
+            ReclaimGraces {
+                failed: Duration::from_secs(1),
+                orphan: Duration::from_hours(1),
+                replicated: Duration::from_hours(24),
+            },
         )
         .await;
 
@@ -1459,9 +1477,11 @@ mod tests {
             &ssd,
             &store,
             &snapshot,
-            Duration::from_secs(1),
-            Duration::from_secs(1),
-            Duration::from_hours(24),
+            ReclaimGraces {
+                failed: Duration::from_secs(1),
+                orphan: Duration::from_secs(1),
+                replicated: Duration::from_hours(24),
+            },
         )
         .await;
 
@@ -1495,9 +1515,11 @@ mod tests {
             &ssd,
             &store,
             &snapshot,
-            Duration::from_secs(1),
-            Duration::from_secs(1),
-            Duration::from_hours(24),
+            ReclaimGraces {
+                failed: Duration::from_secs(1),
+                orphan: Duration::from_secs(1),
+                replicated: Duration::from_hours(24),
+            },
         )
         .await;
 

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -42,7 +42,7 @@ pub use partdrain::{
 };
 pub use reconcile::{DiscoveredPart, PartLandingLog, PartScan, PartStatus, ReconcileError, ReconcileReport, reconcile_parts};
 pub use snapshot::{AgentSnapshot, SnapshotCell};
-pub use ssd_reclaim::{PartRemover, PartStatusAge, ReclaimError, ReclaimLog, ReclaimReport, reclaim_ssd};
+pub use ssd_reclaim::{PartRemover, PartStatusAge, ReclaimError, ReclaimGraces, ReclaimLog, ReclaimReport, reclaim_ssd};
 pub use state::{CephCeiling, PressureZone, ReplicationState};
 pub use units::{ByteRate, Bytes, DiskPressure};
 

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -30,23 +30,30 @@
 //! avoids racing an in-progress MPU whose reserved row is also unservable.
 //!
 //! It reclaims **`replicated` crash-orphans**: on the happy path the drain unlinks its own
-//! SSD copy the instant it commits a replication, and the SSD copy is never read (downloads
-//! stream from the `CephFS` pool, not the ingest SSD). A replicated copy that lingers is a
+//! SSD copy the instant it commits a replication. A replicated copy that lingers is a
 //! **drain crash-orphan** — a crash between the `mark_replicated` commit and the unlink —
 //! which `claim_part` never re-selects, so nothing else re-drives the unlink and it leaks
 //! (an inode/dir leak on `/s3-data`, unbounded across agent restarts). This worker re-drives
 //! it: a `replicated` part older than `replicated_grace` is unlinked, which is exactly what
 //! the happy-path unlink would have done. The safety argument is that this is strictly weaker
 //! than the happy path, not stronger: that unlink runs milliseconds after the commit, so
-//! re-driving it after a grace introduces no risk the happy path does not already accept. The
-//! pool copy is authoritative — the `replicated` state IS the drain's own record that the
-//! `CephFS` copy exists — and, unlike a `failed` part, a `replicated` one is never a
-//! corrupt-live object's last good source (a corrupt pool copy transitions the row to
-//! `failed`/`corrupt`, out of this arm), so no servability gate is needed. The grace only
-//! avoids racing a just-committed part whose in-process unlink has not yet run; a young
-//! `replicated` part is left (`skipped_replicated`). `pending`/`draining` parts are live
-//! (owned by the drain pipeline) and a no-row part whose object still exists may be
-//! mid-upload — both are left strictly alone.
+//! re-driving it after a grace introduces no risk the happy path does not already accept.
+//! Note the ingest SSD IS read — it is the api-local reader's *primary* tier, with the
+//! `CephFS` pool as its read *fallback* (`DualFileSystemPartsStore`) — so a same-node GET can
+//! hit the SSD copy first. But `mark_replicated` is committed only after the pool copy is
+//! written, byte-verified, and fsynced, so deleting the SSD copy merely makes a same-node read
+//! fall through to that durable fallback (the exact behaviour the fallback tier exists for),
+//! identical to the drain's own post-commit unlink. The pool copy is thus authoritative — the
+//! `replicated` state IS the drain's own record that the `CephFS` copy exists — and, unlike a
+//! `failed` part, a `replicated` one is never a corrupt-live object's last good source (a
+//! corrupt pool copy transitions the row to `failed`/`corrupt`, out of this arm), so no
+//! servability gate is needed. The grace only avoids racing a just-committed part whose
+//! in-process unlink has not yet run; a young `replicated` part is left (`skipped_replicated`).
+//! (An in-flight MPU whose address takes longer than the grace to finalize is reclaimed while
+//! still `replicated`/un-enqueued — safe: reads are served from the pool and the janitor's
+//! replication gate holds the pool copy until the upload backends have it.) `pending`/`draining`
+//! parts are live (owned by the drain pipeline) and a no-row part whose object still exists may
+//! be mid-upload — both are left strictly alone.
 //!
 //! Safety: `failed` is a terminal sink (nothing returns a row to `pending` except
 //! `release_part`/`defer_part`, each guarded on `status='draining'`), so the read can

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -1,11 +1,13 @@
-//! The SSD-ingest reclaim backstop: clean up **broken / abandoned uploads** left on
-//! the node-local SSD.
+//! The SSD-ingest reclaim backstop: clean up parts stranded on the node-local SSD that the
+//! drain pipeline structurally cannot reach.
 //!
-//! Scope is deliberately narrow — only [`Failed`](ReplicationState::Failed) parts: an
-//! aborted or abandoned upload (an MPU abort, an abandoned MPU the reaper marked
-//! terminal, or a failed single-part PUT). `claim_part` skips a `failed` row forever,
-//! so the drain never unlinks it and its SSD bytes leak with nothing else to reclaim
-//! them. This worker is that missing owner.
+//! Scope is the leaks whose row `claim_part` never re-selects, so the drain never unlinks
+//! their SSD copy and it leaks with nothing else to reclaim it — three dispositions, each
+//! detailed below: aborted/abandoned uploads ([`Failed`](ReplicationState::Failed) — an MPU
+//! abort, an abandoned MPU the reaper marked terminal, or a failed single-part PUT),
+//! `replicated` crash-orphans (a crash between the `mark_replicated` commit and the drain's
+//! own unlink), and deleted-object orphans (a part whose object was hard-deleted). This
+//! worker is that missing owner.
 //!
 //! But `failed` is not a clean proxy for "safe to delete": the drain's corruption path
 //! (`mark_failed` on a persistent `ChunkMismatch`) can mark a part of a *servable, live*
@@ -99,6 +101,23 @@ pub struct PartStatusAge {
     pub state: ReplicationState,
     /// How long the part has held that state (`now() - updated_at`).
     pub age: Duration,
+}
+
+/// The per-disposition grace windows [`reclaim_ssd`] gates each deletion on. Grouped into a
+/// named struct so the three same-typed `Duration`s are labelled at every call site rather
+/// than passed as three adjacent positional args (which are trivial to transpose).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReclaimGraces {
+    /// How long an aged `failed` (aborted/abandoned-upload) part is kept before reclaim — a
+    /// diagnosis / abort-settle window. Keyed on the store clock (`updated_at`).
+    pub failed: Duration,
+    /// How long a no-DB-backing (deleted-object) orphan is kept before reclaim. Keyed on the
+    /// part's FS `meta.json` age, so set generously to absorb the agent-clock dependence.
+    pub orphan: Duration,
+    /// How long a `replicated` crash-orphan is kept before the reclaim re-drives the drain's
+    /// own unlink. Keyed on the store clock (`updated_at`); only clears the in-flight-unlink
+    /// window, so it can be short.
+    pub replicated: Duration,
 }
 
 /// The store seam the reclaim worker needs: read the replication state + age of a
@@ -253,12 +272,12 @@ impl ReclaimError {
 /// no-DB-backing orphans from the SSD cache, once aged.
 ///
 /// Scans every complete part on SSD, reads all their replication states in one batch, and
-/// unlinks each `failed` part that is older than `grace` **and whose version is unservable**
+/// unlinks each `failed` part that is older than `graces.failed` **and whose version is unservable**
 /// (an aged `failed` part whose object is still servable is the corrupt-live case — held
 /// back as `skipped_corrupt`, never deleted; see the module doc). A part with NO replication
 /// row is checked against [`BackingLog::unbacked_parts`]: if its object was hard-deleted (no
-/// `object_versions` row) AND it has aged past `orphan_grace`, it is a deleted-object orphan
-/// and is reclaimed too. A `replicated` part older than `replicated_grace` is a drain
+/// `object_versions` row) AND it has aged past `graces.orphan`, it is a deleted-object orphan
+/// and is reclaimed too. A `replicated` part older than `graces.replicated` is a drain
 /// crash-orphan (the drain crashed between the `mark_replicated` commit and its own unlink)
 /// and is unlinked — re-driving the happy-path unlink the crash skipped. Everything else is
 /// left untouched: `pending`/`draining` are live (drain-owned), a young `replicated` part
@@ -274,7 +293,7 @@ impl ReclaimError {
 /// neither has an agent-clock dependence; the orphan grace uses the part's SSD `meta.json`
 /// age ([`DiscoveredPart::age`](crate::DiscoveredPart)), since a deleted object has no DB
 /// row to date. Orphan reclaim therefore has an agent-clock dependence that the status-path
-/// reclaims do not — `orphan_grace` is set generously to absorb it.
+/// reclaims do not — `graces.orphan` is set generously to absorb it.
 ///
 /// # Errors
 ///
@@ -282,15 +301,7 @@ impl ReclaimError {
 /// - [`ReclaimError::Log`] if the batched status read fails (nothing is removed).
 /// - [`ReclaimError::Backing`] if the batched object-backing read fails (nothing is removed).
 /// - [`ReclaimError::Remove`] if unlinking a reclaimed part fails.
-pub async fn reclaim_ssd<S, R, L, B>(
-    scanner: &S,
-    remover: &R,
-    log: &L,
-    backing: &B,
-    grace: Duration,
-    orphan_grace: Duration,
-    replicated_grace: Duration,
-) -> Result<ReclaimReport, ReclaimError>
+pub async fn reclaim_ssd<S, R, L, B>(scanner: &S, remover: &R, log: &L, backing: &B, graces: ReclaimGraces) -> Result<ReclaimReport, ReclaimError>
 where
     S: PartScan,
     R: PartRemover,
@@ -331,7 +342,7 @@ where
         .filter(|discovered| {
             states
                 .get(&discovered.part)
-                .is_some_and(|status| status.state == ReplicationState::Failed && status.age >= grace)
+                .is_some_and(|status| status.state == ReplicationState::Failed && status.age >= graces.failed)
         })
         .map(|discovered| discovered.part.clone())
         .collect();
@@ -350,7 +361,7 @@ where
         // live row is mid-upload or pre-reconcile — never touched (the absolute safety
         // gate; reserve-before-write means an absent row can only be a deleted object).
         let Some(status) = states.get(part) else {
-            if unbacked.contains(part) && discovered.age >= orphan_grace {
+            if unbacked.contains(part) && discovered.age >= graces.orphan {
                 remover.unlink_part(part).await.map_err(ReclaimError::Remove)?;
                 report.reclaimed_orphan += 1;
             } else {
@@ -370,7 +381,7 @@ where
             // corrupt-live object's last good source. A young one is left in case its
             // in-flight unlink has simply not run yet.
             ReplicationState::Replicated => {
-                if status.age >= replicated_grace {
+                if status.age >= graces.replicated {
                     remover.unlink_part(part).await.map_err(ReclaimError::Remove)?;
                     report.reclaimed_replicated += 1;
                 } else {
@@ -382,7 +393,7 @@ where
             // servable, in which case `failed` means "corrupt pool copy on a live object"
             // and this SSD part is the last good source (skipped_corrupt; never deleted).
             ReplicationState::Failed => {
-                if status.age < grace {
+                if status.age < graces.failed {
                     report.skipped_young += 1;
                 } else if servable.contains(part) {
                     report.skipped_corrupt += 1;
@@ -410,7 +421,7 @@ where
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::{BackingLog, PartRemover, PartStatusAge, ReclaimError, ReclaimLog, ReclaimReport, reclaim_ssd};
+    use super::{BackingLog, PartRemover, PartStatusAge, ReclaimError, ReclaimGraces, ReclaimLog, ReclaimReport, reclaim_ssd};
     use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
     use crate::reconcile::{DiscoveredPart, PartScan};
     use crate::state::ReplicationState;
@@ -619,6 +630,12 @@ mod tests {
     // Larger than the `HOUR` age the existing `replicated` fixtures use, so those parts stay
     // within grace (`skipped_replicated`); the reclaim-when-aged cases below use ages past it.
     const REPLICATED_GRACE: Duration = Duration::from_hours(2);
+    // The default graces most tests pass; the boundary/proptest cases build their own.
+    const GRACES: ReclaimGraces = ReclaimGraces {
+        failed: GRACE,
+        orphan: ORPHAN_GRACE,
+        replicated: REPLICATED_GRACE,
+    };
 
     #[tokio::test]
     async fn an_aged_failed_part_is_reclaimed() {
@@ -627,9 +644,7 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, HOUR)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap();
         assert_eq!(report.reclaimed, 1);
         assert_eq!(remover.removed(), vec![key(&part)], "the aged failed (abandoned) part was unlinked");
     }
@@ -644,9 +659,7 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Replicated, HOUR)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap();
         assert_eq!(report.skipped_replicated, 1);
         assert_eq!(report.reclaimed_replicated, 0);
         assert!(remover.removed().is_empty(), "a within-grace replicated part is not reclaimed");
@@ -663,9 +676,7 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Replicated, Duration::from_hours(3))]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap();
         assert_eq!(report.reclaimed_replicated, 1);
         assert_eq!(report.skipped_replicated, 0);
         assert_eq!(remover.removed(), vec![key(&part)], "the aged replicated crash-orphan was unlinked");
@@ -680,9 +691,7 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Replicated, REPLICATED_GRACE)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap();
         assert_eq!(report.reclaimed_replicated, 1, "age == replicated_grace reclaims");
         assert_eq!(report.skipped_replicated, 0);
     }
@@ -700,9 +709,7 @@ mod tests {
         let log = FakeLog::with(&[(&part, ReplicationState::Replicated, Duration::from_hours(3))]);
         let backing = FakeBacking::servable(&[&part]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
         assert_eq!(report.reclaimed_replicated, 1, "a servable replicated part is still reclaimed");
         assert_eq!(remover.removed(), vec![key(&part)]);
         assert!(
@@ -730,9 +737,7 @@ mod tests {
             // `absent` has no row in the log at all.
         ]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap();
         assert_eq!(report.reclaimed, 0, "nothing but a failed part is ever reclaimed");
         assert_eq!(report.skipped_live, 2);
         assert_eq!(report.skipped_replicated, 1);
@@ -749,9 +754,7 @@ mod tests {
         // and a corruption sample is worth a brief diagnosis window).
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, Duration::from_mins(1))]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap();
         assert_eq!(report.skipped_young, 1);
         assert!(remover.removed().is_empty(), "a young failed part is kept");
     }
@@ -765,9 +768,7 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, GRACE)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap();
         assert_eq!(report.reclaimed, 1, "age == grace reclaims");
         assert_eq!(report.skipped_young, 0);
     }
@@ -779,9 +780,7 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&parts.iter().map(|p| (p, ReplicationState::Failed, HOUR)).collect::<Vec<_>>());
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap();
         assert_eq!(report.reclaimed, 5);
         assert_eq!(log.calls(), 1, "all five parts' statuses were read in one batched call");
     }
@@ -802,9 +801,7 @@ mod tests {
             (&young, ReplicationState::Failed, Duration::from_secs(1)),
         ]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap();
         assert_eq!(
             report,
             ReclaimReport {
@@ -832,9 +829,7 @@ mod tests {
         let scan = FakeScan { parts: vec![], fail: true };
         let remover = FakeRemover::default();
         let log = FakeLog::default();
-        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap_err();
+        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap_err();
         assert!(matches!(err, ReclaimError::Scan(_)), "got: {err:?}");
         assert!(remover.removed().is_empty());
     }
@@ -848,9 +843,7 @@ mod tests {
             fail: true,
             ..FakeLog::default()
         };
-        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap_err();
+        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap_err();
         assert!(matches!(err, ReclaimError::Log(_)), "got: {err:?}");
         assert!(remover.removed().is_empty(), "a failed status read removes nothing (fail-safe)");
     }
@@ -864,9 +857,7 @@ mod tests {
             ..FakeRemover::default()
         };
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, HOUR)]);
-        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap_err();
+        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap_err();
         assert!(matches!(err, ReclaimError::Remove(_)), "got: {err:?}");
     }
 
@@ -875,9 +866,7 @@ mod tests {
         let scan = FakeScan::of(&[]);
         let remover = FakeRemover::default();
         let log = FakeLog::default();
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap();
         assert_eq!(report, ReclaimReport::default());
         assert_eq!(log.calls(), 0, "an empty scan never queries the store");
     }
@@ -895,9 +884,7 @@ mod tests {
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, HOUR)]);
         let backing = FakeBacking::servable(&[&part]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
         assert_eq!(report.skipped_corrupt, 1);
         assert_eq!(report.reclaimed, 0);
         assert!(remover.removed().is_empty(), "a servable object's last good copy is preserved");
@@ -917,9 +904,7 @@ mod tests {
         ]);
         let backing = FakeBacking::servable(&[&corrupt_live]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
         assert_eq!(report.reclaimed, 1);
         assert_eq!(report.skipped_corrupt, 1);
         assert_eq!(remover.removed(), vec![key(&abandoned)], "only the unservable (abandoned) part");
@@ -944,9 +929,7 @@ mod tests {
         ]);
         let backing = FakeBacking::all_backed();
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
         assert_eq!(report.reclaimed, 1, "the aged failed part reclaims (not servable)");
         assert_eq!(
             backing.servable_asked(),
@@ -968,9 +951,7 @@ mod tests {
             fail: true,
             ..FakeBacking::default()
         };
-        let err = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap_err();
+        let err = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap_err();
         assert!(matches!(err, ReclaimError::Backing(_)), "got: {err:?}");
         assert!(remover.removed().is_empty(), "a failed servability read removes nothing (fail-safe)");
     }
@@ -1014,7 +995,7 @@ mod tests {
                 let refs: Vec<&PartKey> = servable_refs.iter().collect();
                 let backing = FakeBacking::servable(&refs);
 
-                let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE).await.unwrap();
+                let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
                 expected_removed.sort();
                 proptest::prop_assert_eq!(remover.removed(), expected_removed.clone());
                 proptest::prop_assert_eq!(usize::try_from(report.reclaimed).unwrap(), expected_removed.len());
@@ -1035,9 +1016,7 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Corrupt, HOUR)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACES).await.unwrap();
         assert_eq!(report.skipped_corrupt, 1);
         assert_eq!(report.reclaimed, 0);
         assert!(remover.removed().is_empty(), "a Corrupt part's SSD source is preserved");
@@ -1054,9 +1033,7 @@ mod tests {
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, GRACE)]);
         let backing = FakeBacking::servable(&[&part]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
         assert_eq!(
             report.skipped_corrupt, 1,
             "a servable failed part exactly at grace is held, not reclaimed"
@@ -1077,9 +1054,7 @@ mod tests {
         let log = FakeLog::default(); // no replication row
         let backing = FakeBacking::unbacked(&[&part]); // object_versions row gone
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
         assert_eq!(report.reclaimed_orphan, 1);
         assert_eq!(report.skipped_absent, 0);
         assert_eq!(remover.removed(), vec![key(&part)], "the deleted-object orphan was unlinked");
@@ -1095,9 +1070,7 @@ mod tests {
         let log = FakeLog::default();
         let backing = FakeBacking::all_backed(); // object_versions row present
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
         assert_eq!(report.reclaimed_orphan, 0);
         assert_eq!(report.skipped_absent, 1);
         assert!(remover.removed().is_empty(), "a part whose object still exists is protected");
@@ -1113,9 +1086,7 @@ mod tests {
         let log = FakeLog::default();
         let backing = FakeBacking::unbacked(&[&part]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
         assert_eq!(report.skipped_absent, 1);
         assert_eq!(report.reclaimed_orphan, 0);
         assert!(remover.removed().is_empty(), "a young orphan is kept");
@@ -1131,9 +1102,7 @@ mod tests {
         let log = FakeLog::default();
         let backing = FakeBacking::unbacked(&[&part]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
         assert_eq!(report.reclaimed_orphan, 1, "age == orphan_grace reclaims");
         assert_eq!(report.skipped_absent, 0);
     }
@@ -1150,9 +1119,7 @@ mod tests {
         let log = FakeLog::with(&[(&failed, ReplicationState::Failed, HOUR)]);
         let backing = FakeBacking::unbacked(&[&orphan]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
         assert_eq!(report.reclaimed, 1, "the failed part reclaimed via the status path");
         assert_eq!(report.reclaimed_orphan, 1, "the orphan reclaimed via the backing path");
         assert_eq!(backing.asked(), vec![key(&orphan)], "only the no-row part was backing-checked");
@@ -1168,9 +1135,7 @@ mod tests {
             fail: true,
             ..FakeBacking::default()
         };
-        let err = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap_err();
+        let err = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap_err();
         assert!(matches!(err, ReclaimError::Backing(_)), "got: {err:?}");
         assert!(remover.removed().is_empty(), "a failed backing read removes nothing (fail-safe)");
     }
@@ -1186,9 +1151,7 @@ mod tests {
         let log = FakeLog::default();
         let backing = FakeBacking::all_backed();
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
-            .await
-            .unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACES).await.unwrap();
         assert_eq!(report.skipped_absent, 2);
         assert_eq!(report.reclaimed_orphan, 0);
         assert!(remover.removed().is_empty());
@@ -1229,7 +1192,8 @@ mod tests {
                 let refs: Vec<&PartKey> = unbacked_refs.iter().collect();
                 let backing = FakeBacking::unbacked(&refs);
 
-                let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, orphan_grace, REPLICATED_GRACE).await.unwrap();
+                let graces = ReclaimGraces { failed: GRACE, orphan: orphan_grace, replicated: REPLICATED_GRACE };
+                let report = reclaim_ssd(&scan, &remover, &log, &backing, graces).await.unwrap();
                 expected_removed.sort();
                 proptest::prop_assert_eq!(remover.removed(), expected_removed.clone());
                 proptest::prop_assert_eq!(usize::try_from(report.reclaimed_orphan).unwrap(), expected_removed.len());

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -29,16 +29,24 @@
 //! `failed`-marking sweep + the `failed` path here, NOT treated as an orphan — that
 //! avoids racing an in-progress MPU whose reserved row is also unservable.
 //!
-//! It does NOT touch **`replicated`** parts: on the happy path the drain unlinks its own
-//! SSD copy the instant it commits a replication, and the SSD copy is never read
-//! (downloads stream from the `CephFS` pool, not the ingest SSD), so a replicated part is
-//! normally the drain's to clean up. A replicated copy that lingers is only a rare
-//! **drain crash-orphan** (a crash between the `mark_replicated` commit and the unlink);
-//! `claim_part` never re-selects a `replicated` row, so nothing currently re-drives that
-//! unlink — a known residual leak, left out of scope here on purpose (counted
-//! `skipped_replicated` for visibility). `pending`/`draining` parts are live (owned by
-//! the drain pipeline) and a no-row part whose object still exists may be mid-upload —
-//! both are left strictly alone.
+//! It reclaims **`replicated` crash-orphans**: on the happy path the drain unlinks its own
+//! SSD copy the instant it commits a replication, and the SSD copy is never read (downloads
+//! stream from the `CephFS` pool, not the ingest SSD). A replicated copy that lingers is a
+//! **drain crash-orphan** — a crash between the `mark_replicated` commit and the unlink —
+//! which `claim_part` never re-selects, so nothing else re-drives the unlink and it leaks
+//! (an inode/dir leak on `/s3-data`, unbounded across agent restarts). This worker re-drives
+//! it: a `replicated` part older than `replicated_grace` is unlinked, which is exactly what
+//! the happy-path unlink would have done. The safety argument is that this is strictly weaker
+//! than the happy path, not stronger: that unlink runs milliseconds after the commit, so
+//! re-driving it after a grace introduces no risk the happy path does not already accept. The
+//! pool copy is authoritative — the `replicated` state IS the drain's own record that the
+//! `CephFS` copy exists — and, unlike a `failed` part, a `replicated` one is never a
+//! corrupt-live object's last good source (a corrupt pool copy transitions the row to
+//! `failed`/`corrupt`, out of this arm), so no servability gate is needed. The grace only
+//! avoids racing a just-committed part whose in-process unlink has not yet run; a young
+//! `replicated` part is left (`skipped_replicated`). `pending`/`draining` parts are live
+//! (owned by the drain pipeline) and a no-row part whose object still exists may be
+//! mid-upload — both are left strictly alone.
 //!
 //! Safety: `failed` is a terminal sink (nothing returns a row to `pending` except
 //! `release_part`/`defer_part`, each guarded on `status='draining'`), so the read can
@@ -144,7 +152,7 @@ pub trait BackingLog: Send + Sync {
 }
 
 /// What one reclaim pass did, tallied by the part's disposition. `scanned` always
-/// equals the sum of the seven outcome counts.
+/// equals the sum of the eight outcome counts.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ReclaimReport {
     /// Parts seen on SSD.
@@ -155,12 +163,17 @@ pub struct ReclaimReport {
     /// `object_versions` row (a hard-deleted object), aged past `orphan_grace`. The
     /// deleted-object leak the `failed` path cannot reach — see the module doc.
     pub reclaimed_orphan: u64,
+    /// `replicated` crash-orphans reclaimed: the drain committed `mark_replicated` but crashed
+    /// before unlinking its SSD copy, so nothing re-drove the unlink. Reclaimed once older than
+    /// `replicated_grace` — re-driving the happy-path unlink the crash skipped. See the module
+    /// doc and [`skipped_replicated`](Self::skipped_replicated).
+    pub reclaimed_replicated: u64,
     /// Left alone because still `pending`/`draining` — owned by the drain pipeline.
     pub skipped_live: u64,
-    /// Left alone because already `replicated`. On the happy path the drain unlinks its
-    /// own copy on commit; a lingering one is a rare drain crash-orphan that NOTHING
-    /// currently re-drives (a known residual leak — see the module doc). Counted here so
-    /// a non-zero value surfaces that the orphan case is actually happening.
+    /// Left alone because `replicated` but still within `replicated_grace` — a just-committed
+    /// part whose happy-path unlink may not have run yet. Aged ones are reclaimed
+    /// ([`reclaimed_replicated`](Self::reclaimed_replicated)), so this counts only the
+    /// transient in-flight-unlink window, not an unreclaimable leak.
     pub skipped_replicated: u64,
     /// Left alone because the store has no replication row and the part still has a live
     /// `object_versions` row (pre-reconcile or mid-upload) — or is not yet past
@@ -188,6 +201,7 @@ impl ReclaimReport {
     pub fn categorized(&self) -> u64 {
         self.reclaimed
             .saturating_add(self.reclaimed_orphan)
+            .saturating_add(self.reclaimed_replicated)
             .saturating_add(self.skipped_live)
             .saturating_add(self.skipped_replicated)
             .saturating_add(self.skipped_absent)
@@ -228,8 +242,8 @@ impl ReclaimError {
     }
 }
 
-/// Reclaims broken/abandoned-upload (`failed`) parts and no-DB-backing orphans from the
-/// SSD cache, once aged.
+/// Reclaims broken/abandoned-upload (`failed`) parts, `replicated` crash-orphans, and
+/// no-DB-backing orphans from the SSD cache, once aged.
 ///
 /// Scans every complete part on SSD, reads all their replication states in one batch, and
 /// unlinks each `failed` part that is older than `grace` **and whose version is unservable**
@@ -237,20 +251,23 @@ impl ReclaimError {
 /// back as `skipped_corrupt`, never deleted; see the module doc). A part with NO replication
 /// row is checked against [`BackingLog::unbacked_parts`]: if its object was hard-deleted (no
 /// `object_versions` row) AND it has aged past `orphan_grace`, it is a deleted-object orphan
-/// and is reclaimed too. Everything else is left untouched: `pending`/`draining` are live
-/// (drain-owned), `replicated` is the drain's own to clean up, and a no-row part that
-/// still has a live `object_versions` row may be mid-upload — the absolute safety gate.
+/// and is reclaimed too. A `replicated` part older than `replicated_grace` is a drain
+/// crash-orphan (the drain crashed between the `mark_replicated` commit and its own unlink)
+/// and is unlinked — re-driving the happy-path unlink the crash skipped. Everything else is
+/// left untouched: `pending`/`draining` are live (drain-owned), a young `replicated` part
+/// may have an in-flight unlink still pending, and a no-row part that still has a live
+/// `object_versions` row may be mid-upload — the absolute safety gate.
 ///
 /// The servability read ([`BackingLog::servable_parts`]) and the orphan-backing read
 /// ([`BackingLog::unbacked_parts`]) each run over a disjoint subset (aged-`failed` vs
 /// no-row) and are both empty on the steady-state happy path, so neither adds a round-trip
 /// unless there is actually broken data to adjudicate.
 ///
-/// The `failed` grace uses the store clock (the row's `updated_at`); the orphan grace
-/// uses the part's SSD `meta.json` age ([`DiscoveredPart::age`](crate::DiscoveredPart)),
-/// since a deleted object has no DB row to date. Orphan reclaim therefore has an
-/// agent-clock dependence that the `failed` path does not — `orphan_grace` is set
-/// generously to absorb it.
+/// The `failed` and `replicated` graces use the store clock (the row's `updated_at`), so
+/// neither has an agent-clock dependence; the orphan grace uses the part's SSD `meta.json`
+/// age ([`DiscoveredPart::age`](crate::DiscoveredPart)), since a deleted object has no DB
+/// row to date. Orphan reclaim therefore has an agent-clock dependence that the status-path
+/// reclaims do not — `orphan_grace` is set generously to absorb it.
 ///
 /// # Errors
 ///
@@ -265,6 +282,7 @@ pub async fn reclaim_ssd<S, R, L, B>(
     backing: &B,
     grace: Duration,
     orphan_grace: Duration,
+    replicated_grace: Duration,
 ) -> Result<ReclaimReport, ReclaimError>
 where
     S: PartScan,
@@ -337,10 +355,21 @@ where
         match status.state {
             // Live: owned by the drain pipeline.
             ReplicationState::Pending | ReplicationState::Draining => report.skipped_live += 1,
-            // Replicated: the drain unlinks its own SSD copy on commit. A lingering one
-            // is a rare crash-orphan nothing currently re-drives (known residual leak —
-            // see the module doc); left alone here, counted for visibility.
-            ReplicationState::Replicated => report.skipped_replicated += 1,
+            // Replicated: the drain unlinks its own SSD copy the instant it commits, so a
+            // lingering one is a crash-orphan (a crash between the commit and the unlink).
+            // Re-drive that unlink once past `replicated_grace` — exactly what the happy path
+            // would have done, and strictly weaker than it (see the module doc). No
+            // servability gate is needed: unlike `failed`, a `replicated` part is never a
+            // corrupt-live object's last good source. A young one is left in case its
+            // in-flight unlink has simply not run yet.
+            ReplicationState::Replicated => {
+                if status.age >= replicated_grace {
+                    remover.unlink_part(part).await.map_err(ReclaimError::Remove)?;
+                    report.reclaimed_replicated += 1;
+                } else {
+                    report.skipped_replicated += 1;
+                }
+            }
             // Failed = a broken/abandoned upload (MPU abort, abandoned MPU, or a failed
             // single-part PUT) — reclaimed once past grace — UNLESS the version is still
             // servable, in which case `failed` means "corrupt pool copy on a live object"
@@ -580,6 +609,9 @@ mod tests {
     const HOUR: Duration = Duration::from_hours(1);
     const GRACE: Duration = Duration::from_mins(30);
     const ORPHAN_GRACE: Duration = Duration::from_mins(45);
+    // Larger than the `HOUR` age the existing `replicated` fixtures use, so those parts stay
+    // within grace (`skipped_replicated`); the reclaim-when-aged cases below use ages past it.
+    const REPLICATED_GRACE: Duration = Duration::from_hours(2);
 
     #[tokio::test]
     async fn an_aged_failed_part_is_reclaimed() {
@@ -588,7 +620,7 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, HOUR)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap();
         assert_eq!(report.reclaimed, 1);
@@ -596,27 +628,88 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_replicated_part_is_left_for_the_drain() {
-        // A replicated copy still on SSD is the drain's own to clean up (it unlinks on
-        // commit; this is a rare crash-orphan). The reclaimer never touches it.
+    async fn a_replicated_part_within_grace_is_left_for_the_drains_own_unlink() {
+        // A `replicated` part younger than `replicated_grace` may have just committed, with its
+        // happy-path unlink still in flight — leave it; the crash-orphan reclaim waits out the
+        // grace before re-driving. HOUR < REPLICATED_GRACE (2h), so this is within grace.
         let part = part_at(UUID_A, 5, 1);
         let scan = FakeScan::of(std::slice::from_ref(&part));
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Replicated, HOUR)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap();
         assert_eq!(report.skipped_replicated, 1);
-        assert_eq!(report.reclaimed, 0);
-        assert!(remover.removed().is_empty(), "a replicated part is never reclaimed here");
+        assert_eq!(report.reclaimed_replicated, 0);
+        assert!(remover.removed().is_empty(), "a within-grace replicated part is not reclaimed");
+    }
+
+    #[tokio::test]
+    async fn an_aged_replicated_crash_orphan_is_reclaimed() {
+        // The leak this fix targets: the drain committed `mark_replicated` but crashed before
+        // unlinking its SSD copy (agent SIGKILL on eviction/OOM/restart), so nothing re-drove
+        // the unlink and the dir lingers forever. Past `replicated_grace` it is unlinked —
+        // re-driving the happy-path unlink the crash skipped.
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of(std::slice::from_ref(&part));
+        let remover = FakeRemover::default();
+        let log = FakeLog::with(&[(&part, ReplicationState::Replicated, Duration::from_hours(3))]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
+        assert_eq!(report.reclaimed_replicated, 1);
+        assert_eq!(report.skipped_replicated, 0);
+        assert_eq!(remover.removed(), vec![key(&part)], "the aged replicated crash-orphan was unlinked");
+    }
+
+    #[tokio::test]
+    async fn a_replicated_crash_orphan_exactly_at_the_grace_boundary_is_reclaimed() {
+        // The gate is `age >= replicated_grace -> reclaim`, mirroring the failed/orphan arms,
+        // so age == grace reclaims. Pins the boundary against a future `>=` vs `>` slip.
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of(std::slice::from_ref(&part));
+        let remover = FakeRemover::default();
+        let log = FakeLog::with(&[(&part, ReplicationState::Replicated, REPLICATED_GRACE)]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
+        assert_eq!(report.reclaimed_replicated, 1, "age == replicated_grace reclaims");
+        assert_eq!(report.skipped_replicated, 0);
+    }
+
+    #[tokio::test]
+    async fn an_aged_replicated_crash_orphan_is_reclaimed_even_when_servable() {
+        // Unlike `failed`, a `replicated` part is reclaimed regardless of servability — a
+        // servable object is the normal case, and its pool copy is authoritative (a corrupt
+        // pool copy would have transitioned the row to failed/corrupt, out of this arm). The
+        // servability read is for the `failed` arm only and must NOT gate this one, so it is
+        // never even consulted for a `replicated` part.
+        let part = part_at(UUID_A, 5, 1);
+        let scan = FakeScan::of(std::slice::from_ref(&part));
+        let remover = FakeRemover::default();
+        let log = FakeLog::with(&[(&part, ReplicationState::Replicated, Duration::from_hours(3))]);
+        let backing = FakeBacking::servable(&[&part]);
+
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
+        assert_eq!(report.reclaimed_replicated, 1, "a servable replicated part is still reclaimed");
+        assert_eq!(remover.removed(), vec![key(&part)]);
+        assert!(
+            backing.servable_asked().is_empty(),
+            "the servability read is never consulted for a replicated part"
+        );
     }
 
     #[tokio::test]
     async fn pending_draining_replicated_and_no_row_parts_are_never_reclaimed() {
-        // The absolute safety invariant: a part the drain still owns (pending/draining),
-        // one it already replicated, or one with no row must NEVER be unlinked here,
-        // regardless of age.
+        // The absolute safety invariant: a part the drain still owns (pending/draining) or one
+        // with no row must NEVER be unlinked here, regardless of age; a `replicated` part is
+        // left too while within `replicated_grace` (HOUR < 2h here — the aged-replicated
+        // crash-orphan reclaim is exercised separately below).
         let pending = part_at(UUID_A, 1, 1);
         let draining = part_at(UUID_A, 1, 2);
         let replicated = part_at(UUID_A, 1, 3);
@@ -630,7 +723,7 @@ mod tests {
             // `absent` has no row in the log at all.
         ]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap();
         assert_eq!(report.reclaimed, 0, "nothing but a failed part is ever reclaimed");
@@ -649,7 +742,7 @@ mod tests {
         // and a corruption sample is worth a brief diagnosis window).
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, Duration::from_mins(1))]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap();
         assert_eq!(report.skipped_young, 1);
@@ -665,7 +758,7 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, GRACE)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap();
         assert_eq!(report.reclaimed, 1, "age == grace reclaims");
@@ -679,7 +772,7 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&parts.iter().map(|p| (p, ReplicationState::Failed, HOUR)).collect::<Vec<_>>());
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap();
         assert_eq!(report.reclaimed, 5);
@@ -702,7 +795,7 @@ mod tests {
             (&young, ReplicationState::Failed, Duration::from_secs(1)),
         ]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap();
         assert_eq!(
@@ -711,6 +804,7 @@ mod tests {
                 scanned: 5,
                 reclaimed: 1,
                 reclaimed_orphan: 0,
+                reclaimed_replicated: 0,
                 skipped_live: 1,
                 skipped_replicated: 1,
                 skipped_absent: 1,
@@ -731,7 +825,7 @@ mod tests {
         let scan = FakeScan { parts: vec![], fail: true };
         let remover = FakeRemover::default();
         let log = FakeLog::default();
-        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap_err();
         assert!(matches!(err, ReclaimError::Scan(_)), "got: {err:?}");
@@ -747,7 +841,7 @@ mod tests {
             fail: true,
             ..FakeLog::default()
         };
-        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap_err();
         assert!(matches!(err, ReclaimError::Log(_)), "got: {err:?}");
@@ -763,7 +857,7 @@ mod tests {
             ..FakeRemover::default()
         };
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, HOUR)]);
-        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let err = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap_err();
         assert!(matches!(err, ReclaimError::Remove(_)), "got: {err:?}");
@@ -774,7 +868,7 @@ mod tests {
         let scan = FakeScan::of(&[]);
         let remover = FakeRemover::default();
         let log = FakeLog::default();
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap();
         assert_eq!(report, ReclaimReport::default());
@@ -794,7 +888,9 @@ mod tests {
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, HOUR)]);
         let backing = FakeBacking::servable(&[&part]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.skipped_corrupt, 1);
         assert_eq!(report.reclaimed, 0);
         assert!(remover.removed().is_empty(), "a servable object's last good copy is preserved");
@@ -814,7 +910,9 @@ mod tests {
         ]);
         let backing = FakeBacking::servable(&[&corrupt_live]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.reclaimed, 1);
         assert_eq!(report.skipped_corrupt, 1);
         assert_eq!(remover.removed(), vec![key(&abandoned)], "only the unservable (abandoned) part");
@@ -839,7 +937,9 @@ mod tests {
         ]);
         let backing = FakeBacking::all_backed();
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.reclaimed, 1, "the aged failed part reclaims (not servable)");
         assert_eq!(
             backing.servable_asked(),
@@ -861,7 +961,9 @@ mod tests {
             fail: true,
             ..FakeBacking::default()
         };
-        let err = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap_err();
+        let err = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap_err();
         assert!(matches!(err, ReclaimError::Backing(_)), "got: {err:?}");
         assert!(remover.removed().is_empty(), "a failed servability read removes nothing (fail-safe)");
     }
@@ -905,7 +1007,7 @@ mod tests {
                 let refs: Vec<&PartKey> = servable_refs.iter().collect();
                 let backing = FakeBacking::servable(&refs);
 
-                let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+                let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE).await.unwrap();
                 expected_removed.sort();
                 proptest::prop_assert_eq!(remover.removed(), expected_removed.clone());
                 proptest::prop_assert_eq!(usize::try_from(report.reclaimed).unwrap(), expected_removed.len());
@@ -926,7 +1028,7 @@ mod tests {
         let remover = FakeRemover::default();
         let log = FakeLog::with(&[(&part, ReplicationState::Corrupt, HOUR)]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE)
+        let report = reclaim_ssd(&scan, &remover, &log, &FakeBacking::all_backed(), GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
             .await
             .unwrap();
         assert_eq!(report.skipped_corrupt, 1);
@@ -945,7 +1047,9 @@ mod tests {
         let log = FakeLog::with(&[(&part, ReplicationState::Failed, GRACE)]);
         let backing = FakeBacking::servable(&[&part]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
         assert_eq!(
             report.skipped_corrupt, 1,
             "a servable failed part exactly at grace is held, not reclaimed"
@@ -966,7 +1070,9 @@ mod tests {
         let log = FakeLog::default(); // no replication row
         let backing = FakeBacking::unbacked(&[&part]); // object_versions row gone
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.reclaimed_orphan, 1);
         assert_eq!(report.skipped_absent, 0);
         assert_eq!(remover.removed(), vec![key(&part)], "the deleted-object orphan was unlinked");
@@ -982,7 +1088,9 @@ mod tests {
         let log = FakeLog::default();
         let backing = FakeBacking::all_backed(); // object_versions row present
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.reclaimed_orphan, 0);
         assert_eq!(report.skipped_absent, 1);
         assert!(remover.removed().is_empty(), "a part whose object still exists is protected");
@@ -998,7 +1106,9 @@ mod tests {
         let log = FakeLog::default();
         let backing = FakeBacking::unbacked(&[&part]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.skipped_absent, 1);
         assert_eq!(report.reclaimed_orphan, 0);
         assert!(remover.removed().is_empty(), "a young orphan is kept");
@@ -1014,7 +1124,9 @@ mod tests {
         let log = FakeLog::default();
         let backing = FakeBacking::unbacked(&[&part]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.reclaimed_orphan, 1, "age == orphan_grace reclaims");
         assert_eq!(report.skipped_absent, 0);
     }
@@ -1031,7 +1143,9 @@ mod tests {
         let log = FakeLog::with(&[(&failed, ReplicationState::Failed, HOUR)]);
         let backing = FakeBacking::unbacked(&[&orphan]);
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.reclaimed, 1, "the failed part reclaimed via the status path");
         assert_eq!(report.reclaimed_orphan, 1, "the orphan reclaimed via the backing path");
         assert_eq!(backing.asked(), vec![key(&orphan)], "only the no-row part was backing-checked");
@@ -1047,7 +1161,9 @@ mod tests {
             fail: true,
             ..FakeBacking::default()
         };
-        let err = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap_err();
+        let err = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap_err();
         assert!(matches!(err, ReclaimError::Backing(_)), "got: {err:?}");
         assert!(remover.removed().is_empty(), "a failed backing read removes nothing (fail-safe)");
     }
@@ -1063,7 +1179,9 @@ mod tests {
         let log = FakeLog::default();
         let backing = FakeBacking::all_backed();
 
-        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE).await.unwrap();
+        let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, ORPHAN_GRACE, REPLICATED_GRACE)
+            .await
+            .unwrap();
         assert_eq!(report.skipped_absent, 2);
         assert_eq!(report.reclaimed_orphan, 0);
         assert!(remover.removed().is_empty());
@@ -1104,7 +1222,7 @@ mod tests {
                 let refs: Vec<&PartKey> = unbacked_refs.iter().collect();
                 let backing = FakeBacking::unbacked(&refs);
 
-                let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, orphan_grace).await.unwrap();
+                let report = reclaim_ssd(&scan, &remover, &log, &backing, GRACE, orphan_grace, REPLICATED_GRACE).await.unwrap();
                 expected_removed.sort();
                 proptest::prop_assert_eq!(remover.removed(), expected_removed.clone());
                 proptest::prop_assert_eq!(usize::try_from(report.reclaimed_orphan).unwrap(), expected_removed.len());

--- a/k8s/production/drain-agent-daemonset.yaml
+++ b/k8s/production/drain-agent-daemonset.yaml
@@ -140,12 +140,15 @@ spec:
                   name: hippius-s3-secrets
                   key: HIPPIUS_UPLOAD_BACKENDS
             # SSD-ingest reclaim worker: clean up broken/abandoned uploads (failed parts
-            # the drain skips forever) + orphan write-temps, once aged, so abandoned-upload
-            # junk does not accumulate on the node-local disk. Both have safe code defaults
-            # (300s poll / 1h grace); set here for visibility + per-node tuning.
+            # the drain skips forever), replicated crash-orphans (a crash between the
+            # mark_replicated commit and the drain's own unlink), and orphan write-temps,
+            # once aged, so junk does not accumulate on the node-local disk. All have safe
+            # code defaults (300s poll / 1h graces); set here for visibility + per-node tuning.
             - name: CEPHOR_RECLAIM_POLL_SECS
               value: "300"
             - name: CEPHOR_RECLAIM_GRACE_SECS
+              value: "3600"
+            - name: CEPHOR_REPLICATED_RECLAIM_GRACE_SECS
               value: "3600"
             # Max parts drained concurrently — the in-flight gate that lets the node
             # overlap fsync latency across parts (the AIMD allocator only tunes bytes/s).

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -128,12 +128,15 @@ spec:
                   name: hippius-s3-secrets
                   key: HIPPIUS_UPLOAD_BACKENDS
             # SSD-ingest reclaim worker: clean up broken/abandoned uploads (failed parts
-            # the drain skips forever) + orphan write-temps, once aged, so abandoned-upload
-            # junk does not accumulate on the node-local disk. Both have safe code defaults
-            # (300s poll / 1h grace); set here for visibility + per-node tuning.
+            # the drain skips forever), replicated crash-orphans (a crash between the
+            # mark_replicated commit and the drain's own unlink), and orphan write-temps,
+            # once aged, so junk does not accumulate on the node-local disk. All have safe
+            # code defaults (300s poll / 1h graces); set here for visibility + per-node tuning.
             - name: CEPHOR_RECLAIM_POLL_SECS
               value: "300"
             - name: CEPHOR_RECLAIM_GRACE_SECS
+              value: "3600"
+            - name: CEPHOR_REPLICATED_RECLAIM_GRACE_SECS
               value: "3600"
             # Max parts drained concurrently — the in-flight gate that lets the node
             # overlap fsync latency across parts (the AIMD allocator only tunes bytes/s).


### PR DESCRIPTION
## Problem

The SSD reclaim scan (`ssd_reclaim.rs`) deliberately **skipped `replicated` parts**, assuming the drain unlinks its own SSD copy the instant it commits `mark_replicated`. But if the agent dies between that commit and the unlink — a **crash-orphan** on pod eviction / OOM / restart — `claim_part` never re-selects the `replicated` row and the reclaimer skipped it, so **nothing ever re-drove the unlink** and the part's directory leaked forever.

This is an **unbounded inode/directory leak** on the per-node `/s3-data` NVMe, and it spikes on every agent restart (each mass-crash-orphans in-flight parts). Confirmed live during the 2026-07-22 post-release audit: node2 = **155,835** dirs, node3 = **181,314** dirs (roughly doubled over ~6h of deploy churn from ~76k/97k earlier the same day). Bytes are trivial and inode usage is still 0%, so **not urgent** — but genuinely unbounded. Documented in `ssd-leak.md` (fix option 1).

## Fix

Re-drive the unlink for aged `Replicated` orphans, mirroring the existing `Failed`/orphan grace-gated arms:

```rust
ReplicationState::Replicated => {
    if status.age >= replicated_grace {
        remover.unlink_part(part).await?;   // reclaimed_replicated
    } else {
        report.skipped_replicated += 1;     // within grace: leave for the in-flight unlink
    }
}
```

**Safety** — this is *strictly weaker* than the happy path, not stronger: the drain's own unlink runs milliseconds after the commit, so re-driving it after a grace introduces no risk the happy path does not already accept. The pool copy is authoritative (the `replicated` state IS the drain's record that the CephFS copy exists), and — unlike a `failed` part — a `replicated` one is **never** a corrupt-live object's last good source (a corrupt pool copy transitions the row to `failed`/`corrupt`, out of this arm), so **no servability gate is needed**. The grace only avoids racing a just-committed part whose in-process unlink hasn't run.

## Changes
- `ssd_reclaim.rs`: new `replicated_grace` param, `reclaimed_replicated` report counter, the `Replicated` arm, module/fn docs, `categorized()` invariant.
- `config.rs`: `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS` knob (default **1h**), plumbed to `RuntimeConfig`.
- `runtime.rs`: threaded through `reclaim_once`; `record_reclaimed` sums it; new info log; the old un-reclaimable-leak WARN becomes a within-grace DEBUG.

## Tests
- **Unit** (in-memory fakes): reclaim-when-aged, within-grace-is-kept, exact-grace boundary, and **servable-is-still-reclaimed** (proves the `failed` corrupt-live gate does NOT apply and the servability read is never consulted). Existing replicated-skip tests kept (their fixtures are within a 2h test grace).
- **Integration** (real Postgres, `#[sqlx::test]`): `reclaim_once_evicts_an_aged_replicated_crash_orphan` — the `ssd-leak.md` verification end-to-end (evicted, counted, replication row untouched).
- Full suite green locally: core 177, agent 102, clippy `-D warnings` clean, `fmt --check` clean.

## Rollout
Merge → deploy to **staging** first. Verify per `ssd-leak.md`: force a crash-orphan (`kubectl delete pod <drain-agent>` mid-replication), confirm the SSD dir lingers then is unlinked after the grace on the next reclaim scan, with no `replicated` row deleted and the object still readable from the pool. Then prod, where the existing ~170k node2/node3 orphans will drain down over a few reclaim cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)