### PR TITLE
fix(janitor): stop cleanup_stale_parts starving every phase behind it

### DIFF
--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -388,6 +388,31 @@ class Config:
     # cleanup loops are DB-roundtrip bound; this is how many parts are processed
     # in parallel (each over its own pooled connection).
     janitor_concurrency: int = env("HIPPIUS_JANITOR_CONCURRENCY:16", convert=int)
+    # Concurrency for the FS *walk* itself (distinct from janitor_concurrency, which is the
+    # per-part DB roundtrip fan-out). The cache root is a single flat directory of millions of
+    # object dirs on CephFS; a single-threaded walk is metadata-latency bound (~40 objects/s
+    # measured on prod 2026-07-23, so a full pass over ~2.8M objects is ~20h and never completes
+    # inside a cycle — which starves every phase after it). This fans the per-object descent
+    # (scandir + stat) across a thread pool so many CephFS metadata roundtrips are in flight at
+    # once. Set to 1 for the legacy serial walk. Kept modest by default because the same CephFS
+    # MDS serves live GET/PUT — do not crank without watching MDS latency.
+    janitor_walk_concurrency: int = env("HIPPIUS_JANITOR_WALK_CONCURRENCY:8", convert=int)
+    # Wall-clock budget for each FS-walk phase (stale-cleanup, age-GC, tmp-sweep). Once exceeded
+    # the walk stops enqueuing new object dirs and the phase returns, so the cycle always
+    # completes and the phases after it — plus the DB-only durability sentinel + aged-orphan
+    # gauge which now run FIRST regardless — keep ticking. 0 = unbounded. Automatically lifted to
+    # unbounded under CRITICAL disk pressure — freeing space must never be capped by a clock.
+    janitor_walk_budget_seconds: int = env("HIPPIUS_JANITOR_WALK_BUDGET_SECONDS:240", convert=int)
+    # Number of hash-shards the FS walk rotates through, one per cycle, for FAIR coverage: each
+    # cycle descends only into object dirs where crc32(object_id) % shards == cycle_shard, so a
+    # full sweep of the tree takes `shards` cycles and no object waits behind an always-truncated
+    # prefix. SIZING: a shard must fit inside the budget or its tail is never reached — pick
+    # shards ≳ (objects / (walk_concurrency · per-thread-obj/s · budget_s)). At ~2.8M objects,
+    # concurrency 8 (~8× the ~40 obj/s serial rate measured on prod) and a 240s budget, one shard
+    # is ~44k objects → comfortably inside budget; a full sweep is ~64 cycles (~10h at the 600s
+    # normal sleep). Raise it if the cache grows or the walk logs truncated=True; 1 = walk the
+    # whole tree every cycle. Forced to 1 under disk pressure so eviction sees the whole tree.
+    janitor_walk_shards: int = env("HIPPIUS_JANITOR_WALK_SHARDS:64", convert=int)
     # Max soft-deleted objects hard-deleted per janitor cycle. The find query is
     # an index-probe over this many candidates; keep it bounded so a large
     # backlog drains gradually instead of in one DELETE-cascade burst.

