### PR TITLE
fix(drain): sweep empty SSD shells on a grace, not inline at removal

### DIFF
--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -203,6 +203,57 @@ impl LocalSsd {
         }
         Ok(removed)
     }
+
+    /// Removes the empty `<object_id>/v<version>/` and `<object_id>/` shells a drained part
+    /// leaves behind, once untouched for `max_age`.
+    ///
+    /// `remove_part_dir` deletes only `part_<n>/`, so over millions of drained parts the two
+    /// ancestor dirs accumulate as empty shells — an unbounded directory/inode leak on the
+    /// node-local SSD (observed at 100k-338k dirs per prod node, all `<oid>/v1/` with nothing
+    /// inside). The crash-orphan reclaim never sees them: it keys on `meta.json`, and a shell
+    /// has none.
+    ///
+    /// THE AGE GATE IS THE SAFETY PROPERTY, not the emptiness check. Pruning inline at removal
+    /// time looks safe because `rmdir` refuses a non-empty dir — but `mkdir -p` is not atomic.
+    /// The api's writer (`fs_store.set_chunk`) calls `mkdir(parents=True)`, which on ENOENT
+    /// creates the parent and then retries the leaf; a pruner that rmdirs that freshly-created,
+    /// still-empty parent inside the gap makes the retry raise. FS writes are fatal in
+    /// `object_writer`, so that is a 500 on PutObject/UploadPart — and it is reachable, because
+    /// the drain unlinks in-flight MPU parts and so prunes the very directory a client is
+    /// uploading siblings into. Creating an entry in a directory updates that directory's
+    /// mtime, so requiring the shell to have been untouched for `max_age` means no writer has
+    /// created anything in it recently — closing the window rather than narrowing it.
+    ///
+    /// Sweeps version dirs before object dirs, so an object emptied by its last version going
+    /// away is collected in the same pass. Returns how many shells it removed; a missing root
+    /// is an empty cache, not an error.
+    ///
+    /// # Errors
+    ///
+    /// [`io::Error`] if walking the cache fails for a reason other than a concurrently-removed
+    /// entry (which is tolerated).
+    pub async fn sweep_empty_shells(&self, max_age: Duration) -> io::Result<u64> {
+        let mut removed = 0;
+        let Some(mut objects) = open_dir(&self.root).await? else {
+            return Ok(0);
+        };
+        while let Some(object) = objects.next_entry().await? {
+            if !object.file_type().await?.is_dir() {
+                continue;
+            }
+            if let Some(mut versions) = open_dir(&object.path()).await? {
+                while let Some(version) = versions.next_entry().await? {
+                    if !version.file_type().await?.is_dir() {
+                        continue;
+                    }
+                    removed += u64::from(rmdir_if_stale_and_empty(&version.path(), max_age).await?);
+                }
+            }
+            // Only after its versions, so an object whose last version just went is collected now.
+            removed += u64::from(rmdir_if_stale_and_empty(&object.path(), max_age).await?);
+        }
+        Ok(removed)
+    }
 }
 
 impl SsdCache for LocalSsd {
@@ -321,38 +372,14 @@ async fn copy_into(dir: &Path, name: &str, source: &Path, sync_dir: bool) -> io:
 /// re-drive after a crash still converges). Shared by the SSD-source unlink and the
 /// pool corrupt-copy cleanup.
 ///
-/// After removing `part_<n>/`, prune the now-empty `v<version>/` then `<object_id>/`
-/// parents. Without this, every part removal (the drain's happy-path unlink AND the reclaim
-/// worker) left the two ancestor dirs behind as empty shells — an unbounded directory/inode
-/// leak on the node-local SSD (observed at 100k+ dirs per node, all `<oid>/v1/` with nothing
-/// inside). Pruning here fixes it at the single point every removal already funnels through.
+/// Removes ONLY the part dir. The now-empty `v<version>/`/`<object_id>/` parents are left
+/// for [`LocalSsd::sweep_empty_shells`], deliberately — see that method for why pruning them
+/// inline is unsafe.
 async fn remove_part_dir(root: &Path, part: &PartKey) -> io::Result<()> {
-    let dir = part_dir(root, part);
-    match fs::remove_dir_all(&dir).await {
-        Ok(()) => {}
-        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-        Err(err) => return Err(err),
-    }
-    prune_empty_ancestors(root, &dir).await;
-    Ok(())
-}
-
-/// Best-effort removal of the empty ancestor dirs of `dir`, climbing up to but never removing
-/// `root`. Uses `remove_dir` (rmdir), which removes ONLY an empty directory — so it is
-/// race-safe against a concurrent writer that `mkdir -p`s the same path: a still-populated
-/// ancestor (a sibling `part_N`, or a just-recreated dir) fails the rmdir and stops the climb,
-/// and a re-created dir is harmless. A prune failure is swallowed: the part is already gone,
-/// and any residual shell is re-attempted on the next removal under that object.
-async fn prune_empty_ancestors(root: &Path, dir: &Path) {
-    let mut cursor = dir.parent();
-    while let Some(ancestor) = cursor {
-        if ancestor == root || !ancestor.starts_with(root) {
-            break;
-        }
-        if fs::remove_dir(ancestor).await.is_err() {
-            break;
-        }
-        cursor = ancestor.parent();
+    match fs::remove_dir_all(part_dir(root, part)).await {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
     }
 }
 
@@ -385,6 +412,33 @@ fn file_age(meta: &std::fs::Metadata) -> Duration {
 /// Unlinks aged orphan write-temps directly inside one part dir. Only temp FILES older
 /// than `max_age` are removed; real chunk/meta files, fresh temps, and any subdirectory
 /// are left untouched. A temp another writer renamed away mid-sweep is already gone.
+/// `rmdir` `dir` if it is empty AND has been untouched for `max_age`; `Ok(false)` otherwise.
+///
+/// Both conditions are load-bearing. Emptiness is enforced by the kernel (`rmdir` returns
+/// `ENOTEMPTY` otherwise), so a sibling part can never be collateral. The age gate is what
+/// makes it safe against a concurrent `mkdir -p`, whose non-atomicity leaves a window where a
+/// parent is created but still empty — see [`LocalSsd::sweep_empty_shells`].
+///
+/// A concurrently-removed dir (`NotFound`) and a dir that filled up between the stat and the
+/// `rmdir` (`DirectoryNotEmpty`) are both normal races, not failures. Anything else is
+/// surfaced: a silently-swallowed `EACCES`/`EIO` would let the leak grow unbounded while the
+/// sweep reports success.
+async fn rmdir_if_stale_and_empty(dir: &Path, max_age: Duration) -> io::Result<bool> {
+    let meta = match fs::metadata(dir).await {
+        Ok(meta) => meta,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err),
+    };
+    if file_age(&meta) < max_age {
+        return Ok(false);
+    }
+    match fs::remove_dir(dir).await {
+        Ok(()) => Ok(true),
+        Err(err) if matches!(err.kind(), io::ErrorKind::NotFound | io::ErrorKind::DirectoryNotEmpty) => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
 async fn sweep_part_tmp(part_path: &Path, max_age: Duration) -> io::Result<u64> {
     let mut removed = 0;
     let Some(mut entries) = open_dir(part_path).await? else {
@@ -635,6 +689,7 @@ impl PartRemover for LocalSsd {
 mod tests {
     use super::{LocalSsd, TEMP_NONCE, TmpGuard, hex_lower, is_temp_name, part_dir, remove_part_dir, safe_component, temp_name};
     use core::str::FromStr;
+    use core::time::Duration;
     use hippius_drain_core::{FileId, ObjectId, PartKey, PartNumber, SsdCache, Version};
     use proptest::prelude::*;
     use std::io;
@@ -698,46 +753,67 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn removing_a_part_prunes_its_empty_version_and_object_parents() {
-        // The empty-shell leak fix: once the part dir is gone, its now-empty `v<version>/`
-        // and `<object_id>/` parents are pruned too, so a drained part leaves nothing behind.
+    async fn the_sweep_removes_stale_empty_version_and_object_shells() {
+        // The leak fix: a drained part leaves `v<version>/` and `<object_id>/` behind, and the
+        // sweep collects both once they have been untouched for the grace.
         let root = TempDir::new().unwrap();
         let p = part("466916c0-d61b-4518-b81b-9576b574270a", 1, 1);
         seed_part(root.path(), &p);
         let part_path = part_dir(root.path(), &p);
         let version_dir = part_path.parent().unwrap().to_path_buf();
         let object_dir = version_dir.parent().unwrap().to_path_buf();
+        let ssd = LocalSsd::new(root.path().to_path_buf());
 
         remove_part_dir(root.path(), &p).await.unwrap();
+        assert!(version_dir.exists(), "removal itself leaves the shells — that is the point");
 
-        assert!(!part_path.exists(), "the part dir is removed");
-        assert!(!version_dir.exists(), "the empty v<version> parent is pruned");
-        assert!(!object_dir.exists(), "the empty <object_id> parent is pruned");
+        assert_eq!(ssd.sweep_empty_shells(Duration::ZERO).await.unwrap(), 2, "version + object");
+
+        assert!(!version_dir.exists(), "the empty v<version> shell is swept");
+        assert!(!object_dir.exists(), "the empty <object_id> shell is swept");
         assert!(root.path().exists(), "the SSD root is never removed");
     }
 
     #[tokio::test]
+    async fn the_sweep_spares_a_shell_younger_than_the_grace() {
+        // THE race guard. A shell younger than the grace may be a parent that a writer's
+        // non-atomic `mkdir -p` has just created and is about to create its part dir inside.
+        // Removing it there makes the writer's retry raise — a fatal FS write, i.e. a 500 on
+        // PutObject. Only an untouched-for-the-grace shell can be collected.
+        let root = TempDir::new().unwrap();
+        let p = part("466916c0-d61b-4518-b81b-9576b574270a", 1, 1);
+        let version_dir = part_dir(root.path(), &p).parent().unwrap().to_path_buf();
+        std::fs::create_dir_all(&version_dir).unwrap();
+        let ssd = LocalSsd::new(root.path().to_path_buf());
+
+        assert_eq!(ssd.sweep_empty_shells(Duration::from_hours(1)).await.unwrap(), 0);
+
+        assert!(version_dir.exists(), "a freshly-created shell is left for a possible writer");
+    }
+
+    #[tokio::test]
     async fn a_sibling_part_protects_the_shared_parents() {
-        // `rmdir` removes only an EMPTY dir, so a sibling `part_N` under the same version keeps
-        // both shared parents alive — no cross-part collateral removal.
+        // `rmdir` is kernel-gated on emptiness, so a sibling `part_N` under the same version
+        // keeps both shared parents alive — no cross-part collateral removal.
         let root = TempDir::new().unwrap();
         let p1 = part("466916c0-d61b-4518-b81b-9576b574270a", 1, 1);
         let p2 = part("466916c0-d61b-4518-b81b-9576b574270a", 1, 2);
         seed_part(root.path(), &p1);
         seed_part(root.path(), &p2);
         let shared_version = part_dir(root.path(), &p1).parent().unwrap().to_path_buf();
+        let ssd = LocalSsd::new(root.path().to_path_buf());
 
         remove_part_dir(root.path(), &p1).await.unwrap();
+        assert_eq!(ssd.sweep_empty_shells(Duration::ZERO).await.unwrap(), 0, "nothing is empty");
 
-        assert!(!part_dir(root.path(), &p1).exists(), "only the removed part is gone");
         assert!(part_dir(root.path(), &p2).exists(), "the sibling part is untouched");
         assert!(shared_version.exists(), "the shared version dir is kept while a sibling remains");
     }
 
     #[tokio::test]
-    async fn removing_one_version_keeps_a_populated_sibling_version() {
-        // Pruning climbs only through EMPTY ancestors: removing v1's sole part prunes `v1/`,
-        // but the object dir stays because `v2/` is still populated.
+    async fn sweeping_one_version_keeps_a_populated_sibling_version() {
+        // The sweep collects only EMPTY dirs: v1 goes, but the object dir stays because v2 is
+        // still populated.
         let root = TempDir::new().unwrap();
         let v1 = part("466916c0-d61b-4518-b81b-9576b574270a", 1, 1);
         let v2 = part("466916c0-d61b-4518-b81b-9576b574270a", 2, 1);
@@ -745,28 +821,89 @@ mod tests {
         seed_part(root.path(), &v2);
         let v1_dir = part_dir(root.path(), &v1).parent().unwrap().to_path_buf();
         let object_dir = v1_dir.parent().unwrap().to_path_buf();
+        let ssd = LocalSsd::new(root.path().to_path_buf());
 
         remove_part_dir(root.path(), &v1).await.unwrap();
+        assert_eq!(ssd.sweep_empty_shells(Duration::ZERO).await.unwrap(), 1, "v1 only");
 
-        assert!(!v1_dir.exists(), "the emptied v1 dir is pruned");
+        assert!(!v1_dir.exists(), "the emptied v1 dir is swept");
         assert!(object_dir.exists(), "the object dir survives while v2 is populated");
         assert!(part_dir(root.path(), &v2).exists(), "v2's part is untouched");
     }
 
     #[tokio::test]
-    async fn removing_an_already_absent_part_is_ok_and_still_prunes_shells() {
-        // Idempotent: a re-drive after the part is already gone returns Ok, and a leftover
-        // empty ancestor shell is still cleaned.
+    async fn the_sweep_collects_an_object_emptied_by_its_last_version_in_one_pass() {
+        // Version dirs are swept before their object, so the object shell does not need a
+        // second pass — otherwise the leak would drain at one level per reclaim tick.
+        let root = TempDir::new().unwrap();
+        let p = part("00000000-0000-4000-8000-000000000000", 7, 1);
+        let version_dir = part_dir(root.path(), &p).parent().unwrap().to_path_buf();
+        std::fs::create_dir_all(&version_dir).unwrap();
+        let object_dir = version_dir.parent().unwrap().to_path_buf();
+        let ssd = LocalSsd::new(root.path().to_path_buf());
+
+        assert_eq!(ssd.sweep_empty_shells(Duration::ZERO).await.unwrap(), 2);
+
+        assert!(!version_dir.exists());
+        assert!(!object_dir.exists(), "collected in the SAME pass, not the next one");
+    }
+
+    #[tokio::test]
+    async fn removing_an_already_absent_part_is_ok() {
+        // Idempotent: a re-drive after the part is already gone returns Ok.
         let root = TempDir::new().unwrap();
         let p = part("00000000-0000-4000-8000-000000000000", 1, 1);
-        let version_dir = part_dir(root.path(), &p).parent().unwrap().to_path_buf();
-        std::fs::create_dir_all(&version_dir).unwrap(); // a shell with no part dir
-        let object_dir = version_dir.parent().unwrap().to_path_buf();
 
         remove_part_dir(root.path(), &p).await.unwrap();
+    }
 
-        assert!(!version_dir.exists(), "a leftover empty version shell is pruned");
-        assert!(!object_dir.exists(), "a leftover empty object shell is pruned");
+    #[tokio::test]
+    async fn the_sweep_never_breaks_a_concurrent_writers_mkdir_p() {
+        // The regression this whole change exists for. Pruning inline at removal time raced the
+        // api's `mkdir(parents=True)`: that call is not atomic — on ENOENT it creates the parent
+        // then retries the leaf — so removing the freshly-created, still-empty parent in the gap
+        // made the retry fail. FS writes are fatal in object_writer, so that is a 500.
+        //
+        // The sweep is genuinely BUSY here, not idling: 200 pre-aged shells are collected while
+        // the writer runs, so this exercises concurrent removal rather than a no-op. What keeps
+        // the writer safe is the grace — its own dirs are touched on every iteration and so are
+        // never old enough to collect.
+        let root = TempDir::new().unwrap();
+        let ssd = LocalSsd::new(root.path().to_path_buf());
+        let grace = Duration::from_millis(100);
+
+        for i in 0..200 {
+            let shell = root.path().join(format!("0000{i:04}-0000-4000-8000-000000000000")).join("v1");
+            std::fs::create_dir_all(&shell).unwrap();
+        }
+        tokio::time::sleep(grace * 2).await; // age the shells past the grace
+
+        let p = part("466916c0-d61b-4518-b81b-9576b574270a", 1, 2);
+        let dir = part_dir(root.path(), &p);
+
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let sweeper_stop = std::sync::Arc::clone(&stop);
+        let swept = tokio::spawn(async move {
+            let mut total = 0;
+            while !sweeper_stop.load(std::sync::atomic::Ordering::Relaxed) {
+                total += ssd.sweep_empty_shells(grace).await.unwrap_or(0);
+                tokio::task::yield_now().await;
+            }
+            total
+        });
+
+        let mut failures = 0_u32;
+        for _ in 0..3000 {
+            if tokio::fs::create_dir_all(&dir).await.is_err() {
+                failures += 1;
+            }
+            let _ = tokio::fs::remove_dir(&dir).await;
+        }
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        let total_swept = swept.await.unwrap();
+
+        assert_eq!(failures, 0, "the sweep broke a concurrent writer's mkdir -p");
+        assert!(total_swept > 0, "the sweep must have been actively removing, or this proves nothing");
     }
 
     #[test]

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -351,6 +351,15 @@ async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, gr
         Ok(removed) => tracing::info!(removed, "swept orphan SSD write-temps"),
         Err(err) => tracing::warn!(error = %err, "orphan-temp sweep failed; will retry next poll"),
     }
+
+    // Reuses the failed-part grace as the "untouched for long enough" gate: both answer the
+    // same question — has anything written here recently — and a second knob for the same
+    // property is a knob that gets set inconsistently.
+    match ssd.sweep_empty_shells(graces.failed).await {
+        Ok(0) => {}
+        Ok(removed) => tracing::info!(removed, "swept empty SSD object/version shells"),
+        Err(err) => tracing::warn!(error = %err, "empty-shell sweep failed; will retry next poll"),
+    }
 }
 
 /// One R4 re-drive pass: reset this node's bounded `corrupt` parts back to `pending` (so the


### PR DESCRIPTION
Follow-up to #322. Keeps the leak fix, removes the race it introduced.

## The problem

#322 pruned the empty `<object_id>/v<version>/` parents from inside `remove_part_dir`, reasoning that `rmdir` refuses a non-empty directory so it could not race a writer. **`rmdir` is indeed safe. `mkdir -p` is not.**

`pathlib.Path.mkdir(parents=True)` — what the api's `fs_store.set_chunk`/`set_meta` call — is two syscalls, and CPython's implementation retries the leaf with `parents=False`:

```
os.mkdir(part_2)            -> ENOENT (v1 does not exist)
parent.mkdir(parents=True)  -> creates <oid>/v1        <-- EMPTY at this instant
                                                       <-- pruner rmdir's v1
self.mkdir(parents=False)   -> raises
```

FS writes are fatal in `object_writer`, so that is a **500 on PutObject/UploadPart**. Reachable rather than theoretical: the drain unlinks in-flight MPU parts, so it prunes the very directory a client is still uploading siblings into, at `CEPHOR_DRAIN_CONCURRENCY=16`.

Measured against the real `pathlib` call:

| pruner cadence | writes OK | failures |
|---|---|---|
| spinning | 3,695 | 4,759 |
| 1 ms | 19,133 | 2 |
| 10 ms | 20,491 | 0 |

## Why not just retry in the writer

I tried that first — one extra `mkdir` attempt in `fs_store`. It **still failed with the pruner paced at 2 ms**, and that is not a tuning problem: no finite retry count wins against a pruner that can always fire again. It narrows the window instead of closing it, which on a path that 500s a customer upload is not good enough.

## The fix

Move the prune off the hot path into a periodic, age-gated sweep — `LocalSsd::sweep_empty_shells`, called from `reclaim_once` right next to the existing `sweep_orphan_tmp`, reusing its grace (both answer the same question: has anything written here recently).

**The age gate is the safety property, not the emptiness check.** Creating an entry in a directory updates that directory's mtime, so "untouched for the grace" means no writer has created anything in it recently — a writer would have to be paused mid-`mkdir -p` for the whole grace for the window to reopen. Emptiness is still kernel-enforced, so a sibling part can never be collateral damage.

Two smaller corrections while in there:

- Version dirs are swept **before** their object, so an object emptied by its last version is collected in the same pass rather than draining one level per reclaim tick.
- `rmdir` errors are now surfaced except the two expected races (`NotFound`, `DirectoryNotEmpty`). #322 swallowed all of them, so an `EACCES`/`EIO` would have let the leak grow unbounded while the sweep reported success.

## Testing

The four tests from #322 are reworked onto the sweep, plus three new ones:

- **`the_sweep_spares_a_shell_younger_than_the_grace`** — the gate itself.
- **`the_sweep_collects_an_object_emptied_by_its_last_version_in_one_pass`** — the ordering fix.
- **`the_sweep_never_breaks_a_concurrent_writers_mkdir_p`** — the regression guard. 200 pre-aged shells are actively swept while a writer hammers `create_dir_all` 3,000 times. It asserts **both** zero write failures **and** that the sweep really was removing, so it cannot pass by the sweep sitting idle.

Verified non-vacuous: deleting the age gate (reducing the sweep to #322's inline prune) fails both `the_sweep_never_breaks_a_concurrent_writers_mkdir_p` and `the_sweep_spares_a_shell_younger_than_the_grace`.

drain-agent **109 passed**, drain-core **171 passed**, `clippy -D warnings` and `fmt` clean.

## Note on the release

This is why #322 was held out of the prod release (#325 supersedes #324). Once this merges, the leak fix rides the next promotion with the race designed out. The pre-existing shells still need the one-time backfill — and note that the `find <root> -mindepth 2 -type d -empty -delete` in #322's commit message is itself unsafe on a live node for the same reason (it will delete an empty `part_<k>` a writer just created); constrain it to `-maxdepth 2 -mmin +60` or run it on a drained node.