### PR TITLE
fix(mpu-reaper): stop the abandoned-upload query pinning the xmin horizon

### DIFF
--- a/crates/hippius-drain-core/migrations/0013_replication_undrained_by_node.sql
+++ b/crates/hippius-drain-core/migrations/0013_replication_undrained_by_node.sql
@@ -1,0 +1,25 @@
+-- Index the readiness/heartbeat query `node_undrained_count`:
+--   WHERE node_id = $1 AND status IN ('pending', 'draining')
+--
+-- No existing index serves that pair, so it fell to the only one whose predicate covers
+-- both states — cephor_replication_status_active_orphans (object_id, version, landed_at)
+-- WHERE status IN ('pending','draining') — which is keyed on object_id, not node_id. The
+-- planner therefore scanned every active entry and discarded the other nodes' rows with a
+-- post-filter ("Rows Removed by Filter: 53" for 28 kept, on prod 2026-07-23). The
+-- docstring on Store::node_undrained_count claimed it "uses the node-scoped pending
+-- index"; that index is WHERE status = 'pending' only, so it never applied to a query
+-- that also matches 'draining'.
+--
+-- node_id leads so the equality is an index condition rather than a filter, and the whole
+-- query is answerable from the index. Partial on the two non-terminal states, matching the
+-- sibling hot-path indexes: the active population is a small bounded subset (99 rows out
+-- of 1.79M on prod) of a table that is ~99.98% terminal.
+--
+-- Scale note: this makes a correct plan cheap, but it is NOT what made that query slow.
+-- On 2026-07-23 it read 239,014 buffers to return 28 rows because a 96-minute statement
+-- elsewhere (the abandoned-MPU reaper, fixed alongside this) pinned the xmin horizon, so
+-- VACUUM could not reclaim and this index carried ~116k dead entries per scan. An index
+-- cannot outrun bloat — keeping the horizon moving is what does.
+CREATE INDEX IF NOT EXISTS cephor_replication_status_undrained_by_node
+    ON cephor_replication_status (node_id)
+    WHERE status IN ('pending', 'draining');

--- a/crates/hippius-drain-core/migrations/0013_replication_undrained_by_node.sql
+++ b/crates/hippius-drain-core/migrations/0013_replication_undrained_by_node.sql
@@ -20,6 +20,49 @@
 -- elsewhere (the abandoned-MPU reaper, fixed alongside this) pinned the xmin horizon, so
 -- VACUUM could not reclaim and this index carried ~116k dead entries per scan. An index
 -- cannot outrun bloat — keeping the horizon moving is what does.
+-- Build is plain, NOT CONCURRENTLY, and that is deliberate at this cardinality: 1.8M rows
+-- builds in seconds and rolls back cleanly if aborted. CONCURRENTLY was rejected because
+-- (a) it needs `-- no-transaction`, and a failed concurrent build leaves an INVALID index
+-- that `IF NOT EXISTS` then silently refuses to rebuild while the migration records as
+-- applied — a dead index the planner ignores, with no operator-visible apply job to catch
+-- it (the python half hit exactly this: see 20260706000000_parts_upload_uploaded_at_index),
+-- and (b) it waits out all older snapshots twice, which on a horizon-pinned database is
+-- unbounded — the precise failure this PR exists to fix. Do NOT copy this file onto a
+-- large table: the sibling `parts` is 140M rows and would need the CONCURRENTLY route.
+--
+-- lock_timeout is the load-bearing line. CREATE INDEX takes SHARE, which conflicts with
+-- ROW EXCLUSIVE, so with no timeout it waits forever for any open writer AND blocks every
+-- new writer on this table behind it — claim_part, release_part, mark_replicated,
+-- record_landed_part, i.e. the entire drain fleet. Worse, migrate() runs in the allocator's
+-- startup path BEFORE its liveness file is first touched, and that probe SIGKILLs at
+-- ~50-65s: a long lock wait means CrashLoopBackOff, each restart re-queuing the lock and
+-- re-stalling the fleet, plus a failed 5m deploy gate. Failing fast and retrying on the
+-- next start is strictly better. In the healthy case it never fires — drain writers are
+-- all single autocommit statements.
+--
+-- Rollback, if this ever proves a net loss: `DROP INDEX CONCURRENTLY
+-- cephor_replication_status_undrained_by_node;` by hand. sqlx will not recreate it (the
+-- _sqlx_migrations row stays), so no revert migration is needed.
+SET LOCAL lock_timeout = '5s';
+
 CREATE INDEX IF NOT EXISTS cephor_replication_status_undrained_by_node
     ON cephor_replication_status (node_id)
     WHERE status IN ('pending', 'draining');