--- a/tests/unit/test_janitor_sharded_gc.py
+++ b/tests/unit/test_janitor_sharded_gc.py
@@ -172,6 +172,27 @@ async def test_census_publishes_only_on_full_sweep(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_shard_zero_resets_accumulator_so_a_mid_sweep_shard_change_cannot_inflate(tmp_path: Path, monkeypatch):
+    """If pressure flips `shards` to 1 mid-sweep, the next shard-0 walk must start a clean
+    accumulator — otherwise the prior partial sweep's counts blend in and inflate the census."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    _n_objects(tmp_path, 40)
+    store = _FakeFsStore(tmp_path)
+    with patch.object(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=False)):
+        # Partial 4-shard sweep: cover shards 0,1 (accumulates ~half the tree), never published.
+        for s in (0, 1):
+            await janitor.cleanup_old_parts_by_mtime(
+                _FakePool(_db()), store, _redis(), shard=s, shards=4, walk_concurrency=4, publish_sweep=False
+            )
+        # Pressure kicks in → shards=1, shard=0, publish. shard-0 reset must discard the partial
+        # accumulation and publish exactly the whole tree, not tree + the earlier half.
+        await janitor.cleanup_old_parts_by_mtime(
+            _FakePool(_db()), store, _redis(), shard=0, shards=1, walk_concurrency=4, publish_sweep=True
+        )
+    assert janitor._fs_parts_on_disk == 40, "shard-0 reset must prevent the mid-sweep count from inflating"
+
+
+@pytest.mark.asyncio
 async def test_truncated_sweep_does_not_publish_partial_census(tmp_path: Path, monkeypatch):
     """A budget-truncated shard taints the sweep; the gauge must hold its last good value."""
     monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)

--- a/tests/unit/test_janitor_sharded_gc.py
+++ b/tests/unit/test_janitor_sharded_gc.py
@@ -1,0 +1,262 @@
+"""Sharding + budgeting of the janitor FS-walk phases, and the sweep-scoped census.
+
+The starvation fix makes each FS-walk phase cover one hash-shard of the tree per cycle
+(full sweep every `shards` cycles) under a wall-clock budget, so the cycle always completes
+and the DB-only durability phases (moved to the front) always run. The safety-critical
+property is that sharding changes only WHICH objects a cycle visits, never the per-part
+deletion decision: the union of deletions over all shards must equal the un-sharded run.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from workers import run_janitor_in_loop as janitor
+
+
+def _make_part(fs_root: Path, object_id: str, version: int, part: int, *, mtime_offset: float = 0) -> None:
+    d = fs_root / object_id / f"v{version}" / f"part_{part}"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "chunk_0.bin").write_bytes(b"payload")
+    (d / "meta.json").write_text('{"chunk_size": 7, "num_chunks": 1, "size_bytes": 7}')
+    now = time.time()
+    os.utime(d / "meta.json", (now - mtime_offset, now - mtime_offset))
+
+
+class _PoolCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _PoolCtx(self._conn)
+
+
+class _FakeFsStore:
+    def __init__(self, root: Path):
+        self.root = root
+        self.deleted: list[tuple[str, int, int]] = []
+
+    async def delete_part(self, object_id: str, object_version: int, part_number: int) -> None:
+        import shutil
+
+        self.deleted.append((object_id, object_version, part_number))
+        p = self.root / object_id / f"v{object_version}" / f"part_{part_number}"
+        if p.exists():
+            shutil.rmtree(p)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    # hot_retention=1s so the parts these coverage tests create (mtime/atime ~1h ago) are cold;
+    # they isolate the age+replication decision from hot-retention (tested separately).
+    janitor.config.fs_cache_hot_retention_seconds = 1
+    janitor.config.fs_cache_gc_max_age_seconds = 60
+    janitor.config.mpu_stale_seconds = 86400
+    janitor.config.upload_backends = ["arion"]
+    janitor._reset_census_accum()
+    janitor._walk_shard = 0
+    yield
+
+
+def _db():
+    db = AsyncMock()
+    db.fetchrow = AsyncMock(return_value=None)
+    db.fetch = AsyncMock(return_value=[])
+    db.fetchval = AsyncMock(return_value=None)
+    return db
+
+
+def _redis():
+    r = MagicMock()
+    r.lrange = AsyncMock(return_value=[])
+    return r
+
+
+def _n_objects(fs_root: Path, n: int, *, mtime_offset: float = 3600) -> None:
+    for i in range(n):
+        _make_part(fs_root, f"{i:032x}", 1, 1, mtime_offset=mtime_offset)
+
+
+# ---- the safety invariant: shard union == unsharded ----
+
+
+@pytest.mark.asyncio
+async def test_shard_union_deletes_exactly_the_unsharded_set(tmp_path: Path, monkeypatch):
+    """The whole point: sharding must not change WHAT gets deleted, only across how many cycles."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+
+    # Unsharded reference run.
+    ref_root = tmp_path / "ref"
+    _n_objects(ref_root, 60)
+    ref_store = _FakeFsStore(ref_root)
+    with patch.object(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=True)):
+        await janitor.cleanup_old_parts_by_mtime(_FakePool(_db()), ref_store, _redis(), shards=1, walk_concurrency=4)
+    ref_deleted = set(ref_store.deleted)
+    assert ref_deleted, "reference run should have deleted the cold replicated parts"
+
+    # Sharded run: same tree, all shards, deletions accumulated.
+    sh_root = tmp_path / "sh"
+    _n_objects(sh_root, 60)
+    sh_store = _FakeFsStore(sh_root)
+    shards = 6
+    with patch.object(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=True)):
+        for s in range(shards):
+            await janitor.cleanup_old_parts_by_mtime(
+                _FakePool(_db()), sh_store, _redis(), shard=s, shards=shards, walk_concurrency=4, publish_sweep=False
+            )
+    assert set(sh_store.deleted) == ref_deleted
+
+
+@pytest.mark.asyncio
+async def test_stale_cleanup_shard_union_matches(tmp_path: Path):
+    """Same invariant for cleanup_stale_parts (orphan / no-parts-row reap path)."""
+    ref_root = tmp_path / "ref"
+    _n_objects(ref_root, 40, mtime_offset=janitor.config.mpu_stale_seconds + 100)
+    ref_store = _FakeFsStore(ref_root)
+    db = _db()  # fetchrow None => no parts row => orphan => reap
+    await janitor.cleanup_stale_parts(_FakePool(db), ref_store, _redis(), shards=1, walk_concurrency=4)
+    ref = set(ref_store.deleted)
+    assert ref
+
+    sh_root = tmp_path / "sh"
+    _n_objects(sh_root, 40, mtime_offset=janitor.config.mpu_stale_seconds + 100)
+    sh_store = _FakeFsStore(sh_root)
+    shards = 5
+    for s in range(shards):
+        await janitor.cleanup_stale_parts(
+            _FakePool(_db()), sh_store, _redis(), shard=s, shards=shards, walk_concurrency=4
+        )
+    assert set(sh_store.deleted) == ref
+
+
+# ---- census is sweep-scoped ----
+
+
+@pytest.mark.asyncio
+async def test_census_publishes_only_on_full_sweep(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    _n_objects(tmp_path, 30)
+    store = _FakeFsStore(tmp_path)
+    janitor._fs_parts_on_disk = -1  # sentinel: unchanged means "not published"
+    shards = 3
+    with patch.object(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=False)):
+        # shards 0 and 1: accumulate, do NOT publish
+        for s in range(2):
+            await janitor.cleanup_old_parts_by_mtime(
+                _FakePool(_db()), store, _redis(), shard=s, shards=shards, walk_concurrency=4, publish_sweep=False
+            )
+        assert janitor._fs_parts_on_disk == -1, "census must not publish mid-sweep"
+        # last shard: publish the accumulated full-tree census
+        await janitor.cleanup_old_parts_by_mtime(
+            _FakePool(_db()), store, _redis(), shard=2, shards=shards, walk_concurrency=4, publish_sweep=True
+        )
+    assert janitor._fs_parts_on_disk == 30, "a completed sweep must publish the whole-tree count"
+
+
+@pytest.mark.asyncio
+async def test_truncated_sweep_does_not_publish_partial_census(tmp_path: Path, monkeypatch):
+    """A budget-truncated shard taints the sweep; the gauge must hold its last good value."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    _n_objects(tmp_path, 50)
+    store = _FakeFsStore(tmp_path)
+    janitor._fs_parts_on_disk = 999  # last-good value
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    with patch.object(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=False)):
+        # single-shard sweep, already-expired deadline => truncated
+        await janitor.cleanup_old_parts_by_mtime(
+            _FakePool(_db()),
+            store,
+            _redis(),
+            shard=0,
+            shards=1,
+            walk_concurrency=2,
+            deadline=loop.time() - 1.0,
+            publish_sweep=True,
+        )
+    assert janitor._fs_parts_on_disk == 999, "a truncated sweep must not overwrite the census"
+
+
+# ---- deadline helper ----
+
+
+def test_walk_deadline_lifts_under_critical_pressure():
+    import asyncio
+
+    async def _check():
+        loop = asyncio.get_running_loop()
+        assert janitor._walk_deadline(loop, pressure=2, budget=300) is None  # critical => unbounded
+        assert janitor._walk_deadline(loop, pressure=0, budget=0) is None  # disabled
+        d = janitor._walk_deadline(loop, pressure=0, budget=300)
+        assert d is not None and d > loop.time()
+        d1 = janitor._walk_deadline(loop, pressure=1, budget=300)  # elevated still bounded
+        assert d1 is not None
+
+    asyncio.run(_check())
+
+
+# ---- the core durability fix: DB-only phases run BEFORE the FS walks ----
+
+
+@pytest.mark.asyncio
+async def test_durability_phases_run_before_fs_walks(monkeypatch):
+    """The starvation bug: the replication sentinel + aged-orphan gauge ran LAST, behind two
+    full-tree FS walks that never finished, so on prod they never ran. They must now run first,
+    unconditionally, so no FS-walk cost can starve them."""
+    from pathlib import Path
+
+    order: list[str] = []
+
+    async def _rec(name, ret=0):
+        order.append(name)
+        return ret
+
+    monkeypatch.setattr(janitor, "_update_disk_metrics", lambda root: order.append("disk_metrics"))
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    monkeypatch.setattr(janitor, "check_replication_sentinel", lambda *a, **k: _rec("sentinel"))
+    monkeypatch.setattr(janitor, "get_all_dlq_object_ids", lambda *a, **k: _rec("dlq", set()))
+    monkeypatch.setattr(janitor, "check_aged_pending_orphans", lambda *a, **k: _rec("aged_orphans"))
+    monkeypatch.setattr(janitor, "cleanup_stale_parts", lambda *a, **k: _rec("fs_stale"))
+    monkeypatch.setattr(janitor, "cleanup_old_parts_by_mtime", lambda *a, **k: _rec("fs_gc"))
+    monkeypatch.setattr(janitor, "cleanup_orphan_tmp_files", lambda *a, **k: _rec("fs_tmp"))
+    monkeypatch.setattr(janitor, "gc_soft_deleted_objects", lambda *a, **k: _rec("hard_delete"))
+    monkeypatch.setattr(janitor, "_setup_janitor_metrics", lambda: None)
+    monkeypatch.setattr(janitor, "create_fs_store", lambda config: MagicMock(root=Path("/tmp")))
+    monkeypatch.setattr(janitor.asyncpg, "create_pool", AsyncMock(return_value=AsyncMock()))
+    monkeypatch.setattr(janitor.Redis, "from_url", lambda url: AsyncMock())
+
+    class _Stop(Exception):
+        pass
+
+    async def _sleep_then_stop(_seconds):
+        raise _Stop
+
+    monkeypatch.setattr(janitor.asyncio, "sleep", _sleep_then_stop)
+
+    with pytest.raises(_Stop):
+        await janitor.run_janitor_loop()
+
+    assert "sentinel" in order and "aged_orphans" in order
+    # both durability signals must precede every FS-walk phase
+    first_fs = min(order.index(p) for p in ("fs_stale", "fs_gc", "fs_tmp"))
+    assert order.index("sentinel") < first_fs, f"sentinel must run before FS walks; got {order}"
+    assert order.index("aged_orphans") < first_fs, f"aged-orphan gauge must run before FS walks; got {order}"

