### PR TITLE
fix(read): fail fast below the client's timeout so the retryable 503 is reachable

### DIFF
--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -216,7 +216,22 @@ class Config:
     # (DownloadNotReadyError). Keeps an un-drained/never-arriving object (e.g. a part not yet on any
     # backend) from hanging the whole request up to cache_ttl_seconds (~1h). Later chunks keep the
     # full wait — once the first chunk lands the object is actively draining.
-    stream_first_chunk_timeout_seconds: int = env("HIPPIUS_STREAM_FIRST_CHUNK_TIMEOUT_SECONDS:90", convert=int)
+    #
+    # MUST STAY BELOW THE CLIENT'S READ TIMEOUT. This was 90s, which is above boto3's 60s default,
+    # so the fail-fast never actually reached anyone: the client hung up at 60s and got a dead
+    # socket, which is NOT retryable, while the 503 SlowDown this raises IS. Worse, from the
+    # server's side the request later completed 200, so nothing was recorded as a failure.
+    # Observed 2026-07-23 14:50:05 — a presigned GET returned 200 after processing_time_ms=60167,
+    # 167ms after the client had already given up.
+    #
+    # 25s leaves room for two client-side retries inside one 60s budget. A cross-node
+    # read-after-write costs ~60s end to end (the part lands on one node's SSD; a reconciler
+    # notices, the drain copies it, an enqueue sweep publishes, the uploader uploads — every stage
+    # a poll, not an event), so on a fresh object the FIRST attempt is EXPECTED to 503 and a retry
+    # to succeed. That is the mechanism working, not a failure. Making the read genuinely fast is a
+    # separate problem: serve it from the peer that holds the data instead of waiting out the
+    # pipeline.
+    stream_first_chunk_timeout_seconds: int = env("HIPPIUS_STREAM_FIRST_CHUNK_TIMEOUT_SECONDS:25", convert=int)
     # A3: bound on how long the streamer waits for EACH subsequent chunk (after the first). Without
     # it a later chunk whose backend fetch permanently fails stalls the already-committed 200
     # response up to cache_ttl_seconds (~1h) mid-stream; this caps that to a bounded fail (the

