### PR TITLE
Make smoke-test failure alerts human-readable

### DIFF
--- a/.github/workflows/production-smoke-tests.yml
+++ b/.github/workflows/production-smoke-tests.yml
@@ -32,7 +32,10 @@ jobs:
           pip install --upgrade pip
           pip install -r tests/smoke/requirements.txt
 
+      # Per-step timeouts keep a hung suite below the job's 30-minute cap: a job-level
+      # timeout cancels the remaining steps, so the failure notification would never fire.
       - name: Run smoke tests against s3.hippius.com
+        timeout-minutes: 8
         env:
           AWS_ACCESS_KEY: ${{ secrets.HIPPIUS_PROD_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.HIPPIUS_PROD_SECRET_KEY }}
@@ -48,6 +51,7 @@ jobs:
 
       - name: Run smoke tests against regional caches
         if: always()
+        timeout-minutes: 8
         env:
           AWS_ACCESS_KEY: ${{ secrets.HIPPIUS_PROD_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.HIPPIUS_PROD_SECRET_KEY }}
@@ -64,6 +68,7 @@ jobs:
 
       - name: Run sub-token scope smoke tests against s3.hippius.com
         if: always()
+        timeout-minutes: 8
         env:
           AWS_ACCESS_KEY: ${{ secrets.HIPPIUS_PROD_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.HIPPIUS_PROD_SECRET_KEY }}

--- a/scripts/extract_failure_details.py
+++ b/scripts/extract_failure_details.py
@@ -110,9 +110,18 @@ def clean_traceback(longrepr: str, max_lines: int = 10) -> str:
     for line in longrepr.split("\n"):
         if re.match(r"^\[gw\d+\]", line):
             continue
-        frame_header = re.match(r"^(\S+):\d+: in ", line)
-        if frame_header:
-            in_library_frame = "site-packages" in frame_header.group(1)
+        # Frame headers come in two shapes: pytest's --tb=short ("path:NN: in func")
+        # and the classic format used in collection errors ('  File "path", line NN').
+        frame_path = None
+        short_frame = re.match(r"^(\S+):\d+: in ", line)
+        classic_frame = re.match(r'^\s+File "([^"]+)", line \d+', line)
+        if short_frame:
+            frame_path = short_frame.group(1)
+        elif classic_frame:
+            frame_path = classic_frame.group(1)
+        if frame_path is not None:
+            # "lib/python" also covers stdlib frames (importlib etc.), not just site-packages.
+            in_library_frame = "site-packages" in frame_path or "lib/python" in frame_path
             if in_library_frame:
                 continue
         elif in_library_frame and (line.startswith("    ") or not line.strip()):
@@ -123,7 +132,8 @@ def clean_traceback(longrepr: str, max_lines: int = 10) -> str:
     result = "\n".join(kept).strip()
     lines = result.split("\n")
     if len(lines) > max_lines:
-        result = "\n".join(lines[:max_lines]) + "\n... (truncated)"
+        # The exception itself is the last line in both formats — never truncate it away.
+        result = "\n".join(lines[: max_lines - 2]) + "\n... (truncated)\n" + lines[-1]
     return result
 
 

