### PR TITLE
feat(redis): operator-managed HA for redis-queues (RedisReplication + Sentinel)

### DIFF
--- a/docs/redis-queues-ha-cutover.md
+++ b/docs/redis-queues-ha-cutover.md
@@ -1,0 +1,109 @@
+# redis-queues HA cutover runbook
+
+**Goal:** move `redis-queues` from a single StatefulSet to the operator-managed
+`RedisReplication` + `RedisSentinel` (`k8s/base/redis-queues-ha.yaml`) with **no s3 downtime**
+and **no regression of the drain's `cephor:epoch` fence**. Staging first; prod only after the
+gating test passes.
+
+## Why this needs a runbook (not a plain deploy)
+`redis-queues` holds two things whose loss is *not* just a cache miss:
+1. the **upload work queue** (`*_upload_requests`, retries) — a dropped entry is a lost upload;
+2. the drain's **`cephor:*` leader lease + epoch fence** — a regressed epoch can let a stale
+   drain-allocator win (split-brain; the `s3-prod-health` "epoch went BACKWARDS" = sev-3).
+
+Redis replication is stream-based (sub-second under normal load), but a Sentinel failover
+promotes a replica that may be missing the last in-flight writes. For the **epoch** (written
+only on leadership changes, rarely) the odds are low but nonzero — so a failover's effect on
+the fence is the **gating acceptance test** below, not an assumption.
+
+`REDIS_QUEUES_URL` currently = `redis://redis-queues:6379/0` (secret `hippius-s3-secrets`).
+The operator exposes a master-following service `redis-queues-ha-master`; the app only needs
+its URL repointed — **no app-code change**.
+
+---
+
+## Phase 0 — Stand up the HA set on STAGING (non-disruptive; the live redis-queues is untouched)
+```bash
+NS=hippius-s3-staging
+kubectl apply -n $NS -f k8s/base/redis-queues-ha.yaml
+# Wait for: 1 master + 2 replicas Ready, 3 sentinels Ready, and the master service present.
+kubectl -n $NS get redisreplication redis-queues-ha redissentinel redis-queues-sentinel
+kubectl -n $NS get pods -l app=redis-queues-ha -o wide
+kubectl -n $NS get svc redis-queues-ha-master        # this is the repoint target
+# Confirm replication is healthy + the master service points at the master:
+kubectl -n $NS exec redis-queues-ha-0 -- redis-cli info replication   # role:master, connected_slaves:2
+```
+Nothing is repointed yet; the old `redis-queues` still serves all traffic.
+
+## Phase 1 — GATING TEST on staging: does a failover regress the fence? (do this BEFORE prod)
+1. Repoint **staging's** `REDIS_QUEUES_URL` → `redis://redis-queues-ha-master:6379/0` (Phase 2
+   method) and roll the staging consumers. Generate active ingest so the drain is live.
+2. Record the fence + leader BEFORE:
+   ```bash
+   kubectl -n $NS exec redis-queues-ha-0 -- redis-cli get cephor:epoch    # note the value
+   # (leader_count via the drain probe / cephor:* keys)
+   ```
+3. **Kill the master** and watch Sentinel promote a replica:
+   ```bash
+   kubectl -n $NS delete pod redis-queues-ha-0            # the current master
+   # within ~5s (downAfterMs) + failoverTimeout, a replica is promoted; master svc follows it
+   kubectl -n $NS get svc redis-queues-ha-master -o jsonpath='{.spec.selector}{"\n"}'  # now the new master
+   ```
+4. **PASS criteria (all must hold):**
+   - `cephor:epoch` **did not decrease** (monotonic ↑ or unchanged);
+   - drain `leader_count` stays exactly **1** (no split-brain), no allocator crash;
+   - a cache-miss GET issued *during* the failover still completes (pub/sub subscribers
+     re-subscribed to `notify:*` on the new master — the operator/client reconnect handles this);
+   - no upload lost (the drain re-enqueues on transient error; verify the queue drains).
+5. **If the epoch regresses or leader_count ≠ 1:** STOP. Do **not** proceed to prod. File a
+   drain-fence-hardening issue (make the allocator tolerant of a redis failover — e.g. re-assert
+   epoch on leadership, or persist the fence with a WAIT/`min-replicas` guard for the epoch key
+   only). The redis manifests can stay; the cutover is blocked on the fence being failover-safe.
+
+## Phase 2 — Data migration (copy the queue + cephor:* keys into the HA master)
+The HA set comes up empty. To cut over without losing pending uploads or the fence, seed it from
+the live `redis-queues` **before** repointing. Recommended (validate on staging):
+```bash
+# Temporarily make the HA master replicate the live standalone redis-queues to copy ALL keys:
+kubectl -n $NS exec redis-queues-ha-0 -- redis-cli replicaof redis-queues 6379
+kubectl -n $NS exec redis-queues-ha-0 -- redis-cli info replication   # master_link_status:up, sync done
+# Then promote it (keeps every key incl. cephor:* + the queues):
+kubectl -n $NS exec redis-queues-ha-0 -- redis-cli replicaof no one
+```
+**Caveat to validate on staging:** the OT operator reconciler manages `replicaof`; confirm it
+does not fight the manual `replicaof` mid-migration (if it does, use a one-shot `redis-cli --rdb`
+dump of the old + `redis-cli -x restore`/`--pipe` load into the new master instead, during a
+brief writer quiesce). Pick whichever staging proves clean; document it here before prod.
+
+## Phase 3 — Repoint + roll consumers (the actual cutover; seconds)
+```bash
+# Patch the secret key (base64) and roll every workload that reads REDIS_QUEUES_URL:
+NEW=$(printf 'redis://redis-queues-ha-master:6379/0' | base64)
+kubectl -n $NS patch secret hippius-s3-secrets --type merge -p "{\"data\":{\"REDIS_QUEUES_URL\":\"$NEW\"}}"
+kubectl -n $NS rollout restart ds/drain-agent ds/api-local deploy/drain-allocator deploy/mpu-reaper \
+  deploy/arion-uploader deploy/arion-downloader deploy/arion-unpinner   # any consumer of the queues client
+```
+Consumers reconnect to the HA master. The drain is retry-safe, so a per-pod reconnect blip is absorbed.
+
+## Phase 4 — PROD cutover (only after staging Phases 1–3 pass)
+Repeat Phases 0/2/3 in `hippius-s3-prod` during a low-traffic window. Keep the old `redis-queues`
+StatefulSet running (do not delete) until 24–48 h of clean HA operation.
+
+## Rollback (fast, at any point)
+The old standalone `redis-queues` is left running throughout, so rollback = repoint back:
+```bash
+OLD=$(printf 'redis://redis-queues:6379/0' | base64)
+kubectl -n <ns> patch secret hippius-s3-secrets --type merge -p "{\"data\":{\"REDIS_QUEUES_URL\":\"$OLD\"}}"
+kubectl -n <ns> rollout restart ds/drain-agent ds/api-local deploy/drain-allocator deploy/mpu-reaper ...
+```
+If the HA master accumulated new queue entries after cutover, drain them back or accept the
+drain's re-enqueue (idempotent). Instant, no data loss (both redises are CephFS-durable).
+
+## Decommission (after soak)
+Once HA is proven in prod: remove the old `redis-queues` StatefulSet + Service from
+`k8s/base/redis-statefulsets.yaml`, and wire `k8s/base/redis-queues-ha.yaml` into the
+kustomizations so it's the managed default. Separate PR.
+
+## Follow-up: redis-accounts
+`redis-accounts` (persistent credit cache) is the other stateful single-replica Redis — same
+pattern, lower urgency (its miss falls through to the source). Do it after redis-queues soaks.