--- a/tests/unit/test_janitor_walk.py
+++ b/tests/unit/test_janitor_walk.py
@@ -1,0 +1,143 @@
+"""The parallel FS walk that replaces the serial `_safe_iterdir` producer.
+
+The serial walk ran on the event loop at ~40 object-dirs/s over CephFS (measured on prod
+2026-07-23), so a pass over ~2.8M object dirs took ~20h and never completed inside a cycle —
+starving every phase after `cleanup_stale_parts`. `iter_part_dirs` fans the per-object
+descent across a thread pool, shards for fair coverage, and honours a wall-clock budget so
+the cycle always completes. These tests pin the properties the deletion logic relies on:
+completeness, shard-union == full walk, budget truncation, and legacy serial equivalence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from workers.run_janitor_in_loop import PartDirInfo
+from workers.run_janitor_in_loop import WalkState
+from workers.run_janitor_in_loop import _object_in_shard
+from workers.run_janitor_in_loop import iter_part_dirs
+
+
+def _build_tree(root: Path, n_objects: int, versions: int = 1, parts: int = 1, meta: bool = True) -> int:
+    made = 0
+    for i in range(n_objects):
+        oid = f"{i:032x}"
+        for v in range(1, versions + 1):
+            for p in range(1, parts + 1):
+                d = root / oid / f"v{v}" / f"part_{p}"
+                d.mkdir(parents=True, exist_ok=True)
+                (d / "chunk_0.bin").write_bytes(b"x")
+                if meta:
+                    (d / "meta.json").write_text("{}")
+                made += 1
+    return made
+
+
+async def _collect(root: Path, **kw) -> tuple[list[PartDirInfo], WalkState]:
+    state = WalkState()
+    out: list[PartDirInfo] = []
+    async for info in iter_part_dirs(root, state=state, **kw):
+        out.append(info)
+    return out, state
+
+
+@pytest.mark.asyncio
+async def test_full_walk_finds_every_part(tmp_path: Path) -> None:
+    expected = _build_tree(tmp_path, 40, versions=2, parts=3)
+    got, state = await _collect(tmp_path, concurrency=8, shard=0, shards=1, deadline=None)
+    assert len(got) == expected == 240
+    assert state.truncated is False
+    keys = {(i.object_id, i.object_version, i.part_number) for i in got}
+    assert len(keys) == expected  # no duplicates
+
+
+@pytest.mark.asyncio
+async def test_shards_partition_the_tree_exactly(tmp_path: Path) -> None:
+    """Every part appears in exactly one shard; the union over all shards is the full walk."""
+    _build_tree(tmp_path, 100, versions=1, parts=2)
+    full, _ = await _collect(tmp_path, concurrency=4, shard=0, shards=1, deadline=None)
+    full_keys = {(i.object_id, i.object_version, i.part_number) for i in full}
+
+    shards = 5
+    seen: set = set()
+    for s in range(shards):
+        part, _ = await _collect(tmp_path, concurrency=4, shard=s, shards=shards, deadline=None)
+        keys = {(i.object_id, i.object_version, i.part_number) for i in part}
+        assert not (keys & seen), "an object landed in two shards — coverage would double-scan"
+        seen |= keys
+    assert seen == full_keys, "shard union must equal the full walk — no object left unswept"
+
+
+@pytest.mark.asyncio
+async def test_budget_truncates_and_flags(tmp_path: Path) -> None:
+    _build_tree(tmp_path, 200)
+    loop = asyncio.get_running_loop()
+    got, state = await _collect(
+        tmp_path, concurrency=2, shard=0, shards=1, deadline=loop.time() - 1.0
+    )
+    assert state.truncated is True
+    assert len(got) < 200  # stopped early
+
+
+@pytest.mark.asyncio
+async def test_serial_equivalence(tmp_path: Path) -> None:
+    """concurrency=1 is the legacy one-object-at-a-time descent and must find the same set."""
+    _build_tree(tmp_path, 30, versions=2, parts=2)
+    par, _ = await _collect(tmp_path, concurrency=8, shard=0, shards=1, deadline=None)
+    ser, _ = await _collect(tmp_path, concurrency=1, shard=0, shards=1, deadline=None)
+    assert {(i.object_id, i.object_version, i.part_number) for i in par} == {
+        (i.object_id, i.object_version, i.part_number) for i in ser
+    }
+
+
+@pytest.mark.asyncio
+async def test_missing_root_is_empty_not_error(tmp_path: Path) -> None:
+    got, state = await _collect(tmp_path / "does-not-exist", concurrency=4, shard=0, shards=1, deadline=None)
+    assert got == []
+    assert state.objects_scanned == 0
+
+
+@pytest.mark.asyncio
+async def test_stat_prefers_meta_then_falls_back_to_part_dir(tmp_path: Path) -> None:
+    """meta.json's mtime is the readiness signal; without it the part dir's is used."""
+    d = tmp_path / f"{1:032x}" / "v1" / "part_1"
+    d.mkdir(parents=True)
+    (d / "chunk_0.bin").write_bytes(b"x")
+    (d / "meta.json").write_text("{}")
+    meta_mtime = 1_000_000.0
+    os.utime(d / "meta.json", (meta_mtime, meta_mtime))
+    got, _ = await _collect(tmp_path, concurrency=2, shard=0, shards=1, deadline=None)
+    assert len(got) == 1
+    assert got[0].mtime == pytest.approx(meta_mtime)
+
+    # Now a part with no meta.json → falls back to the dir's own mtime.
+    d2 = tmp_path / f"{2:032x}" / "v1" / "part_1"
+    d2.mkdir(parents=True)
+    (d2 / "chunk_0.bin").write_bytes(b"x")
+    got2, _ = await _collect(tmp_path, concurrency=2, shard=0, shards=1, deadline=None)
+    assert len(got2) == 2
+
+
+@pytest.mark.asyncio
+async def test_malformed_dir_names_are_skipped(tmp_path: Path) -> None:
+    _build_tree(tmp_path, 5)
+    # junk that must not crash the walk or be yielded
+    (tmp_path / "not-an-object" / "vXX" / "part_zz").mkdir(parents=True)
+    (tmp_path / f"{99:032x}" / "vbad").mkdir(parents=True)
+    (tmp_path / f"{98:032x}" / "v1" / "partZ").mkdir(parents=True)
+    got, _ = await _collect(tmp_path, concurrency=4, shard=0, shards=1, deadline=None)
+    # only the 5 well-formed parts
+    assert len(got) == 5
+
+
+def test_shard_helper_is_stable_and_bounded() -> None:
+    oid = "a" * 32
+    assert _object_in_shard(oid, 0, 1) is True  # shards<=1 always in
+    hits = [s for s in range(8) if _object_in_shard(oid, s, 8)]
+    assert len(hits) == 1  # exactly one shard claims it
+    # stable across calls
+    assert _object_in_shard(oid, hits[0], 8) is True

--- a/workers/CLAUDE.md
+++ b/workers/CLAUDE.md
@@ -33,12 +33,21 @@ Each `run_*_in_loop.py` is a thin wrapper that imports the shared logic and prov
 - **Elevated** (85-95%): halve the hot-retention window. Evict replicated + cold regardless of age.
 - **Critical** (≥95%): hot retention disabled. Evict replicated + cold aggressively. If nothing replicated → log ERROR, do nothing.
 
+### Cycle order (durability first) + walk bounding
+
+The **DB-only durability phases run FIRST**, before the FS walks — the replication-gate sentinel and the A21 aged-orphan gauge. Deliberate: the FS cache is a single flat CephFS directory of millions of object dirs, and a full walk is metadata-latency bound (~40 objects/s serial on prod → ~20h a pass). Before this ordering those two ran LAST, behind two full-tree walks that never finished, so on prod they never ran at all. They must not be gated on the cache walk.
+
+The FS-walk phases are **parallel, sharded, and budgeted** so a cycle always completes:
+- `iter_part_dirs` fans the per-object descent across a thread pool (`HIPPIUS_JANITOR_WALK_CONCURRENCY`, default 8) so many CephFS metadata roundtrips are in flight at once — the single-threaded event-loop walk was the bottleneck, not the DB (per-part queries are 0.1–0.7ms, indexed).
+- Each cycle covers one hash-shard (`HIPPIUS_JANITOR_WALK_SHARDS`, default 64) of the tree; a full sweep takes `shards` cycles. Under disk pressure `shards=1` (whole tree every cycle).
+- Each walk phase stops at `HIPPIUS_JANITOR_WALK_BUDGET_SECONDS` (default 240s); **lifted to unbounded under CRITICAL pressure** so freeing space is never capped by a clock.
+
 ### Cleanup passes
 
-- `cleanup_stale_parts` ([run_janitor_in_loop.py:253](run_janitor_in_loop.py)) — delete parts whose mtime > `MPU_STALE_SECONDS`. DLQ protection via `get_all_dlq_object_ids` ([line 220](run_janitor_in_loop.py)) — scans every upload DLQ + unpin DLQ dynamically per `config.upload_backends` so new backends automatically get protected.
-- Age-based GC — classify by age bucket (0-1h / 1-6h / 6-24h / 1-3d / 3-7d / 7d+), gate on replication, honor hot retention.
-- Orphan `.tmp.*` cleanup — delete if older than `TMP_FILE_MAX_AGE_SECONDS=3600` (1h). Catches crashed atomic writes.
-- Hard-delete for soft-deleted objects whose unpins have been confirmed on every backend.
+- `cleanup_stale_parts` — delete parts whose mtime > `MPU_STALE_SECONDS` (orphan-with-no-DB-row reap + terminally-abandoned reclaim). DLQ protection via `get_all_dlq_object_ids` — scans every upload + unpin DLQ per `config.upload_backends`. Fail-closed if the DLQ set is unavailable.
+- Age-based GC (`cleanup_old_parts_by_mtime`) — classify by age bucket (0-1h / 1-6h / 6-24h / 1-3d / 3-7d / 7d+), gate on replication, honor hot retention. The census (parts/age-buckets/hot) is accumulated across a full sharded sweep and published only when the sweep completes untruncated, so the gauges reflect the whole cache, not one shard.
+- Orphan `.tmp.*` cleanup — delete if older than `TMP_FILE_MAX_AGE_SECONDS=3600` (1h). Same sharded parallel descent as the GC walk (was a full-tree `rglob` that also blocked the loop for hours).
+- Hard-delete for soft-deleted objects whose unpins have been confirmed on every backend (DB-bound, batch-capped).
 
 ### Metrics (OTel observable gauges + counters)
 

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -28,10 +28,13 @@ import os
 import shutil
 import sys
 import time
+import zlib
 from collections.abc import AsyncIterator
 from collections.abc import Awaitable
 from collections.abc import Callable
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -99,6 +102,20 @@ _fs_hot_parts = 0
 _fs_pressure_mode = 0  # 0 = normal, 1 = elevated, 2 = critical
 _prev_pressure_mode = 0  # C2: last mode returned by _pressure_mode, for hysteresis (single-instance janitor)
 _fs_age_buckets: dict[str, int] = dict.fromkeys(AGE_BUCKET_NAMES, 0)
+# Census is now accumulated across a full sharded sweep (the age-GC walk covers 1/shards of
+# the tree per cycle), then published to the gauges above only when a sweep completes without
+# a budget truncation — so `_fs_parts_on_disk` etc. reflect the whole cache, never one shard
+# or a half-finished pass. Between sweeps the gauges hold the last complete sweep's values.
+_census_accum: dict[str, Any] = {
+    "parts_seen": 0,
+    "hot_parts": 0,
+    "oldest_mtime": None,
+    "age_counts": dict.fromkeys(AGE_BUCKET_NAMES, 0),
+}
+_census_accum_complete = True
+# Which hash-shard the FS walk covers this cycle. Advances by one every cycle; a full sweep
+# of the tree completes every `janitor_walk_shards` cycles. See config.janitor_walk_shards.
+_walk_shard = 0
 # G2 replication-gate sentinel: live/serveable chunks lacking full-union backend coverage
 # (the population the gate must never reclaim). Any nonzero value is a standing durability
 # alarm; sampled/capped by SENTINEL_SCAN_LIMIT, so a value at the cap means ">=".
@@ -212,6 +229,241 @@ def _safe_iterdir(path: Path) -> Iterator[Path]:
         except OSError:
             return
         yield entry
+
+
+@dataclass(frozen=True)
+class PartDirInfo:
+    """One part directory the walk found, with the stat the phases gate on.
+
+    `mtime`/`atime` are read from `meta.json` when present, else the part dir — the same
+    "part complete signal or fall back to the dir" rule the serial walk used.
+    """
+
+    object_id: str
+    object_version: int
+    part_number: int
+    mtime: float
+    atime: float
+
+
+@dataclass
+class WalkState:
+    """Out-of-band result of a walk: whether the wall-clock budget truncated it, and how
+    many object dirs (in this shard) it reached. The census is only trustworthy for a full
+    (untruncated) sweep, so callers check `truncated` before publishing gauges."""
+
+    truncated: bool = False
+    objects_scanned: int = 0
+
+
+def _object_in_shard(object_id: str, shard: int, shards: int) -> bool:
+    # crc32 is deterministic per name, so a given object falls in the same shard every sweep —
+    # rotating `shard` per cycle covers the whole tree over `shards` cycles without a cursor.
+    if shards <= 1:
+        return True
+    return zlib.crc32(object_id.encode("utf-8", "surrogatepass")) % shards == shard % shards
+
+
+def _read_dir_batch(scan_it: Any, n: int) -> tuple[list[str], bool]:
+    """Pull up to `n` sub-directory names from an os.scandir iterator. Returns
+    (names, exhausted). Runs in a worker thread so a slow CephFS readdir never blocks the loop.
+    A vanished/odd entry is skipped, not fatal (the tree mutates under the walk)."""
+    names: list[str] = []
+    for _ in range(n):
+        try:
+            entry = next(scan_it)
+        except StopIteration:
+            return names, True
+        except OSError:
+            return names, True
+        try:
+            if entry.is_dir():
+                names.append(entry.name)
+        except OSError:
+            continue
+    return names, False
+
+
+def _descend_object(root_str: str, object_name: str) -> list[PartDirInfo]:
+    """Blocking descent of ONE object dir → its part dirs, run in a walk thread.
+
+    Mirrors the serial walk exactly: `v<n>` version dirs, `part_<n>` part dirs, stat
+    `meta.json` if present else the part dir. Every FS error is swallowed to a skip — the
+    tree is mutating underneath us. Returns the parts found (possibly empty)."""
+    out: list[PartDirInfo] = []
+    obj_path = os.path.join(root_str, object_name)  # noqa: PTH118 — hot walk path, os.* avoids per-entry Path alloc
+    try:
+        version_scan = os.scandir(obj_path)
+    except OSError:
+        return out
+    with version_scan:
+        for vd in version_scan:
+            name = vd.name
+            if not name.startswith("v"):
+                continue
+            try:
+                if not vd.is_dir():
+                    continue
+            except OSError:
+                continue
+            try:
+                object_version = int(name[1:])
+            except ValueError:
+                continue
+            try:
+                part_scan = os.scandir(vd.path)
+            except OSError:
+                continue
+            with part_scan:
+                for pd in part_scan:
+                    pname = pd.name
+                    if not pname.startswith("part_"):
+                        continue
+                    try:
+                        if not pd.is_dir():
+                            continue
+                    except OSError:
+                        continue
+                    try:
+                        part_number = int(pname.split("_")[1])
+                    except (ValueError, IndexError):
+                        continue
+                    meta = os.path.join(pd.path, "meta.json")  # noqa: PTH118
+                    try:
+                        st = os.stat(meta)  # noqa: PTH116
+                    except OSError:
+                        try:
+                            st = os.stat(pd.path)  # noqa: PTH116
+                        except OSError:
+                            continue
+                    out.append(PartDirInfo(object_name, object_version, part_number, st.st_mtime, st.st_atime))
+    return out
+
+
+async def _stream_shard_object_names(
+    root_str: str,
+    shard: int,
+    shards: int,
+    deadline: float | None,
+    state: WalkState,
+) -> AsyncIterator[str]:
+    """Stream this shard's object-dir names off the event loop, stopping at the budget deadline."""
+    loop = asyncio.get_running_loop()
+    try:
+        scan_it = await asyncio.to_thread(os.scandir, root_str)
+    except OSError:
+        return
+    try:
+        while True:
+            if deadline is not None and loop.time() >= deadline:
+                state.truncated = True
+                return
+            names, exhausted = await asyncio.to_thread(_read_dir_batch, scan_it, 512)
+            for name in names:
+                if _object_in_shard(name, shard, shards):
+                    state.objects_scanned += 1
+                    yield name
+            if exhausted:
+                return
+    finally:
+        await asyncio.to_thread(scan_it.close)
+
+
+async def iter_part_dirs(
+    root: Path,
+    *,
+    concurrency: int,
+    shard: int,
+    shards: int,
+    deadline: float | None,
+    state: WalkState,
+) -> AsyncIterator[PartDirInfo]:
+    """Walk `root` and yield every part dir in the current shard, descending object dirs
+    across a bounded thread pool so many CephFS metadata roundtrips are in flight at once.
+
+    This replaces the single-threaded, event-loop-blocking `_safe_iterdir` walk that could
+    not complete a pass over ~2.8M object dirs inside a cycle (measured ~40 objects/s serial
+    on prod). Callers apply their own per-part gating + census to the yielded records; the
+    deletion logic downstream is unchanged.
+
+    `concurrency<=1` degrades to a serial descent (legacy behaviour, one object at a time).
+    """
+    concurrency = max(1, concurrency)
+    root_str = str(root)
+    loop = asyncio.get_running_loop()
+    executor = ThreadPoolExecutor(max_workers=concurrency, thread_name_prefix="janitor-walk")
+    inflight: set[asyncio.Future[list[PartDirInfo]]] = set()
+    try:
+        async for name in _stream_shard_object_names(root_str, shard, shards, deadline, state):
+            inflight.add(loop.run_in_executor(executor, _descend_object, root_str, name))
+            if len(inflight) >= concurrency:
+                done, inflight = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
+                for fut in done:
+                    for info in fut.result():
+                        yield info
+        while inflight:
+            done, inflight = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
+            for fut in done:
+                for info in fut.result():
+                    yield info
+    finally:
+        for fut in inflight:
+            fut.cancel()
+        executor.shutdown(wait=False)
+
+
+def _walk_deadline(loop: asyncio.AbstractEventLoop, pressure: int, budget: int) -> float | None:
+    """The wall-clock deadline for one FS-walk phase. None (unbounded) under CRITICAL pressure
+    or when the budget is disabled — freeing space must never be capped by a clock."""
+    if pressure >= 2 or budget <= 0:
+        return None
+    return loop.time() + budget
+
+
+def _reset_census_accum() -> None:
+    global _census_accum, _census_accum_complete
+    _census_accum = {
+        "parts_seen": 0,
+        "hot_parts": 0,
+        "oldest_mtime": None,
+        "age_counts": dict.fromkeys(AGE_BUCKET_NAMES, 0),
+    }
+    _census_accum_complete = True
+
+
+def _accumulate_census(stats: dict[str, Any], shard_complete: bool) -> None:
+    """Fold one shard's census into the in-progress sweep. `shard_complete` is False if the
+    shard's walk hit the budget, which taints the whole sweep's completeness."""
+    global _census_accum_complete
+    _census_accum["parts_seen"] += stats["parts_seen"]
+    _census_accum["hot_parts"] += stats["hot_parts"]
+    for bucket, count in stats["age_counts"].items():
+        _census_accum["age_counts"][bucket] += count
+    om = stats["oldest_mtime"]
+    if om is not None and (_census_accum["oldest_mtime"] is None or om < _census_accum["oldest_mtime"]):
+        _census_accum["oldest_mtime"] = om
+    if not shard_complete:
+        _census_accum_complete = False
+
+
+def _publish_census(now: float) -> None:
+    """Publish the completed sweep's census to the gauges, then reset for the next sweep.
+    A sweep tainted by a budget truncation is dropped (gauges hold their last complete value)
+    rather than reported as a full census that undercounts. The pressure gauge is owned by
+    _update_disk_metrics (refreshed every cycle top), so it is not touched here."""
+    global _fs_parts_on_disk, _fs_oldest_age_seconds, _fs_age_buckets, _fs_hot_parts
+    if _census_accum_complete:
+        oldest_mtime = _census_accum["oldest_mtime"]
+        _fs_parts_on_disk = _census_accum["parts_seen"]
+        _fs_oldest_age_seconds = max(0.0, now - float(oldest_mtime)) if oldest_mtime is not None else 0.0
+        _fs_age_buckets = dict(_census_accum["age_counts"])
+        _fs_hot_parts = _census_accum["hot_parts"]
+    else:
+        logger.info(
+            "Census sweep truncated by walk budget — holding last complete census (partial parts_seen=%d)",
+            _census_accum["parts_seen"],
+        )
+    _reset_census_accum()
 
 
 def _update_disk_metrics(root: Path) -> None:
@@ -414,6 +666,11 @@ async def cleanup_stale_parts(
     pool: asyncpg.Pool,
     fs_store: FileSystemPartsStore,
     redis_client: Redis,
+    *,
+    shard: int = 0,
+    shards: int = 1,
+    walk_concurrency: int = 1,
+    deadline: float | None = None,
 ) -> int:
     """Conservative cleanup of stale parts: rely on FS mtime only for now.
 
@@ -422,10 +679,10 @@ async def cleanup_stale_parts(
     approach: remove only parts whose meta/dir mtime is older than the
     configured stale threshold and which have no recent DB part activity.
 
-    The FS walk (cheap, stat-only) runs in the producer; the per-part DB checks
-    and deletes run with bounded concurrency over a connection pool — see
-    `_run_worker_pool`. At 3M+ parts the old serial single-connection loop could
-    not complete a pass in a day; this parallelizes the DB-roundtrip bottleneck.
+    The FS walk (parallel, stat-only) runs in the producer via `iter_part_dirs`; the
+    per-part DB checks and deletes run with bounded concurrency over a connection pool
+    (`_run_worker_pool`). The walk is sharded + budgeted so it cannot monopolise the cycle:
+    it descends only this cycle's shard and stops at `deadline`. Deletion logic is unchanged.
     """
     stale_threshold_seconds = config.mpu_stale_seconds
     cutoff_sql = "NOW() - INTERVAL '1 second' * $4"