--- a/scripts/extract_failure_details.py
+++ b/scripts/extract_failure_details.py
@@ -2,16 +2,77 @@
 """
 Extract detailed failure information from pytest JSON reports.
 
-This script parses pytest-json-report output files and extracts actionable
-failure context for CI alerts, including test names, error messages, and traceback snippets.
+This script parses pytest-json-report output files and builds a human-readable
+CI alert: which test failed, against which suite/region, what the error means
+in plain language, and where in *our* code it happened. Suite-level breakage
+(missing report, collection error, pytest crash) is reported explicitly so the
+alert never claims "no failures" while the workflow is red.
 """
 
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
+
+
+# Report-file stem -> what a reader should understand failed, without opening the run.
+SUITE_LABELS = {
+    "smoke-production": "core S3 suite (s3.hippius.com)",
+    "smoke-regional": "regional cache suite",
+    "smoke-subtoken-scope": "sub-token scope suite",
+}
+
+STAGE_LABELS = {
+    "call": "while running the test",
+    "setup": "while preparing the test (setup)",
+    "teardown": "during cleanup (teardown)",
+}
+
+# Plain-language explanations for error classes that show up in smoke runs.
+# Matched against the exception type in the crash message ("httpx.ReadTimeout: ...").
+ERROR_EXPLANATIONS = [
+    (
+        "ReadTimeout",
+        "The endpoint accepted the connection but did not respond before the client "
+        "timeout — the service is likely slow, overloaded, or hung.",
+    ),
+    (
+        "ConnectTimeout",
+        "Could not establish a connection to the endpoint in time — it may be down or unreachable.",
+    ),
+    (
+        "ConnectError",
+        "The connection to the endpoint failed or was refused — the service may be down.",
+    ),
+    (
+        "ConnectionError",
+        "The connection to the endpoint failed or was refused — the service may be down.",
+    ),
+    (
+        "RemoteProtocolError",
+        "The server closed the connection mid-response — a crash or restart on the server side.",
+    ),
+    (
+        "SSLError",
+        "TLS handshake with the endpoint failed — check certificates on the target.",
+    ),
+    (
+        "AssertionError",
+        "The response did not match what the test expected — see the traceback below.",
+    ),
+]
+
+PYTEST_EXIT_MEANINGS = {
+    1: "some tests failed",
+    2: "the test run was interrupted",
+    3: "pytest itself crashed (internal error)",
+    4: "pytest was invoked incorrectly (usage error)",
+    5: "no tests were collected",
+}
 
 
 def parse_report(report_path: Path) -> Dict[str, Any]:
@@ -22,6 +83,53 @@ def parse_report(report_path: Path) -> Dict[str, Any]:
     except (FileNotFoundError, json.JSONDecodeError) as e:
         print(f"Warning: Could not parse {report_path}: {e}", file=sys.stderr)
         return {}
+
+
+def explain_error(error_message: str) -> str:
+    """Turn a raw exception message into an explanation a reader can act on."""
+    exc_type = error_message.split(":", 1)[0]
+    for needle, explanation in ERROR_EXPLANATIONS:
+        if needle in exc_type:
+            return f"{explanation} (`{error_message.splitlines()[0].strip()}`)"
+    return f"`{error_message.splitlines()[0].strip()}`"
+
+
+def find_test_frame(longrepr: str) -> Optional[str]:
+    """Find the first traceback frame that is in our code, not a library."""
+    for line in longrepr.split("\n"):
+        match = re.match(r"^(\S+\.py):(\d+):", line)
+        if match and "site-packages" not in match.group(1):
+            return f"{match.group(1)}:{match.group(2)}"
+    return None
+
+
+def clean_traceback(longrepr: str, max_lines: int = 10) -> str:
+    """Keep only frames from our code and the final error lines; drop library noise."""
+    kept: List[str] = []
+    in_library_frame = False
+    for line in longrepr.split("\n"):
+        if re.match(r"^\[gw\d+\]", line):
+            continue
+        frame_header = re.match(r"^(\S+):\d+: in ", line)
+        if frame_header:
+            in_library_frame = "site-packages" in frame_header.group(1)
+            if in_library_frame:
+                continue
+        elif in_library_frame and (line.startswith("    ") or not line.strip()):
+            continue
+        else:
+            in_library_frame = False
+        kept.append(line)
+    result = "\n".join(kept).strip()
+    lines = result.split("\n")
+    if len(lines) > max_lines:
+        result = "\n".join(lines[:max_lines]) + "\n... (truncated)"
+    return result
+
+
+def _as_str(value: Any) -> str:
+    """pytest-json-report usually gives longrepr as a string, but not for every failure shape."""
+    return value if isinstance(value, str) else ""
 
 
 def extract_failures(report: Dict[str, Any], report_name: str) -> List[Dict[str, str]]:
@@ -51,26 +159,32 @@ def extract_failures(report: Dict[str, Any], report_name: str) -> List[Dict[str,
         if not failure_info:
             continue
 
-        # Extract error message and traceback
-        crash = failure_info.get("crash", {})
-        longrepr = failure_info.get("longrepr", "")
+        crash = failure_info.get("crash") or {}
+        if not isinstance(crash, dict):
+            crash = {}
+        longrepr = _as_str(failure_info.get("longrepr"))
 
-        error_message = crash.get("message", "Unknown error")
-        error_file = crash.get("path", "unknown")
-        error_line = crash.get("lineno", "?")
+        error_message = crash.get("message") or ""
+        if not error_message:
+            # No structured crash info — fall back to the final "E ..." line of the traceback.
+            error_lines = [ln[1:].strip() for ln in longrepr.split("\n") if ln.startswith("E ")]
+            error_message = error_lines[-1] if error_lines else "Unknown error"
 
-        # Create a compact traceback snippet (first few lines)
-        traceback_lines = longrepr.split("\n")[:5] if longrepr else []
-        traceback_snippet = "\n".join(traceback_lines).strip()
+        # The crash location often points into httpx/botocore internals; the frame
+        # in our own test file is what a reader actually needs.
+        location = find_test_frame(longrepr)
+        if not location:
+            crash_path = str(crash.get("path", ""))
+            if crash_path and "site-packages" not in crash_path:
+                location = f"{crash_path}:{crash.get('lineno', '?')}"
 
         failures.append(
             {
                 "test": nodeid,
-                "stage": failure_stage,
-                "error": error_message,
-                "file": error_file,
-                "line": error_line,
-                "traceback": traceback_snippet,
+                "stage": failure_stage or "unknown",
+                "explanation": explain_error(error_message),
+                "location": location or "",
+                "traceback": clean_traceback(longrepr) if longrepr else "",
                 "report": report_name,
             }
         )
@@ -78,32 +192,116 @@ def extract_failures(report: Dict[str, Any], report_name: str) -> List[Dict[str,
     return failures
 
 
+def extract_suite_problems(report: Dict[str, Any], report_name: str, test_failures: int) -> List[str]:
+    """Report suite-level breakage that never shows up as an individual test failure."""
+    label = SUITE_LABELS.get(report_name, report_name)
+    problems = []
+
+    for collector in report.get("collectors", []):
+        if collector.get("outcome") != "error":
+            continue
+        nodeid = collector.get("nodeid", "unknown")
+        snippet = clean_traceback(_as_str(collector.get("longrepr")), max_lines=5)
+        problem = f"**{label}**: could not even collect `{nodeid}` — an import or fixture error, not a service issue."
+        if snippet:
+            problem += f"\n```\n{snippet}\n```"
+        problems.append(problem)
+
+    exitcode = report.get("exitcode")
+    # A non-zero exit with no per-test failures and no collection errors means the
+    # run broke without producing per-test results (interrupted, internal error, ...).
+    if test_failures == 0 and not problems and isinstance(exitcode, int) and exitcode != 0:
+        meaning = PYTEST_EXIT_MEANINGS.get(exitcode, "unknown exit code")
+        problems.append(
+            f"**{label}**: pytest exited with code {exitcode} ({meaning}) "
+            f"but no individual test failure was recorded — check the run logs."
+        )
+
+    return problems
+
+
 def format_failures_for_alert(failures: List[Dict[str, str]], max_failures: int = 5) -> str:
-    """Format failure details into a compact alert message."""
+    """Format failure details into a readable alert message."""
     if not failures:
-        return "No failures found in reports."
+        return ""
 
     total_failures = len(failures)
     display_failures = failures[:max_failures]
 
-    lines = [f"**Failures: {total_failures}**"]
+    lines = [f"**{total_failures} test(s) failed**"]
 
     for i, failure in enumerate(display_failures, 1):
-        lines.append(f"\n{i}. **{failure['test']}** ({failure['report']})")
-        lines.append(f"   Stage: {failure['stage']}")
-        lines.append(f"   Error: {failure['error']}")
-        lines.append(f"   Location: {failure['file']}:{failure['line']}")
+        suite = SUITE_LABELS.get(failure["report"], failure["report"])
+        stage = STAGE_LABELS.get(failure["stage"], failure["stage"])
+        lines.append(f"\n**{i}. `{failure['test']}`** — {suite}")
+        lines.append(f"   What happened: {failure['explanation']}")
+        lines.append(f"   Failed {stage}.")
+
+        if failure["location"]:
+            lines.append(f"   Test code: `{failure['location']}`")
 
         if failure["traceback"]:
-            # Add traceback as a code block for readability
             lines.append("```")
             lines.append(failure["traceback"])
             lines.append("```")
 
     if total_failures > max_failures:
-        lines.append(f"\n... and {total_failures - max_failures} more failure(s)")
+        lines.append(f"\n... and {total_failures - max_failures} more failure(s) — see the run for the full list.")
 
     return "\n".join(lines)
+
+
+def build_alert_message(report_paths: List[Path]) -> str:
+    """Build the full alert body from all report files, covering suite-level breakage."""
+    all_failures: List[Dict[str, str]] = []
+    suite_problems: List[str] = []
+
+    for report_path in report_paths:
+        report_name = report_path.stem
+        label = SUITE_LABELS.get(report_name, report_name)
+
+        if not report_path.exists():
+            suite_problems.append(
+                f"**{label}**: no report file was written — the pytest step likely crashed "
+                f"before any test ran (dependency install failure, startup error, or the job "
+                f"was cut short). Check the run logs."
+            )
+            continue
+
+        report = parse_report(report_path)
+        if not report:
+            suite_problems.append(
+                f"**{label}**: the report file exists but could not be parsed — the pytest "
+                f"step was probably killed mid-run. Check the run logs."
+            )
+            continue
+
+        failures = extract_failures(report, report_name)
+        all_failures.extend(failures)
+        suite_problems.extend(extract_suite_problems(report, report_name, len(failures)))
+
+    # Sort by report name then test name for consistency
+    all_failures.sort(key=lambda f: (f["report"], f["test"]))
+
+    sections = []
+    failures_text = format_failures_for_alert(all_failures)
+    if failures_text:
+        sections.append(failures_text)
+    if suite_problems:
+        sections.append("**Suite-level problems:**\n" + "\n".join(f"- {p}" for p in suite_problems))
+    if not sections:
+        return (
+            "The workflow failed but no test failures were captured in the reports. "
+            "The failure is likely in a non-test step (dependency install, artifact upload) "
+            "or the job was cancelled — check the run logs."
+        )
+
+    return "\n\n".join(sections)
+
+
+def build_payload(message: str, run_url: str) -> Dict[str, str]:
+    """Build the Mattermost webhook payload."""
+    return {"text": (f":rotating_light: **s3.hippius.com smoke tests failed**\n[View run]({run_url})\n\n{message}")}
 
 
 def main():
@@ -119,20 +317,7 @@ def main():
     # Enrichment must never silence the alert: if parsing an unexpected report
     # shape raises, fall back to a bare message so the failure still reaches the team.
     try:
-        all_failures = []
-
-        for report_path_str in args.reports:
-            report_path = Path(report_path_str)
-            report_name = report_path.stem
-
-            report = parse_report(report_path)
-            failures = extract_failures(report, report_name)
-            all_failures.extend(failures)
-
-        # Sort by report name then test name for consistency
-        all_failures.sort(key=lambda f: (f["report"], f["test"]))
-
-        alert_message = format_failures_for_alert(all_failures)
+        alert_message = build_alert_message([Path(p) for p in args.reports])
     except Exception as e:  # noqa: BLE001
         print(f"Warning: failed to build enriched alert: {e}", file=sys.stderr)
         alert_message = "Could not extract failure details — see the CI run for logs."
@@ -145,13 +330,9 @@ def main():
 
 def send_webhook(message: str, webhook_url: str, run_url: str):
     """Send alert message to Mattermost webhook."""
-    import json as json_module
-
-    payload = {
-        "text": f":rotating_light: **s3.hippius.com smoke tests failed**\n[View run]({run_url})\n\n**Failure Details:**\n{message}\n\n![smoke tests failed](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExcmg4NDIyMnNtMHk0cHpvc2JpcHEwczY4cXR3eDkwdDE4Y3M3bGQ5MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/HUkOv6BNWc1HO/giphy.gif)"
-    }
-
     import subprocess
+
+    payload = build_payload(message, run_url)
 
     result = subprocess.run(
         [
@@ -162,7 +343,7 @@ def send_webhook(message: str, webhook_url: str, run_url: str):
             "-H",
             "Content-Type: application/json",
             "-d",
-            json_module.dumps(payload),
+            json.dumps(payload),
             webhook_url,
         ],
         capture_output=True,

--- a/tests/unit/test_extract_failure_details.py
+++ b/tests/unit/test_extract_failure_details.py
@@ -122,21 +122,45 @@ def test_unparseable_report_file_is_reported(tmp_path):
     assert "killed mid-run" in message
 
 
-def test_collection_error_is_surfaced(tmp_path):
+COLLECTOR_LONGREPR = (
+    "Traceback (most recent call last):\n"
+    '  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/_pytest/python.py", '
+    "line 493, in importtestmodule\n"
+    "    mod = import_path(...)\n"
+    '  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/importlib/__init__.py", '
+    "line 90, in import_module\n"
+    "    return _bootstrap._gcd_import(name[level:], package, level)\n"
+    '  File "tests/smoke/test_smoke_production.py", line 12, in <module>\n'
+    "    from hippius_api_client import HippiusApiClient\n"
+    "ImportError: cannot import name 'HippiusApiClient' from 'hippius_api_client'"
+)
+
+
+def test_collection_error_keeps_the_import_error_not_library_frames(tmp_path):
     report = make_report(
         exitcode=2,
         collectors=[
             {
                 "nodeid": "smoke/test_smoke_production.py",
                 "outcome": "error",
-                "longrepr": "ImportError: cannot import name 'boto3'",
+                "longrepr": COLLECTOR_LONGREPR,
             }
         ],
     )
     message = mod.build_alert_message([write_report(tmp_path, "smoke-production", report)])
 
     assert "could not even collect" in message
-    assert "ImportError" in message
+    assert "ImportError: cannot import name 'HippiusApiClient'" in message
+    assert "site-packages" not in message
+    assert "importlib" not in message
+
+
+def test_truncation_never_drops_the_final_error_line():
+    frames = "\n".join(f"tests/smoke/test_x.py:{n}: in helper_{n}\n    call()" for n in range(1, 12))
+    cleaned = mod.clean_traceback(f"{frames}\nE   RuntimeError: the actual problem", max_lines=6)
+
+    assert "... (truncated)" in cleaned
+    assert cleaned.endswith("E   RuntimeError: the actual problem")
 
 
 def test_nonzero_exit_without_failures_is_surfaced(tmp_path):

--- a/tests/unit/test_extract_failure_details.py
+++ b/tests/unit/test_extract_failure_details.py
@@ -1,0 +1,170 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).parents[2] / "scripts" / "extract_failure_details.py"
+spec = importlib.util.spec_from_file_location("extract_failure_details", SCRIPT_PATH)
+assert spec and spec.loader
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+HTTPX_LONGREPR = (
+    "[gw0] linux -- Python 3.12.13 /opt/hostedtoolcache/Python/3.12.13/x64/bin/python\n"
+    "tests/smoke/test_smoke_regional.py:142: in test_regional_presigned_url_roundtrip\n"
+    "    resp = httpx.get(presigned_url, timeout=30)\n"
+    "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/httpx/_api.py:198: in get\n"
+    "    return request(\n"
+    "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/httpx/_transports/default.py:101: "
+    "in map_httpcore_exceptions\n"
+    "    yield\n"
+    "E   httpx.ReadTimeout: The read operation timed out"
+)
+
+
+def make_test(nodeid: str, longrepr, message: str | None, crash_path: str) -> dict:
+    call: dict = {"outcome": "failed", "longrepr": longrepr}
+    if message is not None:
+        call["crash"] = {"path": crash_path, "lineno": 118, "message": message}
+    return {"nodeid": nodeid, "outcome": "failed", "call": call}
+
+
+def make_report(*tests: dict, exitcode: int = 1, collectors: list | None = None) -> dict:
+    report = {"exitcode": exitcode, "tests": list(tests)}
+    if collectors is not None:
+        report["collectors"] = collectors
+    return report
+
+
+TIMEOUT_TEST = make_test(
+    "smoke/test_smoke_regional.py::test_regional_presigned_url_roundtrip[eu-central-1]",
+    HTTPX_LONGREPR,
+    "httpx.ReadTimeout: The read operation timed out",
+    "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/httpx/_transports/default.py",
+)
+
+
+def write_report(tmp_path: Path, name: str, report: dict) -> Path:
+    path = tmp_path / f"{name}.json"
+    path.write_text(json.dumps(report))
+    return path
+
+
+def test_read_timeout_is_explained_in_plain_language():
+    failures = mod.extract_failures(make_report(TIMEOUT_TEST), "smoke-regional")
+    message = mod.format_failures_for_alert(failures)
+
+    assert "did not respond before the client timeout" in message
+    assert "regional cache suite" in message
+    assert "test_regional_presigned_url_roundtrip[eu-central-1]" in message
+    assert "while running the test" in message
+
+
+def test_location_points_at_test_code_not_library_internals():
+    failures = mod.extract_failures(make_report(TIMEOUT_TEST), "smoke-regional")
+    message = mod.format_failures_for_alert(failures)
+
+    assert "tests/smoke/test_smoke_regional.py:142" in message
+    assert "site-packages" not in message
+    assert "[gw0]" not in message
+
+
+def test_assertion_error_keeps_the_failing_comparison():
+    test = make_test(
+        "smoke/test_smoke_production.py::test_put_get_roundtrip",
+        (
+            "tests/smoke/test_smoke_production.py:88: in test_put_get_roundtrip\n"
+            "    assert body == payload\n"
+            "E   AssertionError: assert b'abc' == b'abd'"
+        ),
+        "AssertionError: assert b'abc' == b'abd'",
+        "tests/smoke/test_smoke_production.py",
+    )
+    failures = mod.extract_failures(make_report(test), "smoke-production")
+    message = mod.format_failures_for_alert(failures)
+
+    assert "did not match what the test expected" in message
+    assert "assert b'abc' == b'abd'" in message
+
+
+def test_missing_crash_info_falls_back_to_traceback_error_line():
+    test = make_test("smoke/test_x.py::test_y", "tests/smoke/test_x.py:10: in test_y\nE   RuntimeError: boom", None, "")
+    failures = mod.extract_failures(make_report(test), "smoke-production")
+
+    assert "RuntimeError: boom" in failures[0]["explanation"]
+
+
+def test_non_string_longrepr_does_not_crash():
+    test = make_test("smoke/test_x.py::test_y", {"weird": "shape"}, "SomeError: x", "tests/smoke/test_x.py")
+    failures = mod.extract_failures(make_report(test), "smoke-production")
+
+    assert failures[0]["traceback"] == ""
+
+
+def test_unknown_error_falls_back_to_raw_message():
+    assert "SomeWeirdError: boom" in mod.explain_error("SomeWeirdError: boom")
+
+
+def test_missing_report_file_is_reported_not_silently_ignored(tmp_path):
+    message = mod.build_alert_message([tmp_path / "smoke-regional.json"])
+
+    assert "no report file was written" in message
+    assert "regional cache suite" in message
+    assert "No failures found" not in message
+
+
+def test_unparseable_report_file_is_reported(tmp_path):
+    path = tmp_path / "smoke-production.json"
+    path.write_text("{truncated")
+    message = mod.build_alert_message([path])
+
+    assert "could not be parsed" in message
+    assert "killed mid-run" in message
+
+
+def test_collection_error_is_surfaced(tmp_path):
+    report = make_report(
+        exitcode=2,
+        collectors=[
+            {
+                "nodeid": "smoke/test_smoke_production.py",
+                "outcome": "error",
+                "longrepr": "ImportError: cannot import name 'boto3'",
+            }
+        ],
+    )
+    message = mod.build_alert_message([write_report(tmp_path, "smoke-production", report)])
+
+    assert "could not even collect" in message
+    assert "ImportError" in message
+
+
+def test_nonzero_exit_without_failures_is_surfaced(tmp_path):
+    report = make_report(exitcode=5)
+    message = mod.build_alert_message([write_report(tmp_path, "smoke-subtoken-scope", report)])
+
+    assert "no tests were collected" in message
+    assert "sub-token scope suite" in message
+
+
+def test_interrupted_run_with_recorded_failures_shows_only_the_failures(tmp_path):
+    report = make_report(TIMEOUT_TEST, exitcode=2)
+    message = mod.build_alert_message([write_report(tmp_path, "smoke-regional", report)])
+
+    assert "did not respond before the client timeout" in message
+    assert "Suite-level problems" not in message
+
+
+def test_all_reports_clean_still_explains_the_red_workflow(tmp_path):
+    message = mod.build_alert_message([write_report(tmp_path, "smoke-production", make_report(exitcode=0))])
+
+    assert "no test failures were captured" in message
+    assert "check the run logs" in message
+
+
+def test_webhook_payload_has_no_gif():
+    payload = mod.build_payload("2 test(s) failed", "https://github.com/x/y/actions/runs/1")
+    assert "giphy" not in payload["text"]
+    assert "![" not in payload["text"]
+    assert "View run" in payload["text"]
+    assert "s3.hippius.com smoke tests failed" in payload["text"]


### PR DESCRIPTION
## What

Rewrites the Mattermost alert produced by the hourly `production-smoke-tests` workflow so a reader can tell what broke without opening the run.

- **Plain-language error explanations** in `scripts/extract_failure_details.py`: timeouts, connection failures, TLS errors, and assertion mismatches are translated (e.g. ReadTimeout → "the endpoint accepted the connection but did not respond before the client timeout"), with the raw exception kept in backticks.
- **Useful locations**: the alert now points at the frame in our test code (`tests/smoke/test_smoke_regional.py:142`) instead of httpx library internals, and tracebacks are stripped of `[gwN]` worker banners and `site-packages` frames.
- **Suite-level breakage is reported instead of hidden**: missing report file, unparseable report, collection errors (from the `collectors` section), and non-zero pytest exits with no recorded failures each produce an explicit message. Previously all of these rendered as "No failures found in reports." under a failure alert.
- **Per-step `timeout-minutes: 8`** on the three pytest steps in `production-smoke-tests.yml`: a job-level timeout cancels remaining steps, so the `if: failure()` notify step never ran and a hung suite produced no alert at all. Step timeouts turn a hang into a step failure so the alert still fires.
- **Removes the GIF** from the webhook payload.
- **Adds unit tests** (`tests/unit/test_extract_failure_details.py`, 13 tests) covering the error explanations, location/traceback filtering, each suite-level breakage case, and a regression test that the payload contains no GIF.

## Verification

- `pytest tests/unit/test_extract_failure_details.py` — 13 passed
- `pre-commit run` (ruff, ruff format, ty, pip-audit) — passed
- `actionlint` on the workflow — clean
- Dry-ran the script against a synthetic report replicating the 2026-07-23 regional ReadTimeout alert and against missing report files