--- a/docs/redis-queues-ha-cutover.md
+++ b/docs/redis-queues-ha-cutover.md
@@ -35,6 +35,20 @@ kubectl -n $NS exec redis-queues-ha-0 -- redis-cli info replication   # role:mas
 ```
 Nothing is repointed yet; the old `redis-queues` still serves all traffic.
 
+**Two prerequisites are baked into the manifest — learned on staging 2026-07-23 (don't strip them):**
+1. **`podSecurityContext {runAsUser/runAsGroup/fsGroup: 1000}`** — without `fsGroup` the opstree
+   image (uid 1000) can't write `appendonlydir` on the root:root CephFS mount → the master
+   CrashLoops on `Can't open the append-only dir: Permission denied`. Symptom if missing:
+   `redis-queues-ha-0` in CrashLoopBackOff.
+2. **The `allow-redis-operator` NetworkPolicy** — the namespace's `allow-internal` policy does not
+   admit `redis-operator-system`, so every operator→pod dial times out. Symptom if missing:
+   `connected_slaves:0` (replicas never told `slaveof`) **and no sentinel StatefulSet is ever
+   created** (operator errors `Failed to Get the role Info … i/o timeout` and bails before making
+   it). Existing `redis-cluster` is unaffected because RedisCluster self-heals via the in-namespace
+   :16379 gossip bus; RedisReplication+Sentinel needs ongoing operator→pod connectivity.
+
+If Phase 0 shows `connected_slaves:0` or a missing sentinel STS, check these two before anything else.
+
 ## Phase 1 — GATING TEST on staging: does a failover regress the fence? (do this BEFORE prod)
 1. Repoint **staging's** `REDIS_QUEUES_URL` → `redis://redis-queues-ha-master:6379/0` (Phase 2
    method) and roll the staging consumers. Generate active ingest so the drain is live.