@@ -447,51 +704,30 @@ async def cleanup_stale_parts(
 
     mtime_cutoff = time.time() - stale_threshold_seconds
 
+    walk_state = WalkState()
+
     async def candidates() -> AsyncIterator[tuple[str, int, int]]:
-        scanned = 0
-        for object_dir in _safe_iterdir(root):
-            if not object_dir.is_dir():
+        async for part in iter_part_dirs(
+            root,
+            concurrency=walk_concurrency,
+            shard=shard,
+            shards=shards,
+            deadline=deadline,
+            state=walk_state,
+        ):
+            if part.mtime > mtime_cutoff:
+                # Recently touched, skip
                 continue
-            object_id = object_dir.name
-            for version_dir in _safe_iterdir(object_dir):
-                if not version_dir.is_dir() or not version_dir.name.startswith("v"):
-                    continue
-                try:
-                    object_version = int(version_dir.name[1:])
-                except (ValueError, IndexError):
-                    continue
 
-                for part_dir in _safe_iterdir(version_dir):
-                    if not part_dir.is_dir() or not part_dir.name.startswith("part_"):
-                        continue
-                    try:
-                        part_number = int(part_dir.name.split("_")[1])
-                    except (ValueError, IndexError):
-                        continue
+            # Skip deletion if object is in DLQ
+            if part.object_id in dlq_object_ids:
+                logger.debug(
+                    f"Skipping DLQ-protected part: object_id={part.object_id} "
+                    f"v={part.object_version} part={part.part_number}"
+                )
+                continue
 
-                    scanned += 1
-                    if scanned % 5000 == 0:
-                        await asyncio.sleep(0)  # yield so workers drain while we walk
-
-                    meta_file = part_dir / "meta.json"
-                    check_path = meta_file if meta_file.exists() else part_dir
-                    try:
-                        mtime = check_path.stat().st_mtime
-                    except OSError:
-                        continue
-
-                    if mtime > mtime_cutoff:
-                        # Recently touched, skip
-                        continue
-
-                    # Skip deletion if object is in DLQ
-                    if object_id in dlq_object_ids:
-                        logger.debug(
-                            f"Skipping DLQ-protected part: object_id={object_id} v={object_version} part={part_number}"
-                        )
-                        continue
-
-                    yield (object_id, object_version, part_number)
+            yield (part.object_id, part.object_version, part.part_number)
 
     async def handle(conn: asyncpg.Connection, item: tuple[str, int, int]) -> bool:
         object_id, object_version, part_number = item
@@ -561,7 +797,14 @@ async def cleanup_stale_parts(
             return False
 
     parts_cleaned = await _run_worker_pool(pool, candidates(), handle, config.janitor_concurrency)
-    logger.info(f"Janitor cleaned {parts_cleaned} stale parts by mtime threshold")
+    logger.info(
+        "Janitor cleaned %d stale parts by mtime threshold (shard=%d/%d objects_scanned=%d truncated=%s)",
+        parts_cleaned,
+        shard,
+        shards,
+        walk_state.objects_scanned,
+        walk_state.truncated,
+    )
     return parts_cleaned
 
 
@@ -733,39 +976,104 @@ async def is_terminally_abandoned(
     return bool(row and row["abandoned"])
 
 
-async def cleanup_orphan_tmp_files(fs_store: FileSystemPartsStore) -> int:
+def _descend_object_tmp(root_str: str, object_name: str, cutoff: float) -> int:
+    """Blocking: unlink `*.tmp.*` files older than `cutoff` under one object dir's part dirs.
+    Runs in a walk thread. Returns how many it removed. Every FS error is a skip."""
+    removed = 0
+    obj_path = os.path.join(root_str, object_name)  # noqa: PTH118 — hot walk path
+    try:
+        version_scan = os.scandir(obj_path)
+    except OSError:
+        return 0
+    with version_scan:
+        for vd in version_scan:
+            if not vd.name.startswith("v"):
+                continue
+            try:
+                if not vd.is_dir():
+                    continue
+            except OSError:
+                continue
+            try:
+                part_scan = os.scandir(vd.path)
+            except OSError:
+                continue
+            with part_scan:
+                for pd in part_scan:
+                    if not pd.name.startswith("part_"):
+                        continue
+                    try:
+                        if not pd.is_dir():
+                            continue
+                    except OSError:
+                        continue
+                    try:
+                        file_scan = os.scandir(pd.path)
+                    except OSError:
+                        continue
+                    with file_scan:
+                        for f in file_scan:
+                            if ".tmp." not in f.name:
+                                continue
+                            try:
+                                if not f.is_file():
+                                    continue
+                                if f.stat().st_mtime > cutoff:
+                                    continue
+                                os.unlink(f.path)  # noqa: PTH108
+                                removed += 1
+                            except OSError:
+                                continue
+    return removed
+
+
+async def cleanup_orphan_tmp_files(
+    fs_store: FileSystemPartsStore,
+    *,
+    shard: int = 0,
+    shards: int = 1,
+    walk_concurrency: int = 1,
+    deadline: float | None = None,
+) -> int:
     """Remove orphan atomic-write temp files that outlived a crashed worker.
 
-    Workers use `<target>.tmp.<uuid>` as the tempfile for atomic rename.
-    If the worker crashes between creating the tempfile and renaming it,
-    the tempfile is left behind. Delete anything named `*.tmp.*` older than
-    `TMP_FILE_MAX_AGE_SECONDS`.
+    Workers use `<target>.tmp.<uuid>` as the tempfile for atomic rename. A crash between
+    create and rename leaves it behind; delete anything named `*.tmp.*` older than
+    `TMP_FILE_MAX_AGE_SECONDS`. Uses the same sharded, budgeted, parallel descent as the GC
+    walk — the previous `root.rglob("*.tmp.*")` was a full-tree walk on the event loop, so on
+    a multi-million-object cache it would block the loop for hours (the same starvation the GC
+    walk had), never mind that it ran after the phase that already never returned.
     """
     root = fs_store.root
     if not root.exists():
         return 0
 
-    now = time.time()
-    cutoff = now - TMP_FILE_MAX_AGE_SECONDS
+    root_str = str(root)
+    cutoff = time.time() - TMP_FILE_MAX_AGE_SECONDS
+    loop = asyncio.get_running_loop()
+    concurrency = max(1, walk_concurrency)
+    executor = ThreadPoolExecutor(max_workers=concurrency, thread_name_prefix="janitor-tmp")
+    state = WalkState()
     removed = 0
-
-    # rglob is fine; the FS is bounded by active objects
-    for path in root.rglob("*.tmp.*"):
-        try:
-            if not path.is_file():
-                continue
-            if path.stat().st_mtime > cutoff:
-                continue
-            path.unlink()
-            removed += 1
-            logger.info(f"Removed orphan tmp file: {path}")
-        except OSError as e:
-            logger.debug(f"Skip orphan tmp {path}: {e}")
+    inflight: set[asyncio.Future[int]] = set()
+    try:
+        async for name in _stream_shard_object_names(root_str, shard, shards, deadline, state):
+            inflight.add(loop.run_in_executor(executor, _descend_object_tmp, root_str, name, cutoff))
+            if len(inflight) >= concurrency:
+                done, inflight = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
+                removed += sum(f.result() for f in done)
+        while inflight:
+            done, inflight = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
+            removed += sum(f.result() for f in done)
+    finally:
+        for fut in inflight:
+            fut.cancel()
+        executor.shutdown(wait=False)
 
     if removed > 0 and _janitor_tmp_deleted_counter is not None:
         _janitor_tmp_deleted_counter.add(removed)
     if removed > 0:
-        logger.info(f"Janitor removed {removed} orphan tmp files")
+        logger.info(f"Janitor removed {removed} orphan tmp files (shard={shard}/{shards} truncated={state.truncated})")
     return removed
 
 
@@ -773,6 +1081,12 @@ async def cleanup_old_parts_by_mtime(
     pool: asyncpg.Pool,
     fs_store: FileSystemPartsStore,
     redis_client: Redis,
+    *,
+    shard: int = 0,
+    shards: int = 1,
+    walk_concurrency: int = 1,
+    deadline: float | None = None,
+    publish_sweep: bool = True,
 ) -> int:
     """Safe, replication-gated GC.
 
@@ -844,108 +1158,91 @@ async def cleanup_old_parts_by_mtime(
         "oldest_mtime": None,
         "age_counts": dict.fromkeys(AGE_BUCKET_NAMES, 0),
     }
+    walk_state = WalkState()
 
     async def candidates() -> AsyncIterator[tuple[str, int, int, bool]]:
-        scanned = 0
-        # Walk the FS hierarchy: <root>/<object_id>/v<version>/part_<n>/
-        for object_dir in _safe_iterdir(root):
-            if not object_dir.is_dir():
-                continue
-
-            object_id = object_dir.name
+        # Walk the FS hierarchy <root>/<object_id>/v<version>/part_<n>/ via the parallel,
+        # sharded, budgeted walker. The mtime/atime the census + gating use come straight
+        # from the walk (meta.json if present else the part dir) — identical to the old
+        # inline stat, just done in the walk threads.
+        async for part in iter_part_dirs(
+            root,
+            concurrency=walk_concurrency,
+            shard=shard,
+            shards=shards,
+            deadline=deadline,
+            state=walk_state,
+        ):
+            object_id = part.object_id
+            object_version = part.object_version
+            part_number = part.part_number
             is_dlq_protected = object_id in dlq_object_ids
 
-            for version_dir in _safe_iterdir(object_dir):
-                if not version_dir.is_dir() or not version_dir.name.startswith("v"):
+            stats["parts_seen"] += 1
+
+            # Check mtime (for age) and atime (for hot retention).
+            #
+            # ZFS + noatime note: in prod the local-cache volume is a ZFS
+            # dataset mounted `noatime` (see `mount | grep local_object_cache`
+            # → `rw,noatime,xattr,noacl,casesensitive`). `noatime` only
+            # blocks VFS-triggered atime updates on reads (the
+            # `file_accessed() → atime_needs_update() → dirty_inode()`
+            # path). It does NOT block explicit `utimensat(2)` metadata
+            # writes, which go through `setattr()`. Our reader refreshes
+            # atime on every chunk read via `os.utime(path, None)` in
+            # `fs_store.get_chunk`, so hot-retention works correctly here.
+            # OpenZFS PR #4482 ("Fix atime handling and relatime") made
+            # this behaviour consistent — atime is handled purely by VFS
+            # and explicit setattr writes are always honoured regardless
+            # of the mount's noatime flag.
+            #
+            # Side effect: `os.utime(path, None)` sets BOTH atime and
+            # mtime to "now" (UTIME_NOW on both). Recently-read chunks
+            # therefore show `atime == mtime` to the nanosecond — that's
+            # expected, not a bug. It also means reads push mtime
+            # forward, so the mtime-based age check below is more
+            # conservative on actively-read content (treats hot chunks
+            # as younger than their original landing time). Replication
+            # is still the absolute gate, so this only relaxes, never
+            # tightens, what we delete.
+            try:
+                mtime = part.mtime
+                atime = part.atime
+                if stats["oldest_mtime"] is None or mtime < stats["oldest_mtime"]:
+                    stats["oldest_mtime"] = mtime
+
+                part_age = now - mtime
+                stats["age_counts"][_classify_age_bucket(part_age)] += 1
+
+                is_hot = hot_window > 0 and atime > (now - hot_window)
+                if is_hot:
+                    stats["hot_parts"] += 1
+
+                # Don't clean DLQ-protected parts (only count them for metrics)
+                if is_dlq_protected:
                     continue
 
-                try:
-                    object_version = int(version_dir.name[1:])
-                except (ValueError, IndexError):
+                # Hot files are protected. Under critical pressure
+                # hot_window is 0, which forces is_hot=False, letting
+                # fully-replicated parts become eligible even if recently read.
+                if is_hot:
                     continue
 
-                for part_dir in _safe_iterdir(version_dir):
-                    if not part_dir.is_dir() or not part_dir.name.startswith("part_"):
-                        continue
-                    stats["parts_seen"] += 1
+                # A fully-replicated, cold, non-DLQ part is safe to evict.
+                # Under normal pressure we additionally require age > cutoff
+                # so we don't thrash. Under any pressure level we evict
+                # replicated cold parts regardless of age. The replication
+                # gate itself is enforced in the worker below.
+                old_enough = mtime < cutoff_time
+                if pressure == 0 and not old_enough:
+                    continue
+            except Exception as e:
+                logger.warning(
+                    f"Failed to classify part object_id={object_id} v={object_version} part={part_number}: {e}"
+                )
+                continue
 
-                    try:
-                        part_number = int(part_dir.name.split("_")[1])
-                    except (ValueError, IndexError):
-                        continue
-
-                    scanned += 1
-                    if scanned % 5000 == 0:
-                        await asyncio.sleep(0)  # yield so workers drain while we walk
-
-                    # Check mtime (for age) and atime (for hot retention).
-                    #
-                    # ZFS + noatime note: in prod the local-cache volume is a ZFS
-                    # dataset mounted `noatime` (see `mount | grep local_object_cache`
-                    # → `rw,noatime,xattr,noacl,casesensitive`). `noatime` only
-                    # blocks VFS-triggered atime updates on reads (the
-                    # `file_accessed() → atime_needs_update() → dirty_inode()`
-                    # path). It does NOT block explicit `utimensat(2)` metadata
-                    # writes, which go through `setattr()`. Our reader refreshes
-                    # atime on every chunk read via `os.utime(path, None)` in
-                    # `fs_store.get_chunk`, so hot-retention works correctly here.
-                    # OpenZFS PR #4482 ("Fix atime handling and relatime") made
-                    # this behaviour consistent — atime is handled purely by VFS
-                    # and explicit setattr writes are always honoured regardless
-                    # of the mount's noatime flag.
-                    #
-                    # Side effect: `os.utime(path, None)` sets BOTH atime and
-                    # mtime to "now" (UTIME_NOW on both). Recently-read chunks
-                    # therefore show `atime == mtime` to the nanosecond — that's
-                    # expected, not a bug. It also means reads push mtime
-                    # forward, so the mtime-based age check below is more
-                    # conservative on actively-read content (treats hot chunks
-                    # as younger than their original landing time). Replication
-                    # is still the absolute gate, so this only relaxes, never
-                    # tightens, what we delete.
-                    meta_file = part_dir / "meta.json"
-                    check_path = meta_file if meta_file.exists() else part_dir
-
-                    # A single stat() can race a concurrent delete or return an
-                    # odd value; be conservative and skip the part rather than
-                    # abort the whole walk (matches the pre-split behaviour).
-                    try:
-                        stat = check_path.stat()
-                        mtime = stat.st_mtime
-                        atime = stat.st_atime
-                        if stats["oldest_mtime"] is None or mtime < stats["oldest_mtime"]:
-                            stats["oldest_mtime"] = mtime
-
-                        part_age = now - mtime
-                        stats["age_counts"][_classify_age_bucket(part_age)] += 1
-
-                        is_hot = hot_window > 0 and atime > (now - hot_window)
-                        if is_hot:
-                            stats["hot_parts"] += 1
-
-                        # Don't clean DLQ-protected parts (only count them for metrics)
-                        if is_dlq_protected:
-                            continue
-
-                        # Hot files are protected. Under critical pressure
-                        # hot_window is 0, which forces is_hot=False, letting
-                        # fully-replicated parts become eligible even if recently read.
-                        if is_hot:
-                            continue
-
-                        # A fully-replicated, cold, non-DLQ part is safe to evict.
-                        # Under normal pressure we additionally require age > cutoff
-                        # so we don't thrash. Under any pressure level we evict
-                        # replicated cold parts regardless of age. The replication
-                        # gate itself is enforced in the worker below.
-                        old_enough = mtime < cutoff_time
-                        if pressure == 0 and not old_enough:
-                            continue
-                    except Exception as e:
-                        logger.warning(f"Failed to classify part {part_dir}: {e}")
-                        continue
-
-                    yield (object_id, object_version, part_number, old_enough)
+            yield (object_id, object_version, part_number, old_enough)
 
     async def handle(conn: asyncpg.Connection, item: tuple[str, int, int, bool]) -> bool:
         object_id, object_version, part_number, old_enough = item
@@ -972,15 +1269,19 @@ async def cleanup_old_parts_by_mtime(
 
     parts_cleaned = await _run_worker_pool(pool, candidates(), handle, config.janitor_concurrency)
 
-    # Update the part-census gauges from the walk. Disk-usage + pressure gauges
-    # are owned by _update_disk_metrics (refreshed at cycle top) — don't re-stat
-    # the disk here.
-    oldest_mtime = stats["oldest_mtime"]
-    _fs_parts_on_disk = stats["parts_seen"]
-    _fs_oldest_age_seconds = max(0.0, now - float(oldest_mtime)) if oldest_mtime is not None else 0.0
-    _fs_age_buckets = stats["age_counts"]
-    _fs_hot_parts = stats["hot_parts"]
+    # Census is accumulated across the sharded sweep (this cycle covered shard `shard` of
+    # `shards`) and only published to the gauges when the sweep completes — see
+    # _accumulate_census / _publish_census. Disk-usage + pressure gauges are owned by
+    # _update_disk_metrics (refreshed at cycle top); don't re-stat the disk here.
+    # Pressure is a per-cycle fact (not per-sweep), so publish it every call regardless of the
+    # sharded census; _update_disk_metrics also sets it at cycle top, this keeps it in sync with
+    # the pressure this GC pass actually acted on.
+    global _fs_pressure_mode
     _fs_pressure_mode = pressure
+
+    _accumulate_census(stats, shard_complete=not walk_state.truncated)
+    if publish_sweep:
+        _publish_census(now)
 
     if parts_cleaned > 0 and _janitor_deleted_counter is not None:
         _janitor_deleted_counter.add(parts_cleaned)
@@ -1051,74 +1352,111 @@ async def run_janitor_loop():
     sleep_normal = 600  # 10m
     sleep_pressure = 120  # 2m
 
+    global _walk_shard
+    loop = asyncio.get_running_loop()
+
     try:
         while True:
             logger.info("Janitor cycle starting...")
-            # Refresh disk/pressure gauges up front. The GC walk below can take
-            # hours over millions of parts; disk visibility must not wait on it.
+            # Refresh disk/pressure gauges up front, and read pressure ONCE for the whole cycle.
             _update_disk_metrics(fs_store.root)
-
-            stale_count = 0
-            gc_count = 0
-            hard_deleted = 0
-            tmp_count = 0
-
-            # Phase 1: Clean stale MPU parts (aborted uploads)
-            try:
-                stale_count = await cleanup_stale_parts(db_pool, fs_store, redis_client)
-            except Exception as e:
-                logger.error(f"Phase 1 (stale cleanup) error: {e}", exc_info=True)
-
-            # Phase 2: GC old parts by mtime + update disk/cache metrics
-            try:
-                gc_count = await cleanup_old_parts_by_mtime(db_pool, fs_store, redis_client)
-            except Exception as e:
-                logger.error(f"Phase 2 (GC) error: {e}", exc_info=True)
-
-            # Phase 3: Clean orphan .tmp.* files from crashed atomic writes
-            try:
-                tmp_count = await cleanup_orphan_tmp_files(fs_store)
-            except Exception as e:
-                logger.error(f"Phase 3 (tmp cleanup) error: {e}", exc_info=True)
-
-            # Phase 4: Hard-delete soft-deleted objects where all unpins are confirmed
-            try:
-                hard_deleted = await gc_soft_deleted_objects(db_pool)
-            except Exception as e:
-                logger.error(f"Phase 4 (hard delete) error: {e}", exc_info=True)
-
-            # Phase 5: read-only replication-gate sentinel (G2). Publishes the durability
-            # gauge and alarms on any live/serveable chunk lacking full-union coverage.
             pressure = _pressure_mode(fs_store.root)
+
+            # --- DB-only DURABILITY phases run FIRST ------------------------------------------
+            # These used to run LAST, behind two full-tree FS walks. cleanup_stale_parts could
+            # not finish a pass over ~2.8M object dirs inside a cycle, so on prod these never ran
+            # at all — the replication-gate sentinel and the A21 aged-orphan leak gauge went dark.
+            # They are single indexed DB reads; nothing about the FS cache should gate them.
             sentinel_violations = 0
             try:
                 sentinel_violations = await check_replication_sentinel(db_pool, pressure)
             except Exception as e:
-                logger.error(f"Phase 5 (replication sentinel) error: {e}", exc_info=True)
+                logger.error(f"Replication sentinel error: {e}", exc_info=True)
 
-            # Phase 6: read-only aged-pending orphan gauge (A21 soak-gate feed). Publishes the
-            # standing leak backlog the replicated-only soak gate cannot see. The DLQ set is
-            # gathered fresh via the janitor's fail-closed get_all_dlq_object_ids and excluded so
-            # the gauge counts EXACTLY the population the sweep clears — a DLQ-parked orphan the
-            # sweep skips must not read as a phantom leak. On a DLQ-read failure the whole phase is
-            # skipped (gauge holds its prior value) rather than over-counting against an empty set.
-            # Note: the sweep's own DLQ set comes from mpu_cleanup.gather_dlq_object_ids, which is
-            # BEST-EFFORT (a Redis read failure logs and skips that key rather than aborting), so
-            # under a partial Redis failure the two briefly diverge — the sweep proceeds with a
-            # smaller set (clears more) while this gauge deliberately fails closed and stalls.
+            # Aged-pending orphan gauge (A21 soak-gate feed). The DLQ set is gathered fresh via
+            # the fail-closed get_all_dlq_object_ids and excluded so the gauge counts EXACTLY the
+            # population the sweep clears; on a DLQ-read failure the whole phase is skipped (gauge
+            # holds its prior value) rather than over-counting against an empty set.
             aged_orphans = 0
             try:
                 gauge_dlq_object_ids = await get_all_dlq_object_ids(redis_client)
                 aged_orphans = await check_aged_pending_orphans(db_pool, gauge_dlq_object_ids)
             except Exception as e:
-                logger.error(f"Phase 6 (aged-pending orphan gauge) error: {e}", exc_info=True)
+                logger.error(f"Aged-pending orphan gauge error: {e}", exc_info=True)
+
+            # --- FS-walk phases: sharded + budgeted so the cycle ALWAYS completes -------------
+            # Each cycle covers one hash-shard of the tree; a full sweep takes `shards` cycles.
+            # Under disk pressure we walk the whole tree every cycle (shards=1) and, at CRITICAL,
+            # lift the wall-clock budget entirely — freeing space must never be capped by a clock.
+            shards = 1 if pressure > 0 else max(1, config.janitor_walk_shards)
+            walk_shard = _walk_shard % shards
+            publish_sweep = walk_shard == shards - 1  # census publishes when the sweep wraps
+            walk_conc = max(1, config.janitor_walk_concurrency)
+            budget = config.janitor_walk_budget_seconds
+
+            stale_count = 0
+            gc_count = 0
+            tmp_count = 0
+            hard_deleted = 0
+
+            # Phase A: clean stale/orphan/terminally-abandoned parts (each phase gets its OWN
+            # fresh budget so the first walk can't starve the second — the bug we are fixing).
+            try:
+                stale_count = await cleanup_stale_parts(
+                    db_pool,
+                    fs_store,
+                    redis_client,
+                    shard=walk_shard,
+                    shards=shards,
+                    walk_concurrency=walk_conc,
+                    deadline=_walk_deadline(loop, pressure, budget),
+                )
+            except Exception as e:
+                logger.error(f"Stale cleanup error: {e}", exc_info=True)
+
+            # Phase B: replication-gated age GC + census (census published only on a full sweep).
+            try:
+                gc_count = await cleanup_old_parts_by_mtime(
+                    db_pool,
+                    fs_store,
+                    redis_client,
+                    shard=walk_shard,
+                    shards=shards,
+                    walk_concurrency=walk_conc,
+                    deadline=_walk_deadline(loop, pressure, budget),
+                    publish_sweep=publish_sweep,
+                )
+            except Exception as e:
+                logger.error(f"Age-GC error: {e}", exc_info=True)
+
+            # Phase C: orphan .tmp.* files from crashed atomic writes.
+            try:
+                tmp_count = await cleanup_orphan_tmp_files(
+                    fs_store,
+                    shard=walk_shard,
+                    shards=shards,
+                    walk_concurrency=walk_conc,
+                    deadline=_walk_deadline(loop, pressure, budget),
+                )
+            except Exception as e:
+                logger.error(f"Tmp cleanup error: {e}", exc_info=True)
+
+            # Phase D: hard-delete soft-deleted objects where all unpins are confirmed (DB-bound,
+            # batch-capped — cannot starve the cycle).
+            try:
+                hard_deleted = await gc_soft_deleted_objects(db_pool)
+            except Exception as e:
+                logger.error(f"Hard delete error: {e}", exc_info=True)
+
+            _walk_shard += 1  # advance the shard for next cycle
 
             logger.info(
-                f"Janitor cycle complete: stale={stale_count} gc={gc_count} tmp={tmp_count} "
-                f"hard_deleted={hard_deleted} sentinel_violations={sentinel_violations} aged_orphans={aged_orphans}"
+                f"Janitor cycle complete: shard={walk_shard}/{shards} publish_sweep={publish_sweep} "
+                f"stale={stale_count} gc={gc_count} tmp={tmp_count} hard_deleted={hard_deleted} "
+                f"sentinel_violations={sentinel_violations} aged_orphans={aged_orphans}"
             )
 
-            # Pick sleep interval based on current pressure (already probed for Phase 5)
+            # Pick sleep interval based on current pressure.
             sleep_interval = sleep_pressure if pressure > 0 else sleep_normal
             logger.info(f"Janitor sleeping {sleep_interval}s (pressure={pressure})")
             await asyncio.sleep(sleep_interval)

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -447,9 +447,10 @@ def _accumulate_census(stats: dict[str, Any], shard_complete: bool) -> None:
 
 
 def _publish_census(now: float) -> None:
-    """Publish the completed sweep's census to the gauges, then reset for the next sweep.
-    A sweep tainted by a budget truncation is dropped (gauges hold their last complete value)
-    rather than reported as a full census that undercounts. The pressure gauge is owned by
+    """Publish the completed sweep's census to the gauges. A sweep tainted by a budget
+    truncation is dropped (gauges hold their last complete value) rather than reported as a
+    full census that undercounts. The accumulator is reset at the NEXT sweep's shard 0, not
+    here, so a same-cycle re-read stays consistent. The pressure gauge is owned by
     _update_disk_metrics (refreshed every cycle top), so it is not touched here."""
     global _fs_parts_on_disk, _fs_oldest_age_seconds, _fs_age_buckets, _fs_hot_parts
     if _census_accum_complete:
@@ -463,7 +464,6 @@ def _publish_census(now: float) -> None:
             "Census sweep truncated by walk budget — holding last complete census (partial parts_seen=%d)",
             _census_accum["parts_seen"],
         )
-    _reset_census_accum()
 
 
 def _update_disk_metrics(root: Path) -> None:
@@ -1279,6 +1279,12 @@ async def cleanup_old_parts_by_mtime(
     global _fs_pressure_mode
     _fs_pressure_mode = pressure
 
+    # A sweep always starts at shard 0, so reset the accumulator there. This bounds the
+    # accumulator to exactly one sweep even if `shards` changed mid-sweep (e.g. a pressure
+    # transition flips it to 1) — without it the old partial sweep's counts would blend into
+    # the new one and inflate the published census once.
+    if shard == 0:
+        _reset_census_accum()
     _accumulate_census(stats, shard_complete=not walk_state.truncated)
     if publish_sweep:
         _publish_census(now)


### PR DESCRIPTION
The janitor runs six phases per cycle. Phases 1 (`cleanup_stale_parts`) and 2 (age-GC) each walk the **entire** CephFS pool cache single-threaded on the event loop, *before* the DB-only durability phases. On prod, phase 1 never returns within a cycle — so age-GC, the census gauges, the **replication-gate sentinel**, and the **A21 aged-orphan leak gauge** never run. This is the functional gap PR #331's cycle-health metric exposed.

## Root cause (measured on prod, 2026-07-23)

- The cache root is a **single flat directory of ~2.8M object dirs** (`nlink=2804506`); a bare `ls` of it exceeds 30s.
- `Path.iterdir()` → `os.listdir()` **materialises all 2.8M entries** before yielding the first — a >30s stall + memory spike, on every walk, done twice per cycle.
- The walk descends + stats at **~40 object-dirs/s** (CephFS MDS latency-bound, single-threaded) → a full pass is **~20 hours**. So phase 1 never returns and phases 2–6 never run.
- **The DB is not the bottleneck:** the per-candidate queries are 0.11 ms and 0.68 ms, indexed (`parts_object_version_part_unique`), ~16k candidates/s across the 16-worker pool.

| signal | value |
|---|---|
| object dirs in the flat cache root | **2,804,505** |
| serial walk throughput (scandir+descend+stat) | **39 obj/s** → ~20h/pass |
| "Cleaned stale part by mtime" in one ~2h window | 18,737 |
| janitor cycle completions in that window | **0** |

## Fix

**Deletion predicates and the per-part DB checks are byte-for-byte unchanged.** Only the walk mechanism and phase order change. The tests pin exactly that.

1. **Reorder — durability first.** The DB-only phases (disk-pressure probe, replication sentinel, aged-orphan gauge) now run *first*, every cycle, so no FS-walk cost can starve them. This alone fixes the durability half.

2. **Parallelise the walk.** New `iter_part_dirs` fans the per-object descent across a thread pool (`HIPPIUS_JANITOR_WALK_CONCURRENCY`, default 8) using `os.scandir` — no `os.listdir` materialisation, `is_dir()` without an extra stat, many CephFS roundtrips in flight. **Benchmarked ~8×** (70 → 554 obj/s) under simulated 10 ms/object latency; ~14× at concurrency 16. `=1` restores the legacy serial walk for instant rollback.

3. **Shard + budget.** Each cycle covers one hash-shard (`HIPPIUS_JANITOR_WALK_SHARDS`, default 64) of the tree; a full sweep takes `shards` cycles so no object waits behind an always-truncated prefix. Each walk phase stops at `HIPPIUS_JANITOR_WALK_BUDGET_SECONDS` (default 240s) so the cycle always completes. **Under disk pressure `shards=1`** (whole tree every cycle) and **at CRITICAL the budget is lifted** — freeing space is never capped by a clock.

4. **Sweep-scoped census.** Accumulated across a full sharded sweep and published only when the sweep completes untruncated, so `fs_store_parts_on_disk` / age buckets / hot reflect the whole cache, never one shard or a half-finished pass.

5. **Phase 3 too.** `cleanup_orphan_tmp_files` had the identical bug via `root.rglob("*.tmp.*")` — a full-tree blocking walk — and gets the same sharded parallel descent.

## Safety

Every existing janitor safety test passes unchanged: the replication gate, hot retention, elevated/critical pressure, DLQ protection, terminally-abandoned reclaim, critical-pressure-blocked paging. The one behavioural invariant sharding could threaten — *does splitting the walk change what gets deleted?* — is pinned by a test asserting **the union of deletions over all shards equals the un-sharded run**, for both the age-GC and the stale/orphan reap.

## Tests

- `tests/unit/test_janitor_walk.py` — walk completeness, **shard-union == full walk**, budget truncation flags, serial (`concurrency=1`) equivalence, meta-vs-dir stat fallback, malformed-name skip, missing-root.
- `tests/unit/test_janitor_sharded_gc.py` — **shard-union deletions == unsharded** (age-GC *and* stale reap), census publishes only on a full sweep, a truncated sweep holds the last-good census, `_walk_deadline` lifts under critical pressure, and **the reorder: durability phases run before the FS walks**.
- Full unit suite **2014 passed**, 37 skipped. `ruff` / `ruff format` / `ty` (CI scope) clean. Both kustomize overlays unaffected.

## Rollout & tuning

All four knobs are env-tunable with safe defaults; `WALK_CONCURRENCY=1` + `WALK_SHARDS=1` ≈ legacy behaviour. The walk logs `truncated=<bool>` and `objects_scanned` per shard, so if the ~2.8M cache needs a different shard count (the walk shouldn't truncate at steady state), it's visible and adjustable without a redeploy. Recommend deploying to staging, watching a full sweep, then tuning `WALK_SHARDS` on prod against the observed per-cycle `objects_scanned`.

## Not in this PR (follow-ups)

- The three FS-walk phases still each walk the tree separately; unifying them into one descent would cut the per-sweep metadata cost ~3×.
- The flat 2.8M-entry cache directory is itself a CephFS anti-pattern; a hashed subdirectory layout would make every walk cheaper.
- Pairs naturally with #331 (which added `fs_janitor_last_cycle_age_seconds`) — that gauge is how you confirm this fix is working in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)