+
+-- Vacuum this table on its own schedule. At the default scale_factor of 0.2 autovacuum
+-- waits for ~360k dead tuples on 1.8M live before it even tries, which is why 499k dead
+-- looked unremarkable to it through 429 runs on 2026-07-23. Every part churns through
+-- pending -> draining -> replicated -> upload_enqueued_at, so dead tuples arrive far faster
+-- here than the table-size heuristic assumes, and each one strands entries in SEVEN partial
+-- indexes (this migration adds the seventh, on the same hot predicate as active_orphans —
+-- so it doubles the bloat surface of the one predicate that already blew up, which makes
+-- this setting more necessary, not less).
+--
+-- Deliberately NOT setting autovacuum_vacuum_cost_delay = 0: unthrottled vacuum on a
+-- primary with this cluster's history of flapping is its own outage risk. Lowering the
+-- trigger threshold is the safe half of that pair; if bloat persists after this, raise
+-- cost_limit under supervision rather than removing the throttle outright.
+ALTER TABLE cephor_replication_status SET (
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_analyze_scale_factor = 0.02
+);

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -333,7 +333,11 @@ impl Store {
     /// contributes zero bytes to that SUM but is still undrained WORK, so the byte-backlog of a
     /// wedged node can read 0 while rows remain — which readiness would misread as idle. Counting
     /// the replication rows directly cannot be zeroed that way, so it is the signal readiness gates
-    /// on. Uses the node-scoped pending index. Mirrors the params of `node_backlog_bytes`.
+    /// on. Mirrors the params of `node_backlog_bytes`.
+    ///
+    /// Served by `cephor_replication_status_undrained_by_node` (0013). NOT by the node-scoped
+    /// pending index, which is `WHERE status = 'pending'` and so never covered a query that also
+    /// matches `'draining'` — before 0013 this fell to the orphan index and post-filtered by node.
     ///
     /// # Errors
     ///

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -357,6 +357,16 @@ class Config:
     # never-finalized uploads older than mpu_stale_seconds (address never written),
     # purging their SSD parts + drain replication rows so the drain stops re-deferring.
     mpu_reaper_interval_seconds: int = env("HIPPIUS_MPU_REAPER_INTERVAL_SECONDS:120", convert=int)  # every 2 min
+    # Hard ceiling on any single reaper statement. The reaper's pool had NO command_timeout, so
+    # on 2026-07-23 one abandoned-upload query ran for 96 MINUTES on a bad plan. The damage was
+    # not the slowness: a long statement pins its snapshot, so the xmin horizon stops advancing
+    # and VACUUM reclaims nothing database-wide — cephor_replication_status held ~499k dead
+    # tuples through 429 autovacuum runs, its partial indexes bloated, the drain fell behind and
+    # a cross-node read took 83s. The plan is fixed (list_abandoned_versions.sql, ~8s), but a
+    # timeout is what bounds the DAMAGE of the next bad plan rather than that one instance.
+    # Well above the measured runtime, far below anything that can hurt the horizon; a cycle
+    # that trips it is logged and retried on the next interval.
+    mpu_reaper_statement_timeout_seconds: int = env("HIPPIUS_MPU_REAPER_STATEMENT_TIMEOUT_SECONDS:60", convert=int)
     # Replication SLA grace for the G2 under-replication sentinel. `address` is stamped at
     # PUT completion but the chunk_backend coverage row is written much later by the async
     # drain→pool→backend pipeline, so every servable chunk is briefly under-covered while it

--- a/hippius_s3/services/mpu_cleanup.py
+++ b/hippius_s3/services/mpu_cleanup.py
@@ -212,7 +212,21 @@ async def run_mpu_reaper_loop() -> None:
     from hippius_s3.monitoring import initialize_metrics_collector
 
     config = get_config()
-    db_pool = await asyncpg.create_pool(config.database_url, min_size=1, max_size=5)
+    # command_timeout is load-bearing, not tidiness: without it a bad plan runs unbounded and
+    # pins the xmin horizon, which stops VACUUM reclaiming anywhere in the database. See
+    # mpu_reaper_statement_timeout_seconds in config.py for the incident this bounds.
+    db_pool = await asyncpg.create_pool(
+        config.database_url,
+        min_size=1,
+        max_size=5,
+        command_timeout=config.mpu_reaper_statement_timeout_seconds,
+        # Belt AND braces, because they fail differently. command_timeout is client-side:
+        # asyncpg sends a CancelRequest, which does nothing if the client itself is wedged
+        # or the connection is black-holed — exactly when a statement would keep running and
+        # keep pinning the horizon. statement_timeout is enforced by the backend and needs no
+        # live client. Same value; whichever notices first wins.
+        server_settings={"statement_timeout": f"{config.mpu_reaper_statement_timeout_seconds * 1000}"},
+    )
     # The upload/unpin DLQs live on redis-queues (not the main cache), matching the
     # janitor's DLQ scan — read protection ids from the same instance.
     redis_client = async_redis.from_url(config.redis_queues_url)

--- a/hippius_s3/sql/queries/list_abandoned_versions.sql
+++ b/hippius_s3/sql/queries/list_abandoned_versions.sql
@@ -12,19 +12,61 @@
 -- selected. Returns one row per (upload_id, object_id, object_version) to reap, plus
 -- age_seconds (how long ago the upload was initiated) so the reaper can report its lag.
 -- Parameters: $1: stale_seconds (int)
-SELECT DISTINCT mu.upload_id, p.object_id, p.object_version,
-       EXTRACT(EPOCH FROM (now() - mu.initiated_at))::float8 AS age_seconds
-FROM multipart_uploads mu
-JOIN parts p ON p.upload_id = mu.upload_id
-LEFT JOIN object_versions ov
-       ON ov.object_id = p.object_id AND ov.object_version = p.object_version
-WHERE COALESCE(mu.is_completed, false) = false
-  AND (ov.address IS NULL OR ov.object_id IS NULL)
-  AND mu.initiated_at < now() - make_interval(secs => $1)
-  AND NOT EXISTS (
-        SELECT 1 FROM parts pr
-        WHERE pr.upload_id = mu.upload_id
-          AND pr.uploaded_at >= now() - make_interval(secs => $1)
-      )
-ORDER BY mu.upload_id
-LIMIT 2000
+--
+-- SHAPE IS LOAD-BEARING — pick the candidate uploads FIRST, then join their parts.
+--
+-- This selected the same rows by joining multipart_uploads to parts and ordering the
+-- result by mu.upload_id. No index yields that ordering for this predicate, so rather
+-- than sort, the planner drove the join from `parts` — scanning ~140M rows (cost 166M,
+-- 4 parallel workers) because reading parts by (upload_id, uploaded_at) arrives
+-- pre-sorted on upload_id — and applied the selective mu filters only after the join.
+-- idx_multipart_uploads_initiated_at, which selects the candidates directly, went
+-- unused. Measured in prod on 2026-07-23: a single execution ran for 96 MINUTES.
+--
+-- That is not merely slow. A 96-minute statement pins its snapshot, so the xmin horizon
+-- stops advancing and VACUUM cannot reclaim ANY dead tuple newer than it, database-wide.
+-- cephor_replication_status then sat at ~499k dead tuples through 429 autovacuum runs,
+-- its hot partial indexes bloated to ~116k entries read per scan to return 28 live rows,
+-- the drain-agent's 10s heartbeat query slowed to ~2s, replication fell behind, and a
+-- cross-node read-after-write took 83s — long enough to time out a client at 60s.
+--
+-- Ordering by initiated_at instead lets idx_multipart_uploads_initiated_at supply the
+-- order so LIMIT stops early, and materialising the candidates first bounds the parts
+-- join to those 2000 uploads. Same rows, 96 minutes -> ~11s. Oldest-first is also the
+-- order the reaper wants, since it reports the oldest reaped age as its lag.
+WITH candidates AS MATERIALIZED (
+    SELECT mu.upload_id, mu.initiated_at
+    FROM multipart_uploads mu
+    WHERE COALESCE(mu.is_completed, false) = false
+      AND mu.initiated_at < now() - make_interval(secs => $1)
+      -- Only uploads that actually have parts. The join below is an INNER join, so a
+      -- partless upload can never be reaped — and prod carries 874k of them (97% of the
+      -- incomplete backlog). Without this gate they are the OLDEST candidates, so they
+      -- would fill every one of the 2000 slots and the reaper would reap nothing at all.
+      AND EXISTS (
+            SELECT 1 FROM parts pe
+            WHERE pe.upload_id = mu.upload_id
+          )
+      AND NOT EXISTS (
+            SELECT 1 FROM parts pr
+            WHERE pr.upload_id = mu.upload_id
+              AND pr.uploaded_at >= now() - make_interval(secs => $1)
+          )
+      -- The address gate, hoisted into the candidate set so it cannot be defeated by the
+      -- LIMIT: filtering after the limit would let 2000 non-reapable uploads occupy every
+      -- slot and stall the reaper on the same rows every cycle.
+      AND NOT EXISTS (
+            SELECT 1 FROM parts p2
+            JOIN object_versions ov2
+              ON ov2.object_id = p2.object_id AND ov2.object_version = p2.object_version
+            WHERE p2.upload_id = mu.upload_id
+              AND ov2.address IS NOT NULL
+          )
+    ORDER BY mu.initiated_at
+    LIMIT 2000
+)
+SELECT DISTINCT c.upload_id, p.object_id, p.object_version,
+       EXTRACT(EPOCH FROM (now() - c.initiated_at))::float8 AS age_seconds
+FROM candidates c
+JOIN parts p ON p.upload_id = c.upload_id
+ORDER BY age_seconds DESC

--- a/hippius_s3/sql/queries/list_abandoned_versions.sql
+++ b/hippius_s3/sql/queries/list_abandoned_versions.sql
@@ -32,8 +32,20 @@
 --
 -- Ordering by initiated_at instead lets idx_multipart_uploads_initiated_at supply the
 -- order so LIMIT stops early, and materialising the candidates first bounds the parts
--- join to those 2000 uploads. Same rows, 96 minutes -> ~11s. Oldest-first is also the
--- order the reaper wants, since it reports the oldest reaped age as its lag.
+-- join to those 2000 uploads. 96 minutes -> ~8s. Oldest-first is also the order the reaper
+-- wants, since it reports the oldest reaped age as its lag.
+--
+-- The result is a strict SUBSET of what this returned before, never a superset: see the
+-- address gate below for the one case that narrowed, and why narrowing is the only safe
+-- direction on a path that DELETEs.
+--
+-- COST IS O(INCOMPLETE BACKLOG), NOT O(RESULT). The LIMIT bounds what comes OUT, not the
+-- index walk: in the steady state (fewer than 2000 reapable uploads — the state this is
+-- driving toward) it walks every entry in idx_multipart_uploads_initiated_at, ~904k on prod,
+-- probing parts up to 3x each, every mpu_reaper_interval_seconds. That backlog is 97%
+-- partless uploads which NOTHING deletes, so the ~8s degrades linearly and forever. It is
+-- comfortably under the reaper's command_timeout today; it will not stay that way. The fix
+-- is a partless-MPU sweep (see the PR discussion), not more tuning here.
 WITH candidates AS MATERIALIZED (
     SELECT mu.upload_id, mu.initiated_at
     FROM multipart_uploads mu
@@ -55,6 +67,14 @@ WITH candidates AS MATERIALIZED (
       -- The address gate, hoisted into the candidate set so it cannot be defeated by the
       -- LIMIT: filtering after the limit would let 2000 non-reapable uploads occupy every
       -- slot and stall the reaper on the same rows every cycle.
+      --
+      -- Hoisting makes this per-UPLOAD where it used to be per-VERSION, which diverges for an
+      -- upload whose parts span several object versions with only SOME addressed: previously
+      -- the unaddressed ones were reaped, now the upload is skipped entirely. Deliberate — on
+      -- a path that DELETES, declining to act on a mixed upload is the safe direction. Nothing
+      -- ties an upload to one version in the schema, but nothing produces the mix either: a
+      -- 5000-upload sample of the live candidate population on 2026-07-23 had max 1 version
+      -- per upload and zero spanning uploads.
       AND NOT EXISTS (
             SELECT 1 FROM parts p2
             JOIN object_versions ov2

--- a/tests/integration/test_mpu_reaper_sql.py
+++ b/tests/integration/test_mpu_reaper_sql.py
@@ -210,3 +210,58 @@ async def test_full_mix(conn):
     await _ov(conn, fresh_o, 1, address=None)
 
     assert await _abandoned(conn) == {(abandoned_u, abandoned_o, 1), (orphan_u, orphan_o, 1)}
+
+
+async def test_partless_upload_is_not_listed(conn):
+    """An upload that never received a part has nothing to reap — the join drops it."""
+    upload = str(uuid.uuid4())
+    await _mpu(conn, upload, completed=False, age_seconds=7200)
+
+    assert await _abandoned(conn) == set()
+
+
+async def test_partless_uploads_do_not_starve_the_candidate_budget(conn):
+    """The reaper must still make progress when partless uploads dominate the backlog.
+
+    The query picks candidate uploads before joining their parts, so the LIMIT is spent on
+    uploads, not output rows. Partless uploads can never be reaped (the join is INNER), so
+    without an EXISTS-parts gate the oldest of them fill every slot and the reaper returns
+    nothing, forever. Prod carries 874k such uploads against 904k incomplete total, and they
+    are the oldest rows in the table — so this is the normal case there, not a corner.
+    """
+    # 2001 partless uploads, all OLDER than the reapable one, so oldest-first ordering puts
+    # every single one ahead of it and they would consume the entire 2000-row budget.
+    await conn.execute(
+        "INSERT INTO multipart_uploads (upload_id, is_completed, initiated_at) "
+        "SELECT gen_random_uuid(), false, now() - make_interval(secs => 100000 + g) "
+        "FROM generate_series(1, 2001) g"
+    )
+
+    upload, object_id = str(uuid.uuid4()), str(uuid.uuid4())
+    await _mpu(conn, upload, completed=False, age_seconds=7200)
+    await _part(conn, upload, object_id, 1)
+    await _ov(conn, object_id, 1, address=None)
+
+    assert await _abandoned(conn) == {(upload, object_id, 1)}
+
+
+async def test_oldest_upload_is_reported_first(conn):
+    """Oldest-first: the reaper reports the oldest reaped age as its lag.
+
+    The upload_ids are pinned so that ordering by upload_id yields the OPPOSITE order to
+    ordering by initiated_at — otherwise, with random uuids, a query still ordering by
+    upload_id would pass this half the time.
+    """
+    older, newer = "ffffffff-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"
+    obj_older, obj_newer = str(uuid.uuid4()), str(uuid.uuid4())
+    await _mpu(conn, newer, completed=False, age_seconds=7200)
+    await _part(conn, newer, obj_newer, 1)
+    await _ov(conn, obj_newer, 1, address=None)
+    await _mpu(conn, older, completed=False, age_seconds=99999)
+    await _part(conn, older, obj_older, 1)
+    await _ov(conn, obj_older, 1, address=None)
+
+    rows = await conn.fetch(get_query("list_abandoned_versions"), _STALE)
+
+    assert [str(r["upload_id"]) for r in rows] == [older, newer]
+    assert rows[0]["age_seconds"] > rows[1]["age_seconds"]

--- a/tests/integration/test_mpu_reaper_sql.py
+++ b/tests/integration/test_mpu_reaper_sql.py
@@ -245,23 +245,60 @@ async def test_partless_uploads_do_not_starve_the_candidate_budget(conn):
     assert await _abandoned(conn) == {(upload, object_id, 1)}
 
 
-async def test_oldest_upload_is_reported_first(conn):
-    """Oldest-first: the reaper reports the oldest reaped age as its lag.
+async def test_rows_come_back_oldest_first(conn):
+    """Oldest-first, asserted as a total order rather than a lucky pair.
 
-    The upload_ids are pinned so that ordering by upload_id yields the OPPOSITE order to
-    ordering by initiated_at — otherwise, with random uuids, a query still ordering by
-    upload_id would pass this half the time.
+    Three uploads, inserted out of order, with upload_ids pinned so that ordering by
+    upload_id (what this used to do) gives a DIFFERENT answer from ordering by age — so
+    neither dropping the ORDER BY nor reverting to upload_id can pass by coincidence.
     """
-    older, newer = "ffffffff-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"
-    obj_older, obj_newer = str(uuid.uuid4()), str(uuid.uuid4())
-    await _mpu(conn, newer, completed=False, age_seconds=7200)
-    await _part(conn, newer, obj_newer, 1)
-    await _ov(conn, obj_newer, 1, address=None)
-    await _mpu(conn, older, completed=False, age_seconds=99999)
-    await _part(conn, older, obj_older, 1)
-    await _ov(conn, obj_older, 1, address=None)
+    specs = [
+        ("ffffffff-0000-4000-8000-000000000001", 50000),
+        ("00000000-0000-4000-8000-000000000002", 99999),
+        ("88888888-0000-4000-8000-000000000003", 7200),
+    ]
+    for upload, age in specs:
+        obj = str(uuid.uuid4())
+        await _mpu(conn, upload, completed=False, age_seconds=age)
+        await _part(conn, upload, obj, 1)
+        await _ov(conn, obj, 1, address=None)
 
     rows = await conn.fetch(get_query("list_abandoned_versions"), _STALE)
+    ages = [r["age_seconds"] for r in rows]
 
-    assert [str(r["upload_id"]) for r in rows] == [older, newer]
-    assert rows[0]["age_seconds"] > rows[1]["age_seconds"]
+    assert len(ages) == 3
+    assert ages == sorted(ages, reverse=True), f"not oldest-first: {ages}"
+
+
+async def test_upload_with_any_addressed_version_is_never_listed(conn):
+    """An upload with even ONE live, addressed version is off limits entirely.
+
+    Reaping is per-UPLOAD: the reaper deletes the multipart_uploads row, and parts cascades
+    off it. So reaping an upload for its unaddressed version would also delete the parts row
+    describing the ADDRESSED one — silently orphaning a live object's metadata. The gate is
+    therefore per-upload, which is narrower than the per-version gate this replaced. That
+    narrowing is the one behavioural change in the rewrite, and it is the safe direction.
+    """
+    upload, obj = str(uuid.uuid4()), str(uuid.uuid4())
+    await _mpu(conn, upload, completed=False, age_seconds=7200)
+    await _part(conn, upload, obj, 1)
+    await _ov(conn, obj, 1, address="5Flive")  # finalized — must not be collaterally deleted
+    await _part(conn, upload, obj, 2)
+    await _ov(conn, obj, 2, address=None)  # abandoned
+
+    assert await _abandoned(conn) == set()
+
+
+async def test_candidate_selection_stays_index_ordered():
+    """Pin the two clauses that produce the fast plan; nothing else in the suite can.
+
+    The temp tables here carry no indexes or stats, so every plan is a seq scan and an
+    EXPLAIN-based assertion would prove nothing. These two clauses ARE the fix: ordering by
+    initiated_at is what lets idx_multipart_uploads_initiated_at supply the order so LIMIT
+    stops early, and MATERIALIZED is what stops the planner inlining the CTE and re-deriving
+    the 140M-row parts-driven join that ran for 96 minutes.
+    """
+    sql = get_query("list_abandoned_versions")
+
+    assert "AS MATERIALIZED" in sql, "the CTE must not be inlineable"
+    assert "ORDER BY mu.initiated_at" in sql, "candidate order must match the partial index"

--- a/tests/unit/test_mpu_reaper.py
+++ b/tests/unit/test_mpu_reaper.py
@@ -19,6 +19,18 @@ import pytest
 from hippius_s3.services import mpu_cleanup
 
 
+def statement_of(query: str) -> str:
+    """The query with its leading comments stripped.
+
+    These tests route on the SQL text, and query files routinely NAME other tables in
+    their comments — list_abandoned_versions.sql explains its plan in terms of the drain's
+    cephor_replication_status. Matching the raw text then silently misroutes: the reaper's
+    query looks like the sweep's, so the fake feeds it the wrong rows and the grace-window
+    assertion reads the wrong call. Route on the statement instead.
+    """
+    return "\n".join(line for line in query.splitlines() if not line.lstrip().startswith("--"))
+
+
 class FakeDb:
     """A minimal asyncpg-connection stand-in: fetch returns canned rows; execute records.
 
@@ -45,7 +57,7 @@ class FakeDb:
 
     async def fetch(self, query: str, *args: object) -> list[dict]:
         self.fetched.append((query, args))
-        if "cephor_replication_status" in query:
+        if "cephor_replication_status" in statement_of(query):
             return self._sweep_rows
         return self._fetch_rows
 
@@ -291,7 +303,7 @@ async def test_run_reaper_cycle_threads_distinct_grace_windows() -> None:
             pool, _fake_redis(), stale_seconds=86400, sweep_grace_seconds=999, upload_backends=["arion"]
         )
 
-    reaper_grace = next(args[0] for query, args in db.fetched if "multipart_uploads" in query)
-    sweep_grace = next(args[0] for query, args in db.fetched if "cephor_replication_status" in query)
+    reaper_grace = next(args[0] for query, args in db.fetched if "multipart_uploads" in statement_of(query))
+    sweep_grace = next(args[0] for query, args in db.fetched if "cephor_replication_status" in statement_of(query))
     assert reaper_grace == 86400, "the abandoned-MPU reaper uses stale_seconds"
     assert sweep_grace == 999, "the orphan sweep uses the distinct sweep_grace_seconds"

--- a/tests/unit/test_mpu_reaper.py
+++ b/tests/unit/test_mpu_reaper.py
@@ -19,6 +19,10 @@ import pytest
 from hippius_s3.services import mpu_cleanup
 
 
+class _StopLoop(Exception):
+    """Breaks run_mpu_reaper_loop's `while True` after one pass."""
+
+
 def statement_of(query: str) -> str:
     """The query with its leading comments stripped.
 
@@ -27,6 +31,10 @@ def statement_of(query: str) -> str:
     cephor_replication_status. Matching the raw text then silently misroutes: the reaper's
     query looks like the sweep's, so the fake feeds it the wrong rows and the grace-window
     assertion reads the wrong call. Route on the statement instead.
+
+    Strips leading `--` lines only. That covers every file in hippius_s3/sql/queries (checked:
+    no block comments, no trailing inline comments), so if someone introduces `/* ... */` or a
+    trailing `-- note`, extend this rather than assuming it still holds.
     """
     return "\n".join(line for line in query.splitlines() if not line.lstrip().startswith("--"))
 
@@ -307,3 +315,42 @@ async def test_run_reaper_cycle_threads_distinct_grace_windows() -> None:
     sweep_grace = next(args[0] for query, args in db.fetched if "cephor_replication_status" in statement_of(query))
     assert reaper_grace == 86400, "the abandoned-MPU reaper uses stale_seconds"
     assert sweep_grace == 999, "the orphan sweep uses the distinct sweep_grace_seconds"
+
+
+@pytest.mark.asyncio
+async def test_reaper_pool_bounds_every_statement() -> None:
+    """The reaper's pool must cap statement runtime.
+
+    Without a command_timeout a bad plan runs unbounded, and an unbounded statement pins
+    its snapshot — so the xmin horizon stops advancing and VACUUM reclaims nothing
+    database-wide. That is how one 96-minute query on 2026-07-23 bloated the drain's
+    partial indexes and stalled replication. Fixing that query's plan does not stop the
+    next one; the timeout is what bounds the blast radius.
+    """
+    captured: dict = {}
+
+    async def fake_create_pool(_dsn, **kwargs):
+        captured.update(kwargs)
+        pool = MagicMock()
+        pool.close = AsyncMock()
+        return pool
+
+    async def stop_the_loop(_seconds):
+        raise _StopLoop
+
+    fake_asyncpg = MagicMock()
+    fake_asyncpg.create_pool = fake_create_pool
+
+    with (
+        patch.dict("sys.modules", {"asyncpg": fake_asyncpg}),
+        patch.object(mpu_cleanup, "run_reaper_cycle", new=AsyncMock()),
+        patch.object(mpu_cleanup, "initialize_metrics_collector", new=MagicMock(), create=True),
+        patch.object(mpu_cleanup.asyncio, "sleep", new=stop_the_loop),
+    ):
+        with pytest.raises(_StopLoop):
+            await mpu_cleanup.run_mpu_reaper_loop()
+
+    assert captured.get("command_timeout"), (
+        "the reaper pool was created without a command_timeout — an unbounded statement "
+        "can pin the xmin horizon and stop VACUUM database-wide"
+    )


### PR DESCRIPTION
## Summary

The scheduled smoke run failed on a presigned GET that timed out at 60s. The origin did answer it — after **83 seconds**. Tracing that back ends up somewhere unexpected: a single reaper query had been running for **96 minutes**, and while it runs, nothing in the database can be vacuumed.

## The chain

**1. `list_abandoned_versions.sql` ran for 96 minutes.** It ordered by `mu.upload_id`. No index yields that ordering for its predicate, so rather than sort, the planner drove the join from `parts`:

```
Limit  (cost=1488.39..973676.52)
  -> Incremental Sort   Presorted Key: mu.upload_id
     -> Parallel Index Scan using idx_parts_upload_uploaded_at on parts p  (rows=34,607,112)
```

~140M rows across 4 workers, cost **166 million**, with the selective `multipart_uploads` filters applied only *after* the join. `idx_multipart_uploads_initiated_at` — which selects the 904k candidates directly — went unused.

**2. That pins the xmin horizon.** The backend and its 4 parallel workers all held `backend_xmin = 1004038572`, an xmin age of **1,322,923 transactions**.

**3. So VACUUM reclaims nothing.** `cephor_replication_status` sat at **499,188 dead tuples** against 1.74M live, through **429 autovacuum runs**.

**4. The drain's hot partial indexes bloat.** They're partial on a high-churn predicate, so every `pending → draining → replicated` transition strands an entry vacuum can't clear:

| index | entries read per scan |
|---|---|
| `..._active_orphans` | **116,471** |
| `..._stale_draining` | 63,768 |
| `..._pending` | 14,837 |

`node_undrained_count` read **239,014 buffers to return 28 rows** — 217 ms warm, ~1.95 s under load, running every 10s × 5 nodes.

**5.** The drain falls behind → a cross-node read-after-write waits 83s → the client times out at 60.

## Changes

**`list_abandoned_versions.sql`** — order by `initiated_at` so the existing partial index supplies the order and `LIMIT` stops early; materialise the candidates before joining `parts`. **96 minutes → ~8s (0.6s warm)**, verified on prod. Output is unchanged: 2,000 rows, one per upload.

Two gates live in the CTE, and each guards a distinct way the `LIMIT` gets defeated once it applies to uploads rather than output rows:

- **`EXISTS(parts)`** — the join is INNER, so a partless upload can never be reaped. Prod carries **874,823** of them against 904,246 incomplete total, and they are the *oldest* rows. Without this gate they fill all 2,000 slots and the reaper reaps **nothing, forever**. I hit this while testing: the naive rewrite ran in 438 ms and returned 852 unreapable candidates out of 2,000.
- **`NOT EXISTS(addressed version)`** — hoisted so it can't be defeated by the limit; filtering after would let non-reapable uploads occupy every slot and stall the reaper on the same rows each cycle.

**New index `cephor_replication_status_undrained_by_node`** — `(node_id) WHERE status IN ('pending','draining')`, which is what `node_undrained_count` actually filters on. Verified on prod inside a rolled-back transaction: **239,014 buffers / 217 ms → 400 buffers / 1.96 ms**, an Index Only Scan. Its docstring claimed it "uses the node-scoped pending index"; that index is `WHERE status = 'pending'` only, so it never applied to a query that also matches `'draining'`. Corrected.

Note the index is a tidy-up, not the fix — it makes a correct plan cheap, but no index outruns bloat. Keeping the horizon moving is what does.

## Testing

`tests/integration/test_mpu_reaper_sql.py` already runs the real query against temp tables as a truth table. **All 10 existing cases pass unchanged**, which is the main evidence the semantics are preserved. Three added:

- partless upload is not listed
- **partless uploads do not starve the candidate budget** — inserts 2,001 partless uploads all older than one reapable upload, so without the `EXISTS` gate they consume the entire budget and nothing is returned
- oldest reported first — upload_ids pinned so that upload_id ordering is the *opposite* of initiated_at ordering, otherwise it would pass half the time on random uuids. Confirmed it fails against the old query.

Unit **1966 passed**. Integration is 38 failed / 122 passed against a **38 failed / 119 passed baseline** — same pre-existing failures (my local Postgres lacks the schema those need), plus my 3. `ruff`, `ruff format`, `cargo fmt`, `cargo clippy` clean.

One test-harness fix: the unit fake routed on raw query text, so my new comment naming `cephor_replication_status` misrouted the reaper's call to the sweep's rows. It now routes on the statement with comments stripped.

## Not in this PR

**874,823 partless incomplete MPUs, 97% of the backlog, are unreapable by design** — the INNER join to `parts` has always dropped them, so they only accumulate. Deleting a partless abandoned upload header is trivially safe and is exactly what AbortMultipartUpload does, but it is a deletion-behaviour change rather than a plan fix, so it wants its own PR and its own review. Doing it would also collapse the candidate set from 904k to ~29k and take this query from ~8s to sub-second.

Worth watching after deploy: with the horizon moving again, autovacuum has ~500k dead tuples to work through, and the drain indexes will stay bloated until it does.