--- a/k8s/base/redis-queues-ha.yaml
+++ b/k8s/base/redis-queues-ha.yaml
@@ -114,9 +114,12 @@ metadata:
 spec:
   podSelector:
     matchExpressions:
+      # NB the operator names sentinel pods `<sentinelName>-sentinel`, so their `app` label is
+      # `redis-queues-sentinel-sentinel` (doubled suffix) — matching only `redis-queues-sentinel`
+      # would leave operator->sentinel:26379 blocked and the sentinels never configured.
       - key: app
         operator: In
-        values: ["redis-queues-ha", "redis-queues-sentinel"]
+        values: ["redis-queues-ha", "redis-queues-sentinel-sentinel"]
   policyTypes: ["Ingress"]
   ingress:
     - from:

--- a/k8s/base/redis-queues-ha.yaml
+++ b/k8s/base/redis-queues-ha.yaml
@@ -38,6 +38,13 @@ metadata:
   name: redis-queues-ha
 spec:
   clusterSize: 3 # 1 master + 2 replicas — survives a replica loss while keeping a failover target
+  # The opstree image runs as uid/gid 1000 (redis), but the CephFS PVC mounts root:root, so AOF
+  # (`appendonlydir` under /data) fails with EACCES and the pod CrashLoops. fsGroup makes the
+  # mount group-owned + setgid so uid 1000 can write; the CephFS CSI (fsGroupPolicy=File) honors it.
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.15
     imagePullPolicy: IfNotPresent
@@ -69,6 +76,10 @@ metadata:
   name: redis-queues-sentinel
 spec:
   clusterSize: 3 # 3 sentinels, quorum 2 — no sentinel is itself a SPOF
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis-sentinel:v7.0.15
     imagePullPolicy: IfNotPresent
@@ -87,3 +98,33 @@ spec:
     downAfterMilliseconds: "5000"
     failoverTimeout: "18000"
     parallelSyncs: "1"
+---
+# The namespace's `allow-internal` NetworkPolicy only admits in-namespace + ingress-nginx +
+# `hippius.io/role: cache` pods. The redis-operator lives in `redis-operator-system`, so without
+# this hole every operator->pod dial times out — and unlike RedisCluster (which self-heals via the
+# in-namespace :16379 gossip bus), RedisReplication+Sentinel needs ONGOING operator->pod
+# connectivity: it dials :6379 to determine the master role and orchestrate `slaveof`, and dials
+# :26379 to configure the sentinels. Missing this, replicas never attach (connected_slaves:0) and
+# the sentinel StatefulSet is never created. Scope is tight: only the operator namespace, only to
+# these pods, only on the two redis ports.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-redis-operator
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: ["redis-queues-ha", "redis-queues-sentinel"]
+  policyTypes: ["Ingress"]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redis-operator-system
+      ports:
+        - protocol: TCP
+          port: 6379
+        - protocol: TCP
+          port: 26379