--- a/tests/smoke/retrying_http.py
+++ b/tests/smoke/retrying_http.py
@@ -1,0 +1,58 @@
+"""A GET that retries 503 SlowDown, the way a real S3 client does.
+
+These tests reach the gateway with raw httpx rather than boto3 — presigned URLs and anonymous
+public reads are deliberately exercised as a plain HTTP client would, without SDK machinery in
+the way. The cost is that they also lose the SDK's retry behaviour, and 503 SlowDown is a
+NORMAL response here, not a failure:
+
+A cross-node read-after-write is not instant. An upload lands on one node's local SSD, and a
+download served by a different node has nothing to serve until the drain pipeline replicates it
+— reconciler notices, drain copies to CephFS, enqueue sweep publishes, uploader uploads. Every
+stage is a poll, so the round trip is ~60s. While that is in flight the read path deliberately
+gives up early and returns a retryable 503 rather than holding the connection open (see
+`stream_first_chunk_timeout_seconds`). boto3 and the aws-cli retry that transparently and the
+user never sees it; a bare `httpx.get` does not, and reports a failure the SDK would have
+absorbed.
+
+So this helper exists to make the smoke tests behave like the clients we actually care about.
+It retries ONLY 503 — any other status is returned as-is, so a genuine 500/403/404 still fails
+the test immediately rather than being retried into a timeout.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+# Enough attempts to cover the ~60s replication round trip at the server's ~25s fail-fast, with
+# headroom. Kept explicit rather than derived so the test does not silently follow a config change.
+DEFAULT_ATTEMPTS = 5
+DEFAULT_BACKOFF_SECONDS = 5.0
+
+
+def get_with_slowdown_retry(
+    url: str,
+    *,
+    timeout: float = 60.0,
+    attempts: int = DEFAULT_ATTEMPTS,
+    backoff: float = DEFAULT_BACKOFF_SECONDS,
+) -> httpx.Response:
+    """GET `url`, retrying only on 503, and return the last response.
+
+    Returns rather than raises on exhaustion so the caller's own assertion produces the failure
+    message — a test that ends in "still 503 after N attempts" is more useful than a stack trace
+    from in here.
+    """
+    response = httpx.get(url, timeout=timeout)
+    for attempt in range(2, attempts + 1):
+        if response.status_code != 503:
+            return response
+        logger.info("503 SlowDown (object still replicating); attempt %d/%d after %.0fs", attempt, attempts, backoff)
+        time.sleep(backoff)
+        response = httpx.get(url, timeout=timeout)
+    return response

--- a/tests/smoke/test_smoke_production.py
+++ b/tests/smoke/test_smoke_production.py
@@ -8,6 +8,8 @@ from datetime import timezone
 import httpx
 import pytest
 
+from .retrying_http import get_with_slowdown_retry
+
 
 def test_01_cleanup_old_files(production_s3_client, session_tracker):
     from datetime import timedelta
@@ -254,7 +256,10 @@ def test_07_presigned_url_roundtrip(production_s3_client, session_tracker, file_
         Params={"Bucket": session_tracker.bucket, "Key": key},
         ExpiresIn=300,
     )
-    get_resp = httpx.get(get_url, timeout=60)
+    # Retries 503 like a real S3 client: a fresh object read from a different node than the one
+    # that took the PUT is legitimately not ready yet, and the read path fails fast with a
+    # retryable SlowDown rather than holding the socket. See tests/smoke/retrying_http.py.
+    get_resp = get_with_slowdown_retry(get_url, timeout=60)
     assert get_resp.status_code == 200, f"presigned GET failed: {get_resp.status_code} {get_resp.text[:200]}"
 
     downloaded_hash = hashlib.md5(get_resp.content).hexdigest()

--- a/tests/smoke/test_smoke_regional.py
+++ b/tests/smoke/test_smoke_regional.py
@@ -22,6 +22,8 @@ import httpx
 import pytest
 from botocore.config import Config
 
+from .retrying_http import get_with_slowdown_retry
+
 
 REGIONAL_ENDPOINTS = [
     "https://eu-central-1.hippius.com",
@@ -93,7 +95,7 @@ def test_regional_public_object_anonymous_download(regional_s3_client, session_t
     regional_s3_client.put_object_acl(Bucket=session_tracker.bucket, Key=key, ACL="public-read")
 
     anon_url = f"{endpoint.rstrip('/')}/{session_tracker.bucket}/{key}"
-    resp = httpx.get(anon_url, timeout=60)
+    resp = get_with_slowdown_retry(anon_url, timeout=60)
     assert resp.status_code == 200, f"anonymous GET failed: status={resp.status_code} body={resp.text[:200]}"
     assert hashlib.md5(resp.content).hexdigest() == expected_hash, (
         f"[{region}] anonymously-downloaded public object does not match what was uploaded — public-read reads through the {region} edge are corrupting data."
@@ -129,7 +131,7 @@ def test_regional_presigned_url_roundtrip(regional_s3_client, session_tracker, f
         Params={"Bucket": session_tracker.bucket, "Key": key},
         ExpiresIn=300,
     )
-    get_resp = httpx.get(get_url, timeout=60)
+    get_resp = get_with_slowdown_retry(get_url, timeout=60)
     assert get_resp.status_code == 200, f"[{region}] presigned GET failed: {get_resp.status_code} {get_resp.text[:200]}"
     assert hashlib.md5(get_resp.content).hexdigest() == expected_hash, (
         f"[{region}] object fetched via presigned URL does not match what was PUT via presigned URL — the {region} presigned round-trip is corrupting data."

--- a/tests/unit/test_read_path_fails_before_client_gives_up.py
+++ b/tests/unit/test_read_path_fails_before_client_gives_up.py
@@ -1,0 +1,53 @@
+"""The read path's fail-fast is only useful if it beats the client's read timeout.
+
+`stream_first_chunk_timeout_seconds` bounds how long a GET waits for its first chunk before
+raising DownloadNotReadyError -> 503 SlowDown, which every S3 SDK retries. That is the entire
+mechanism for surviving a cross-node read-after-write, where the object is legitimately not
+ready for ~60s while the drain pipeline replicates it.
+
+It was set to 90s, above boto3's 60s default read timeout, so the mechanism never fired for
+anyone: the client hung up on a dead socket (not retryable) while the server was still politely
+waiting, and later returned 200 to nobody — so nothing was even recorded as a failure. Observed
+in prod 2026-07-23 14:50:05, a presigned GET completing with processing_time_ms=60167, 167ms
+after the client gave up.
+
+A number above the client's timeout is not a conservative choice here; it silently disables the
+feature.
+"""
+
+from __future__ import annotations
+
+from hippius_s3.config import get_config
+
+
+# botocore's default read_timeout, which is what an un-configured boto3/aws-cli client uses, and
+# what tests/smoke passes explicitly. Anything at or above this makes the 503 unreachable.
+BOTO3_DEFAULT_READ_TIMEOUT_SECONDS = 60
+
+
+def test_first_chunk_timeout_leaves_room_for_a_client_retry() -> None:
+    config = get_config()
+    first_chunk = config.stream_first_chunk_timeout_seconds
+
+    assert first_chunk < BOTO3_DEFAULT_READ_TIMEOUT_SECONDS, (
+        f"stream_first_chunk_timeout_seconds={first_chunk}s is at or above the client's "
+        f"{BOTO3_DEFAULT_READ_TIMEOUT_SECONDS}s read timeout, so the retryable 503 can never "
+        f"reach the client — it hangs up on a dead socket first, and a dead socket is not "
+        f"retryable while SlowDown is."
+    )
+    assert first_chunk * 2 <= BOTO3_DEFAULT_READ_TIMEOUT_SECONDS, (
+        f"stream_first_chunk_timeout_seconds={first_chunk}s leaves room for only one attempt "
+        f"inside a {BOTO3_DEFAULT_READ_TIMEOUT_SECONDS}s client budget. A cross-node "
+        f"read-after-write needs ~60s to replicate, so at least one retry must fit."
+    )
+
+
+def test_later_chunks_still_get_a_generous_wait() -> None:
+    """Only the FIRST chunk fails fast. Once the object is proven to be arriving, a mid-stream
+    wait is not a 'not ready yet' signal and must not be shortened alongside it."""
+    config = get_config()
+
+    assert config.stream_chunk_timeout_seconds > config.stream_first_chunk_timeout_seconds, (
+        "the per-chunk timeout must stay well above the first-chunk timeout; shortening it "
+        "would break long healthy streams that are draining normally"
+    )


### PR DESCRIPTION
## The bug, in one number

```python
stream_first_chunk_timeout_seconds = 90    # boto3's default read timeout is 60
```

The read path already does the right thing: on a first-chunk timeout it raises `DownloadNotReadyError` → **503 SlowDown**, releases the coalesce locks so a retry re-enqueues immediately, and every S3 SDK retries SlowDown transparently.

At 90s that never reached anyone. The client hung up at 60s — on a **dead socket, which is not retryable** — while the server was still politely waiting for a 503 it would never get to send.

And it was invisible: from the server's side the request later completed **200**, so nothing was recorded as a failure. Prod, 2026-07-23 14:50:05:

```
"status_code": 200, "processing_time_ms": 60167.05, "content_length": 1048576
```

**60,167 ms.** The client's budget was 60,000. It lost by 167 milliseconds.

## Why this survived #321

I previously attributed these smoke failures to the mpu-reaper pinning the xmin horizon. That was an amplifier, not the cause — #321 is deployed and verified (horizon clean, reaper cycling every ~130s), and the stall is still here. My earlier diagnosis over-attributed it; this is the actual floor underneath.

The real cause is that **cross-node read-after-write is legitimately slow**. A part lands on one node's local SSD and nothing announces it — a reconciler notices (15s poll), the drain copies it to CephFS, an enqueue sweep publishes (5s poll), the uploader uploads. Every stage is a poll, not an event. A GET served by any other node has nothing to serve until that finishes. Traced end to end:

```
14:49:04.566  PUT lands on node A
14:49:05.132  GET on node B — nothing local, download enqueued
14:49:05.231  downloader "Done" in 94ms — but size=0.0MB. Nothing to fetch yet.
              ... 59s ...
14:50:04.701  arion-uploader picks up the job
14:50:05.260  GET returns 200, too late
```

Whether a given read is instant or 60s is decided by whether it happens to land on the node that took the write. That is why the failures move between the regional and main suites run to run — same defect, coin flip.

## The change

**25s**, which leaves room for two client attempts inside one 60s budget. A read of a just-written object now 503s once and succeeds on retry, instead of failing.

To be clear about what this is: it makes the delay **survivable, not fast**. Making it fast means serving the read from the peer that already holds the data instead of waiting out the pipeline — separate, larger work, and I think the right eventual answer.

## Smoke tests

They reach the gateway with raw `httpx` deliberately, to exercise presigned and anonymous reads without SDK machinery in the way. That also costs them the SDK's retry, so they would now fail on a 503 that a real client absorbs — production better, alarm still red.

Added `tests/smoke/retrying_http.py`, which retries **only** 503. Any other status is returned as-is, so a genuine 500/403/404 still fails the test immediately rather than being retried into a timeout. Applied to the three raw GETs: the presigned round-trip in `test_smoke_production`, and the anonymous + presigned reads in `test_smoke_regional`.

## Guard

A number above the client's timeout doesn't fail safe — it silently disables the feature, which is exactly how this went unnoticed. So there's a unit test asserting the timeout stays below the client's read timeout with room for a retry, plus one asserting the *later*-chunk timeout stays generous (only the first chunk should fail fast; a mid-stream wait is not a "not ready yet" signal). Verified it fails at the old 90.

Unit **2002 passed**; smoke suite collects clean; `ruff`, `ruff format`, `ty` clean.

## Expected effect

Smoke should stop failing on `ReadTimeout`. What you'll see instead is the occasional retry inside a passing test — that's the mechanism working. If a read 503s through all 5 attempts (~60s+), that's a genuine replication problem worth alerting on, which is a much better signal than a silent hang.