### PR TITLE
feat(scripts): one-time sweep for multipart uploads that never got a part

### DIFF
--- a/hippius_s3/scripts/CLAUDE.md
+++ b/hippius_s3/scripts/CLAUDE.md
@@ -33,6 +33,7 @@ Operational and migration scripts. Most are invoked manually by an operator duri
 |---|---|
 | [nuke_user.py](nuke_user.py) | **⚠️ DESTRUCTIVE**. Deletes a user and all their buckets/objects. Usually invoked for GDPR requests or test cleanup. |
 | [purge_buckets.py](purge_buckets.py) | **⚠️ DESTRUCTIVE**. Delete one or more buckets and their contents. |
+| [sweep_partless_multipart_uploads.py](sweep_partless_multipart_uploads.py) | **⚠️ DELETES**, but only MPU headers with **zero** `parts` rows — no chunk data exists behind them, so this is what `AbortMultipartUpload` already does. One-time cleanup of the ~874k such rows (97% of the incomplete backlog) that the mpu-reaper can never reach, because its query INNER-joins to `parts`. Dry run by default; needs `--yes`. Batched with a `statement_timeout` so it cannot itself pin the xmin horizon. |
 
 ## Invocation
 

--- a/hippius_s3/scripts/sweep_partless_multipart_uploads.py
+++ b/hippius_s3/scripts/sweep_partless_multipart_uploads.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""One-time sweep: delete incomplete multipart uploads that never received a part.
+
+WHY THIS EXISTS
+
+The mpu-reaper (`list_abandoned_versions.sql`) joins `multipart_uploads` to `parts` with an
+INNER join, so an upload with zero parts can never be selected and therefore never reaped.
+Nothing else deletes them either — the only other paths are `abort_multipart_upload` and the
+same-key DELETE in `delete_object_endpoint`. So they accumulate forever.
+
+Measured on prod 2026-07-23: **874,823 partless incomplete uploads older than 48h, out of
+904,246 incomplete total — 97% of the backlog.**
+
+That is not just untidy. The reaper's candidate scan walks `idx_multipart_uploads_initiated_at`
+oldest-first, and these are the oldest rows, so every cycle pays to skip past all of them. It is
+why the rewritten query costs ~8s instead of ~0.5s, and the cost grows linearly with a
+population that has no other GC. Clearing it is what makes that query cheap and keeps it cheap.
+
+WHY DELETING IS SAFE
+
+A partless upload is an MPU header with no data behind it: no `parts` row, therefore no
+`part_chunks`, no chunk on the SSD or in any backend. Deleting the header is exactly what
+`AbortMultipartUpload` does, and the only FK pointing at `multipart_uploads` is
+`parts.upload_id ON DELETE CASCADE` — which has nothing to cascade here. The age gate is the
+same `stale_seconds` policy the reaper already applies to abandoned uploads, so a client that
+initiated an MPU and has not uploaded a part in 48h is treated identically to today.
+
+OPERATIONAL SHAPE
+
+Deliberately NOT one big DELETE. This script exists because of an incident where a single
+96-minute statement pinned the xmin horizon and stopped VACUUM database-wide; repeating that
+sin while cleaning up after it would be poor form. So: bounded batches, each its own
+autocommit statement, a hard `statement_timeout`, and a pause between batches so autovacuum and
+normal traffic get the primary back.
+
+    # look first — prints counts and a sample, touches nothing
+    python -m hippius_s3.scripts.sweep_partless_multipart_uploads
+
+    # then, for real
+    python -m hippius_s3.scripts.sweep_partless_multipart_uploads --yes
+
+Resumable: it re-queries each batch, so an interrupted run is continued simply by running it
+again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import time
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import asyncpg  # noqa: E402
+import redis.asyncio as async_redis  # noqa: E402
+
+from hippius_s3.config import get_config  # noqa: E402
+
+
+logger = logging.getLogger("sweep-partless-mpu")
+
+# Counting the whole population is a seq-scan-ish query on a 139M-row table; it is worth it
+# once for the dry run, but give it room without being unbounded.
+COUNT_TIMEOUT_MS = 300_000
+
+SELECT_BATCH_SQL = """
+SELECT mu.upload_id, mu.object_id
+FROM multipart_uploads mu
+WHERE COALESCE(mu.is_completed, false) = false
+  AND mu.initiated_at < now() - make_interval(secs => $1)
+  AND NOT EXISTS (SELECT 1 FROM parts p WHERE p.upload_id = mu.upload_id)
+ORDER BY mu.initiated_at
+LIMIT $2
+"""
+
+COUNT_SQL = """
+SELECT count(*) FROM multipart_uploads mu
+WHERE COALESCE(mu.is_completed, false) = false
+  AND mu.initiated_at < now() - make_interval(secs => $1)
+  AND NOT EXISTS (SELECT 1 FROM parts p WHERE p.upload_id = mu.upload_id)
+"""
+
+DELETE_SQL = "DELETE FROM multipart_uploads WHERE upload_id = ANY($1::uuid[])"
+
+
+async def _dlq_protected_ids(config) -> set[str]:  # noqa: ANN001
+    """Object ids with an in-flight DLQ entry, which the janitor and reaper both spare.
+
+    A partless upload has no data to protect, so this cannot matter in principle — but both
+    existing reapers gate on it, and silently being the one caller that does not is exactly the
+    sort of inconsistency that is uncomfortable to explain after the fact.
+    """
+    from workers.run_janitor_in_loop import get_all_dlq_object_ids
+
+    redis_client = async_redis.from_url(config.redis_queues_url)
+    try:
+        return await get_all_dlq_object_ids(redis_client)
+    finally:
+        await redis_client.aclose()
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    config = get_config()
+    stale_seconds = args.stale_seconds if args.stale_seconds > 0 else config.mpu_stale_seconds
+
+    protected = set() if args.skip_dlq_check else await _dlq_protected_ids(config)
+    logger.info("DLQ-protected object ids: %d", len(protected))
+
+    pool = await asyncpg.create_pool(
+        config.database_url,
+        min_size=1,
+        max_size=2,
+        command_timeout=args.statement_timeout_ms / 1000,
+        server_settings={"statement_timeout": str(args.statement_timeout_ms)},
+    )
+    try:
+        if args.count:
+            async with pool.acquire() as conn:
+                await conn.execute(f"SET statement_timeout = {COUNT_TIMEOUT_MS}")
+                total = await conn.fetchval(COUNT_SQL, stale_seconds)
+            logger.info("partless incomplete uploads older than %ss: %d", stale_seconds, total)
+
+        deleted = 0
+        skipped = 0
+        batches = 0
+        started = time.monotonic()
+
+        while True:
+            if args.max_batches and batches >= args.max_batches:
+                logger.info("reached --max-batches=%d; stopping", args.max_batches)
+                break
+
+            async with pool.acquire() as conn:
+                rows = await conn.fetch(SELECT_BATCH_SQL, stale_seconds, args.batch_size)
+
+            if not rows:
+                logger.info("no more partless uploads; done")
+                break
+
+            targets = []
+            for row in rows:
+                object_id = row["object_id"]
+                if object_id is not None and str(object_id) in protected:
+                    skipped += 1
+                    continue
+                targets.append(row["upload_id"])
+
+            batches += 1
+
+            if not args.yes:
+                logger.info(
+                    "[DRY RUN] batch %d: would delete %d upload(s), skip %d DLQ-protected; sample=%s",
+                    batches,
+                    len(targets),
+                    len(rows) - len(targets),
+                    [str(u) for u in targets[:3]],
+                )
+                # A dry run must not loop forever re-reading the same rows it never deletes.
+                logger.info("[DRY RUN] stopping after one batch. Re-run with --yes to delete.")
+                break
+
+            if targets:
+                async with pool.acquire() as conn:
+                    await conn.execute(DELETE_SQL, targets)
+                deleted += len(targets)
+
+            elapsed = time.monotonic() - started
+            rate = deleted / elapsed if elapsed > 0 else 0
+            logger.info(
+                "batch %d: deleted %d (total %d, %.0f/s, skipped %d)", batches, len(targets), deleted, rate, skipped
+            )
+
+            # Hand the primary back between batches: this runs against the same instance the
+            # drain and the api are using, and the whole point is to not be the heavy query.
+            await asyncio.sleep(args.sleep_between)
+
+        logger.info("finished: deleted=%d skipped_dlq=%d batches=%d", deleted, skipped, batches)
+    finally:
+        await pool.close()
+    return 0
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    ap = argparse.ArgumentParser(description="One-time sweep of incomplete multipart uploads that never got a part.")
+    ap.add_argument(
+        "--stale-seconds",
+        type=int,
+        default=0,
+        help="Only uploads older than this. 0 (default) uses HIPPIUS_MPU_STALE_SECONDS, matching the reaper.",
+    )
+    ap.add_argument("--batch-size", type=int, default=5000, help="Uploads deleted per statement (default 5000)")
+    ap.add_argument("--max-batches", type=int, default=0, help="Stop after N batches (0 = until exhausted)")
+    ap.add_argument("--sleep-between", type=float, default=0.5, help="Seconds to pause between batches (default 0.5)")
+    ap.add_argument(
+        "--statement-timeout-ms",
+        type=int,
+        default=60_000,
+        help="Hard ceiling per statement. Do not raise casually: an unbounded statement pins the xmin horizon.",
+    )
+    ap.add_argument("--count", action="store_true", help="Also report the total population up front (slow on prod)")
+    ap.add_argument(
+        "--skip-dlq-check",
+        action="store_true",
+        help="Skip the DLQ protection lookup (only if redis-queues is unreachable)",
+    )
+    ap.add_argument("--yes", action="store_true", help="Actually delete. Without this it is a dry run.")
+    args = ap.parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_sweep_partless_multipart_uploads.py
+++ b/tests/unit/scripts/test_sweep_partless_multipart_uploads.py
@@ -1,0 +1,151 @@
+"""Guards for the partless-MPU sweep — a script that DELETEs, so its brakes must work.
+
+The two that matter: a run without --yes must not issue a DELETE at all, and a DLQ-protected
+object must be excluded from the ids handed to one. Everything else in the script is I/O.
+"""
+
+from __future__ import annotations
+
+import argparse
+import uuid
+from typing import Any
+
+import pytest
+
+from hippius_s3.scripts import sweep_partless_multipart_uploads as sweep
+
+
+class FakeConnection:
+    def __init__(self, batches: list[list[dict[str, Any]]]) -> None:
+        self._batches = batches
+        self.fetched: list[tuple[str, tuple]] = []
+        self.executed: list[tuple[str, tuple]] = []
+
+    async def fetch(self, sql: str, *params: Any) -> list[dict[str, Any]]:
+        self.fetched.append((sql, params))
+        return self._batches.pop(0) if self._batches else []
+
+    async def execute(self, sql: str, *params: Any) -> str:
+        self.executed.append((sql, params))
+        return "DELETE"
+
+    async def fetchval(self, sql: str, *params: Any) -> int:
+        self.fetched.append((sql, params))
+        return 0
+
+
+class FakePool:
+    def __init__(self, conn: FakeConnection) -> None:
+        self.conn = conn
+        self.closed = False
+
+    def acquire(self) -> Any:
+        conn = self.conn
+
+        class _Ctx:
+            async def __aenter__(self) -> FakeConnection:
+                return conn
+
+            async def __aexit__(self, *_: object) -> None:
+                return None
+
+        return _Ctx()
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    base = dict(
+        stale_seconds=3600,
+        batch_size=10,
+        max_batches=1,
+        sleep_between=0.0,
+        statement_timeout_ms=60_000,
+        count=False,
+        skip_dlq_check=True,
+        yes=False,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _deletes(conn: FakeConnection) -> list[tuple[str, tuple]]:
+    return [op for op in conn.executed if "DELETE" in op[0]]
+
+
+@pytest.mark.asyncio
+async def test_a_run_without_yes_issues_no_delete(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The dry run is the default, and it must be a genuine no-op against the database."""
+    conn = FakeConnection([[{"upload_id": uuid.uuid4(), "object_id": uuid.uuid4()} for _ in range(3)]])
+
+    async def fake_create_pool(*_a: Any, **_kw: Any) -> FakePool:
+        return FakePool(conn)
+
+    monkeypatch.setattr(sweep.asyncpg, "create_pool", fake_create_pool)
+
+    assert await sweep.main_async(_args(yes=False)) == 0
+
+    assert _deletes(conn) == [], "a dry run must not delete"
+
+
+@pytest.mark.asyncio
+async def test_dlq_protected_objects_are_never_deleted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mirrors the janitor/reaper gate: an object with an in-flight DLQ entry is spared."""
+    protected_id = uuid.uuid4()
+    keep = uuid.uuid4()
+    rows = [
+        {"upload_id": uuid.uuid4(), "object_id": protected_id},
+        {"upload_id": keep, "object_id": uuid.uuid4()},
+    ]
+    conn = FakeConnection([rows])
+
+    async def fake_create_pool(*_a: Any, **_kw: Any) -> FakePool:
+        return FakePool(conn)
+
+    async def fake_protected(_config: Any) -> set[str]:
+        return {str(protected_id)}
+
+    monkeypatch.setattr(sweep.asyncpg, "create_pool", fake_create_pool)
+    monkeypatch.setattr(sweep, "_dlq_protected_ids", fake_protected)
+
+    assert await sweep.main_async(_args(yes=True, skip_dlq_check=False)) == 0
+
+    deletes = _deletes(conn)
+    assert len(deletes) == 1
+    targets = deletes[0][1][0]
+    assert targets == [keep], "only the unprotected upload is deleted"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_batch_ends_the_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nothing left to sweep terminates rather than spinning on an empty query."""
+    conn = FakeConnection([[]])
+
+    async def fake_create_pool(*_a: Any, **_kw: Any) -> FakePool:
+        return FakePool(conn)
+
+    monkeypatch.setattr(sweep.asyncpg, "create_pool", fake_create_pool)
+
+    assert await sweep.main_async(_args(yes=True, max_batches=0)) == 0
+
+    assert _deletes(conn) == []
+
+
+@pytest.mark.asyncio
+async def test_every_statement_is_bounded_by_a_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """This script cleans up after an unbounded statement that pinned the xmin horizon for 96
+    minutes and stopped VACUUM database-wide. It must not be capable of repeating that."""
+    captured: dict = {}
+    conn = FakeConnection([[]])
+
+    async def fake_create_pool(*_a: Any, **kwargs: Any) -> FakePool:
+        captured.update(kwargs)
+        return FakePool(conn)
+
+    monkeypatch.setattr(sweep.asyncpg, "create_pool", fake_create_pool)
+
+    await sweep.main_async(_args(yes=True))
+
+    assert captured.get("command_timeout"), "no client-side ceiling on a statement"
+    assert captured.get("server_settings", {}).get("statement_timeout"), "no server-side ceiling"


### PR DESCRIPTION
## The gap

The mpu-reaper's query INNER-joins `multipart_uploads` to `parts`, so **an upload with zero parts can never be selected, and therefore never reaped**. Nothing else deletes them either — the only other paths are `abort_multipart_upload` and the same-key DELETE in `delete_object_endpoint`. They accumulate with no GC at all.

Measured on prod 2026-07-23:

```
partless incomplete uploads older than 48h : 874,823
incomplete uploads total                   : 904,246
```

**97% of the backlog is rows the reaper structurally cannot reach.**

## Why it matters beyond tidiness

The rewritten reaper query (#321) walks `idx_multipart_uploads_initiated_at` oldest-first, and these *are* the oldest rows — so every 120s cycle pays to skip past all of them before finding anything reapable. That is why the fixed query costs ~8s rather than ~0.5s, and why that cost grows linearly with a population nothing collects. Clearing the backlog is what makes #321 cheap and keeps it cheap.

## Why deleting is safe

A partless upload is an MPU header with nothing behind it: no `parts` row, therefore no `part_chunks`, no chunk on the SSD or in any backend. Deleting the header is precisely what `AbortMultipartUpload` does.

Checked rather than assumed — the only FK referencing `multipart_uploads` is:

```
conname         | from_table | confdeltype
fk_parts_upload | parts      | c            (ON DELETE CASCADE)
```

which has nothing to cascade for these rows. The age gate reuses the reaper's own `stale_seconds`, so a client that initiated an MPU and uploaded nothing for 48h is treated exactly as it is today.

## Operational shape

Deliberately **not** one big DELETE. This script exists to clean up after an incident where a single 96-minute statement pinned the xmin horizon and stopped VACUUM database-wide; repeating that while cleaning up after it would be poor form. So:

- bounded batches (5000 default), each its own autocommit statement
- **both** a client `command_timeout` and a server-side `statement_timeout`
- a pause between batches, so autovacuum and live traffic get the primary back
- dry run by default — `--yes` required to delete anything
- DLQ-protected object ids skipped, mirroring the janitor and reaper (a partless upload has no data to protect, but being the one caller that skips an established safety gate is not a thing I want to explain later)
- resumable: each batch re-queries, so an interrupted run is continued by re-running

Batch query verified against prod — **272 ms for 5000 rows**, using `idx_multipart_uploads_initiated_at` with an anti-join into `idx_parts_upload_uploaded_at`. ~175 batches for the full backlog, so a few minutes end to end.

## Usage

```bash
# look first — prints what it would do, touches nothing
python -m hippius_s3.scripts.sweep_partless_multipart_uploads --count

# then, for real
python -m hippius_s3.scripts.sweep_partless_multipart_uploads --yes
```

## Testing

Four tests on the parts that are logic rather than I/O, focused on the brakes — this script deletes, so what matters is that its safeties work:

- no DELETE is issued without `--yes`
- a DLQ-protected object is excluded from the ids handed to a DELETE
- an empty batch ends the run rather than spinning
- the pool is created with both timeouts

Verified non-vacuous: making the script ignore `--yes` fails the first, and making it ignore DLQ protection fails the second.

Unit **2016 passed**; `ruff`, `ruff format`, `ty` clean.

## Note: no companion script for the SSD shells

I had flagged a second one-time backfill for the 100k–338k already-leaked empty `<object_id>/v<version>/` dirs. On re-reading the implementation, **it isn't needed**: `sweep_empty_shells` (#326) walks the entire SSD root every reclaim tick, not just the directory being removed, so it collects pre-existing shells along with new ones. The first few ticks after that deploys will drain the backlog on their own. Worth watching the `swept empty SSD object/version shells` log line to confirm it does.