--- a/k8s/base/redis-queues-ha.yaml
+++ b/k8s/base/redis-queues-ha.yaml
@@ -1,0 +1,89 @@
+# redis-queues HA — operator-managed RedisReplication + RedisSentinel (auto-failover)
+#
+# WHY: today redis-queues is a single-replica StatefulSet. Its data is on CephFS (3x, so a
+# node loss is NOT data loss), but the single pod is stuck Terminating on a hard node loss
+# until a human force-deletes it — a few-minute manual-recovery outage of the s3 WRITE path
+# (uploads can't enqueue; cache-miss GETs stall on chunk-ready pub/sub). redis-queues also
+# holds the drain's `cephor:*` leader lease + epoch fence, so its loss stalls the drain too.
+#
+# THIS FILE IS STAGED, NOT AUTO-APPLIED. It is deliberately NOT listed in any kustomization —
+# applying it must be a controlled cutover (see docs/redis-queues-ha-cutover.md), because it
+# introduces a SECOND redis holding the queue + fence, and the app must be repointed at the
+# operator's master service without losing pending uploads or regressing the cephor:epoch
+# fence. Apply per the runbook, staging first.
+#
+# Operator: quay.io/opstree/redis-operator:v0.23.0 (CRDs redis.redis.opstreelabs.in/v1beta2),
+# already installed cluster-wide and already managing the staging redis-cluster.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-queues-ha-config
+data:
+  # Preserves the semantics of the current standalone redis-queues (see redis-statefulsets.yaml):
+  # noeviction (dropping a queue entry = a lost upload; a reset epoch deadlocks the allocator —
+  # must fail writes LOUDLY under memory pressure, never silently evict) + AOF everysec on CephFS.
+  # NOTE: intentionally NO `min-replicas-to-write` — requiring a replica ack would BLOCK writes
+  # when a replica is down, defeating the availability goal. The failover-safety of the epoch
+  # fence is handled by the cutover acceptance test, not by blocking writes.
+  redis-additional.conf: |
+    maxmemory 4gb
+    maxmemory-policy noeviction
+    appendonly yes
+    appendfsync everysec
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisReplication
+metadata:
+  name: redis-queues-ha
+spec:
+  clusterSize: 3 # 1 master + 2 replicas — survives a replica loss while keeping a failover target
+  kubernetesConfig:
+    image: quay.io/opstree/redis:v7.0.15
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 4Gi
+      limits:
+        # Keep limit (6Gi) > maxmemory (4gb) so Redis rejects writes at ITS limit first (the
+        # intended loud OOM under noeviction) before k8s OOM-kills the pod; headroom absorbs
+        # AOF-rewrite copy-on-write + replication buffers.
+        cpu: 1000m
+        memory: 6Gi
+  redisConfig:
+    additionalRedisConfig: redis-queues-ha-config
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: ceph-filesystem
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisSentinel
+metadata:
+  name: redis-queues-sentinel
+spec:
+  clusterSize: 3 # 3 sentinels, quorum 2 — no sentinel is itself a SPOF
+  kubernetesConfig:
+    image: quay.io/opstree/redis-sentinel:v7.0.15
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+  redisSentinelConfig:
+    redisReplicationName: redis-queues-ha
+    masterGroupName: myMaster
+    quorum: "2"
+    # Detect a dead master in 5s, then fail over. failoverTimeout bounds a stuck failover.
+    downAfterMilliseconds: "5000"
+    failoverTimeout: "18000"
+    parallelSyncs: "1"


### PR DESCRIPTION
## Problem
`redis-queues` is the s3 **write-path SPOF**: a single-replica StatefulSet holding the upload work queue **and** the drain's `cephor:*` leader lease + epoch fence. Its data is CephFS-durable (3×), so a node loss is **not data loss** — but the single pod is stuck `Terminating` on a hard node loss until a human force-deletes it, a **few-minute manual-recovery outage** of upload-enqueue + chunk-ready pub/sub. (It's already bitten prod once — the 1.29M-unpin-overrun `IncompleteRead` incident.)

## Fix
The **opstree redis-operator is already installed** (and already runs the staging redis-cluster), so this uses it rather than hand-rolling Sentinel:
- **`RedisReplication`** `redis-queues-ha` — 1 master + 2 replicas, preserving the exact standalone config (`maxmemory 4gb`, **`noeviction`**, AOF `everysec` on `ceph-filesystem`).
- **`RedisSentinel`** `redis-queues-sentinel` — 3 sentinels, quorum 2, 5s down-detection → automatic failover.
- App repoints `REDIS_QUEUES_URL` (secret `hippius-s3-secrets`) at the operator's master-following service `redis-queues-ha-master` — **no app-code change**; the pub/sub client reconnects to the new master on failover.

## Safety / why it's staged, not auto-applied
`k8s/base/redis-queues-ha.yaml` is **deliberately not in any kustomization** — a deploy will not apply it. Cutover is a controlled, **staging-first** procedure (`docs/redis-queues-ha-cutover.md`) because:
- **The gating acceptance test is the `cephor:epoch` fence.** A Sentinel failover promotes a replica that could be missing the last in-flight write; for the epoch key (written only on leadership changes) that's rare but nonzero, and a **regressed epoch = drain split-brain** (the `s3-prod-health` "epoch went BACKWARDS" sev-3). The runbook's Phase 1 kills the master under active drain and **blocks the prod cutover unless** epoch stays monotonic, `leader_count` stays 1, and cache-miss GETs still wake. If it regresses → a drain-fence-hardening issue, not a prod change.
- Deliberately **no `min-replicas-to-write`** — requiring a replica ack would block writes when a replica is down, defeating the availability goal.
- **Rollback is a one-line secret repoint** back to the still-running standalone `redis-queues` (kept until 24–48 h clean soak).

## Validation
Server dry-run validates all three objects against the live `v1beta2` CRDs. Full data-migration + failover verification happen on staging per the runbook before any prod touch.

## Scope / follow-ups
- Not in scope: redis-cluster HA (it's an ephemeral cache — a node loss is a degradation, not data loss — explicitly deprioritised).
- Follow-up: `redis-accounts` (same pattern, lower urgency) after redis-queues soaks; decommission the standalone `redis-queues` + wire this into the kustomizations in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)