### PR TITLE
release: staging → prod 2026-07-24

### DIFF
--- a/.github/workflows/production-smoke-tests.yml
+++ b/.github/workflows/production-smoke-tests.yml
@@ -32,7 +32,10 @@ jobs:
           pip install --upgrade pip
           pip install -r tests/smoke/requirements.txt
 
+      # Per-step timeouts keep a hung suite below the job's 30-minute cap: a job-level
+      # timeout cancels the remaining steps, so the failure notification would never fire.
       - name: Run smoke tests against s3.hippius.com
+        timeout-minutes: 8
         env:
           AWS_ACCESS_KEY: ${{ secrets.HIPPIUS_PROD_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.HIPPIUS_PROD_SECRET_KEY }}
@@ -48,6 +51,7 @@ jobs:
 
       - name: Run smoke tests against regional caches
         if: always()
+        timeout-minutes: 8
         env:
           AWS_ACCESS_KEY: ${{ secrets.HIPPIUS_PROD_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.HIPPIUS_PROD_SECRET_KEY }}
@@ -64,6 +68,7 @@ jobs:
 
       - name: Run sub-token scope smoke tests against s3.hippius.com
         if: always()
+        timeout-minutes: 8
         env:
           AWS_ACCESS_KEY: ${{ secrets.HIPPIUS_PROD_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.HIPPIUS_PROD_SECRET_KEY }}

--- a/docs/redis-queues-ha-cutover.md
+++ b/docs/redis-queues-ha-cutover.md
@@ -1,0 +1,109 @@
+# redis-queues HA cutover runbook
+
+**Goal:** move `redis-queues` from a single StatefulSet to the operator-managed
+`RedisReplication` + `RedisSentinel` (`k8s/base/redis-queues-ha.yaml`) with **no s3 downtime**
+and **no regression of the drain's `cephor:epoch` fence**. Staging first; prod only after the
+gating test passes.
+
+## Why this needs a runbook (not a plain deploy)
+`redis-queues` holds two things whose loss is *not* just a cache miss:
+1. the **upload work queue** (`*_upload_requests`, retries) — a dropped entry is a lost upload;
+2. the drain's **`cephor:*` leader lease + epoch fence** — a regressed epoch can let a stale
+   drain-allocator win (split-brain; the `s3-prod-health` "epoch went BACKWARDS" = sev-3).
+
+Redis replication is stream-based (sub-second under normal load), but a Sentinel failover
+promotes a replica that may be missing the last in-flight writes. For the **epoch** (written
+only on leadership changes, rarely) the odds are low but nonzero — so a failover's effect on
+the fence is the **gating acceptance test** below, not an assumption.
+
+`REDIS_QUEUES_URL` currently = `redis://redis-queues:6379/0` (secret `hippius-s3-secrets`).
+The operator exposes a master-following service `redis-queues-ha-master`; the app only needs
+its URL repointed — **no app-code change**.
+
+---
+
+## Phase 0 — Stand up the HA set on STAGING (non-disruptive; the live redis-queues is untouched)
+```bash
+NS=hippius-s3-staging
+kubectl apply -n $NS -f k8s/base/redis-queues-ha.yaml
+# Wait for: 1 master + 2 replicas Ready, 3 sentinels Ready, and the master service present.
+kubectl -n $NS get redisreplication redis-queues-ha redissentinel redis-queues-sentinel
+kubectl -n $NS get pods -l app=redis-queues-ha -o wide
+kubectl -n $NS get svc redis-queues-ha-master        # this is the repoint target
+# Confirm replication is healthy + the master service points at the master:
+kubectl -n $NS exec redis-queues-ha-0 -- redis-cli info replication   # role:master, connected_slaves:2
+```
+Nothing is repointed yet; the old `redis-queues` still serves all traffic.
+
+## Phase 1 — GATING TEST on staging: does a failover regress the fence? (do this BEFORE prod)
+1. Repoint **staging's** `REDIS_QUEUES_URL` → `redis://redis-queues-ha-master:6379/0` (Phase 2
+   method) and roll the staging consumers. Generate active ingest so the drain is live.
+2. Record the fence + leader BEFORE:
+   ```bash
+   kubectl -n $NS exec redis-queues-ha-0 -- redis-cli get cephor:epoch    # note the value
+   # (leader_count via the drain probe / cephor:* keys)
+   ```
+3. **Kill the master** and watch Sentinel promote a replica:
+   ```bash
+   kubectl -n $NS delete pod redis-queues-ha-0            # the current master
+   # within ~5s (downAfterMs) + failoverTimeout, a replica is promoted; master svc follows it
+   kubectl -n $NS get svc redis-queues-ha-master -o jsonpath='{.spec.selector}{"\n"}'  # now the new master
+   ```
+4. **PASS criteria (all must hold):**
+   - `cephor:epoch` **did not decrease** (monotonic ↑ or unchanged);
+   - drain `leader_count` stays exactly **1** (no split-brain), no allocator crash;
+   - a cache-miss GET issued *during* the failover still completes (pub/sub subscribers
+     re-subscribed to `notify:*` on the new master — the operator/client reconnect handles this);
+   - no upload lost (the drain re-enqueues on transient error; verify the queue drains).
+5. **If the epoch regresses or leader_count ≠ 1:** STOP. Do **not** proceed to prod. File a
+   drain-fence-hardening issue (make the allocator tolerant of a redis failover — e.g. re-assert
+   epoch on leadership, or persist the fence with a WAIT/`min-replicas` guard for the epoch key
+   only). The redis manifests can stay; the cutover is blocked on the fence being failover-safe.
+
+## Phase 2 — Data migration (copy the queue + cephor:* keys into the HA master)
+The HA set comes up empty. To cut over without losing pending uploads or the fence, seed it from
+the live `redis-queues` **before** repointing. Recommended (validate on staging):
+```bash
+# Temporarily make the HA master replicate the live standalone redis-queues to copy ALL keys:
+kubectl -n $NS exec redis-queues-ha-0 -- redis-cli replicaof redis-queues 6379
+kubectl -n $NS exec redis-queues-ha-0 -- redis-cli info replication   # master_link_status:up, sync done
+# Then promote it (keeps every key incl. cephor:* + the queues):
+kubectl -n $NS exec redis-queues-ha-0 -- redis-cli replicaof no one
+```
+**Caveat to validate on staging:** the OT operator reconciler manages `replicaof`; confirm it
+does not fight the manual `replicaof` mid-migration (if it does, use a one-shot `redis-cli --rdb`
+dump of the old + `redis-cli -x restore`/`--pipe` load into the new master instead, during a
+brief writer quiesce). Pick whichever staging proves clean; document it here before prod.
+
+## Phase 3 — Repoint + roll consumers (the actual cutover; seconds)
+```bash
+# Patch the secret key (base64) and roll every workload that reads REDIS_QUEUES_URL:
+NEW=$(printf 'redis://redis-queues-ha-master:6379/0' | base64)
+kubectl -n $NS patch secret hippius-s3-secrets --type merge -p "{\"data\":{\"REDIS_QUEUES_URL\":\"$NEW\"}}"
+kubectl -n $NS rollout restart ds/drain-agent ds/api-local deploy/drain-allocator deploy/mpu-reaper \
+  deploy/arion-uploader deploy/arion-downloader deploy/arion-unpinner   # any consumer of the queues client
+```
+Consumers reconnect to the HA master. The drain is retry-safe, so a per-pod reconnect blip is absorbed.
+
+## Phase 4 — PROD cutover (only after staging Phases 1–3 pass)
+Repeat Phases 0/2/3 in `hippius-s3-prod` during a low-traffic window. Keep the old `redis-queues`
+StatefulSet running (do not delete) until 24–48 h of clean HA operation.
+
+## Rollback (fast, at any point)
+The old standalone `redis-queues` is left running throughout, so rollback = repoint back:
+```bash
+OLD=$(printf 'redis://redis-queues:6379/0' | base64)
+kubectl -n <ns> patch secret hippius-s3-secrets --type merge -p "{\"data\":{\"REDIS_QUEUES_URL\":\"$OLD\"}}"
+kubectl -n <ns> rollout restart ds/drain-agent ds/api-local deploy/drain-allocator deploy/mpu-reaper ...
+```
+If the HA master accumulated new queue entries after cutover, drain them back or accept the
+drain's re-enqueue (idempotent). Instant, no data loss (both redises are CephFS-durable).
+
+## Decommission (after soak)
+Once HA is proven in prod: remove the old `redis-queues` StatefulSet + Service from
+`k8s/base/redis-statefulsets.yaml`, and wire `k8s/base/redis-queues-ha.yaml` into the
+kustomizations so it's the managed default. Separate PR.
+
+## Follow-up: redis-accounts
+`redis-accounts` (persistent credit cache) is the other stateful single-replica Redis — same
+pattern, lower urgency (its miss falls through to the source). Do it after redis-queues soaks.

--- a/docs/redis-queues-ha-cutover.md
+++ b/docs/redis-queues-ha-cutover.md
@@ -35,6 +35,20 @@ kubectl -n $NS exec redis-queues-ha-0 -- redis-cli info replication   # role:mas
 ```
 Nothing is repointed yet; the old `redis-queues` still serves all traffic.
 
+**Two prerequisites are baked into the manifest — learned on staging 2026-07-23 (don't strip them):**
+1. **`podSecurityContext {runAsUser/runAsGroup/fsGroup: 1000}`** — without `fsGroup` the opstree
+   image (uid 1000) can't write `appendonlydir` on the root:root CephFS mount → the master
+   CrashLoops on `Can't open the append-only dir: Permission denied`. Symptom if missing:
+   `redis-queues-ha-0` in CrashLoopBackOff.
+2. **The `allow-redis-operator` NetworkPolicy** — the namespace's `allow-internal` policy does not
+   admit `redis-operator-system`, so every operator→pod dial times out. Symptom if missing:
+   `connected_slaves:0` (replicas never told `slaveof`) **and no sentinel StatefulSet is ever
+   created** (operator errors `Failed to Get the role Info … i/o timeout` and bails before making
+   it). Existing `redis-cluster` is unaffected because RedisCluster self-heals via the in-namespace
+   :16379 gossip bus; RedisReplication+Sentinel needs ongoing operator→pod connectivity.
+
+If Phase 0 shows `connected_slaves:0` or a missing sentinel STS, check these two before anything else.
+
 ## Phase 1 — GATING TEST on staging: does a failover regress the fence? (do this BEFORE prod)
 1. Repoint **staging's** `REDIS_QUEUES_URL` → `redis://redis-queues-ha-master:6379/0` (Phase 2
    method) and roll the staging consumers. Generate active ingest so the drain is live.

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -388,6 +388,31 @@ class Config:
     # cleanup loops are DB-roundtrip bound; this is how many parts are processed
     # in parallel (each over its own pooled connection).
     janitor_concurrency: int = env("HIPPIUS_JANITOR_CONCURRENCY:16", convert=int)
+    # Concurrency for the FS *walk* itself (distinct from janitor_concurrency, which is the
+    # per-part DB roundtrip fan-out). The cache root is a single flat directory of millions of
+    # object dirs on CephFS; a single-threaded walk is metadata-latency bound (~40 objects/s
+    # measured on prod 2026-07-23, so a full pass over ~2.8M objects is ~20h and never completes
+    # inside a cycle — which starves every phase after it). This fans the per-object descent
+    # (scandir + stat) across a thread pool so many CephFS metadata roundtrips are in flight at
+    # once. Set to 1 for the legacy serial walk. Kept modest by default because the same CephFS
+    # MDS serves live GET/PUT — do not crank without watching MDS latency.
+    janitor_walk_concurrency: int = env("HIPPIUS_JANITOR_WALK_CONCURRENCY:8", convert=int)
+    # Wall-clock budget for each FS-walk phase (stale-cleanup, age-GC, tmp-sweep). Once exceeded
+    # the walk stops enqueuing new object dirs and the phase returns, so the cycle always
+    # completes and the phases after it — plus the DB-only durability sentinel + aged-orphan
+    # gauge which now run FIRST regardless — keep ticking. 0 = unbounded. Automatically lifted to
+    # unbounded under CRITICAL disk pressure — freeing space must never be capped by a clock.
+    janitor_walk_budget_seconds: int = env("HIPPIUS_JANITOR_WALK_BUDGET_SECONDS:240", convert=int)
+    # Number of hash-shards the FS walk rotates through, one per cycle, for FAIR coverage: each
+    # cycle descends only into object dirs where crc32(object_id) % shards == cycle_shard, so a
+    # full sweep of the tree takes `shards` cycles and no object waits behind an always-truncated
+    # prefix. SIZING: a shard must fit inside the budget or its tail is never reached — pick
+    # shards ≳ (objects / (walk_concurrency · per-thread-obj/s · budget_s)). At ~2.8M objects,
+    # concurrency 8 (~8× the ~40 obj/s serial rate measured on prod) and a 240s budget, one shard
+    # is ~44k objects → comfortably inside budget; a full sweep is ~64 cycles (~10h at the 600s
+    # normal sleep). Raise it if the cache grows or the walk logs truncated=True; 1 = walk the
+    # whole tree every cycle. Forced to 1 under disk pressure so eviction sees the whole tree.
+    janitor_walk_shards: int = env("HIPPIUS_JANITOR_WALK_SHARDS:64", convert=int)
     # Max soft-deleted objects hard-deleted per janitor cycle. The find query is
     # an index-probe over this many candidates; keep it bounded so a large
     # backlog drains gradually instead of in one DELETE-cascade burst.

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -216,7 +216,22 @@ class Config:
     # (DownloadNotReadyError). Keeps an un-drained/never-arriving object (e.g. a part not yet on any
     # backend) from hanging the whole request up to cache_ttl_seconds (~1h). Later chunks keep the
     # full wait — once the first chunk lands the object is actively draining.
-    stream_first_chunk_timeout_seconds: int = env("HIPPIUS_STREAM_FIRST_CHUNK_TIMEOUT_SECONDS:90", convert=int)
+    #
+    # MUST STAY BELOW THE CLIENT'S READ TIMEOUT. This was 90s, which is above boto3's 60s default,
+    # so the fail-fast never actually reached anyone: the client hung up at 60s and got a dead
+    # socket, which is NOT retryable, while the 503 SlowDown this raises IS. Worse, from the
+    # server's side the request later completed 200, so nothing was recorded as a failure.
+    # Observed 2026-07-23 14:50:05 — a presigned GET returned 200 after processing_time_ms=60167,
+    # 167ms after the client had already given up.
+    #
+    # 25s leaves room for two client-side retries inside one 60s budget. A cross-node
+    # read-after-write costs ~60s end to end (the part lands on one node's SSD; a reconciler
+    # notices, the drain copies it, an enqueue sweep publishes, the uploader uploads — every stage
+    # a poll, not an event), so on a fresh object the FIRST attempt is EXPECTED to 503 and a retry
+    # to succeed. That is the mechanism working, not a failure. Making the read genuinely fast is a
+    # separate problem: serve it from the peer that holds the data instead of waiting out the
+    # pipeline.
+    stream_first_chunk_timeout_seconds: int = env("HIPPIUS_STREAM_FIRST_CHUNK_TIMEOUT_SECONDS:25", convert=int)
     # A3: bound on how long the streamer waits for EACH subsequent chunk (after the first). Without
     # it a later chunk whose backend fetch permanently fails stalls the already-committed 200
     # response up to cache_ttl_seconds (~1h) mid-stream; this caps that to a bounded fail (the

--- a/hippius_s3/scripts/CLAUDE.md
+++ b/hippius_s3/scripts/CLAUDE.md
@@ -33,6 +33,7 @@ Operational and migration scripts. Most are invoked manually by an operator duri
 |---|---|
 | [nuke_user.py](nuke_user.py) | **⚠️ DESTRUCTIVE**. Deletes a user and all their buckets/objects. Usually invoked for GDPR requests or test cleanup. |
 | [purge_buckets.py](purge_buckets.py) | **⚠️ DESTRUCTIVE**. Delete one or more buckets and their contents. |
+| [sweep_partless_multipart_uploads.py](sweep_partless_multipart_uploads.py) | **⚠️ DELETES**, but only MPU headers with **zero** `parts` rows — no chunk data exists behind them, so this is what `AbortMultipartUpload` already does. One-time cleanup of the ~874k such rows (97% of the incomplete backlog) that the mpu-reaper can never reach, because its query INNER-joins to `parts`. Dry run by default; needs `--yes`. Batched with a `statement_timeout` so it cannot itself pin the xmin horizon. |
 
 ## Invocation
 

--- a/hippius_s3/scripts/sweep_partless_multipart_uploads.py
+++ b/hippius_s3/scripts/sweep_partless_multipart_uploads.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""One-time sweep: delete incomplete multipart uploads that never received a part.
+
+WHY THIS EXISTS
+
+The mpu-reaper (`list_abandoned_versions.sql`) joins `multipart_uploads` to `parts` with an
+INNER join, so an upload with zero parts can never be selected and therefore never reaped.
+Nothing else deletes them either — the only other paths are `abort_multipart_upload` and the
+same-key DELETE in `delete_object_endpoint`. So they accumulate forever.
+
+Measured on prod 2026-07-23: **874,823 partless incomplete uploads older than 48h, out of
+904,246 incomplete total — 97% of the backlog.**
+
+That is not just untidy. The reaper's candidate scan walks `idx_multipart_uploads_initiated_at`
+oldest-first, and these are the oldest rows, so every cycle pays to skip past all of them. It is
+why the rewritten query costs ~8s instead of ~0.5s, and the cost grows linearly with a
+population that has no other GC. Clearing it is what makes that query cheap and keeps it cheap.
+
+WHY DELETING IS SAFE
+
+A partless upload is an MPU header with no data behind it: no `parts` row, therefore no
+`part_chunks`, no chunk on the SSD or in any backend. Deleting the header is exactly what
+`AbortMultipartUpload` does, and the only FK pointing at `multipart_uploads` is
+`parts.upload_id ON DELETE CASCADE` — which has nothing to cascade here. The age gate is the
+same `stale_seconds` policy the reaper already applies to abandoned uploads, so a client that
+initiated an MPU and has not uploaded a part in 48h is treated identically to today.
+
+OPERATIONAL SHAPE
+
+Deliberately NOT one big DELETE. This script exists because of an incident where a single
+96-minute statement pinned the xmin horizon and stopped VACUUM database-wide; repeating that
+sin while cleaning up after it would be poor form. So: bounded batches, each its own
+autocommit statement, a hard `statement_timeout`, and a pause between batches so autovacuum and
+normal traffic get the primary back.
+
+    # look first — prints counts and a sample, touches nothing
+    python -m hippius_s3.scripts.sweep_partless_multipart_uploads
+
+    # then, for real
+    python -m hippius_s3.scripts.sweep_partless_multipart_uploads --yes
+
+Resumable: it re-queries each batch, so an interrupted run is continued simply by running it
+again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import time
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import asyncpg  # noqa: E402
+import redis.asyncio as async_redis  # noqa: E402
+
+from hippius_s3.config import get_config  # noqa: E402
+
+
+logger = logging.getLogger("sweep-partless-mpu")
+
+# Counting the whole population is a seq-scan-ish query on a 139M-row table; it is worth it
+# once for the dry run, but give it room without being unbounded.
+COUNT_TIMEOUT_MS = 300_000
+
+SELECT_BATCH_SQL = """
+SELECT mu.upload_id, mu.object_id
+FROM multipart_uploads mu
+WHERE COALESCE(mu.is_completed, false) = false
+  AND mu.initiated_at < now() - make_interval(secs => $1)
+  AND NOT EXISTS (SELECT 1 FROM parts p WHERE p.upload_id = mu.upload_id)
+ORDER BY mu.initiated_at
+LIMIT $2
+"""
+
+COUNT_SQL = """
+SELECT count(*) FROM multipart_uploads mu
+WHERE COALESCE(mu.is_completed, false) = false
+  AND mu.initiated_at < now() - make_interval(secs => $1)
+  AND NOT EXISTS (SELECT 1 FROM parts p WHERE p.upload_id = mu.upload_id)
+"""
+
+DELETE_SQL = "DELETE FROM multipart_uploads WHERE upload_id = ANY($1::uuid[])"
+
+
+async def _dlq_protected_ids(config) -> set[str]:  # noqa: ANN001
+    """Object ids with an in-flight DLQ entry, which the janitor and reaper both spare.
+
+    A partless upload has no data to protect, so this cannot matter in principle — but both
+    existing reapers gate on it, and silently being the one caller that does not is exactly the
+    sort of inconsistency that is uncomfortable to explain after the fact.
+    """
+    from workers.run_janitor_in_loop import get_all_dlq_object_ids
+
+    redis_client = async_redis.from_url(config.redis_queues_url)
+    try:
+        return await get_all_dlq_object_ids(redis_client)
+    finally:
+        await redis_client.aclose()
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    config = get_config()
+    stale_seconds = args.stale_seconds if args.stale_seconds > 0 else config.mpu_stale_seconds
+
+    protected = set() if args.skip_dlq_check else await _dlq_protected_ids(config)
+    logger.info("DLQ-protected object ids: %d", len(protected))
+
+    pool = await asyncpg.create_pool(
+        config.database_url,
+        min_size=1,
+        max_size=2,
+        command_timeout=args.statement_timeout_ms / 1000,
+        server_settings={"statement_timeout": str(args.statement_timeout_ms)},
+    )
+    try:
+        if args.count:
+            async with pool.acquire() as conn:
+                await conn.execute(f"SET statement_timeout = {COUNT_TIMEOUT_MS}")
+                total = await conn.fetchval(COUNT_SQL, stale_seconds)
+            logger.info("partless incomplete uploads older than %ss: %d", stale_seconds, total)
+
+        deleted = 0
+        skipped = 0
+        batches = 0
+        started = time.monotonic()
+
+        while True:
+            if args.max_batches and batches >= args.max_batches:
+                logger.info("reached --max-batches=%d; stopping", args.max_batches)
+                break
+
+            async with pool.acquire() as conn:
+                rows = await conn.fetch(SELECT_BATCH_SQL, stale_seconds, args.batch_size)
+
+            if not rows:
+                logger.info("no more partless uploads; done")
+                break
+
+            targets = []
+            for row in rows:
+                object_id = row["object_id"]
+                if object_id is not None and str(object_id) in protected:
+                    skipped += 1
+                    continue
+                targets.append(row["upload_id"])
+
+            batches += 1
+
+            if not args.yes:
+                logger.info(
+                    "[DRY RUN] batch %d: would delete %d upload(s), skip %d DLQ-protected; sample=%s",
+                    batches,
+                    len(targets),
+                    len(rows) - len(targets),
+                    [str(u) for u in targets[:3]],
+                )
+                # A dry run must not loop forever re-reading the same rows it never deletes.
+                logger.info("[DRY RUN] stopping after one batch. Re-run with --yes to delete.")
+                break
+
+            if targets:
+                async with pool.acquire() as conn:
+                    await conn.execute(DELETE_SQL, targets)
+                deleted += len(targets)
+
+            elapsed = time.monotonic() - started
+            rate = deleted / elapsed if elapsed > 0 else 0
+            logger.info(
+                "batch %d: deleted %d (total %d, %.0f/s, skipped %d)", batches, len(targets), deleted, rate, skipped
+            )
+
+            # Hand the primary back between batches: this runs against the same instance the
+            # drain and the api are using, and the whole point is to not be the heavy query.
+            await asyncio.sleep(args.sleep_between)
+
+        logger.info("finished: deleted=%d skipped_dlq=%d batches=%d", deleted, skipped, batches)
+    finally:
+        await pool.close()
+    return 0
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    ap = argparse.ArgumentParser(description="One-time sweep of incomplete multipart uploads that never got a part.")
+    ap.add_argument(
+        "--stale-seconds",
+        type=int,
+        default=0,
+        help="Only uploads older than this. 0 (default) uses HIPPIUS_MPU_STALE_SECONDS, matching the reaper.",
+    )
+    ap.add_argument("--batch-size", type=int, default=5000, help="Uploads deleted per statement (default 5000)")
+    ap.add_argument("--max-batches", type=int, default=0, help="Stop after N batches (0 = until exhausted)")
+    ap.add_argument("--sleep-between", type=float, default=0.5, help="Seconds to pause between batches (default 0.5)")
+    ap.add_argument(
+        "--statement-timeout-ms",
+        type=int,
+        default=60_000,
+        help="Hard ceiling per statement. Do not raise casually: an unbounded statement pins the xmin horizon.",
+    )
+    ap.add_argument("--count", action="store_true", help="Also report the total population up front (slow on prod)")
+    ap.add_argument(
+        "--skip-dlq-check",
+        action="store_true",
+        help="Skip the DLQ protection lookup (only if redis-queues is unreachable)",
+    )
+    ap.add_argument("--yes", action="store_true", help="Actually delete. Without this it is a dry run.")
+    args = ap.parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hippius_s3/scripts/sweep_partless_multipart_uploads.py
+++ b/hippius_s3/scripts/sweep_partless_multipart_uploads.py
@@ -84,7 +84,16 @@ WHERE COALESCE(mu.is_completed, false) = false
   AND NOT EXISTS (SELECT 1 FROM parts p WHERE p.upload_id = mu.upload_id)
 """
 
-DELETE_SQL = "DELETE FROM multipart_uploads WHERE upload_id = ANY($1::uuid[])"
+# Re-assert the partless guard AT DELETE TIME (not just in the SELECT above): a client can upload
+# a part to a 48h-old MPU between the SELECT and this DELETE, and `parts.upload_id ON DELETE CASCADE`
+# would then silently cascade-delete that fresh part (UploadPart already returned 200 →
+# CompleteMultipartUpload later fails confusingly). The NOT EXISTS makes the delete a no-op for any
+# upload that grew a part in the meantime — closing the TOCTOU window.
+DELETE_SQL = """
+DELETE FROM multipart_uploads
+WHERE upload_id = ANY($1::uuid[])
+  AND NOT EXISTS (SELECT 1 FROM parts p WHERE p.upload_id = multipart_uploads.upload_id)
+"""
 
 
 async def _dlq_protected_ids(config) -> set[str]:  # noqa: ANN001

--- a/hippius_s3/workers/shutdown.py
+++ b/hippius_s3/workers/shutdown.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import signal
+import time
+from collections.abc import Callable
+from collections.abc import Coroutine
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+# Must fit inside terminationGracePeriodSeconds on the worker Deployments, or the kubelet
+# SIGKILLs us mid-drain and the cleanup this module exists to run never finishes.
+DEFAULT_DRAIN_TIMEOUT_SECONDS = 20.0
+DEFAULT_RESTART_DELAY_SECONDS = 5.0
+
+CoroFactory = Callable[[], Coroutine[Any, Any, Any]]
+
+
+def _drain_timeout() -> float:
+    return float(os.environ.get("HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS", DEFAULT_DRAIN_TIMEOUT_SECONDS))
+
+
+async def _supervise(factory: CoroFactory, name: str, drain_timeout: float) -> bool:
+    """Run the worker until it finishes or a shutdown signal arrives.
+
+    Returns True if we stopped because of a signal, False if the worker returned by itself.
+    Re-raises whatever the worker raised, so the caller can decide to restart.
+    """
+    loop = asyncio.get_running_loop()
+    task = asyncio.ensure_future(factory())
+    stop = asyncio.Event()
+
+    def _request_stop(signame: str) -> None:
+        # Log before cancelling: if the drain then wedges, this line is the only evidence
+        # that we ever received the signal at all.
+        logger.info("%s: %s received, draining (bounded at %.0fs)", name, signame, drain_timeout)
+        stop.set()
+
+    for signame in ("SIGTERM", "SIGINT"):
+        loop.add_signal_handler(getattr(signal, signame), _request_stop, signame)
+
+    waiter = asyncio.ensure_future(stop.wait())
+    done, _ = await asyncio.wait({task, waiter}, return_when=asyncio.FIRST_COMPLETED)
+    waiter.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await waiter
+
+    if task in done:
+        await task  # surface a crash to the caller's restart logic
+        return False
+
+    task.cancel()
+    # Cancelling is the whole point of this module. Every worker loop closes its asyncpg
+    # pool and redis clients in a `finally`, and that cleanup is what tells Postgres the
+    # client is gone. A backend that is never told keeps running its statement — and keeps
+    # pinning the xmin horizon — long after the pod has been deleted, which is how one
+    # mpu-reaper query survived its own SIGKILLed pod for 7,377s on prod (2026-07-23) and
+    # blocked VACUUM database-wide. wait_for bounds the drain so a wedged cleanup cannot
+    # outlive the grace period and get SIGKILLed anyway.
+    try:
+        await asyncio.wait_for(task, timeout=drain_timeout)
+    except asyncio.CancelledError:
+        pass  # our own cancellation completing; the `finally` blocks have run
+    except TimeoutError:
+        logger.error("%s: drain exceeded %.0fs, exiting with cleanup incomplete", name, drain_timeout)
+    return True
+
+
+def run_worker(
+    factory: CoroFactory,
+    name: str,
+    *,
+    restart_delay: float = DEFAULT_RESTART_DELAY_SECONDS,
+    drain_timeout: float | None = None,
+) -> None:
+    """Entry point for a long-running worker: run `factory()` until SIGTERM/SIGINT.
+
+    Restarts the worker if it crashes, but never after a shutdown signal — a pod that is
+    being terminated must not start a fresh cycle it has no time to finish.
+    """
+    timeout = _drain_timeout() if drain_timeout is None else drain_timeout
+    while True:
+        try:
+            signalled = asyncio.run(_supervise(factory, name, timeout))
+        except Exception as exc:
+            logger.error("%s: crashed, restarting in %.0fs: %s", name, restart_delay, exc, exc_info=True)
+            time.sleep(restart_delay)
+            continue
+        if signalled:
+            logger.info("%s: shutdown complete", name)
+        return

--- a/hippius_s3/workers/shutdown.py
+++ b/hippius_s3/workers/shutdown.py
@@ -75,19 +75,30 @@ def run_worker(
     factory: CoroFactory,
     name: str,
     *,
+    restart_on_crash: bool = False,
     restart_delay: float = DEFAULT_RESTART_DELAY_SECONDS,
     drain_timeout: float | None = None,
 ) -> None:
     """Entry point for a long-running worker: run `factory()` until SIGTERM/SIGINT.
 
-    Restarts the worker if it crashes, but never after a shutdown signal — a pod that is
-    being terminated must not start a fresh cycle it has no time to finish.
+    `restart_on_crash` mirrors whatever each entrypoint did before this module existed, and
+    defaults off deliberately. Restarting in-process keeps the pod Ready with restart_count
+    at 0, so a persistently crashing worker becomes invisible to the pod-restart alerting;
+    letting the crash exit hands that job to the kubelet, which makes it visible. Only the
+    entrypoints that already had a `while True / except Exception / sleep(5)` wrapper pass
+    True, so this PR changes shutdown behaviour without also changing crash behaviour.
+
+    A shutdown signal never restarts, either way — a pod being terminated must not start a
+    fresh cycle it has no time to finish.
     """
     timeout = _drain_timeout() if drain_timeout is None else drain_timeout
     while True:
         try:
             signalled = asyncio.run(_supervise(factory, name, timeout))
         except Exception as exc:
+            if not restart_on_crash:
+                logger.error("%s: crashed, exiting for the kubelet to restart: %s", name, exc, exc_info=True)
+                raise
             logger.error("%s: crashed, restarting in %.0fs: %s", name, restart_delay, exc, exc_info=True)
             time.sleep(restart_delay)
             continue

--- a/k8s/base/grafana-dashboards.yaml
+++ b/k8s/base/grafana-dashboards.yaml
@@ -2148,7 +2148,8 @@ data:
             }
           ],
           "title": "Cache parts on disk",
-          "type": "stat"
+          "type": "stat",
+          "description": "Census from the last COMPLETED GC phase. If 'Janitor cycle health' shows a stuck/never-completed cycle, this is stale rather than zero."
         },
         {
           "collapsed": false,
@@ -2447,7 +2448,8 @@ data:
             }
           ],
           "title": "Cache age distribution",
-          "type": "timeseries"
+          "type": "timeseries",
+          "description": "Census from the last COMPLETED GC phase \u2014 see 'Janitor cycle health'. All-zero with a non-zero cache disk means the phase has not finished."
         },
         {
           "datasource": {
@@ -2627,12 +2629,17 @@ data:
           "pluginVersion": "12.3.1",
           "targets": [
             {
-              "expr": "sum(rate(fs_janitor_deleted_total{service_namespace=\"$namespace\"}[10m]))",
-              "legendFormat": "GC rate",
+              "expr": "sum by (reason) (rate(fs_janitor_deleted_total{service_namespace=\"$namespace\"}[10m]))",
+              "legendFormat": "{{reason}}",
               "refId": "A"
+            },
+            {
+              "expr": "sum(rate(fs_janitor_tmp_deleted_total{service_namespace=\"$namespace\"}[10m]))",
+              "legendFormat": "orphan tmp",
+              "refId": "B"
             }
           ],
-          "title": "GC rate",
+          "title": "Janitor delete rate (by reason)",
           "type": "timeseries"
         },
         {
@@ -3124,8 +3131,8 @@ data:
                 "type": "prometheus",
                 "uid": "prometheus"
               },
-              "expr": "max(drain_ssd_backlog_bytes{service_namespace=\"$namespace\"})",
-              "legendFormat": "backlog",
+              "expr": "max by (service_instance_id) (drain_ssd_backlog_bytes{service_namespace=\"$namespace\"})",
+              "legendFormat": "{{service_instance_id}}",
               "refId": "A"
             }
           ],
@@ -3644,6 +3651,105 @@ data:
           ],
           "title": "Account cacher \u2014 cycles",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 0,
+            "y": 64
+          },
+          "id": 65,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "expr": "max(fs_janitor_last_cycle_age_seconds{service_namespace=\"$namespace\"})",
+              "legendFormat": "since last completed cycle",
+              "refId": "A"
+            },
+            {
+              "expr": "max(fs_janitor_cycle_seconds{service_namespace=\"$namespace\"})",
+              "legendFormat": "last cycle duration",
+              "refId": "B"
+            }
+          ],
+          "title": "Janitor cycle health",
+          "type": "timeseries",
+          "description": "Seconds since the last COMPLETED janitor cycle (-1 = none since start). A line climbing without resetting means a phase is stuck and every census gauge on this dashboard is stale."
         }
       ],
       "preload": false,
@@ -3690,178 +3796,4 @@ data:
       "title": "Hippius S3 \u2014 System Load",
       "uid": "hippius-s3-system-load",
       "version": 10
-    }
-  cache-overview.json: |
-    {
-      "annotations": { "list": [] },
-      "editable": true,
-      "graphTooltip": 1,
-      "id": null,
-      "links": [],
-      "templating": {
-        "list": [
-          {
-            "current": { "selected": true, "text": "hippius-s3-cache-us-0", "value": "hippius-s3-cache-us-0" },
-            "hide": 0,
-            "includeAll": true,
-            "label": "Cache Region",
-            "multi": true,
-            "name": "cache_region",
-            "options": [
-              { "selected": false, "text": "All", "value": "$__all" },
-              { "selected": true, "text": "cache-us-0", "value": "hippius-s3-cache-us-0" },
-              { "selected": false, "text": "cache-eu-0", "value": "hippius-s3-cache-eu-0" }
-            ],
-            "query": "hippius-s3-cache-us-0,hippius-s3-cache-eu-0",
-            "type": "custom"
-          }
-        ]
-      },
-      "panels": [
-        {
-          "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
-          "id": 1,
-          "title": "Cache Traffic by Region",
-          "type": "row"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
-          "id": 2,
-          "targets": [
-            {
-              "expr": "sum by (service_namespace) (rate(http_requests_total{service_namespace=~\"$cache_region\", handler=~\"gateway.*\"}[5m]))",
-              "legendFormat": "{{service_namespace}}"
-            }
-          ],
-          "title": "Gateway req/s by Region",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
-          "id": 3,
-          "targets": [
-            {
-              "expr": "sum by (service_namespace) (rate(http_requests_total{service_namespace=~\"$cache_region\", handler!~\"gateway.*\"}[5m]))",
-              "legendFormat": "{{service_namespace}}"
-            }
-          ],
-          "title": "API req/s by Region",
-          "type": "timeseries"
-        },
-        {
-          "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
-          "id": 4,
-          "title": "Cache Performance",
-          "type": "row"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "percentunit", "min": 0, "max": 1 }
-          },
-          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 10 },
-          "id": 5,
-          "targets": [
-            {
-              "expr": "sum by (service_namespace) (rate(cache_hits_total{service_namespace=~\"$cache_region\"}[5m])) / (sum by (service_namespace) (rate(cache_hits_total{service_namespace=~\"$cache_region\"}[5m])) + sum by (service_namespace) (rate(cache_misses_total{service_namespace=~\"$cache_region\"}[5m])))",
-              "legendFormat": "{{service_namespace}}"
-            }
-          ],
-          "title": "Cache Hit Ratio by Region",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" }
-          },
-          "gridPos": { "h": 8, "w": 8, "x": 8, "y": 10 },
-          "id": 6,
-          "targets": [
-            {
-              "expr": "histogram_quantile(0.95, sum by (le, service_namespace) (rate(downloader_duration_seconds_bucket{service_namespace=~\"$cache_region\"}[5m])))",
-              "legendFormat": "p95 {{service_namespace}}"
-            },
-            {
-              "expr": "histogram_quantile(0.50, sum by (le, service_namespace) (rate(downloader_duration_seconds_bucket{service_namespace=~\"$cache_region\"}[5m])))",
-              "legendFormat": "p50 {{service_namespace}}"
-            }
-          ],
-          "title": "Download Latency by Region",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "bytes" }
-          },
-          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 10 },
-          "id": 7,
-          "targets": [
-            {
-              "expr": "max by (service_namespace) (redis_memory_used_bytes{service_namespace=~\"$cache_region\"})",
-              "legendFormat": "{{service_namespace}}"
-            }
-          ],
-          "title": "Redis Memory by Region",
-          "type": "timeseries"
-        },
-        {
-          "collapsed": false,
-          "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
-          "id": 8,
-          "title": "Errors & Health",
-          "type": "row"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 19 },
-          "id": 9,
-          "targets": [
-            {
-              "expr": "sum by (service_namespace, status_code) (rate(http_requests_total{service_namespace=~\"$cache_region\", status_code=~\"[45]..\"}[5m]))",
-              "legendFormat": "{{service_namespace}} {{status_code}}"
-            }
-          ],
-          "title": "Error Rates by Region",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 19 },
-          "id": 10,
-          "targets": [
-            {
-              "expr": "kube_deployment_status_replicas_ready{namespace=~\"hippius-s3-cache-.*\"}",
-              "legendFormat": "{{namespace}} / {{deployment}}"
-            }
-          ],
-          "title": "Ready Replicas by Region",
-          "type": "timeseries"
-        }
-      ],
-      "schemaVersion": 39,
-      "tags": ["hippius", "s3", "cache", "cdn"],
-      "time": { "from": "now-1h", "to": "now" },
-      "timepicker": {},
-      "timezone": "browser",
-      "title": "Hippius S3 — Cache Overview",
-      "uid": "hippius-s3-cache-overview",
-      "version": 1
     }

--- a/k8s/base/redis-queues-ha.yaml
+++ b/k8s/base/redis-queues-ha.yaml
@@ -114,9 +114,12 @@ metadata:
 spec:
   podSelector:
     matchExpressions:
+      # NB the operator names sentinel pods `<sentinelName>-sentinel`, so their `app` label is
+      # `redis-queues-sentinel-sentinel` (doubled suffix) — matching only `redis-queues-sentinel`
+      # would leave operator->sentinel:26379 blocked and the sentinels never configured.
       - key: app
         operator: In
-        values: ["redis-queues-ha", "redis-queues-sentinel"]
+        values: ["redis-queues-ha", "redis-queues-sentinel-sentinel"]
   policyTypes: ["Ingress"]
   ingress:
     - from:

--- a/k8s/base/redis-queues-ha.yaml
+++ b/k8s/base/redis-queues-ha.yaml
@@ -38,6 +38,13 @@ metadata:
   name: redis-queues-ha
 spec:
   clusterSize: 3 # 1 master + 2 replicas — survives a replica loss while keeping a failover target
+  # The opstree image runs as uid/gid 1000 (redis), but the CephFS PVC mounts root:root, so AOF
+  # (`appendonlydir` under /data) fails with EACCES and the pod CrashLoops. fsGroup makes the
+  # mount group-owned + setgid so uid 1000 can write; the CephFS CSI (fsGroupPolicy=File) honors it.
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis:v7.0.15
     imagePullPolicy: IfNotPresent
@@ -69,6 +76,10 @@ metadata:
   name: redis-queues-sentinel
 spec:
   clusterSize: 3 # 3 sentinels, quorum 2 — no sentinel is itself a SPOF
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
   kubernetesConfig:
     image: quay.io/opstree/redis-sentinel:v7.0.15
     imagePullPolicy: IfNotPresent
@@ -87,3 +98,33 @@ spec:
     downAfterMilliseconds: "5000"
     failoverTimeout: "18000"
     parallelSyncs: "1"
+---
+# The namespace's `allow-internal` NetworkPolicy only admits in-namespace + ingress-nginx +
+# `hippius.io/role: cache` pods. The redis-operator lives in `redis-operator-system`, so without
+# this hole every operator->pod dial times out — and unlike RedisCluster (which self-heals via the
+# in-namespace :16379 gossip bus), RedisReplication+Sentinel needs ONGOING operator->pod
+# connectivity: it dials :6379 to determine the master role and orchestrate `slaveof`, and dials
+# :26379 to configure the sentinels. Missing this, replicas never attach (connected_slaves:0) and
+# the sentinel StatefulSet is never created. Scope is tight: only the operator namespace, only to
+# these pods, only on the two redis ports.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-redis-operator
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: ["redis-queues-ha", "redis-queues-sentinel"]
+  policyTypes: ["Ingress"]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redis-operator-system
+      ports:
+        - protocol: TCP
+          port: 6379
+        - protocol: TCP
+          port: 26379

--- a/k8s/base/redis-queues-ha.yaml
+++ b/k8s/base/redis-queues-ha.yaml
@@ -1,0 +1,89 @@
+# redis-queues HA — operator-managed RedisReplication + RedisSentinel (auto-failover)
+#
+# WHY: today redis-queues is a single-replica StatefulSet. Its data is on CephFS (3x, so a
+# node loss is NOT data loss), but the single pod is stuck Terminating on a hard node loss
+# until a human force-deletes it — a few-minute manual-recovery outage of the s3 WRITE path
+# (uploads can't enqueue; cache-miss GETs stall on chunk-ready pub/sub). redis-queues also
+# holds the drain's `cephor:*` leader lease + epoch fence, so its loss stalls the drain too.
+#
+# THIS FILE IS STAGED, NOT AUTO-APPLIED. It is deliberately NOT listed in any kustomization —
+# applying it must be a controlled cutover (see docs/redis-queues-ha-cutover.md), because it
+# introduces a SECOND redis holding the queue + fence, and the app must be repointed at the
+# operator's master service without losing pending uploads or regressing the cephor:epoch
+# fence. Apply per the runbook, staging first.
+#
+# Operator: quay.io/opstree/redis-operator:v0.23.0 (CRDs redis.redis.opstreelabs.in/v1beta2),
+# already installed cluster-wide and already managing the staging redis-cluster.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-queues-ha-config
+data:
+  # Preserves the semantics of the current standalone redis-queues (see redis-statefulsets.yaml):
+  # noeviction (dropping a queue entry = a lost upload; a reset epoch deadlocks the allocator —
+  # must fail writes LOUDLY under memory pressure, never silently evict) + AOF everysec on CephFS.
+  # NOTE: intentionally NO `min-replicas-to-write` — requiring a replica ack would BLOCK writes
+  # when a replica is down, defeating the availability goal. The failover-safety of the epoch
+  # fence is handled by the cutover acceptance test, not by blocking writes.
+  redis-additional.conf: |
+    maxmemory 4gb
+    maxmemory-policy noeviction
+    appendonly yes
+    appendfsync everysec
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisReplication
+metadata:
+  name: redis-queues-ha
+spec:
+  clusterSize: 3 # 1 master + 2 replicas — survives a replica loss while keeping a failover target
+  kubernetesConfig:
+    image: quay.io/opstree/redis:v7.0.15
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 4Gi
+      limits:
+        # Keep limit (6Gi) > maxmemory (4gb) so Redis rejects writes at ITS limit first (the
+        # intended loud OOM under noeviction) before k8s OOM-kills the pod; headroom absorbs
+        # AOF-rewrite copy-on-write + replication buffers.
+        cpu: 1000m
+        memory: 6Gi
+  redisConfig:
+    additionalRedisConfig: redis-queues-ha-config
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: ceph-filesystem
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: RedisSentinel
+metadata:
+  name: redis-queues-sentinel
+spec:
+  clusterSize: 3 # 3 sentinels, quorum 2 — no sentinel is itself a SPOF
+  kubernetesConfig:
+    image: quay.io/opstree/redis-sentinel:v7.0.15
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+  redisSentinelConfig:
+    redisReplicationName: redis-queues-ha
+    masterGroupName: myMaster
+    quorum: "2"
+    # Detect a dead master in 5s, then fail over. failoverTimeout bounds a stuck failover.
+    downAfterMilliseconds: "5000"
+    failoverTimeout: "18000"
+    parallelSyncs: "1"

--- a/k8s/base/workers-deployments.yaml
+++ b/k8s/base/workers-deployments.yaml
@@ -17,6 +17,12 @@ spec:
         worker-type: uploader
         backend: arion
     spec:
+      # Workers take no inbound traffic, so there is no preStop endpoint-propagation wait —
+      # this is purely drain headroom. run_worker() cancels the loop on SIGTERM and bounds the
+      # cleanup at HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS (20s), and that cleanup closing the
+      # asyncpg pool is what stops a long statement outliving the pod and pinning the xmin
+      # horizon. 40 leaves headroom over the 20s bound.
+      terminationGracePeriodSeconds: 40
       initContainers:
         - name: wait-for-services
           image: busybox:1.35
@@ -207,6 +213,12 @@ spec:
         worker-type: downloader
         backend: arion
     spec:
+      # Workers take no inbound traffic, so there is no preStop endpoint-propagation wait —
+      # this is purely drain headroom. run_worker() cancels the loop on SIGTERM and bounds the
+      # cleanup at HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS (20s), and that cleanup closing the
+      # asyncpg pool is what stops a long statement outliving the pod and pinning the xmin
+      # horizon. 40 leaves headroom over the 20s bound.
+      terminationGracePeriodSeconds: 40
       initContainers:
         - name: wait-for-services
           image: busybox:1.35
@@ -390,6 +402,12 @@ spec:
         worker-type: unpinner
         backend: arion
     spec:
+      # Workers take no inbound traffic, so there is no preStop endpoint-propagation wait —
+      # this is purely drain headroom. run_worker() cancels the loop on SIGTERM and bounds the
+      # cleanup at HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS (20s), and that cleanup closing the
+      # asyncpg pool is what stops a long statement outliving the pod and pinning the xmin
+      # horizon. 40 leaves headroom over the 20s bound.
+      terminationGracePeriodSeconds: 40
       initContainers:
         - name: wait-for-services
           image: busybox:1.35
@@ -540,6 +558,12 @@ spec:
         app: janitor
         worker-type: janitor
     spec:
+      # Workers take no inbound traffic, so there is no preStop endpoint-propagation wait —
+      # this is purely drain headroom. run_worker() cancels the loop on SIGTERM and bounds the
+      # cleanup at HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS (20s), and that cleanup closing the
+      # asyncpg pool is what stops a long statement outliving the pod and pinning the xmin
+      # horizon. 40 leaves headroom over the 20s bound.
+      terminationGracePeriodSeconds: 40
       initContainers:
         - name: wait-for-services
           image: busybox:1.35
@@ -694,6 +718,12 @@ spec:
         app: account-cacher
         worker-type: account-cacher
     spec:
+      # Workers take no inbound traffic, so there is no preStop endpoint-propagation wait —
+      # this is purely drain headroom. run_worker() cancels the loop on SIGTERM and bounds the
+      # cleanup at HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS (20s), and that cleanup closing the
+      # asyncpg pool is what stops a long statement outliving the pod and pinning the xmin
+      # horizon. 40 leaves headroom over the 20s bound.
+      terminationGracePeriodSeconds: 40
       initContainers:
         - name: wait-for-services
           image: busybox:1.35
@@ -819,6 +849,12 @@ spec:
         app: cachet-health-checker
         worker-type: cachet-health-checker
     spec:
+      # Workers take no inbound traffic, so there is no preStop endpoint-propagation wait —
+      # this is purely drain headroom. run_worker() cancels the loop on SIGTERM and bounds the
+      # cleanup at HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS (20s), and that cleanup closing the
+      # asyncpg pool is what stops a long statement outliving the pod and pinning the xmin
+      # horizon. 40 leaves headroom over the 20s bound.
+      terminationGracePeriodSeconds: 40
       initContainers:
         - name: wait-for-services
           image: busybox:1.35

--- a/k8s/production/mpu-reaper-deployment.yaml
+++ b/k8s/production/mpu-reaper-deployment.yaml
@@ -22,6 +22,12 @@ spec:
         app: mpu-reaper
         worker-type: mpu-reaper
     spec:
+      # Workers take no inbound traffic, so there is no preStop endpoint-propagation wait —
+      # this is purely drain headroom. run_worker() cancels the loop on SIGTERM and bounds the
+      # cleanup at HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS (20s), and that cleanup closing the
+      # asyncpg pool is what stops a long statement outliving the pod and pinning the xmin
+      # horizon. 40 leaves headroom over the 20s bound.
+      terminationGracePeriodSeconds: 40
       initContainers:
         - name: wait-for-services
           image: busybox:1.35

--- a/k8s/staging/mpu-reaper-deployment.yaml
+++ b/k8s/staging/mpu-reaper-deployment.yaml
@@ -22,6 +22,12 @@ spec:
         app: mpu-reaper
         worker-type: mpu-reaper
     spec:
+      # Workers take no inbound traffic, so there is no preStop endpoint-propagation wait —
+      # this is purely drain headroom. run_worker() cancels the loop on SIGTERM and bounds the
+      # cleanup at HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS (20s), and that cleanup closing the
+      # asyncpg pool is what stops a long statement outliving the pod and pinning the xmin
+      # horizon. 40 leaves headroom over the 20s bound.
+      terminationGracePeriodSeconds: 40
       initContainers:
         - name: wait-for-services
           image: busybox:1.35

--- a/monitoring/grafana/dashboards/system-load.json
+++ b/monitoring/grafana/dashboards/system-load.json
@@ -2141,7 +2141,8 @@
         }
       ],
       "title": "Cache parts on disk",
-      "type": "stat"
+      "type": "stat",
+      "description": "Census from the last COMPLETED GC phase. If 'Janitor cycle health' shows a stuck/never-completed cycle, this is stale rather than zero."
     },
     {
       "collapsed": false,
@@ -2440,7 +2441,8 @@
         }
       ],
       "title": "Cache age distribution",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Census from the last COMPLETED GC phase \u2014 see 'Janitor cycle health'. All-zero with a non-zero cache disk means the phase has not finished."
     },
     {
       "datasource": {
@@ -2620,12 +2622,17 @@
       "pluginVersion": "12.3.1",
       "targets": [
         {
-          "expr": "sum(rate(fs_janitor_deleted_total{service_namespace=\"$namespace\"}[10m]))",
-          "legendFormat": "GC rate",
+          "expr": "sum by (reason) (rate(fs_janitor_deleted_total{service_namespace=\"$namespace\"}[10m]))",
+          "legendFormat": "{{reason}}",
           "refId": "A"
+        },
+        {
+          "expr": "sum(rate(fs_janitor_tmp_deleted_total{service_namespace=\"$namespace\"}[10m]))",
+          "legendFormat": "orphan tmp",
+          "refId": "B"
         }
       ],
-      "title": "GC rate",
+      "title": "Janitor delete rate (by reason)",
       "type": "timeseries"
     },
     {
@@ -3117,8 +3124,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "max(drain_ssd_backlog_bytes{service_namespace=\"$namespace\"})",
-          "legendFormat": "backlog",
+          "expr": "max by (service_instance_id) (drain_ssd_backlog_bytes{service_namespace=\"$namespace\"})",
+          "legendFormat": "{{service_instance_id}}",
           "refId": "A"
         }
       ],
@@ -3637,6 +3644,105 @@
       ],
       "title": "Account cacher \u2014 cycles",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 64
+      },
+      "id": 65,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "expr": "max(fs_janitor_last_cycle_age_seconds{service_namespace=\"$namespace\"})",
+          "legendFormat": "since last completed cycle",
+          "refId": "A"
+        },
+        {
+          "expr": "max(fs_janitor_cycle_seconds{service_namespace=\"$namespace\"})",
+          "legendFormat": "last cycle duration",
+          "refId": "B"
+        }
+      ],
+      "title": "Janitor cycle health",
+      "type": "timeseries",
+      "description": "Seconds since the last COMPLETED janitor cycle (-1 = none since start). A line climbing without resetting means a phase is stuck and every census gauge on this dashboard is stale."
     }
   ],
   "preload": false,

--- a/scripts/extract_failure_details.py
+++ b/scripts/extract_failure_details.py
@@ -110,9 +110,18 @@ def clean_traceback(longrepr: str, max_lines: int = 10) -> str:
     for line in longrepr.split("\n"):
         if re.match(r"^\[gw\d+\]", line):
             continue
-        frame_header = re.match(r"^(\S+):\d+: in ", line)
-        if frame_header:
-            in_library_frame = "site-packages" in frame_header.group(1)
+        # Frame headers come in two shapes: pytest's --tb=short ("path:NN: in func")
+        # and the classic format used in collection errors ('  File "path", line NN').
+        frame_path = None
+        short_frame = re.match(r"^(\S+):\d+: in ", line)
+        classic_frame = re.match(r'^\s+File "([^"]+)", line \d+', line)
+        if short_frame:
+            frame_path = short_frame.group(1)
+        elif classic_frame:
+            frame_path = classic_frame.group(1)
+        if frame_path is not None:
+            # "lib/python" also covers stdlib frames (importlib etc.), not just site-packages.
+            in_library_frame = "site-packages" in frame_path or "lib/python" in frame_path
             if in_library_frame:
                 continue
         elif in_library_frame and (line.startswith("    ") or not line.strip()):
@@ -123,7 +132,8 @@ def clean_traceback(longrepr: str, max_lines: int = 10) -> str:
     result = "\n".join(kept).strip()
     lines = result.split("\n")
     if len(lines) > max_lines:
-        result = "\n".join(lines[:max_lines]) + "\n... (truncated)"
+        # The exception itself is the last line in both formats — never truncate it away.
+        result = "\n".join(lines[: max_lines - 2]) + "\n... (truncated)\n" + lines[-1]
     return result
 
 

--- a/scripts/extract_failure_details.py
+++ b/scripts/extract_failure_details.py
@@ -2,16 +2,77 @@
 """
 Extract detailed failure information from pytest JSON reports.
 
-This script parses pytest-json-report output files and extracts actionable
-failure context for CI alerts, including test names, error messages, and traceback snippets.
+This script parses pytest-json-report output files and builds a human-readable
+CI alert: which test failed, against which suite/region, what the error means
+in plain language, and where in *our* code it happened. Suite-level breakage
+(missing report, collection error, pytest crash) is reported explicitly so the
+alert never claims "no failures" while the workflow is red.
 """
 
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
+
+
+# Report-file stem -> what a reader should understand failed, without opening the run.
+SUITE_LABELS = {
+    "smoke-production": "core S3 suite (s3.hippius.com)",
+    "smoke-regional": "regional cache suite",
+    "smoke-subtoken-scope": "sub-token scope suite",
+}
+
+STAGE_LABELS = {
+    "call": "while running the test",
+    "setup": "while preparing the test (setup)",
+    "teardown": "during cleanup (teardown)",
+}
+
+# Plain-language explanations for error classes that show up in smoke runs.
+# Matched against the exception type in the crash message ("httpx.ReadTimeout: ...").
+ERROR_EXPLANATIONS = [
+    (
+        "ReadTimeout",
+        "The endpoint accepted the connection but did not respond before the client "
+        "timeout — the service is likely slow, overloaded, or hung.",
+    ),
+    (
+        "ConnectTimeout",
+        "Could not establish a connection to the endpoint in time — it may be down or unreachable.",
+    ),
+    (
+        "ConnectError",
+        "The connection to the endpoint failed or was refused — the service may be down.",
+    ),
+    (
+        "ConnectionError",
+        "The connection to the endpoint failed or was refused — the service may be down.",
+    ),
+    (
+        "RemoteProtocolError",
+        "The server closed the connection mid-response — a crash or restart on the server side.",
+    ),
+    (
+        "SSLError",
+        "TLS handshake with the endpoint failed — check certificates on the target.",
+    ),
+    (
+        "AssertionError",
+        "The response did not match what the test expected — see the traceback below.",
+    ),
+]
+
+PYTEST_EXIT_MEANINGS = {
+    1: "some tests failed",
+    2: "the test run was interrupted",
+    3: "pytest itself crashed (internal error)",
+    4: "pytest was invoked incorrectly (usage error)",
+    5: "no tests were collected",
+}
 
 
 def parse_report(report_path: Path) -> Dict[str, Any]:
@@ -22,6 +83,53 @@ def parse_report(report_path: Path) -> Dict[str, Any]:
     except (FileNotFoundError, json.JSONDecodeError) as e:
         print(f"Warning: Could not parse {report_path}: {e}", file=sys.stderr)
         return {}
+
+
+def explain_error(error_message: str) -> str:
+    """Turn a raw exception message into an explanation a reader can act on."""
+    exc_type = error_message.split(":", 1)[0]
+    for needle, explanation in ERROR_EXPLANATIONS:
+        if needle in exc_type:
+            return f"{explanation} (`{error_message.splitlines()[0].strip()}`)"
+    return f"`{error_message.splitlines()[0].strip()}`"
+
+
+def find_test_frame(longrepr: str) -> Optional[str]:
+    """Find the first traceback frame that is in our code, not a library."""
+    for line in longrepr.split("\n"):
+        match = re.match(r"^(\S+\.py):(\d+):", line)
+        if match and "site-packages" not in match.group(1):
+            return f"{match.group(1)}:{match.group(2)}"
+    return None
+
+
+def clean_traceback(longrepr: str, max_lines: int = 10) -> str:
+    """Keep only frames from our code and the final error lines; drop library noise."""
+    kept: List[str] = []
+    in_library_frame = False
+    for line in longrepr.split("\n"):
+        if re.match(r"^\[gw\d+\]", line):
+            continue
+        frame_header = re.match(r"^(\S+):\d+: in ", line)
+        if frame_header:
+            in_library_frame = "site-packages" in frame_header.group(1)
+            if in_library_frame:
+                continue
+        elif in_library_frame and (line.startswith("    ") or not line.strip()):
+            continue
+        else:
+            in_library_frame = False
+        kept.append(line)
+    result = "\n".join(kept).strip()
+    lines = result.split("\n")
+    if len(lines) > max_lines:
+        result = "\n".join(lines[:max_lines]) + "\n... (truncated)"
+    return result
+
+
+def _as_str(value: Any) -> str:
+    """pytest-json-report usually gives longrepr as a string, but not for every failure shape."""
+    return value if isinstance(value, str) else ""
 
 
 def extract_failures(report: Dict[str, Any], report_name: str) -> List[Dict[str, str]]:
@@ -51,26 +159,32 @@ def extract_failures(report: Dict[str, Any], report_name: str) -> List[Dict[str,
         if not failure_info:
             continue
 
-        # Extract error message and traceback
-        crash = failure_info.get("crash", {})
-        longrepr = failure_info.get("longrepr", "")
+        crash = failure_info.get("crash") or {}
+        if not isinstance(crash, dict):
+            crash = {}
+        longrepr = _as_str(failure_info.get("longrepr"))
 
-        error_message = crash.get("message", "Unknown error")
-        error_file = crash.get("path", "unknown")
-        error_line = crash.get("lineno", "?")
+        error_message = crash.get("message") or ""
+        if not error_message:
+            # No structured crash info — fall back to the final "E ..." line of the traceback.
+            error_lines = [ln[1:].strip() for ln in longrepr.split("\n") if ln.startswith("E ")]
+            error_message = error_lines[-1] if error_lines else "Unknown error"
 
-        # Create a compact traceback snippet (first few lines)
-        traceback_lines = longrepr.split("\n")[:5] if longrepr else []
-        traceback_snippet = "\n".join(traceback_lines).strip()
+        # The crash location often points into httpx/botocore internals; the frame
+        # in our own test file is what a reader actually needs.
+        location = find_test_frame(longrepr)
+        if not location:
+            crash_path = str(crash.get("path", ""))
+            if crash_path and "site-packages" not in crash_path:
+                location = f"{crash_path}:{crash.get('lineno', '?')}"
 
         failures.append(
             {
                 "test": nodeid,
-                "stage": failure_stage,
-                "error": error_message,
-                "file": error_file,
-                "line": error_line,
-                "traceback": traceback_snippet,
+                "stage": failure_stage or "unknown",
+                "explanation": explain_error(error_message),
+                "location": location or "",
+                "traceback": clean_traceback(longrepr) if longrepr else "",
                 "report": report_name,
             }
         )
@@ -78,32 +192,116 @@ def extract_failures(report: Dict[str, Any], report_name: str) -> List[Dict[str,
     return failures
 
 
+def extract_suite_problems(report: Dict[str, Any], report_name: str, test_failures: int) -> List[str]:
+    """Report suite-level breakage that never shows up as an individual test failure."""
+    label = SUITE_LABELS.get(report_name, report_name)
+    problems = []
+
+    for collector in report.get("collectors", []):
+        if collector.get("outcome") != "error":
+            continue
+        nodeid = collector.get("nodeid", "unknown")
+        snippet = clean_traceback(_as_str(collector.get("longrepr")), max_lines=5)
+        problem = f"**{label}**: could not even collect `{nodeid}` — an import or fixture error, not a service issue."
+        if snippet:
+            problem += f"\n```\n{snippet}\n```"
+        problems.append(problem)
+
+    exitcode = report.get("exitcode")
+    # A non-zero exit with no per-test failures and no collection errors means the
+    # run broke without producing per-test results (interrupted, internal error, ...).
+    if test_failures == 0 and not problems and isinstance(exitcode, int) and exitcode != 0:
+        meaning = PYTEST_EXIT_MEANINGS.get(exitcode, "unknown exit code")
+        problems.append(
+            f"**{label}**: pytest exited with code {exitcode} ({meaning}) "
+            f"but no individual test failure was recorded — check the run logs."
+        )
+
+    return problems
+
+
 def format_failures_for_alert(failures: List[Dict[str, str]], max_failures: int = 5) -> str:
-    """Format failure details into a compact alert message."""
+    """Format failure details into a readable alert message."""
     if not failures:
-        return "No failures found in reports."
+        return ""
 
     total_failures = len(failures)
     display_failures = failures[:max_failures]
 
-    lines = [f"**Failures: {total_failures}**"]
+    lines = [f"**{total_failures} test(s) failed**"]
 
     for i, failure in enumerate(display_failures, 1):
-        lines.append(f"\n{i}. **{failure['test']}** ({failure['report']})")
-        lines.append(f"   Stage: {failure['stage']}")
-        lines.append(f"   Error: {failure['error']}")
-        lines.append(f"   Location: {failure['file']}:{failure['line']}")
+        suite = SUITE_LABELS.get(failure["report"], failure["report"])
+        stage = STAGE_LABELS.get(failure["stage"], failure["stage"])
+        lines.append(f"\n**{i}. `{failure['test']}`** — {suite}")
+        lines.append(f"   What happened: {failure['explanation']}")
+        lines.append(f"   Failed {stage}.")
+
+        if failure["location"]:
+            lines.append(f"   Test code: `{failure['location']}`")
 
         if failure["traceback"]:
-            # Add traceback as a code block for readability
             lines.append("```")
             lines.append(failure["traceback"])
             lines.append("```")
 
     if total_failures > max_failures:
-        lines.append(f"\n... and {total_failures - max_failures} more failure(s)")
+        lines.append(f"\n... and {total_failures - max_failures} more failure(s) — see the run for the full list.")
 
     return "\n".join(lines)
+
+
+def build_alert_message(report_paths: List[Path]) -> str:
+    """Build the full alert body from all report files, covering suite-level breakage."""
+    all_failures: List[Dict[str, str]] = []
+    suite_problems: List[str] = []
+
+    for report_path in report_paths:
+        report_name = report_path.stem
+        label = SUITE_LABELS.get(report_name, report_name)
+
+        if not report_path.exists():
+            suite_problems.append(
+                f"**{label}**: no report file was written — the pytest step likely crashed "
+                f"before any test ran (dependency install failure, startup error, or the job "
+                f"was cut short). Check the run logs."
+            )
+            continue
+
+        report = parse_report(report_path)
+        if not report:
+            suite_problems.append(
+                f"**{label}**: the report file exists but could not be parsed — the pytest "
+                f"step was probably killed mid-run. Check the run logs."
+            )
+            continue
+
+        failures = extract_failures(report, report_name)
+        all_failures.extend(failures)
+        suite_problems.extend(extract_suite_problems(report, report_name, len(failures)))
+
+    # Sort by report name then test name for consistency
+    all_failures.sort(key=lambda f: (f["report"], f["test"]))
+
+    sections = []
+    failures_text = format_failures_for_alert(all_failures)
+    if failures_text:
+        sections.append(failures_text)
+    if suite_problems:
+        sections.append("**Suite-level problems:**\n" + "\n".join(f"- {p}" for p in suite_problems))
+    if not sections:
+        return (
+            "The workflow failed but no test failures were captured in the reports. "
+            "The failure is likely in a non-test step (dependency install, artifact upload) "
+            "or the job was cancelled — check the run logs."
+        )
+
+    return "\n\n".join(sections)
+
+
+def build_payload(message: str, run_url: str) -> Dict[str, str]:
+    """Build the Mattermost webhook payload."""
+    return {"text": (f":rotating_light: **s3.hippius.com smoke tests failed**\n[View run]({run_url})\n\n{message}")}
 
 
 def main():
@@ -119,20 +317,7 @@ def main():
     # Enrichment must never silence the alert: if parsing an unexpected report
     # shape raises, fall back to a bare message so the failure still reaches the team.
     try:
-        all_failures = []
-
-        for report_path_str in args.reports:
-            report_path = Path(report_path_str)
-            report_name = report_path.stem
-
-            report = parse_report(report_path)
-            failures = extract_failures(report, report_name)
-            all_failures.extend(failures)
-
-        # Sort by report name then test name for consistency
-        all_failures.sort(key=lambda f: (f["report"], f["test"]))
-
-        alert_message = format_failures_for_alert(all_failures)
+        alert_message = build_alert_message([Path(p) for p in args.reports])
     except Exception as e:  # noqa: BLE001
         print(f"Warning: failed to build enriched alert: {e}", file=sys.stderr)
         alert_message = "Could not extract failure details — see the CI run for logs."
@@ -145,13 +330,9 @@ def main():
 
 def send_webhook(message: str, webhook_url: str, run_url: str):
     """Send alert message to Mattermost webhook."""
-    import json as json_module
-
-    payload = {
-        "text": f":rotating_light: **s3.hippius.com smoke tests failed**\n[View run]({run_url})\n\n**Failure Details:**\n{message}\n\n![smoke tests failed](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExcmg4NDIyMnNtMHk0cHpvc2JpcHEwczY4cXR3eDkwdDE4Y3M3bGQ5MiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/HUkOv6BNWc1HO/giphy.gif)"
-    }
-
     import subprocess
+
+    payload = build_payload(message, run_url)
 
     result = subprocess.run(
         [
@@ -162,7 +343,7 @@ def send_webhook(message: str, webhook_url: str, run_url: str):
             "-H",
             "Content-Type: application/json",
             "-d",
-            json_module.dumps(payload),
+            json.dumps(payload),
             webhook_url,
         ],
         capture_output=True,

--- a/tests/smoke/retrying_http.py
+++ b/tests/smoke/retrying_http.py
@@ -1,0 +1,58 @@
+"""A GET that retries 503 SlowDown, the way a real S3 client does.
+
+These tests reach the gateway with raw httpx rather than boto3 — presigned URLs and anonymous
+public reads are deliberately exercised as a plain HTTP client would, without SDK machinery in
+the way. The cost is that they also lose the SDK's retry behaviour, and 503 SlowDown is a
+NORMAL response here, not a failure:
+
+A cross-node read-after-write is not instant. An upload lands on one node's local SSD, and a
+download served by a different node has nothing to serve until the drain pipeline replicates it
+— reconciler notices, drain copies to CephFS, enqueue sweep publishes, uploader uploads. Every
+stage is a poll, so the round trip is ~60s. While that is in flight the read path deliberately
+gives up early and returns a retryable 503 rather than holding the connection open (see
+`stream_first_chunk_timeout_seconds`). boto3 and the aws-cli retry that transparently and the
+user never sees it; a bare `httpx.get` does not, and reports a failure the SDK would have
+absorbed.
+
+So this helper exists to make the smoke tests behave like the clients we actually care about.
+It retries ONLY 503 — any other status is returned as-is, so a genuine 500/403/404 still fails
+the test immediately rather than being retried into a timeout.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+# Enough attempts to cover the ~60s replication round trip at the server's ~25s fail-fast, with
+# headroom. Kept explicit rather than derived so the test does not silently follow a config change.
+DEFAULT_ATTEMPTS = 5
+DEFAULT_BACKOFF_SECONDS = 5.0
+
+
+def get_with_slowdown_retry(
+    url: str,
+    *,
+    timeout: float = 60.0,
+    attempts: int = DEFAULT_ATTEMPTS,
+    backoff: float = DEFAULT_BACKOFF_SECONDS,
+) -> httpx.Response:
+    """GET `url`, retrying only on 503, and return the last response.
+
+    Returns rather than raises on exhaustion so the caller's own assertion produces the failure
+    message — a test that ends in "still 503 after N attempts" is more useful than a stack trace
+    from in here.
+    """
+    response = httpx.get(url, timeout=timeout)
+    for attempt in range(2, attempts + 1):
+        if response.status_code != 503:
+            return response
+        logger.info("503 SlowDown (object still replicating); attempt %d/%d after %.0fs", attempt, attempts, backoff)
+        time.sleep(backoff)
+        response = httpx.get(url, timeout=timeout)
+    return response

--- a/tests/smoke/test_smoke_production.py
+++ b/tests/smoke/test_smoke_production.py
@@ -8,6 +8,8 @@ from datetime import timezone
 import httpx
 import pytest
 
+from .retrying_http import get_with_slowdown_retry
+
 
 def test_01_cleanup_old_files(production_s3_client, session_tracker):
     from datetime import timedelta
@@ -254,7 +256,10 @@ def test_07_presigned_url_roundtrip(production_s3_client, session_tracker, file_
         Params={"Bucket": session_tracker.bucket, "Key": key},
         ExpiresIn=300,
     )
-    get_resp = httpx.get(get_url, timeout=60)
+    # Retries 503 like a real S3 client: a fresh object read from a different node than the one
+    # that took the PUT is legitimately not ready yet, and the read path fails fast with a
+    # retryable SlowDown rather than holding the socket. See tests/smoke/retrying_http.py.
+    get_resp = get_with_slowdown_retry(get_url, timeout=60)
     assert get_resp.status_code == 200, f"presigned GET failed: {get_resp.status_code} {get_resp.text[:200]}"
 
     downloaded_hash = hashlib.md5(get_resp.content).hexdigest()

--- a/tests/smoke/test_smoke_regional.py
+++ b/tests/smoke/test_smoke_regional.py
@@ -22,6 +22,8 @@ import httpx
 import pytest
 from botocore.config import Config
 
+from .retrying_http import get_with_slowdown_retry
+
 
 REGIONAL_ENDPOINTS = [
     "https://eu-central-1.hippius.com",
@@ -93,7 +95,7 @@ def test_regional_public_object_anonymous_download(regional_s3_client, session_t
     regional_s3_client.put_object_acl(Bucket=session_tracker.bucket, Key=key, ACL="public-read")
 
     anon_url = f"{endpoint.rstrip('/')}/{session_tracker.bucket}/{key}"
-    resp = httpx.get(anon_url, timeout=60)
+    resp = get_with_slowdown_retry(anon_url, timeout=60)
     assert resp.status_code == 200, f"anonymous GET failed: status={resp.status_code} body={resp.text[:200]}"
     assert hashlib.md5(resp.content).hexdigest() == expected_hash, (
         f"[{region}] anonymously-downloaded public object does not match what was uploaded — public-read reads through the {region} edge are corrupting data."
@@ -129,7 +131,7 @@ def test_regional_presigned_url_roundtrip(regional_s3_client, session_tracker, f
         Params={"Bucket": session_tracker.bucket, "Key": key},
         ExpiresIn=300,
     )
-    get_resp = httpx.get(get_url, timeout=60)
+    get_resp = get_with_slowdown_retry(get_url, timeout=60)
     assert get_resp.status_code == 200, f"[{region}] presigned GET failed: {get_resp.status_code} {get_resp.text[:200]}"
     assert hashlib.md5(get_resp.content).hexdigest() == expected_hash, (
         f"[{region}] object fetched via presigned URL does not match what was PUT via presigned URL — the {region} presigned round-trip is corrupting data."

--- a/tests/unit/scripts/test_sweep_partless_multipart_uploads.py
+++ b/tests/unit/scripts/test_sweep_partless_multipart_uploads.py
@@ -1,0 +1,151 @@
+"""Guards for the partless-MPU sweep — a script that DELETEs, so its brakes must work.
+
+The two that matter: a run without --yes must not issue a DELETE at all, and a DLQ-protected
+object must be excluded from the ids handed to one. Everything else in the script is I/O.
+"""
+
+from __future__ import annotations
+
+import argparse
+import uuid
+from typing import Any
+
+import pytest
+
+from hippius_s3.scripts import sweep_partless_multipart_uploads as sweep
+
+
+class FakeConnection:
+    def __init__(self, batches: list[list[dict[str, Any]]]) -> None:
+        self._batches = batches
+        self.fetched: list[tuple[str, tuple]] = []
+        self.executed: list[tuple[str, tuple]] = []
+
+    async def fetch(self, sql: str, *params: Any) -> list[dict[str, Any]]:
+        self.fetched.append((sql, params))
+        return self._batches.pop(0) if self._batches else []
+
+    async def execute(self, sql: str, *params: Any) -> str:
+        self.executed.append((sql, params))
+        return "DELETE"
+
+    async def fetchval(self, sql: str, *params: Any) -> int:
+        self.fetched.append((sql, params))
+        return 0
+
+
+class FakePool:
+    def __init__(self, conn: FakeConnection) -> None:
+        self.conn = conn
+        self.closed = False
+
+    def acquire(self) -> Any:
+        conn = self.conn
+
+        class _Ctx:
+            async def __aenter__(self) -> FakeConnection:
+                return conn
+
+            async def __aexit__(self, *_: object) -> None:
+                return None
+
+        return _Ctx()
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    base = dict(
+        stale_seconds=3600,
+        batch_size=10,
+        max_batches=1,
+        sleep_between=0.0,
+        statement_timeout_ms=60_000,
+        count=False,
+        skip_dlq_check=True,
+        yes=False,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _deletes(conn: FakeConnection) -> list[tuple[str, tuple]]:
+    return [op for op in conn.executed if "DELETE" in op[0]]
+
+
+@pytest.mark.asyncio
+async def test_a_run_without_yes_issues_no_delete(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The dry run is the default, and it must be a genuine no-op against the database."""
+    conn = FakeConnection([[{"upload_id": uuid.uuid4(), "object_id": uuid.uuid4()} for _ in range(3)]])
+
+    async def fake_create_pool(*_a: Any, **_kw: Any) -> FakePool:
+        return FakePool(conn)
+
+    monkeypatch.setattr(sweep.asyncpg, "create_pool", fake_create_pool)
+
+    assert await sweep.main_async(_args(yes=False)) == 0
+
+    assert _deletes(conn) == [], "a dry run must not delete"
+
+
+@pytest.mark.asyncio
+async def test_dlq_protected_objects_are_never_deleted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mirrors the janitor/reaper gate: an object with an in-flight DLQ entry is spared."""
+    protected_id = uuid.uuid4()
+    keep = uuid.uuid4()
+    rows = [
+        {"upload_id": uuid.uuid4(), "object_id": protected_id},
+        {"upload_id": keep, "object_id": uuid.uuid4()},
+    ]
+    conn = FakeConnection([rows])
+
+    async def fake_create_pool(*_a: Any, **_kw: Any) -> FakePool:
+        return FakePool(conn)
+
+    async def fake_protected(_config: Any) -> set[str]:
+        return {str(protected_id)}
+
+    monkeypatch.setattr(sweep.asyncpg, "create_pool", fake_create_pool)
+    monkeypatch.setattr(sweep, "_dlq_protected_ids", fake_protected)
+
+    assert await sweep.main_async(_args(yes=True, skip_dlq_check=False)) == 0
+
+    deletes = _deletes(conn)
+    assert len(deletes) == 1
+    targets = deletes[0][1][0]
+    assert targets == [keep], "only the unprotected upload is deleted"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_batch_ends_the_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nothing left to sweep terminates rather than spinning on an empty query."""
+    conn = FakeConnection([[]])
+
+    async def fake_create_pool(*_a: Any, **_kw: Any) -> FakePool:
+        return FakePool(conn)
+
+    monkeypatch.setattr(sweep.asyncpg, "create_pool", fake_create_pool)
+
+    assert await sweep.main_async(_args(yes=True, max_batches=0)) == 0
+
+    assert _deletes(conn) == []
+
+
+@pytest.mark.asyncio
+async def test_every_statement_is_bounded_by_a_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """This script cleans up after an unbounded statement that pinned the xmin horizon for 96
+    minutes and stopped VACUUM database-wide. It must not be capable of repeating that."""
+    captured: dict = {}
+    conn = FakeConnection([[]])
+
+    async def fake_create_pool(*_a: Any, **kwargs: Any) -> FakePool:
+        captured.update(kwargs)
+        return FakePool(conn)
+
+    monkeypatch.setattr(sweep.asyncpg, "create_pool", fake_create_pool)
+
+    await sweep.main_async(_args(yes=True))
+
+    assert captured.get("command_timeout"), "no client-side ceiling on a statement"
+    assert captured.get("server_settings", {}).get("statement_timeout"), "no server-side ceiling"

--- a/tests/unit/test_extract_failure_details.py
+++ b/tests/unit/test_extract_failure_details.py
@@ -122,21 +122,45 @@ def test_unparseable_report_file_is_reported(tmp_path):
     assert "killed mid-run" in message
 
 
-def test_collection_error_is_surfaced(tmp_path):
+COLLECTOR_LONGREPR = (
+    "Traceback (most recent call last):\n"
+    '  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/_pytest/python.py", '
+    "line 493, in importtestmodule\n"
+    "    mod = import_path(...)\n"
+    '  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/importlib/__init__.py", '
+    "line 90, in import_module\n"
+    "    return _bootstrap._gcd_import(name[level:], package, level)\n"
+    '  File "tests/smoke/test_smoke_production.py", line 12, in <module>\n'
+    "    from hippius_api_client import HippiusApiClient\n"
+    "ImportError: cannot import name 'HippiusApiClient' from 'hippius_api_client'"
+)
+
+
+def test_collection_error_keeps_the_import_error_not_library_frames(tmp_path):
     report = make_report(
         exitcode=2,
         collectors=[
             {
                 "nodeid": "smoke/test_smoke_production.py",
                 "outcome": "error",
-                "longrepr": "ImportError: cannot import name 'boto3'",
+                "longrepr": COLLECTOR_LONGREPR,
             }
         ],
     )
     message = mod.build_alert_message([write_report(tmp_path, "smoke-production", report)])
 
     assert "could not even collect" in message
-    assert "ImportError" in message
+    assert "ImportError: cannot import name 'HippiusApiClient'" in message
+    assert "site-packages" not in message
+    assert "importlib" not in message
+
+
+def test_truncation_never_drops_the_final_error_line():
+    frames = "\n".join(f"tests/smoke/test_x.py:{n}: in helper_{n}\n    call()" for n in range(1, 12))
+    cleaned = mod.clean_traceback(f"{frames}\nE   RuntimeError: the actual problem", max_lines=6)
+
+    assert "... (truncated)" in cleaned
+    assert cleaned.endswith("E   RuntimeError: the actual problem")
 
 
 def test_nonzero_exit_without_failures_is_surfaced(tmp_path):

--- a/tests/unit/test_extract_failure_details.py
+++ b/tests/unit/test_extract_failure_details.py
@@ -1,0 +1,170 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).parents[2] / "scripts" / "extract_failure_details.py"
+spec = importlib.util.spec_from_file_location("extract_failure_details", SCRIPT_PATH)
+assert spec and spec.loader
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+HTTPX_LONGREPR = (
+    "[gw0] linux -- Python 3.12.13 /opt/hostedtoolcache/Python/3.12.13/x64/bin/python\n"
+    "tests/smoke/test_smoke_regional.py:142: in test_regional_presigned_url_roundtrip\n"
+    "    resp = httpx.get(presigned_url, timeout=30)\n"
+    "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/httpx/_api.py:198: in get\n"
+    "    return request(\n"
+    "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/httpx/_transports/default.py:101: "
+    "in map_httpcore_exceptions\n"
+    "    yield\n"
+    "E   httpx.ReadTimeout: The read operation timed out"
+)
+
+
+def make_test(nodeid: str, longrepr, message: str | None, crash_path: str) -> dict:
+    call: dict = {"outcome": "failed", "longrepr": longrepr}
+    if message is not None:
+        call["crash"] = {"path": crash_path, "lineno": 118, "message": message}
+    return {"nodeid": nodeid, "outcome": "failed", "call": call}
+
+
+def make_report(*tests: dict, exitcode: int = 1, collectors: list | None = None) -> dict:
+    report = {"exitcode": exitcode, "tests": list(tests)}
+    if collectors is not None:
+        report["collectors"] = collectors
+    return report
+
+
+TIMEOUT_TEST = make_test(
+    "smoke/test_smoke_regional.py::test_regional_presigned_url_roundtrip[eu-central-1]",
+    HTTPX_LONGREPR,
+    "httpx.ReadTimeout: The read operation timed out",
+    "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/httpx/_transports/default.py",
+)
+
+
+def write_report(tmp_path: Path, name: str, report: dict) -> Path:
+    path = tmp_path / f"{name}.json"
+    path.write_text(json.dumps(report))
+    return path
+
+
+def test_read_timeout_is_explained_in_plain_language():
+    failures = mod.extract_failures(make_report(TIMEOUT_TEST), "smoke-regional")
+    message = mod.format_failures_for_alert(failures)
+
+    assert "did not respond before the client timeout" in message
+    assert "regional cache suite" in message
+    assert "test_regional_presigned_url_roundtrip[eu-central-1]" in message
+    assert "while running the test" in message
+
+
+def test_location_points_at_test_code_not_library_internals():
+    failures = mod.extract_failures(make_report(TIMEOUT_TEST), "smoke-regional")
+    message = mod.format_failures_for_alert(failures)
+
+    assert "tests/smoke/test_smoke_regional.py:142" in message
+    assert "site-packages" not in message
+    assert "[gw0]" not in message
+
+
+def test_assertion_error_keeps_the_failing_comparison():
+    test = make_test(
+        "smoke/test_smoke_production.py::test_put_get_roundtrip",
+        (
+            "tests/smoke/test_smoke_production.py:88: in test_put_get_roundtrip\n"
+            "    assert body == payload\n"
+            "E   AssertionError: assert b'abc' == b'abd'"
+        ),
+        "AssertionError: assert b'abc' == b'abd'",
+        "tests/smoke/test_smoke_production.py",
+    )
+    failures = mod.extract_failures(make_report(test), "smoke-production")
+    message = mod.format_failures_for_alert(failures)
+
+    assert "did not match what the test expected" in message
+    assert "assert b'abc' == b'abd'" in message
+
+
+def test_missing_crash_info_falls_back_to_traceback_error_line():
+    test = make_test("smoke/test_x.py::test_y", "tests/smoke/test_x.py:10: in test_y\nE   RuntimeError: boom", None, "")
+    failures = mod.extract_failures(make_report(test), "smoke-production")
+
+    assert "RuntimeError: boom" in failures[0]["explanation"]
+
+
+def test_non_string_longrepr_does_not_crash():
+    test = make_test("smoke/test_x.py::test_y", {"weird": "shape"}, "SomeError: x", "tests/smoke/test_x.py")
+    failures = mod.extract_failures(make_report(test), "smoke-production")
+
+    assert failures[0]["traceback"] == ""
+
+
+def test_unknown_error_falls_back_to_raw_message():
+    assert "SomeWeirdError: boom" in mod.explain_error("SomeWeirdError: boom")
+
+
+def test_missing_report_file_is_reported_not_silently_ignored(tmp_path):
+    message = mod.build_alert_message([tmp_path / "smoke-regional.json"])
+
+    assert "no report file was written" in message
+    assert "regional cache suite" in message
+    assert "No failures found" not in message
+
+
+def test_unparseable_report_file_is_reported(tmp_path):
+    path = tmp_path / "smoke-production.json"
+    path.write_text("{truncated")
+    message = mod.build_alert_message([path])
+
+    assert "could not be parsed" in message
+    assert "killed mid-run" in message
+
+
+def test_collection_error_is_surfaced(tmp_path):
+    report = make_report(
+        exitcode=2,
+        collectors=[
+            {
+                "nodeid": "smoke/test_smoke_production.py",
+                "outcome": "error",
+                "longrepr": "ImportError: cannot import name 'boto3'",
+            }
+        ],
+    )
+    message = mod.build_alert_message([write_report(tmp_path, "smoke-production", report)])
+
+    assert "could not even collect" in message
+    assert "ImportError" in message
+
+
+def test_nonzero_exit_without_failures_is_surfaced(tmp_path):
+    report = make_report(exitcode=5)
+    message = mod.build_alert_message([write_report(tmp_path, "smoke-subtoken-scope", report)])
+
+    assert "no tests were collected" in message
+    assert "sub-token scope suite" in message
+
+
+def test_interrupted_run_with_recorded_failures_shows_only_the_failures(tmp_path):
+    report = make_report(TIMEOUT_TEST, exitcode=2)
+    message = mod.build_alert_message([write_report(tmp_path, "smoke-regional", report)])
+
+    assert "did not respond before the client timeout" in message
+    assert "Suite-level problems" not in message
+
+
+def test_all_reports_clean_still_explains_the_red_workflow(tmp_path):
+    message = mod.build_alert_message([write_report(tmp_path, "smoke-production", make_report(exitcode=0))])
+
+    assert "no test failures were captured" in message
+    assert "check the run logs" in message
+
+
+def test_webhook_payload_has_no_gif():
+    payload = mod.build_payload("2 test(s) failed", "https://github.com/x/y/actions/runs/1")
+    assert "giphy" not in payload["text"]
+    assert "![" not in payload["text"]
+    assert "View run" in payload["text"]
+    assert "s3.hippius.com smoke tests failed" in payload["text"]

--- a/tests/unit/test_janitor_cache_metrics.py
+++ b/tests/unit/test_janitor_cache_metrics.py
@@ -1,0 +1,140 @@
+"""The janitor must report the work it actually does.
+
+Two independent gaps made every cache panel on the "Hippius S3 — System Load" dashboard read
+zero on prod while the janitor was busy:
+
+1. `cleanup_stale_parts` deletes the overwhelming majority of parts in prod and incremented
+   nothing. Only its `abandoned` sub-case touched a counter, and only a dedicated one. So
+   `fs_janitor_deleted_total` — the metric behind the GC-rate panel — had never been
+   incremented at all and did not exist as a series in Prometheus.
+
+2. The census gauges (`fs_store_parts_on_disk`, `fs_cache_age_bucket_parts`,
+   `fs_cache_hot_parts`) are only assigned at the END of the GC phase, which runs after
+   `cleanup_stale_parts`. When that earlier phase runs long they stay at their initial 0,
+   which is indistinguishable from "the cache is empty".
+
+Measured on prod 2026-07-23: 18,737 parts deleted in <2h with zero cycle completions, disk at
+5.18 TB, and every one of those gauges reporting 0.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JANITOR = REPO_ROOT / "workers" / "run_janitor_in_loop.py"
+DASHBOARD = REPO_ROOT / "monitoring" / "grafana" / "dashboards" / "system-load.json"
+
+
+@pytest.fixture(scope="module")
+def janitor_source() -> str:
+    return JANITOR.read_text()
+
+
+@pytest.fixture(scope="module")
+def dashboard() -> dict:
+    return json.loads(DASHBOARD.read_text())
+
+
+def _panel(dashboard: dict, panel_id: int) -> dict:
+    for panel in dashboard["panels"]:
+        if panel.get("id") == panel_id:
+            return panel
+    raise AssertionError(f"panel {panel_id} is missing from the dashboard")
+
+
+def _exprs(panel: dict) -> list[str]:
+    return [t["expr"] for t in panel.get("targets", []) if t.get("expr")]
+
+
+# ---- emission ----
+
+
+@pytest.mark.parametrize("reason", ["stale_mtime", "gc_age", "abandoned"])
+def test_every_delete_path_increments_the_counter(janitor_source: str, reason: str) -> None:
+    assert f'{{"reason": "{reason}"}}' in janitor_source, (
+        f"the {reason} deletion path does not increment fs_janitor_deleted_total, so the "
+        f"delete-rate panel under-reports (it read flat zero on prod because stale_mtime — "
+        f"the busiest path by far — counted nothing)."
+    )
+
+
+def test_stale_path_counts_outside_the_abandoned_branch(janitor_source: str) -> None:
+    """The bug was that only the `abandoned` sub-case counted; the plain path fell through."""
+    assert janitor_source.count("_janitor_deleted_counter.add(") >= 3, (
+        "expected the counter to be incremented from the gc_age, stale_mtime and abandoned "
+        "paths"
+    )
+
+
+def test_cycle_progress_gauges_are_registered(janitor_source: str) -> None:
+    """Without these, a stuck phase is indistinguishable from an empty cache."""
+    for name in ("fs_janitor_phase", "fs_janitor_last_cycle_age_seconds", "fs_janitor_cycle_seconds"):
+        assert f'name="{name}"' in janitor_source, f"{name} gauge is not registered"
+
+
+def test_phase_index_stays_within_the_phase_names(janitor_source: str) -> None:
+    """_obs_janitor_phase indexes JANITOR_PHASES directly — an out-of-range assignment would
+    raise inside the OTel callback and silently drop the whole metric export."""
+    import re
+
+    assigned = {int(m) for m in re.findall(r"^\s*_janitor_phase = (\d+)$", janitor_source, re.MULTILINE)}
+    phases = re.search(r"JANITOR_PHASES = \((.*?)\)", janitor_source, re.DOTALL)
+    assert phases, "JANITOR_PHASES tuple not found"
+    count = len([p for p in phases.group(1).split(",") if p.strip()])
+    assert assigned, "no phase assignments found"
+    assert max(assigned) < count, f"phase index {max(assigned)} is out of range for {count} names"
+
+
+def test_last_cycle_age_reports_negative_before_any_cycle_completes() -> None:
+    """-1 distinguishes 'never completed a cycle' from 'completed one just now' (0)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("janitor_probe", JANITOR)
+    assert spec and spec.loader
+    source = JANITOR.read_text()
+    assert "_janitor_last_cycle_completed_at <= 0" in source
+    assert "Observation(-1.0, {})" in source
+
+
+# ---- dashboard ----
+
+
+def test_delete_rate_panel_breaks_out_by_reason(dashboard: dict) -> None:
+    exprs = _exprs(_panel(dashboard, 64))
+    assert any("by (reason)" in e and "fs_janitor_deleted_total" in e for e in exprs), (
+        "the delete-rate panel must group by reason, otherwise the stale_mtime path (the bulk "
+        "of prod deletions) is invisible next to gc_age"
+    )
+
+
+def test_cycle_health_panel_exists(dashboard: dict) -> None:
+    exprs = _exprs(_panel(dashboard, 65))
+    assert any("fs_janitor_last_cycle_age_seconds" in e for e in exprs)
+
+
+def test_census_panels_say_they_can_be_stale(dashboard: dict) -> None:
+    """A zero on these panels means 'not measured yet' as often as it means 'empty'."""
+    for panel_id in (54, 62):
+        description = _panel(dashboard, panel_id).get("description", "")
+        assert "COMPLETED" in description, (
+            f"panel {panel_id} does not say its census comes from the last completed GC phase, "
+            f"so a stale zero reads as a real zero"
+        )
+
+
+def test_ssd_backlog_is_per_node(dashboard: dict) -> None:
+    """The drain is per-node; a bare max() hides which node is falling behind."""
+    exprs = _exprs(_panel(dashboard, 87))
+    assert any("by (service_instance_id)" in e for e in exprs), (
+        "SSD backlog collapses every ingest node into one line"
+    )
+
+
+def test_dashboard_is_valid_json_and_panel_ids_are_unique(dashboard: dict) -> None:
+    ids = [p.get("id") for p in dashboard["panels"]]
+    assert len(ids) == len(set(ids)), f"duplicate panel ids: {[i for i in ids if ids.count(i) > 1]}"

--- a/tests/unit/test_janitor_cache_metrics.py
+++ b/tests/unit/test_janitor_cache_metrics.py
@@ -56,7 +56,7 @@ def _exprs(panel: dict) -> list[str]:
 
 @pytest.mark.parametrize("reason", ["stale_mtime", "gc_age", "abandoned"])
 def test_every_delete_path_increments_the_counter(janitor_source: str, reason: str) -> None:
-    assert f'{{"reason": "{reason}"}}' in janitor_source, (
+    assert f'attributes={{"reason": "{reason}"}}' in janitor_source, (
         f"the {reason} deletion path does not increment fs_janitor_deleted_total, so the "
         f"delete-rate panel under-reports (it read flat zero on prod because stale_mtime — "
         f"the busiest path by far — counted nothing)."

--- a/tests/unit/test_janitor_sharded_gc.py
+++ b/tests/unit/test_janitor_sharded_gc.py
@@ -172,6 +172,27 @@ async def test_census_publishes_only_on_full_sweep(tmp_path: Path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_shard_zero_resets_accumulator_so_a_mid_sweep_shard_change_cannot_inflate(tmp_path: Path, monkeypatch):
+    """If pressure flips `shards` to 1 mid-sweep, the next shard-0 walk must start a clean
+    accumulator — otherwise the prior partial sweep's counts blend in and inflate the census."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    _n_objects(tmp_path, 40)
+    store = _FakeFsStore(tmp_path)
+    with patch.object(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=False)):
+        # Partial 4-shard sweep: cover shards 0,1 (accumulates ~half the tree), never published.
+        for s in (0, 1):
+            await janitor.cleanup_old_parts_by_mtime(
+                _FakePool(_db()), store, _redis(), shard=s, shards=4, walk_concurrency=4, publish_sweep=False
+            )
+        # Pressure kicks in → shards=1, shard=0, publish. shard-0 reset must discard the partial
+        # accumulation and publish exactly the whole tree, not tree + the earlier half.
+        await janitor.cleanup_old_parts_by_mtime(
+            _FakePool(_db()), store, _redis(), shard=0, shards=1, walk_concurrency=4, publish_sweep=True
+        )
+    assert janitor._fs_parts_on_disk == 40, "shard-0 reset must prevent the mid-sweep count from inflating"
+
+
+@pytest.mark.asyncio
 async def test_truncated_sweep_does_not_publish_partial_census(tmp_path: Path, monkeypatch):
     """A budget-truncated shard taints the sweep; the gauge must hold its last good value."""
     monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)

--- a/tests/unit/test_janitor_sharded_gc.py
+++ b/tests/unit/test_janitor_sharded_gc.py
@@ -1,0 +1,262 @@
+"""Sharding + budgeting of the janitor FS-walk phases, and the sweep-scoped census.
+
+The starvation fix makes each FS-walk phase cover one hash-shard of the tree per cycle
+(full sweep every `shards` cycles) under a wall-clock budget, so the cycle always completes
+and the DB-only durability phases (moved to the front) always run. The safety-critical
+property is that sharding changes only WHICH objects a cycle visits, never the per-part
+deletion decision: the union of deletions over all shards must equal the un-sharded run.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from workers import run_janitor_in_loop as janitor
+
+
+def _make_part(fs_root: Path, object_id: str, version: int, part: int, *, mtime_offset: float = 0) -> None:
+    d = fs_root / object_id / f"v{version}" / f"part_{part}"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "chunk_0.bin").write_bytes(b"payload")
+    (d / "meta.json").write_text('{"chunk_size": 7, "num_chunks": 1, "size_bytes": 7}')
+    now = time.time()
+    os.utime(d / "meta.json", (now - mtime_offset, now - mtime_offset))
+
+
+class _PoolCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _PoolCtx(self._conn)
+
+
+class _FakeFsStore:
+    def __init__(self, root: Path):
+        self.root = root
+        self.deleted: list[tuple[str, int, int]] = []
+
+    async def delete_part(self, object_id: str, object_version: int, part_number: int) -> None:
+        import shutil
+
+        self.deleted.append((object_id, object_version, part_number))
+        p = self.root / object_id / f"v{object_version}" / f"part_{part_number}"
+        if p.exists():
+            shutil.rmtree(p)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    # hot_retention=1s so the parts these coverage tests create (mtime/atime ~1h ago) are cold;
+    # they isolate the age+replication decision from hot-retention (tested separately).
+    janitor.config.fs_cache_hot_retention_seconds = 1
+    janitor.config.fs_cache_gc_max_age_seconds = 60
+    janitor.config.mpu_stale_seconds = 86400
+    janitor.config.upload_backends = ["arion"]
+    janitor._reset_census_accum()
+    janitor._walk_shard = 0
+    yield
+
+
+def _db():
+    db = AsyncMock()
+    db.fetchrow = AsyncMock(return_value=None)
+    db.fetch = AsyncMock(return_value=[])
+    db.fetchval = AsyncMock(return_value=None)
+    return db
+
+
+def _redis():
+    r = MagicMock()
+    r.lrange = AsyncMock(return_value=[])
+    return r
+
+
+def _n_objects(fs_root: Path, n: int, *, mtime_offset: float = 3600) -> None:
+    for i in range(n):
+        _make_part(fs_root, f"{i:032x}", 1, 1, mtime_offset=mtime_offset)
+
+
+# ---- the safety invariant: shard union == unsharded ----
+
+
+@pytest.mark.asyncio
+async def test_shard_union_deletes_exactly_the_unsharded_set(tmp_path: Path, monkeypatch):
+    """The whole point: sharding must not change WHAT gets deleted, only across how many cycles."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+
+    # Unsharded reference run.
+    ref_root = tmp_path / "ref"
+    _n_objects(ref_root, 60)
+    ref_store = _FakeFsStore(ref_root)
+    with patch.object(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=True)):
+        await janitor.cleanup_old_parts_by_mtime(_FakePool(_db()), ref_store, _redis(), shards=1, walk_concurrency=4)
+    ref_deleted = set(ref_store.deleted)
+    assert ref_deleted, "reference run should have deleted the cold replicated parts"
+
+    # Sharded run: same tree, all shards, deletions accumulated.
+    sh_root = tmp_path / "sh"
+    _n_objects(sh_root, 60)
+    sh_store = _FakeFsStore(sh_root)
+    shards = 6
+    with patch.object(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=True)):
+        for s in range(shards):
+            await janitor.cleanup_old_parts_by_mtime(
+                _FakePool(_db()), sh_store, _redis(), shard=s, shards=shards, walk_concurrency=4, publish_sweep=False
+            )
+    assert set(sh_store.deleted) == ref_deleted
+
+
+@pytest.mark.asyncio
+async def test_stale_cleanup_shard_union_matches(tmp_path: Path):
+    """Same invariant for cleanup_stale_parts (orphan / no-parts-row reap path)."""
+    ref_root = tmp_path / "ref"
+    _n_objects(ref_root, 40, mtime_offset=janitor.config.mpu_stale_seconds + 100)
+    ref_store = _FakeFsStore(ref_root)
+    db = _db()  # fetchrow None => no parts row => orphan => reap
+    await janitor.cleanup_stale_parts(_FakePool(db), ref_store, _redis(), shards=1, walk_concurrency=4)
+    ref = set(ref_store.deleted)
+    assert ref
+
+    sh_root = tmp_path / "sh"
+    _n_objects(sh_root, 40, mtime_offset=janitor.config.mpu_stale_seconds + 100)
+    sh_store = _FakeFsStore(sh_root)
+    shards = 5
+    for s in range(shards):
+        await janitor.cleanup_stale_parts(
+            _FakePool(_db()), sh_store, _redis(), shard=s, shards=shards, walk_concurrency=4
+        )
+    assert set(sh_store.deleted) == ref
+
+
+# ---- census is sweep-scoped ----
+
+
+@pytest.mark.asyncio
+async def test_census_publishes_only_on_full_sweep(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    _n_objects(tmp_path, 30)
+    store = _FakeFsStore(tmp_path)
+    janitor._fs_parts_on_disk = -1  # sentinel: unchanged means "not published"
+    shards = 3
+    with patch.object(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=False)):
+        # shards 0 and 1: accumulate, do NOT publish
+        for s in range(2):
+            await janitor.cleanup_old_parts_by_mtime(
+                _FakePool(_db()), store, _redis(), shard=s, shards=shards, walk_concurrency=4, publish_sweep=False
+            )
+        assert janitor._fs_parts_on_disk == -1, "census must not publish mid-sweep"
+        # last shard: publish the accumulated full-tree census
+        await janitor.cleanup_old_parts_by_mtime(
+            _FakePool(_db()), store, _redis(), shard=2, shards=shards, walk_concurrency=4, publish_sweep=True
+        )
+    assert janitor._fs_parts_on_disk == 30, "a completed sweep must publish the whole-tree count"
+
+
+@pytest.mark.asyncio
+async def test_truncated_sweep_does_not_publish_partial_census(tmp_path: Path, monkeypatch):
+    """A budget-truncated shard taints the sweep; the gauge must hold its last good value."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    _n_objects(tmp_path, 50)
+    store = _FakeFsStore(tmp_path)
+    janitor._fs_parts_on_disk = 999  # last-good value
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    with patch.object(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=False)):
+        # single-shard sweep, already-expired deadline => truncated
+        await janitor.cleanup_old_parts_by_mtime(
+            _FakePool(_db()),
+            store,
+            _redis(),
+            shard=0,
+            shards=1,
+            walk_concurrency=2,
+            deadline=loop.time() - 1.0,
+            publish_sweep=True,
+        )
+    assert janitor._fs_parts_on_disk == 999, "a truncated sweep must not overwrite the census"
+
+
+# ---- deadline helper ----
+
+
+def test_walk_deadline_lifts_under_critical_pressure():
+    import asyncio
+
+    async def _check():
+        loop = asyncio.get_running_loop()
+        assert janitor._walk_deadline(loop, pressure=2, budget=300) is None  # critical => unbounded
+        assert janitor._walk_deadline(loop, pressure=0, budget=0) is None  # disabled
+        d = janitor._walk_deadline(loop, pressure=0, budget=300)
+        assert d is not None and d > loop.time()
+        d1 = janitor._walk_deadline(loop, pressure=1, budget=300)  # elevated still bounded
+        assert d1 is not None
+
+    asyncio.run(_check())
+
+
+# ---- the core durability fix: DB-only phases run BEFORE the FS walks ----
+
+
+@pytest.mark.asyncio
+async def test_durability_phases_run_before_fs_walks(monkeypatch):
+    """The starvation bug: the replication sentinel + aged-orphan gauge ran LAST, behind two
+    full-tree FS walks that never finished, so on prod they never ran. They must now run first,
+    unconditionally, so no FS-walk cost can starve them."""
+    from pathlib import Path
+
+    order: list[str] = []
+
+    async def _rec(name, ret=0):
+        order.append(name)
+        return ret
+
+    monkeypatch.setattr(janitor, "_update_disk_metrics", lambda root: order.append("disk_metrics"))
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    monkeypatch.setattr(janitor, "check_replication_sentinel", lambda *a, **k: _rec("sentinel"))
+    monkeypatch.setattr(janitor, "get_all_dlq_object_ids", lambda *a, **k: _rec("dlq", set()))
+    monkeypatch.setattr(janitor, "check_aged_pending_orphans", lambda *a, **k: _rec("aged_orphans"))
+    monkeypatch.setattr(janitor, "cleanup_stale_parts", lambda *a, **k: _rec("fs_stale"))
+    monkeypatch.setattr(janitor, "cleanup_old_parts_by_mtime", lambda *a, **k: _rec("fs_gc"))
+    monkeypatch.setattr(janitor, "cleanup_orphan_tmp_files", lambda *a, **k: _rec("fs_tmp"))
+    monkeypatch.setattr(janitor, "gc_soft_deleted_objects", lambda *a, **k: _rec("hard_delete"))
+    monkeypatch.setattr(janitor, "_setup_janitor_metrics", lambda: None)
+    monkeypatch.setattr(janitor, "create_fs_store", lambda config: MagicMock(root=Path("/tmp")))
+    monkeypatch.setattr(janitor.asyncpg, "create_pool", AsyncMock(return_value=AsyncMock()))
+    monkeypatch.setattr(janitor.Redis, "from_url", lambda url: AsyncMock())
+
+    class _Stop(Exception):
+        pass
+
+    async def _sleep_then_stop(_seconds):
+        raise _Stop
+
+    monkeypatch.setattr(janitor.asyncio, "sleep", _sleep_then_stop)
+
+    with pytest.raises(_Stop):
+        await janitor.run_janitor_loop()
+
+    assert "sentinel" in order and "aged_orphans" in order
+    # both durability signals must precede every FS-walk phase
+    first_fs = min(order.index(p) for p in ("fs_stale", "fs_gc", "fs_tmp"))
+    assert order.index("sentinel") < first_fs, f"sentinel must run before FS walks; got {order}"
+    assert order.index("aged_orphans") < first_fs, f"aged-orphan gauge must run before FS walks; got {order}"

--- a/tests/unit/test_janitor_sharded_gc.py
+++ b/tests/unit/test_janitor_sharded_gc.py
@@ -281,3 +281,59 @@ async def test_durability_phases_run_before_fs_walks(monkeypatch):
     first_fs = min(order.index(p) for p in ("fs_stale", "fs_gc", "fs_tmp"))
     assert order.index("sentinel") < first_fs, f"sentinel must run before FS walks; got {order}"
     assert order.index("aged_orphans") < first_fs, f"aged-orphan gauge must run before FS walks; got {order}"
+
+
+@pytest.mark.asyncio
+async def test_disk_pressure_collapses_the_walk_to_a_single_whole_tree_shard(monkeypatch):
+    """Safety rule (config.janitor_walk_shards): under ANY disk pressure the janitor must collapse
+    sharding to shards=1 so ONE cycle walks the WHOLE tree and eviction sees every deletable part —
+    never a 1/Nth slice while the disk fills. A regression that kept the normal shard count under
+    pressure would silently slow eviction exactly when it matters most; pin it here."""
+
+    async def _shards_passed_at_pressure(pressure: int) -> dict:
+        captured: dict = {}
+
+        async def _capture_stale(*a, **k):
+            captured["stale"] = k.get("shards")
+            return 0
+
+        async def _capture_gc(*a, **k):
+            captured["gc"] = k.get("shards")
+            return 0
+
+        monkeypatch.setattr(janitor, "_update_disk_metrics", lambda root: None)
+        monkeypatch.setattr(janitor, "_pressure_mode", lambda root: pressure)
+        monkeypatch.setattr(janitor, "check_replication_sentinel", AsyncMock(return_value=0))
+        monkeypatch.setattr(janitor, "get_all_dlq_object_ids", AsyncMock(return_value=set()))
+        monkeypatch.setattr(janitor, "check_aged_pending_orphans", AsyncMock(return_value=0))
+        monkeypatch.setattr(janitor, "cleanup_stale_parts", _capture_stale)
+        monkeypatch.setattr(janitor, "cleanup_old_parts_by_mtime", _capture_gc)
+        monkeypatch.setattr(janitor, "cleanup_orphan_tmp_files", AsyncMock(return_value=0))
+        monkeypatch.setattr(janitor, "gc_soft_deleted_objects", AsyncMock(return_value=0))
+        monkeypatch.setattr(janitor, "_setup_janitor_metrics", lambda: None)
+        monkeypatch.setattr(janitor, "create_fs_store", lambda config: MagicMock(root=Path("/tmp")))
+        monkeypatch.setattr(janitor.asyncpg, "create_pool", AsyncMock(return_value=AsyncMock()))
+        monkeypatch.setattr(janitor.Redis, "from_url", lambda url: AsyncMock())
+
+        class _Stop(Exception):
+            pass
+
+        async def _sleep_then_stop(_seconds):
+            raise _Stop
+
+        monkeypatch.setattr(janitor.asyncio, "sleep", _sleep_then_stop)
+        with pytest.raises(_Stop):
+            await janitor.run_janitor_loop()
+        return captured
+
+    # Elevated (1) AND critical (2) both force the whole-tree single-shard walk.
+    for pressure in (1, 2):
+        captured = await _shards_passed_at_pressure(pressure)
+        assert captured["stale"] == 1, f"pressure={pressure} must force shards=1 (stale phase), got {captured}"
+        assert captured["gc"] == 1, f"pressure={pressure} must force shards=1 (age-GC phase), got {captured}"
+
+    # Normal pressure keeps the configured sharded sweep.
+    normal = await _shards_passed_at_pressure(0)
+    expected = max(1, janitor.config.janitor_walk_shards)
+    assert normal["stale"] == expected, f"normal pressure must use the configured shard count, got {normal}"
+    assert normal["gc"] == expected, f"normal pressure must use the configured shard count, got {normal}"

--- a/tests/unit/test_janitor_walk.py
+++ b/tests/unit/test_janitor_walk.py
@@ -1,0 +1,143 @@
+"""The parallel FS walk that replaces the serial `_safe_iterdir` producer.
+
+The serial walk ran on the event loop at ~40 object-dirs/s over CephFS (measured on prod
+2026-07-23), so a pass over ~2.8M object dirs took ~20h and never completed inside a cycle —
+starving every phase after `cleanup_stale_parts`. `iter_part_dirs` fans the per-object
+descent across a thread pool, shards for fair coverage, and honours a wall-clock budget so
+the cycle always completes. These tests pin the properties the deletion logic relies on:
+completeness, shard-union == full walk, budget truncation, and legacy serial equivalence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from workers.run_janitor_in_loop import PartDirInfo
+from workers.run_janitor_in_loop import WalkState
+from workers.run_janitor_in_loop import _object_in_shard
+from workers.run_janitor_in_loop import iter_part_dirs
+
+
+def _build_tree(root: Path, n_objects: int, versions: int = 1, parts: int = 1, meta: bool = True) -> int:
+    made = 0
+    for i in range(n_objects):
+        oid = f"{i:032x}"
+        for v in range(1, versions + 1):
+            for p in range(1, parts + 1):
+                d = root / oid / f"v{v}" / f"part_{p}"
+                d.mkdir(parents=True, exist_ok=True)
+                (d / "chunk_0.bin").write_bytes(b"x")
+                if meta:
+                    (d / "meta.json").write_text("{}")
+                made += 1
+    return made
+
+
+async def _collect(root: Path, **kw) -> tuple[list[PartDirInfo], WalkState]:
+    state = WalkState()
+    out: list[PartDirInfo] = []
+    async for info in iter_part_dirs(root, state=state, **kw):
+        out.append(info)
+    return out, state
+
+
+@pytest.mark.asyncio
+async def test_full_walk_finds_every_part(tmp_path: Path) -> None:
+    expected = _build_tree(tmp_path, 40, versions=2, parts=3)
+    got, state = await _collect(tmp_path, concurrency=8, shard=0, shards=1, deadline=None)
+    assert len(got) == expected == 240
+    assert state.truncated is False
+    keys = {(i.object_id, i.object_version, i.part_number) for i in got}
+    assert len(keys) == expected  # no duplicates
+
+
+@pytest.mark.asyncio
+async def test_shards_partition_the_tree_exactly(tmp_path: Path) -> None:
+    """Every part appears in exactly one shard; the union over all shards is the full walk."""
+    _build_tree(tmp_path, 100, versions=1, parts=2)
+    full, _ = await _collect(tmp_path, concurrency=4, shard=0, shards=1, deadline=None)
+    full_keys = {(i.object_id, i.object_version, i.part_number) for i in full}
+
+    shards = 5
+    seen: set = set()
+    for s in range(shards):
+        part, _ = await _collect(tmp_path, concurrency=4, shard=s, shards=shards, deadline=None)
+        keys = {(i.object_id, i.object_version, i.part_number) for i in part}
+        assert not (keys & seen), "an object landed in two shards — coverage would double-scan"
+        seen |= keys
+    assert seen == full_keys, "shard union must equal the full walk — no object left unswept"
+
+
+@pytest.mark.asyncio
+async def test_budget_truncates_and_flags(tmp_path: Path) -> None:
+    _build_tree(tmp_path, 200)
+    loop = asyncio.get_running_loop()
+    got, state = await _collect(
+        tmp_path, concurrency=2, shard=0, shards=1, deadline=loop.time() - 1.0
+    )
+    assert state.truncated is True
+    assert len(got) < 200  # stopped early
+
+
+@pytest.mark.asyncio
+async def test_serial_equivalence(tmp_path: Path) -> None:
+    """concurrency=1 is the legacy one-object-at-a-time descent and must find the same set."""
+    _build_tree(tmp_path, 30, versions=2, parts=2)
+    par, _ = await _collect(tmp_path, concurrency=8, shard=0, shards=1, deadline=None)
+    ser, _ = await _collect(tmp_path, concurrency=1, shard=0, shards=1, deadline=None)
+    assert {(i.object_id, i.object_version, i.part_number) for i in par} == {
+        (i.object_id, i.object_version, i.part_number) for i in ser
+    }
+
+
+@pytest.mark.asyncio
+async def test_missing_root_is_empty_not_error(tmp_path: Path) -> None:
+    got, state = await _collect(tmp_path / "does-not-exist", concurrency=4, shard=0, shards=1, deadline=None)
+    assert got == []
+    assert state.objects_scanned == 0
+
+
+@pytest.mark.asyncio
+async def test_stat_prefers_meta_then_falls_back_to_part_dir(tmp_path: Path) -> None:
+    """meta.json's mtime is the readiness signal; without it the part dir's is used."""
+    d = tmp_path / f"{1:032x}" / "v1" / "part_1"
+    d.mkdir(parents=True)
+    (d / "chunk_0.bin").write_bytes(b"x")
+    (d / "meta.json").write_text("{}")
+    meta_mtime = 1_000_000.0
+    os.utime(d / "meta.json", (meta_mtime, meta_mtime))
+    got, _ = await _collect(tmp_path, concurrency=2, shard=0, shards=1, deadline=None)
+    assert len(got) == 1
+    assert got[0].mtime == pytest.approx(meta_mtime)
+
+    # Now a part with no meta.json → falls back to the dir's own mtime.
+    d2 = tmp_path / f"{2:032x}" / "v1" / "part_1"
+    d2.mkdir(parents=True)
+    (d2 / "chunk_0.bin").write_bytes(b"x")
+    got2, _ = await _collect(tmp_path, concurrency=2, shard=0, shards=1, deadline=None)
+    assert len(got2) == 2
+
+
+@pytest.mark.asyncio
+async def test_malformed_dir_names_are_skipped(tmp_path: Path) -> None:
+    _build_tree(tmp_path, 5)
+    # junk that must not crash the walk or be yielded
+    (tmp_path / "not-an-object" / "vXX" / "part_zz").mkdir(parents=True)
+    (tmp_path / f"{99:032x}" / "vbad").mkdir(parents=True)
+    (tmp_path / f"{98:032x}" / "v1" / "partZ").mkdir(parents=True)
+    got, _ = await _collect(tmp_path, concurrency=4, shard=0, shards=1, deadline=None)
+    # only the 5 well-formed parts
+    assert len(got) == 5
+
+
+def test_shard_helper_is_stable_and_bounded() -> None:
+    oid = "a" * 32
+    assert _object_in_shard(oid, 0, 1) is True  # shards<=1 always in
+    hits = [s for s in range(8) if _object_in_shard(oid, s, 8)]
+    assert len(hits) == 1  # exactly one shard claims it
+    # stable across calls
+    assert _object_in_shard(oid, hits[0], 8) is True

--- a/tests/unit/test_read_path_fails_before_client_gives_up.py
+++ b/tests/unit/test_read_path_fails_before_client_gives_up.py
@@ -1,0 +1,53 @@
+"""The read path's fail-fast is only useful if it beats the client's read timeout.
+
+`stream_first_chunk_timeout_seconds` bounds how long a GET waits for its first chunk before
+raising DownloadNotReadyError -> 503 SlowDown, which every S3 SDK retries. That is the entire
+mechanism for surviving a cross-node read-after-write, where the object is legitimately not
+ready for ~60s while the drain pipeline replicates it.
+
+It was set to 90s, above boto3's 60s default read timeout, so the mechanism never fired for
+anyone: the client hung up on a dead socket (not retryable) while the server was still politely
+waiting, and later returned 200 to nobody — so nothing was even recorded as a failure. Observed
+in prod 2026-07-23 14:50:05, a presigned GET completing with processing_time_ms=60167, 167ms
+after the client gave up.
+
+A number above the client's timeout is not a conservative choice here; it silently disables the
+feature.
+"""
+
+from __future__ import annotations
+
+from hippius_s3.config import get_config
+
+
+# botocore's default read_timeout, which is what an un-configured boto3/aws-cli client uses, and
+# what tests/smoke passes explicitly. Anything at or above this makes the 503 unreachable.
+BOTO3_DEFAULT_READ_TIMEOUT_SECONDS = 60
+
+
+def test_first_chunk_timeout_leaves_room_for_a_client_retry() -> None:
+    config = get_config()
+    first_chunk = config.stream_first_chunk_timeout_seconds
+
+    assert first_chunk < BOTO3_DEFAULT_READ_TIMEOUT_SECONDS, (
+        f"stream_first_chunk_timeout_seconds={first_chunk}s is at or above the client's "
+        f"{BOTO3_DEFAULT_READ_TIMEOUT_SECONDS}s read timeout, so the retryable 503 can never "
+        f"reach the client — it hangs up on a dead socket first, and a dead socket is not "
+        f"retryable while SlowDown is."
+    )
+    assert first_chunk * 2 <= BOTO3_DEFAULT_READ_TIMEOUT_SECONDS, (
+        f"stream_first_chunk_timeout_seconds={first_chunk}s leaves room for only one attempt "
+        f"inside a {BOTO3_DEFAULT_READ_TIMEOUT_SECONDS}s client budget. A cross-node "
+        f"read-after-write needs ~60s to replicate, so at least one retry must fit."
+    )
+
+
+def test_later_chunks_still_get_a_generous_wait() -> None:
+    """Only the FIRST chunk fails fast. Once the object is proven to be arriving, a mid-stream
+    wait is not a 'not ready yet' signal and must not be shortened alongside it."""
+    config = get_config()
+
+    assert config.stream_chunk_timeout_seconds > config.stream_first_chunk_timeout_seconds, (
+        "the per-chunk timeout must stay well above the first-chunk timeout; shortening it "
+        "would break long healthy streams that are draining normally"
+    )

--- a/tests/unit/test_worker_graceful_shutdown.py
+++ b/tests/unit/test_worker_graceful_shutdown.py
@@ -1,0 +1,184 @@
+"""Workers must run their cleanup on SIGTERM, not be killed before it.
+
+PR #319 gave api/gateway/api-local `exec` + preStop + a grace period. The worker
+deployments were out of that scope, and they had a different hole: `start-worker.sh`
+already `exec`s, so uvicorn-style PID-1 was never the problem — the problem was that no
+worker installed a SIGTERM handler at all. Python's default disposition terminates the
+process outright, so the `finally:` blocks that close the asyncpg pool never ran.
+
+That is not cosmetic. Closing the pool is what tells Postgres the client is gone. A
+backend that is never told keeps executing its statement, and a long statement keeps
+pinning the xmin horizon, so VACUUM reclaims nothing database-wide. Measured on prod
+2026-07-23: the mpu-reaper pod exited 137 (SIGKILL) during a rollout and its
+`list_abandoned_versions` query was still running 7,377s later, with
+`cephor_replication_status` sitting at 746,972 dead tuples.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import signal
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hippius_s3.workers.shutdown import _supervise
+from hippius_s3.workers.shutdown import run_worker
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+async def _raise_signal_soon(signame: int) -> None:
+    await asyncio.sleep(0.05)
+    signal.raise_signal(signame)
+
+
+@pytest.mark.parametrize("signame", [signal.SIGTERM, signal.SIGINT])
+def test_cleanup_runs_on_signal(signame: int) -> None:
+    """The whole point: a signalled worker still gets through its `finally`."""
+    cleaned: list[str] = []
+
+    async def worker() -> None:
+        try:
+            await asyncio.Event().wait()  # never completes on its own
+        finally:
+            cleaned.append("pool closed")
+
+    async def scenario() -> bool:
+        asyncio.ensure_future(_raise_signal_soon(signame))
+        return await _supervise(worker, "test-worker", 5.0)
+
+    signalled = asyncio.run(scenario())
+
+    assert signalled is True
+    assert cleaned == ["pool closed"], "worker was killed before its cleanup ran"
+
+
+def test_worker_returning_normally_is_not_reported_as_signalled() -> None:
+    async def worker() -> None:
+        return None
+
+    assert asyncio.run(_supervise(worker, "test-worker", 5.0)) is False
+
+
+def test_crash_propagates_to_the_caller() -> None:
+    async def worker() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(_supervise(worker, "test-worker", 5.0))
+
+
+def test_wedged_cleanup_is_bounded_not_hung() -> None:
+    """A cleanup that never finishes must not outlive terminationGracePeriodSeconds."""
+
+    async def worker() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await asyncio.sleep(30)  # wedged cleanup
+
+    async def scenario() -> bool:
+        asyncio.ensure_future(_raise_signal_soon(signal.SIGTERM))
+        return await _supervise(worker, "test-worker", 0.2)
+
+    loop = asyncio.new_event_loop()
+    started = loop.time()
+    try:
+        signalled = loop.run_until_complete(scenario())
+    finally:
+        loop.close()
+
+    assert signalled is True
+    assert (loop.time() - started) < 5, "drain was not bounded by drain_timeout"
+
+
+def test_signal_does_not_restart_the_worker() -> None:
+    """A pod being terminated must not begin a cycle it has no time to finish."""
+    starts = 0
+
+    # run_worker owns its own asyncio.run, so arm the signal from inside the worker.
+    async def worker_that_signals_itself() -> None:
+        nonlocal starts
+        starts += 1
+        asyncio.ensure_future(_raise_signal_soon(signal.SIGTERM))
+        await asyncio.Event().wait()
+
+    run_worker(worker_that_signals_itself, "test-worker", drain_timeout=1.0)
+    assert starts == 1
+
+
+def test_crash_restarts_then_stops() -> None:
+    attempts = 0
+
+    async def flaky() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise RuntimeError("transient")
+        return None
+
+    run_worker(flaky, "test-worker", restart_delay=0.0, drain_timeout=1.0)
+    assert attempts == 3
+
+
+# ---- the manifests have to give that cleanup room to run ----
+
+WORKER_MANIFESTS = [
+    REPO_ROOT / "k8s" / "base" / "workers-deployments.yaml",
+    REPO_ROOT / "k8s" / "staging" / "mpu-reaper-deployment.yaml",
+    REPO_ROOT / "k8s" / "production" / "mpu-reaper-deployment.yaml",
+]
+
+DRAIN_BOUND_SECONDS = 20  # DEFAULT_DRAIN_TIMEOUT_SECONDS
+
+
+def _worker_deployments() -> list[tuple[str, dict]]:
+    found = []
+    for path in WORKER_MANIFESTS:
+        assert path.is_file(), f"{path} is missing"
+        for doc in yaml.safe_load_all(path.read_text()):
+            if not doc or doc.get("kind") != "Deployment":
+                continue
+            found.append((doc["metadata"]["name"], doc["spec"]["template"]["spec"]))
+    return found
+
+
+def test_every_worker_deployment_sets_a_grace_period() -> None:
+    deployments = _worker_deployments()
+    assert deployments, "no worker Deployments parsed — did the manifests move?"
+
+    missing = [name for name, spec in deployments if "terminationGracePeriodSeconds" not in spec]
+    assert not missing, (
+        f"{missing} have no terminationGracePeriodSeconds, so they fall back to the 30s "
+        f"default with no headroom stated. Cleanup that overruns is SIGKILLed and the "
+        f"Postgres backend is orphaned."
+    )
+
+
+def test_grace_period_exceeds_the_drain_bound() -> None:
+    for name, spec in _worker_deployments():
+        grace = spec["terminationGracePeriodSeconds"]
+        assert grace > DRAIN_BOUND_SECONDS, (
+            f"{name} allows {grace}s but run_worker drains for up to "
+            f"{DRAIN_BOUND_SECONDS}s; the kubelet would SIGKILL it mid-cleanup."
+        )
+
+
+def test_worker_entrypoints_use_the_supervisor() -> None:
+    """A bare `asyncio.run(...)` in an entrypoint is the bug this PR fixes."""
+    offenders = []
+    for script in sorted((REPO_ROOT / "workers").glob("run_*_in_loop.py")):
+        body = script.read_text()
+        main_block = body.split('if __name__ == "__main__":', 1)
+        if len(main_block) < 2:
+            continue
+        if re.search(r"^\s*asyncio\.run\(", main_block[1], flags=re.MULTILINE):
+            offenders.append(script.name)
+    assert not offenders, (
+        f"{offenders} call asyncio.run() directly instead of run_worker(), so they install "
+        f"no SIGTERM handler and their cleanup never runs."
+    )

--- a/tests/unit/test_worker_graceful_shutdown.py
+++ b/tests/unit/test_worker_graceful_shutdown.py
@@ -24,6 +24,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from hippius_s3.workers.shutdown import DEFAULT_DRAIN_TIMEOUT_SECONDS
+from hippius_s3.workers.shutdown import _drain_timeout
 from hippius_s3.workers.shutdown import _supervise
 from hippius_s3.workers.shutdown import run_worker
 
@@ -213,3 +215,26 @@ def test_worker_entrypoints_use_the_supervisor() -> None:
         f"{offenders} call asyncio.run() directly instead of run_worker(), so they install "
         f"no SIGTERM handler and their cleanup never runs."
     )
+
+
+def test_drain_timeout_honors_env_override(monkeypatch) -> None:
+    """The drain bound is operator-tunable via HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS; the supervisor
+    reads that env, not just the compiled-in default. Exercises the override path (unset in every
+    manifest today, so otherwise never covered)."""
+    monkeypatch.delenv("HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS", raising=False)
+    assert _drain_timeout() == DEFAULT_DRAIN_TIMEOUT_SECONDS
+
+    monkeypatch.setenv("HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS", "37")
+    assert _drain_timeout() == 37.0
+
+
+def test_effective_drain_timeout_fits_every_worker_grace_period(monkeypatch) -> None:
+    """Guard the EFFECTIVE drain bound (what _drain_timeout() actually returns at the default),
+    not just the hardcoded 20, against every worker's terminationGracePeriodSeconds. If the default
+    ever drifts above a grace, the kubelet SIGKILLs mid-cleanup — the exact bug this PR fixes.
+    (Raising the env above a grace is an operator's explicit choice and out of scope here.)"""
+    monkeypatch.delenv("HIPPIUS_WORKER_DRAIN_TIMEOUT_SECONDS", raising=False)
+    effective = _drain_timeout()
+    for name, spec in _worker_deployments():
+        grace = spec["terminationGracePeriodSeconds"]
+        assert grace > effective, f"{name} grace={grace}s <= effective drain {effective}s → kubelet SIGKILL mid-cleanup"

--- a/tests/unit/test_worker_graceful_shutdown.py
+++ b/tests/unit/test_worker_graceful_shutdown.py
@@ -111,7 +111,7 @@ def test_signal_does_not_restart_the_worker() -> None:
     assert starts == 1
 
 
-def test_crash_restarts_then_stops() -> None:
+def test_crash_restarts_then_stops_when_opted_in() -> None:
     attempts = 0
 
     async def flaky() -> None:
@@ -121,8 +121,39 @@ def test_crash_restarts_then_stops() -> None:
             raise RuntimeError("transient")
         return None
 
-    run_worker(flaky, "test-worker", restart_delay=0.0, drain_timeout=1.0)
+    run_worker(flaky, "test-worker", restart_on_crash=True, restart_delay=0.0, drain_timeout=1.0)
     assert attempts == 3
+
+
+def test_crash_exits_by_default() -> None:
+    """Restarting in-process hides a persistent crash: the pod stays Ready with
+    restart_count 0. Only entrypoints that already restarted themselves opt in."""
+    attempts = 0
+
+    async def always_broken() -> None:
+        nonlocal attempts
+        attempts += 1
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        run_worker(always_broken, "test-worker", restart_delay=0.0, drain_timeout=1.0)
+    assert attempts == 1, "default must not retry in-process"
+
+
+def test_only_previously_self_restarting_entrypoints_opt_in() -> None:
+    """Guards the behaviour-preservation claim: before this module, exactly these three
+    entrypoints wrapped themselves in `while True / except Exception / sleep(5)`."""
+    expected = {
+        "run_mpu_reaper_in_loop.py",
+        "run_orphan_checker_in_loop.py",
+        "run_arion_unpinner_in_loop.py",
+    }
+    opted_in = {
+        script.name
+        for script in (REPO_ROOT / "workers").glob("run_*_in_loop.py")
+        if "restart_on_crash=True" in script.read_text()
+    }
+    assert opted_in == expected
 
 
 # ---- the manifests have to give that cleanup room to run ----

--- a/workers/CLAUDE.md
+++ b/workers/CLAUDE.md
@@ -33,12 +33,21 @@ Each `run_*_in_loop.py` is a thin wrapper that imports the shared logic and prov
 - **Elevated** (85-95%): halve the hot-retention window. Evict replicated + cold regardless of age.
 - **Critical** (≥95%): hot retention disabled. Evict replicated + cold aggressively. If nothing replicated → log ERROR, do nothing.
 
+### Cycle order (durability first) + walk bounding
+
+The **DB-only durability phases run FIRST**, before the FS walks — the replication-gate sentinel and the A21 aged-orphan gauge. Deliberate: the FS cache is a single flat CephFS directory of millions of object dirs, and a full walk is metadata-latency bound (~40 objects/s serial on prod → ~20h a pass). Before this ordering those two ran LAST, behind two full-tree walks that never finished, so on prod they never ran at all. They must not be gated on the cache walk.
+
+The FS-walk phases are **parallel, sharded, and budgeted** so a cycle always completes:
+- `iter_part_dirs` fans the per-object descent across a thread pool (`HIPPIUS_JANITOR_WALK_CONCURRENCY`, default 8) so many CephFS metadata roundtrips are in flight at once — the single-threaded event-loop walk was the bottleneck, not the DB (per-part queries are 0.1–0.7ms, indexed).
+- Each cycle covers one hash-shard (`HIPPIUS_JANITOR_WALK_SHARDS`, default 64) of the tree; a full sweep takes `shards` cycles. Under disk pressure `shards=1` (whole tree every cycle).
+- Each walk phase stops at `HIPPIUS_JANITOR_WALK_BUDGET_SECONDS` (default 240s); **lifted to unbounded under CRITICAL pressure** so freeing space is never capped by a clock.
+
 ### Cleanup passes
 
-- `cleanup_stale_parts` ([run_janitor_in_loop.py:253](run_janitor_in_loop.py)) — delete parts whose mtime > `MPU_STALE_SECONDS`. DLQ protection via `get_all_dlq_object_ids` ([line 220](run_janitor_in_loop.py)) — scans every upload DLQ + unpin DLQ dynamically per `config.upload_backends` so new backends automatically get protected.
-- Age-based GC — classify by age bucket (0-1h / 1-6h / 6-24h / 1-3d / 3-7d / 7d+), gate on replication, honor hot retention.
-- Orphan `.tmp.*` cleanup — delete if older than `TMP_FILE_MAX_AGE_SECONDS=3600` (1h). Catches crashed atomic writes.
-- Hard-delete for soft-deleted objects whose unpins have been confirmed on every backend.
+- `cleanup_stale_parts` — delete parts whose mtime > `MPU_STALE_SECONDS` (orphan-with-no-DB-row reap + terminally-abandoned reclaim). DLQ protection via `get_all_dlq_object_ids` — scans every upload + unpin DLQ per `config.upload_backends`. Fail-closed if the DLQ set is unavailable.
+- Age-based GC (`cleanup_old_parts_by_mtime`) — classify by age bucket (0-1h / 1-6h / 6-24h / 1-3d / 3-7d / 7d+), gate on replication, honor hot retention. The census (parts/age-buckets/hot) is accumulated across a full sharded sweep and published only when the sweep completes untruncated, so the gauges reflect the whole cache, not one shard.
+- Orphan `.tmp.*` cleanup — delete if older than `TMP_FILE_MAX_AGE_SECONDS=3600` (1h). Same sharded parallel descent as the GC walk (was a full-tree `rglob` that also blocked the loop for hours).
+- Hard-delete for soft-deleted objects whose unpins have been confirmed on every backend (DB-bound, batch-capped).
 
 ### Metrics (OTel observable gauges + counters)
 

--- a/workers/run_account_cacher_in_loop.py
+++ b/workers/run_account_cacher_in_loop.py
@@ -11,6 +11,7 @@ from hippius_s3.config import get_config
 from hippius_s3.monitoring import get_metrics_collector
 from hippius_s3.monitoring import initialize_metrics_collector
 from hippius_s3.sentry import init_sentry
+from hippius_s3.workers.shutdown import run_worker
 
 
 logging.basicConfig(level=logging.INFO)
@@ -63,4 +64,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_worker(main, "account-cacher")

--- a/workers/run_arion_downloader_in_loop.py
+++ b/workers/run_arion_downloader_in_loop.py
@@ -7,7 +7,6 @@ writes it into the shared filesystem cache (``FileSystemPartsStore``),
 and publishes a pub/sub notification so waiting streamers can read it.
 """
 
-import asyncio
 import logging
 import sys
 from pathlib import Path
@@ -20,6 +19,7 @@ from hippius_s3.logging_config import setup_loki_logging
 from hippius_s3.sentry import init_sentry
 from hippius_s3.services.arion_service import ArionClient
 from hippius_s3.workers.downloader import run_downloader_loop
+from hippius_s3.workers.shutdown import run_worker
 
 
 config = get_config()
@@ -50,4 +50,4 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    run_worker(main, "arion-downloader")

--- a/workers/run_arion_unpinner_in_loop.py
+++ b/workers/run_arion_unpinner_in_loop.py
@@ -28,4 +28,5 @@ if __name__ == "__main__":
             queue_name="arion_unpin_requests",
         ),
         "arion-unpinner",
+        restart_on_crash=True,
     )

--- a/workers/run_arion_unpinner_in_loop.py
+++ b/workers/run_arion_unpinner_in_loop.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-import asyncio
 import logging
 import sys
-import time
 from pathlib import Path
 
 
@@ -12,6 +10,7 @@ from hippius_s3.config import get_config
 from hippius_s3.logging_config import setup_loki_logging
 from hippius_s3.sentry import init_sentry
 from hippius_s3.services.arion_service import ArionClient
+from hippius_s3.workers.shutdown import run_worker
 from hippius_s3.workers.unpinner import run_unpinner_loop
 
 
@@ -22,18 +21,11 @@ init_sentry("arion-unpinner", is_worker=True)
 
 
 if __name__ == "__main__":
-    while True:
-        try:
-            asyncio.run(
-                run_unpinner_loop(
-                    backend_name="arion",
-                    backend_client_factory=ArionClient,
-                    queue_name="arion_unpin_requests",
-                )
-            )
-        except KeyboardInterrupt:
-            logger.info("Arion unpinner service stopped by user")
-            break
-        except Exception as e:
-            logger.error(f"Arion unpinner crashed, restarting in 5 seconds: {e}", exc_info=True)
-            time.sleep(5)
+    run_worker(
+        lambda: run_unpinner_loop(
+            backend_name="arion",
+            backend_client_factory=ArionClient,
+            queue_name="arion_unpin_requests",
+        ),
+        "arion-unpinner",
+    )

--- a/workers/run_arion_uploader_in_loop.py
+++ b/workers/run_arion_uploader_in_loop.py
@@ -31,6 +31,7 @@ from hippius_s3.services.ray_id_service import ray_id_context
 from hippius_s3.workers.errors import classify_error
 from hippius_s3.workers.errors import compute_backoff_ms
 from hippius_s3.workers.errors import extract_http_status_code
+from hippius_s3.workers.shutdown import run_worker
 from hippius_s3.workers.uploader import Uploader
 
 
@@ -212,4 +213,4 @@ async def run_arion_uploader_loop():
 
 
 if __name__ == "__main__":
-    asyncio.run(run_arion_uploader_loop())
+    run_worker(run_arion_uploader_loop, "arion-uploader")

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -108,6 +108,25 @@ _replication_sentinel_violations = 0
 # than the sweep clears them — a re-introduced leak.
 _aged_pending_orphans = 0
 
+# Cycle progress. The census gauges below (parts_on_disk, age buckets, hot parts) are only
+# written at the END of the GC phase, so if an earlier phase runs long they report 0 forever
+# and read as "cache is empty" rather than "never measured". Prod 2026-07-23: cleanup_stale_parts
+# ran >1h48m without returning, so every one of those gauges sat at 0 while the janitor was
+# deleting 18,737 parts. These two make that state visible instead of silent.
+_janitor_phase = 0  # index into JANITOR_PHASES; 0 = idle/sleeping
+_janitor_last_cycle_completed_at = 0.0
+_janitor_cycle_seconds = 0.0
+
+JANITOR_PHASES = (
+    "idle",
+    "stale_parts",
+    "gc_age",
+    "orphan_tmp",
+    "soft_deleted",
+    "sentinel",
+    "aged_orphans",
+)
+
 _janitor_deleted_counter = None  # set by _setup_janitor_metrics
 _janitor_tmp_deleted_counter = None
 _janitor_abandoned_deleted_counter = None
@@ -147,6 +166,22 @@ def _obs_replication_sentinel(_: object) -> list[otel_metrics.Observation]:
 
 def _obs_aged_pending_orphans(_: object) -> list[otel_metrics.Observation]:
     return [otel_metrics.Observation(_aged_pending_orphans, {})]
+
+
+def _obs_janitor_phase(_: object) -> list[otel_metrics.Observation]:
+    return [otel_metrics.Observation(_janitor_phase, {"phase": JANITOR_PHASES[_janitor_phase]})]
+
+
+def _obs_cycle_age(_: object) -> list[otel_metrics.Observation]:
+    # Age of the last COMPLETED cycle. Rises without bound while a phase is stuck, which is
+    # the signal that the census gauges are stale rather than genuinely zero.
+    if _janitor_last_cycle_completed_at <= 0:
+        return [otel_metrics.Observation(-1.0, {})]
+    return [otel_metrics.Observation(max(0.0, time.time() - _janitor_last_cycle_completed_at), {})]
+
+
+def _obs_cycle_seconds(_: object) -> list[otel_metrics.Observation]:
+    return [otel_metrics.Observation(_janitor_cycle_seconds, {})]
 
 
 def _classify_age_bucket(age_seconds: float) -> str:
@@ -352,9 +387,24 @@ def _setup_janitor_metrics() -> None:
         callbacks=[_obs_aged_pending_orphans],
         description="Aged pending/draining unservable orphan versions (A21 leak backlog; the soak gate asserts bounded / slope ~ 0)",
     )
+    meter.create_observable_gauge(
+        name="fs_janitor_phase",
+        callbacks=[_obs_janitor_phase],
+        description="Janitor phase currently executing (0=idle); label carries the phase name",
+    )
+    meter.create_observable_gauge(
+        name="fs_janitor_last_cycle_age_seconds",
+        callbacks=[_obs_cycle_age],
+        description="Seconds since the last COMPLETED janitor cycle (-1 = none since start). Rising without bound means a phase is stuck and the census gauges are stale, not zero",
+    )
+    meter.create_observable_gauge(
+        name="fs_janitor_cycle_seconds",
+        callbacks=[_obs_cycle_seconds],
+        description="Duration of the last completed janitor cycle",
+    )
     _janitor_deleted_counter = meter.create_counter(
         name="fs_janitor_deleted_total",
-        description="Total number of FS parts deleted by the janitor",
+        description="FS parts deleted by the janitor, by reason (gc_age|stale_mtime|abandoned)",
         unit="1",
     )
     _janitor_tmp_deleted_counter = meter.create_counter(
@@ -553,8 +603,12 @@ async def cleanup_stale_parts(
                 )
                 if _janitor_abandoned_deleted_counter is not None:
                     _janitor_abandoned_deleted_counter.add(1)
+                if _janitor_deleted_counter is not None:
+                    _janitor_deleted_counter.add(1, {"reason": "abandoned"})
             else:
                 logger.info(f"Cleaned stale part by mtime: object_id={object_id} v={object_version} part={part_number}")
+                if _janitor_deleted_counter is not None:
+                    _janitor_deleted_counter.add(1, {"reason": "stale_mtime"})
             return True
         except Exception as e:
             logger.warning(f"Failed to clean part: object_id={object_id} v={object_version} part={part_number}: {e}")
@@ -983,7 +1037,7 @@ async def cleanup_old_parts_by_mtime(
     _fs_pressure_mode = pressure
 
     if parts_cleaned > 0 and _janitor_deleted_counter is not None:
-        _janitor_deleted_counter.add(parts_cleaned)
+        _janitor_deleted_counter.add(parts_cleaned, {"reason": "gc_age"})
 
     logger.info(f"GC cleaned {parts_cleaned=} hot_parts={stats['hot_parts']} pressure={pressure}")
 
@@ -1051,8 +1105,11 @@ async def run_janitor_loop():
     sleep_normal = 600  # 10m
     sleep_pressure = 120  # 2m
 
+    global _janitor_phase, _janitor_last_cycle_completed_at, _janitor_cycle_seconds
+
     try:
         while True:
+            _cycle_started = time.time()
             logger.info("Janitor cycle starting...")
             # Refresh disk/pressure gauges up front. The GC walk below can take
             # hours over millions of parts; disk visibility must not wait on it.
@@ -1065,24 +1122,28 @@ async def run_janitor_loop():
 
             # Phase 1: Clean stale MPU parts (aborted uploads)
             try:
+                _janitor_phase = 1
                 stale_count = await cleanup_stale_parts(db_pool, fs_store, redis_client)
             except Exception as e:
                 logger.error(f"Phase 1 (stale cleanup) error: {e}", exc_info=True)
 
             # Phase 2: GC old parts by mtime + update disk/cache metrics
             try:
+                _janitor_phase = 2
                 gc_count = await cleanup_old_parts_by_mtime(db_pool, fs_store, redis_client)
             except Exception as e:
                 logger.error(f"Phase 2 (GC) error: {e}", exc_info=True)
 
             # Phase 3: Clean orphan .tmp.* files from crashed atomic writes
             try:
+                _janitor_phase = 3
                 tmp_count = await cleanup_orphan_tmp_files(fs_store)
             except Exception as e:
                 logger.error(f"Phase 3 (tmp cleanup) error: {e}", exc_info=True)
 
             # Phase 4: Hard-delete soft-deleted objects where all unpins are confirmed
             try:
+                _janitor_phase = 4
                 hard_deleted = await gc_soft_deleted_objects(db_pool)
             except Exception as e:
                 logger.error(f"Phase 4 (hard delete) error: {e}", exc_info=True)
@@ -1092,6 +1153,7 @@ async def run_janitor_loop():
             pressure = _pressure_mode(fs_store.root)
             sentinel_violations = 0
             try:
+                _janitor_phase = 5
                 sentinel_violations = await check_replication_sentinel(db_pool, pressure)
             except Exception as e:
                 logger.error(f"Phase 5 (replication sentinel) error: {e}", exc_info=True)
@@ -1109,6 +1171,7 @@ async def run_janitor_loop():
             aged_orphans = 0
             try:
                 gauge_dlq_object_ids = await get_all_dlq_object_ids(redis_client)
+                _janitor_phase = 6
                 aged_orphans = await check_aged_pending_orphans(db_pool, gauge_dlq_object_ids)
             except Exception as e:
                 logger.error(f"Phase 6 (aged-pending orphan gauge) error: {e}", exc_info=True)
@@ -1118,9 +1181,13 @@ async def run_janitor_loop():
                 f"hard_deleted={hard_deleted} sentinel_violations={sentinel_violations} aged_orphans={aged_orphans}"
             )
 
+            _janitor_cycle_seconds = time.time() - _cycle_started
+            _janitor_last_cycle_completed_at = time.time()
+
             # Pick sleep interval based on current pressure (already probed for Phase 5)
             sleep_interval = sleep_pressure if pressure > 0 else sleep_normal
             logger.info(f"Janitor sleeping {sleep_interval}s (pressure={pressure})")
+            _janitor_phase = 0
             await asyncio.sleep(sleep_interval)
     finally:
         if redis_client:

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -28,10 +28,13 @@ import os
 import shutil
 import sys
 import time
+import zlib
 from collections.abc import AsyncIterator
 from collections.abc import Awaitable
 from collections.abc import Callable
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -99,6 +102,20 @@ _fs_hot_parts = 0
 _fs_pressure_mode = 0  # 0 = normal, 1 = elevated, 2 = critical
 _prev_pressure_mode = 0  # C2: last mode returned by _pressure_mode, for hysteresis (single-instance janitor)
 _fs_age_buckets: dict[str, int] = dict.fromkeys(AGE_BUCKET_NAMES, 0)
+# Census is now accumulated across a full sharded sweep (the age-GC walk covers 1/shards of
+# the tree per cycle), then published to the gauges above only when a sweep completes without
+# a budget truncation — so `_fs_parts_on_disk` etc. reflect the whole cache, never one shard
+# or a half-finished pass. Between sweeps the gauges hold the last complete sweep's values.
+_census_accum: dict[str, Any] = {
+    "parts_seen": 0,
+    "hot_parts": 0,
+    "oldest_mtime": None,
+    "age_counts": dict.fromkeys(AGE_BUCKET_NAMES, 0),
+}
+_census_accum_complete = True
+# Which hash-shard the FS walk covers this cycle. Advances by one every cycle; a full sweep
+# of the tree completes every `janitor_walk_shards` cycles. See config.janitor_walk_shards.
+_walk_shard = 0
 # G2 replication-gate sentinel: live/serveable chunks lacking full-union backend coverage
 # (the population the gate must never reclaim). Any nonzero value is a standing durability
 # alarm; sampled/capped by SENTINEL_SCAN_LIMIT, so a value at the cap means ">=".
@@ -212,6 +229,241 @@ def _safe_iterdir(path: Path) -> Iterator[Path]:
         except OSError:
             return
         yield entry
+
+
+@dataclass(frozen=True)
+class PartDirInfo:
+    """One part directory the walk found, with the stat the phases gate on.
+
+    `mtime`/`atime` are read from `meta.json` when present, else the part dir — the same
+    "part complete signal or fall back to the dir" rule the serial walk used.
+    """
+
+    object_id: str
+    object_version: int
+    part_number: int
+    mtime: float
+    atime: float
+
+
+@dataclass
+class WalkState:
+    """Out-of-band result of a walk: whether the wall-clock budget truncated it, and how
+    many object dirs (in this shard) it reached. The census is only trustworthy for a full
+    (untruncated) sweep, so callers check `truncated` before publishing gauges."""
+
+    truncated: bool = False
+    objects_scanned: int = 0
+
+
+def _object_in_shard(object_id: str, shard: int, shards: int) -> bool:
+    # crc32 is deterministic per name, so a given object falls in the same shard every sweep —
+    # rotating `shard` per cycle covers the whole tree over `shards` cycles without a cursor.
+    if shards <= 1:
+        return True
+    return zlib.crc32(object_id.encode("utf-8", "surrogatepass")) % shards == shard % shards
+
+
+def _read_dir_batch(scan_it: Any, n: int) -> tuple[list[str], bool]:
+    """Pull up to `n` sub-directory names from an os.scandir iterator. Returns
+    (names, exhausted). Runs in a worker thread so a slow CephFS readdir never blocks the loop.
+    A vanished/odd entry is skipped, not fatal (the tree mutates under the walk)."""
+    names: list[str] = []
+    for _ in range(n):
+        try:
+            entry = next(scan_it)
+        except StopIteration:
+            return names, True
+        except OSError:
+            return names, True
+        try:
+            if entry.is_dir():
+                names.append(entry.name)
+        except OSError:
+            continue
+    return names, False
+
+
+def _descend_object(root_str: str, object_name: str) -> list[PartDirInfo]:
+    """Blocking descent of ONE object dir → its part dirs, run in a walk thread.
+
+    Mirrors the serial walk exactly: `v<n>` version dirs, `part_<n>` part dirs, stat
+    `meta.json` if present else the part dir. Every FS error is swallowed to a skip — the
+    tree is mutating underneath us. Returns the parts found (possibly empty)."""
+    out: list[PartDirInfo] = []
+    obj_path = os.path.join(root_str, object_name)  # noqa: PTH118 — hot walk path, os.* avoids per-entry Path alloc
+    try:
+        version_scan = os.scandir(obj_path)
+    except OSError:
+        return out
+    with version_scan:
+        for vd in version_scan:
+            name = vd.name
+            if not name.startswith("v"):
+                continue
+            try:
+                if not vd.is_dir():
+                    continue
+            except OSError:
+                continue
+            try:
+                object_version = int(name[1:])
+            except ValueError:
+                continue
+            try:
+                part_scan = os.scandir(vd.path)
+            except OSError:
+                continue
+            with part_scan:
+                for pd in part_scan:
+                    pname = pd.name
+                    if not pname.startswith("part_"):
+                        continue
+                    try:
+                        if not pd.is_dir():
+                            continue
+                    except OSError:
+                        continue
+                    try:
+                        part_number = int(pname.split("_")[1])
+                    except (ValueError, IndexError):
+                        continue
+                    meta = os.path.join(pd.path, "meta.json")  # noqa: PTH118
+                    try:
+                        st = os.stat(meta)  # noqa: PTH116
+                    except OSError:
+                        try:
+                            st = os.stat(pd.path)  # noqa: PTH116
+                        except OSError:
+                            continue
+                    out.append(PartDirInfo(object_name, object_version, part_number, st.st_mtime, st.st_atime))
+    return out
+
+
+async def _stream_shard_object_names(
+    root_str: str,
+    shard: int,
+    shards: int,
+    deadline: float | None,
+    state: WalkState,
+) -> AsyncIterator[str]:
+    """Stream this shard's object-dir names off the event loop, stopping at the budget deadline."""
+    loop = asyncio.get_running_loop()
+    try:
+        scan_it = await asyncio.to_thread(os.scandir, root_str)
+    except OSError:
+        return
+    try:
+        while True:
+            if deadline is not None and loop.time() >= deadline:
+                state.truncated = True
+                return
+            names, exhausted = await asyncio.to_thread(_read_dir_batch, scan_it, 512)
+            for name in names:
+                if _object_in_shard(name, shard, shards):
+                    state.objects_scanned += 1
+                    yield name
+            if exhausted:
+                return
+    finally:
+        await asyncio.to_thread(scan_it.close)
+
+
+async def iter_part_dirs(
+    root: Path,
+    *,
+    concurrency: int,
+    shard: int,
+    shards: int,
+    deadline: float | None,
+    state: WalkState,
+) -> AsyncIterator[PartDirInfo]:
+    """Walk `root` and yield every part dir in the current shard, descending object dirs
+    across a bounded thread pool so many CephFS metadata roundtrips are in flight at once.
+
+    This replaces the single-threaded, event-loop-blocking `_safe_iterdir` walk that could
+    not complete a pass over ~2.8M object dirs inside a cycle (measured ~40 objects/s serial
+    on prod). Callers apply their own per-part gating + census to the yielded records; the
+    deletion logic downstream is unchanged.
+
+    `concurrency<=1` degrades to a serial descent (legacy behaviour, one object at a time).
+    """
+    concurrency = max(1, concurrency)
+    root_str = str(root)
+    loop = asyncio.get_running_loop()
+    executor = ThreadPoolExecutor(max_workers=concurrency, thread_name_prefix="janitor-walk")
+    inflight: set[asyncio.Future[list[PartDirInfo]]] = set()
+    try:
+        async for name in _stream_shard_object_names(root_str, shard, shards, deadline, state):
+            inflight.add(loop.run_in_executor(executor, _descend_object, root_str, name))
+            if len(inflight) >= concurrency:
+                done, inflight = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
+                for fut in done:
+                    for info in fut.result():
+                        yield info
+        while inflight:
+            done, inflight = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
+            for fut in done:
+                for info in fut.result():
+                    yield info
+    finally:
+        for fut in inflight:
+            fut.cancel()
+        executor.shutdown(wait=False)
+
+
+def _walk_deadline(loop: asyncio.AbstractEventLoop, pressure: int, budget: int) -> float | None:
+    """The wall-clock deadline for one FS-walk phase. None (unbounded) under CRITICAL pressure
+    or when the budget is disabled — freeing space must never be capped by a clock."""
+    if pressure >= 2 or budget <= 0:
+        return None
+    return loop.time() + budget
+
+
+def _reset_census_accum() -> None:
+    global _census_accum, _census_accum_complete
+    _census_accum = {
+        "parts_seen": 0,
+        "hot_parts": 0,
+        "oldest_mtime": None,
+        "age_counts": dict.fromkeys(AGE_BUCKET_NAMES, 0),
+    }
+    _census_accum_complete = True
+
+
+def _accumulate_census(stats: dict[str, Any], shard_complete: bool) -> None:
+    """Fold one shard's census into the in-progress sweep. `shard_complete` is False if the
+    shard's walk hit the budget, which taints the whole sweep's completeness."""
+    global _census_accum_complete
+    _census_accum["parts_seen"] += stats["parts_seen"]
+    _census_accum["hot_parts"] += stats["hot_parts"]
+    for bucket, count in stats["age_counts"].items():
+        _census_accum["age_counts"][bucket] += count
+    om = stats["oldest_mtime"]
+    if om is not None and (_census_accum["oldest_mtime"] is None or om < _census_accum["oldest_mtime"]):
+        _census_accum["oldest_mtime"] = om
+    if not shard_complete:
+        _census_accum_complete = False
+
+
+def _publish_census(now: float) -> None:
+    """Publish the completed sweep's census to the gauges, then reset for the next sweep.
+    A sweep tainted by a budget truncation is dropped (gauges hold their last complete value)
+    rather than reported as a full census that undercounts. The pressure gauge is owned by
+    _update_disk_metrics (refreshed every cycle top), so it is not touched here."""
+    global _fs_parts_on_disk, _fs_oldest_age_seconds, _fs_age_buckets, _fs_hot_parts
+    if _census_accum_complete:
+        oldest_mtime = _census_accum["oldest_mtime"]
+        _fs_parts_on_disk = _census_accum["parts_seen"]
+        _fs_oldest_age_seconds = max(0.0, now - float(oldest_mtime)) if oldest_mtime is not None else 0.0
+        _fs_age_buckets = dict(_census_accum["age_counts"])
+        _fs_hot_parts = _census_accum["hot_parts"]
+    else:
+        logger.info(
+            "Census sweep truncated by walk budget — holding last complete census (partial parts_seen=%d)",
+            _census_accum["parts_seen"],
+        )
+    _reset_census_accum()
 
 
 def _update_disk_metrics(root: Path) -> None:
@@ -414,6 +666,11 @@ async def cleanup_stale_parts(
     pool: asyncpg.Pool,
     fs_store: FileSystemPartsStore,
     redis_client: Redis,
+    *,
+    shard: int = 0,
+    shards: int = 1,
+    walk_concurrency: int = 1,
+    deadline: float | None = None,
 ) -> int:
     """Conservative cleanup of stale parts: rely on FS mtime only for now.
 
@@ -422,10 +679,10 @@ async def cleanup_stale_parts(
     approach: remove only parts whose meta/dir mtime is older than the
     configured stale threshold and which have no recent DB part activity.
 
-    The FS walk (cheap, stat-only) runs in the producer; the per-part DB checks
-    and deletes run with bounded concurrency over a connection pool — see
-    `_run_worker_pool`. At 3M+ parts the old serial single-connection loop could
-    not complete a pass in a day; this parallelizes the DB-roundtrip bottleneck.
+    The FS walk (parallel, stat-only) runs in the producer via `iter_part_dirs`; the
+    per-part DB checks and deletes run with bounded concurrency over a connection pool
+    (`_run_worker_pool`). The walk is sharded + budgeted so it cannot monopolise the cycle:
+    it descends only this cycle's shard and stops at `deadline`. Deletion logic is unchanged.
     """
     stale_threshold_seconds = config.mpu_stale_seconds
     cutoff_sql = "NOW() - INTERVAL '1 second' * $4"
@@ -447,51 +704,30 @@ async def cleanup_stale_parts(
 
     mtime_cutoff = time.time() - stale_threshold_seconds
 
+    walk_state = WalkState()
+
     async def candidates() -> AsyncIterator[tuple[str, int, int]]:
-        scanned = 0
-        for object_dir in _safe_iterdir(root):
-            if not object_dir.is_dir():
+        async for part in iter_part_dirs(
+            root,
+            concurrency=walk_concurrency,
+            shard=shard,
+            shards=shards,
+            deadline=deadline,
+            state=walk_state,
+        ):
+            if part.mtime > mtime_cutoff:
+                # Recently touched, skip
                 continue
-            object_id = object_dir.name
-            for version_dir in _safe_iterdir(object_dir):
-                if not version_dir.is_dir() or not version_dir.name.startswith("v"):
-                    continue
-                try:
-                    object_version = int(version_dir.name[1:])
-                except (ValueError, IndexError):
-                    continue
 
-                for part_dir in _safe_iterdir(version_dir):
-                    if not part_dir.is_dir() or not part_dir.name.startswith("part_"):
-                        continue
-                    try:
-                        part_number = int(part_dir.name.split("_")[1])
-                    except (ValueError, IndexError):
-                        continue
+            # Skip deletion if object is in DLQ
+            if part.object_id in dlq_object_ids:
+                logger.debug(
+                    f"Skipping DLQ-protected part: object_id={part.object_id} "
+                    f"v={part.object_version} part={part.part_number}"
+                )
+                continue
 
-                    scanned += 1
-                    if scanned % 5000 == 0:
-                        await asyncio.sleep(0)  # yield so workers drain while we walk
-
-                    meta_file = part_dir / "meta.json"
-                    check_path = meta_file if meta_file.exists() else part_dir
-                    try:
-                        mtime = check_path.stat().st_mtime
-                    except OSError:
-                        continue
-
-                    if mtime > mtime_cutoff:
-                        # Recently touched, skip
-                        continue
-
-                    # Skip deletion if object is in DLQ
-                    if object_id in dlq_object_ids:
-                        logger.debug(
-                            f"Skipping DLQ-protected part: object_id={object_id} v={object_version} part={part_number}"
-                        )
-                        continue
-
-                    yield (object_id, object_version, part_number)
+            yield (part.object_id, part.object_version, part.part_number)
 
     async def handle(conn: asyncpg.Connection, item: tuple[str, int, int]) -> bool:
         object_id, object_version, part_number = item
@@ -561,7 +797,14 @@ async def cleanup_stale_parts(
             return False
 
     parts_cleaned = await _run_worker_pool(pool, candidates(), handle, config.janitor_concurrency)
-    logger.info(f"Janitor cleaned {parts_cleaned} stale parts by mtime threshold")
+    logger.info(
+        "Janitor cleaned %d stale parts by mtime threshold (shard=%d/%d objects_scanned=%d truncated=%s)",
+        parts_cleaned,
+        shard,
+        shards,
+        walk_state.objects_scanned,
+        walk_state.truncated,
+    )
     return parts_cleaned
 
 
@@ -733,39 +976,104 @@ async def is_terminally_abandoned(
     return bool(row and row["abandoned"])
 
 
-async def cleanup_orphan_tmp_files(fs_store: FileSystemPartsStore) -> int:
+def _descend_object_tmp(root_str: str, object_name: str, cutoff: float) -> int:
+    """Blocking: unlink `*.tmp.*` files older than `cutoff` under one object dir's part dirs.
+    Runs in a walk thread. Returns how many it removed. Every FS error is a skip."""
+    removed = 0
+    obj_path = os.path.join(root_str, object_name)  # noqa: PTH118 — hot walk path
+    try:
+        version_scan = os.scandir(obj_path)
+    except OSError:
+        return 0
+    with version_scan:
+        for vd in version_scan:
+            if not vd.name.startswith("v"):
+                continue
+            try:
+                if not vd.is_dir():
+                    continue
+            except OSError:
+                continue
+            try:
+                part_scan = os.scandir(vd.path)
+            except OSError:
+                continue
+            with part_scan:
+                for pd in part_scan:
+                    if not pd.name.startswith("part_"):
+                        continue
+                    try:
+                        if not pd.is_dir():
+                            continue
+                    except OSError:
+                        continue
+                    try:
+                        file_scan = os.scandir(pd.path)
+                    except OSError:
+                        continue
+                    with file_scan:
+                        for f in file_scan:
+                            if ".tmp." not in f.name:
+                                continue
+                            try:
+                                if not f.is_file():
+                                    continue
+                                if f.stat().st_mtime > cutoff:
+                                    continue
+                                os.unlink(f.path)  # noqa: PTH108
+                                removed += 1
+                            except OSError:
+                                continue
+    return removed
+
+
+async def cleanup_orphan_tmp_files(
+    fs_store: FileSystemPartsStore,
+    *,
+    shard: int = 0,
+    shards: int = 1,
+    walk_concurrency: int = 1,
+    deadline: float | None = None,
+) -> int:
     """Remove orphan atomic-write temp files that outlived a crashed worker.
 
-    Workers use `<target>.tmp.<uuid>` as the tempfile for atomic rename.
-    If the worker crashes between creating the tempfile and renaming it,
-    the tempfile is left behind. Delete anything named `*.tmp.*` older than
-    `TMP_FILE_MAX_AGE_SECONDS`.
+    Workers use `<target>.tmp.<uuid>` as the tempfile for atomic rename. A crash between
+    create and rename leaves it behind; delete anything named `*.tmp.*` older than
+    `TMP_FILE_MAX_AGE_SECONDS`. Uses the same sharded, budgeted, parallel descent as the GC
+    walk — the previous `root.rglob("*.tmp.*")` was a full-tree walk on the event loop, so on
+    a multi-million-object cache it would block the loop for hours (the same starvation the GC
+    walk had), never mind that it ran after the phase that already never returned.
     """
     root = fs_store.root
     if not root.exists():
         return 0
 
-    now = time.time()
-    cutoff = now - TMP_FILE_MAX_AGE_SECONDS
+    root_str = str(root)
+    cutoff = time.time() - TMP_FILE_MAX_AGE_SECONDS
+    loop = asyncio.get_running_loop()
+    concurrency = max(1, walk_concurrency)
+    executor = ThreadPoolExecutor(max_workers=concurrency, thread_name_prefix="janitor-tmp")
+    state = WalkState()
     removed = 0
-
-    # rglob is fine; the FS is bounded by active objects
-    for path in root.rglob("*.tmp.*"):
-        try:
-            if not path.is_file():
-                continue
-            if path.stat().st_mtime > cutoff:
-                continue
-            path.unlink()
-            removed += 1
-            logger.info(f"Removed orphan tmp file: {path}")
-        except OSError as e:
-            logger.debug(f"Skip orphan tmp {path}: {e}")
+    inflight: set[asyncio.Future[int]] = set()
+    try:
+        async for name in _stream_shard_object_names(root_str, shard, shards, deadline, state):
+            inflight.add(loop.run_in_executor(executor, _descend_object_tmp, root_str, name, cutoff))
+            if len(inflight) >= concurrency:
+                done, inflight = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
+                removed += sum(f.result() for f in done)
+        while inflight:
+            done, inflight = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
+            removed += sum(f.result() for f in done)
+    finally:
+        for fut in inflight:
+            fut.cancel()
+        executor.shutdown(wait=False)
 
     if removed > 0 and _janitor_tmp_deleted_counter is not None:
         _janitor_tmp_deleted_counter.add(removed)
     if removed > 0:
-        logger.info(f"Janitor removed {removed} orphan tmp files")
+        logger.info(f"Janitor removed {removed} orphan tmp files (shard={shard}/{shards} truncated={state.truncated})")
     return removed
 
 
@@ -773,6 +1081,12 @@ async def cleanup_old_parts_by_mtime(
     pool: asyncpg.Pool,
     fs_store: FileSystemPartsStore,
     redis_client: Redis,
+    *,
+    shard: int = 0,
+    shards: int = 1,
+    walk_concurrency: int = 1,
+    deadline: float | None = None,
+    publish_sweep: bool = True,
 ) -> int:
     """Safe, replication-gated GC.
 
@@ -844,108 +1158,91 @@ async def cleanup_old_parts_by_mtime(
         "oldest_mtime": None,
         "age_counts": dict.fromkeys(AGE_BUCKET_NAMES, 0),
     }
+    walk_state = WalkState()
 
     async def candidates() -> AsyncIterator[tuple[str, int, int, bool]]:
-        scanned = 0
-        # Walk the FS hierarchy: <root>/<object_id>/v<version>/part_<n>/
-        for object_dir in _safe_iterdir(root):
-            if not object_dir.is_dir():
-                continue
-
-            object_id = object_dir.name
+        # Walk the FS hierarchy <root>/<object_id>/v<version>/part_<n>/ via the parallel,
+        # sharded, budgeted walker. The mtime/atime the census + gating use come straight
+        # from the walk (meta.json if present else the part dir) — identical to the old
+        # inline stat, just done in the walk threads.
+        async for part in iter_part_dirs(
+            root,
+            concurrency=walk_concurrency,
+            shard=shard,
+            shards=shards,
+            deadline=deadline,
+            state=walk_state,
+        ):
+            object_id = part.object_id
+            object_version = part.object_version
+            part_number = part.part_number
             is_dlq_protected = object_id in dlq_object_ids
 
-            for version_dir in _safe_iterdir(object_dir):
-                if not version_dir.is_dir() or not version_dir.name.startswith("v"):
+            stats["parts_seen"] += 1
+
+            # Check mtime (for age) and atime (for hot retention).
+            #
+            # ZFS + noatime note: in prod the local-cache volume is a ZFS
+            # dataset mounted `noatime` (see `mount | grep local_object_cache`
+            # → `rw,noatime,xattr,noacl,casesensitive`). `noatime` only
+            # blocks VFS-triggered atime updates on reads (the
+            # `file_accessed() → atime_needs_update() → dirty_inode()`
+            # path). It does NOT block explicit `utimensat(2)` metadata
+            # writes, which go through `setattr()`. Our reader refreshes
+            # atime on every chunk read via `os.utime(path, None)` in
+            # `fs_store.get_chunk`, so hot-retention works correctly here.
+            # OpenZFS PR #4482 ("Fix atime handling and relatime") made
+            # this behaviour consistent — atime is handled purely by VFS
+            # and explicit setattr writes are always honoured regardless
+            # of the mount's noatime flag.
+            #
+            # Side effect: `os.utime(path, None)` sets BOTH atime and
+            # mtime to "now" (UTIME_NOW on both). Recently-read chunks
+            # therefore show `atime == mtime` to the nanosecond — that's
+            # expected, not a bug. It also means reads push mtime
+            # forward, so the mtime-based age check below is more
+            # conservative on actively-read content (treats hot chunks
+            # as younger than their original landing time). Replication
+            # is still the absolute gate, so this only relaxes, never
+            # tightens, what we delete.
+            try:
+                mtime = part.mtime
+                atime = part.atime
+                if stats["oldest_mtime"] is None or mtime < stats["oldest_mtime"]:
+                    stats["oldest_mtime"] = mtime
+
+                part_age = now - mtime
+                stats["age_counts"][_classify_age_bucket(part_age)] += 1
+
+                is_hot = hot_window > 0 and atime > (now - hot_window)
+                if is_hot:
+                    stats["hot_parts"] += 1
+
+                # Don't clean DLQ-protected parts (only count them for metrics)
+                if is_dlq_protected:
                     continue
 
-                try:
-                    object_version = int(version_dir.name[1:])
-                except (ValueError, IndexError):
+                # Hot files are protected. Under critical pressure
+                # hot_window is 0, which forces is_hot=False, letting
+                # fully-replicated parts become eligible even if recently read.
+                if is_hot:
                     continue
 
-                for part_dir in _safe_iterdir(version_dir):
-                    if not part_dir.is_dir() or not part_dir.name.startswith("part_"):
-                        continue
-                    stats["parts_seen"] += 1
+                # A fully-replicated, cold, non-DLQ part is safe to evict.
+                # Under normal pressure we additionally require age > cutoff
+                # so we don't thrash. Under any pressure level we evict
+                # replicated cold parts regardless of age. The replication
+                # gate itself is enforced in the worker below.
+                old_enough = mtime < cutoff_time
+                if pressure == 0 and not old_enough:
+                    continue
+            except Exception as e:
+                logger.warning(
+                    f"Failed to classify part object_id={object_id} v={object_version} part={part_number}: {e}"
+                )
+                continue
 
-                    try:
-                        part_number = int(part_dir.name.split("_")[1])
-                    except (ValueError, IndexError):
-                        continue
-
-                    scanned += 1
-                    if scanned % 5000 == 0:
-                        await asyncio.sleep(0)  # yield so workers drain while we walk
-
-                    # Check mtime (for age) and atime (for hot retention).
-                    #
-                    # ZFS + noatime note: in prod the local-cache volume is a ZFS
-                    # dataset mounted `noatime` (see `mount | grep local_object_cache`
-                    # → `rw,noatime,xattr,noacl,casesensitive`). `noatime` only
-                    # blocks VFS-triggered atime updates on reads (the
-                    # `file_accessed() → atime_needs_update() → dirty_inode()`
-                    # path). It does NOT block explicit `utimensat(2)` metadata
-                    # writes, which go through `setattr()`. Our reader refreshes
-                    # atime on every chunk read via `os.utime(path, None)` in
-                    # `fs_store.get_chunk`, so hot-retention works correctly here.
-                    # OpenZFS PR #4482 ("Fix atime handling and relatime") made
-                    # this behaviour consistent — atime is handled purely by VFS
-                    # and explicit setattr writes are always honoured regardless
-                    # of the mount's noatime flag.
-                    #
-                    # Side effect: `os.utime(path, None)` sets BOTH atime and
-                    # mtime to "now" (UTIME_NOW on both). Recently-read chunks
-                    # therefore show `atime == mtime` to the nanosecond — that's
-                    # expected, not a bug. It also means reads push mtime
-                    # forward, so the mtime-based age check below is more
-                    # conservative on actively-read content (treats hot chunks
-                    # as younger than their original landing time). Replication
-                    # is still the absolute gate, so this only relaxes, never
-                    # tightens, what we delete.
-                    meta_file = part_dir / "meta.json"
-                    check_path = meta_file if meta_file.exists() else part_dir
-
-                    # A single stat() can race a concurrent delete or return an
-                    # odd value; be conservative and skip the part rather than
-                    # abort the whole walk (matches the pre-split behaviour).
-                    try:
-                        stat = check_path.stat()
-                        mtime = stat.st_mtime
-                        atime = stat.st_atime
-                        if stats["oldest_mtime"] is None or mtime < stats["oldest_mtime"]:
-                            stats["oldest_mtime"] = mtime
-
-                        part_age = now - mtime
-                        stats["age_counts"][_classify_age_bucket(part_age)] += 1
-
-                        is_hot = hot_window > 0 and atime > (now - hot_window)
-                        if is_hot:
-                            stats["hot_parts"] += 1
-
-                        # Don't clean DLQ-protected parts (only count them for metrics)
-                        if is_dlq_protected:
-                            continue
-
-                        # Hot files are protected. Under critical pressure
-                        # hot_window is 0, which forces is_hot=False, letting
-                        # fully-replicated parts become eligible even if recently read.
-                        if is_hot:
-                            continue
-
-                        # A fully-replicated, cold, non-DLQ part is safe to evict.
-                        # Under normal pressure we additionally require age > cutoff
-                        # so we don't thrash. Under any pressure level we evict
-                        # replicated cold parts regardless of age. The replication
-                        # gate itself is enforced in the worker below.
-                        old_enough = mtime < cutoff_time
-                        if pressure == 0 and not old_enough:
-                            continue
-                    except Exception as e:
-                        logger.warning(f"Failed to classify part {part_dir}: {e}")
-                        continue
-
-                    yield (object_id, object_version, part_number, old_enough)
+            yield (object_id, object_version, part_number, old_enough)
 
     async def handle(conn: asyncpg.Connection, item: tuple[str, int, int, bool]) -> bool:
         object_id, object_version, part_number, old_enough = item
@@ -972,15 +1269,19 @@ async def cleanup_old_parts_by_mtime(
 
     parts_cleaned = await _run_worker_pool(pool, candidates(), handle, config.janitor_concurrency)
 
-    # Update the part-census gauges from the walk. Disk-usage + pressure gauges
-    # are owned by _update_disk_metrics (refreshed at cycle top) — don't re-stat
-    # the disk here.
-    oldest_mtime = stats["oldest_mtime"]
-    _fs_parts_on_disk = stats["parts_seen"]
-    _fs_oldest_age_seconds = max(0.0, now - float(oldest_mtime)) if oldest_mtime is not None else 0.0
-    _fs_age_buckets = stats["age_counts"]
-    _fs_hot_parts = stats["hot_parts"]
+    # Census is accumulated across the sharded sweep (this cycle covered shard `shard` of
+    # `shards`) and only published to the gauges when the sweep completes — see
+    # _accumulate_census / _publish_census. Disk-usage + pressure gauges are owned by
+    # _update_disk_metrics (refreshed at cycle top); don't re-stat the disk here.
+    # Pressure is a per-cycle fact (not per-sweep), so publish it every call regardless of the
+    # sharded census; _update_disk_metrics also sets it at cycle top, this keeps it in sync with
+    # the pressure this GC pass actually acted on.
+    global _fs_pressure_mode
     _fs_pressure_mode = pressure
+
+    _accumulate_census(stats, shard_complete=not walk_state.truncated)
+    if publish_sweep:
+        _publish_census(now)
 
     if parts_cleaned > 0 and _janitor_deleted_counter is not None:
         _janitor_deleted_counter.add(parts_cleaned)
@@ -1051,74 +1352,111 @@ async def run_janitor_loop():
     sleep_normal = 600  # 10m
     sleep_pressure = 120  # 2m
 
+    global _walk_shard
+    loop = asyncio.get_running_loop()
+
     try:
         while True:
             logger.info("Janitor cycle starting...")
-            # Refresh disk/pressure gauges up front. The GC walk below can take
-            # hours over millions of parts; disk visibility must not wait on it.
+            # Refresh disk/pressure gauges up front, and read pressure ONCE for the whole cycle.
             _update_disk_metrics(fs_store.root)
-
-            stale_count = 0
-            gc_count = 0
-            hard_deleted = 0
-            tmp_count = 0
-
-            # Phase 1: Clean stale MPU parts (aborted uploads)
-            try:
-                stale_count = await cleanup_stale_parts(db_pool, fs_store, redis_client)
-            except Exception as e:
-                logger.error(f"Phase 1 (stale cleanup) error: {e}", exc_info=True)
-
-            # Phase 2: GC old parts by mtime + update disk/cache metrics
-            try:
-                gc_count = await cleanup_old_parts_by_mtime(db_pool, fs_store, redis_client)
-            except Exception as e:
-                logger.error(f"Phase 2 (GC) error: {e}", exc_info=True)
-
-            # Phase 3: Clean orphan .tmp.* files from crashed atomic writes
-            try:
-                tmp_count = await cleanup_orphan_tmp_files(fs_store)
-            except Exception as e:
-                logger.error(f"Phase 3 (tmp cleanup) error: {e}", exc_info=True)
-
-            # Phase 4: Hard-delete soft-deleted objects where all unpins are confirmed
-            try:
-                hard_deleted = await gc_soft_deleted_objects(db_pool)
-            except Exception as e:
-                logger.error(f"Phase 4 (hard delete) error: {e}", exc_info=True)
-
-            # Phase 5: read-only replication-gate sentinel (G2). Publishes the durability
-            # gauge and alarms on any live/serveable chunk lacking full-union coverage.
             pressure = _pressure_mode(fs_store.root)
+
+            # --- DB-only DURABILITY phases run FIRST ------------------------------------------
+            # These used to run LAST, behind two full-tree FS walks. cleanup_stale_parts could
+            # not finish a pass over ~2.8M object dirs inside a cycle, so on prod these never ran
+            # at all — the replication-gate sentinel and the A21 aged-orphan leak gauge went dark.
+            # They are single indexed DB reads; nothing about the FS cache should gate them.
             sentinel_violations = 0
             try:
                 sentinel_violations = await check_replication_sentinel(db_pool, pressure)
             except Exception as e:
-                logger.error(f"Phase 5 (replication sentinel) error: {e}", exc_info=True)
+                logger.error(f"Replication sentinel error: {e}", exc_info=True)
 
-            # Phase 6: read-only aged-pending orphan gauge (A21 soak-gate feed). Publishes the
-            # standing leak backlog the replicated-only soak gate cannot see. The DLQ set is
-            # gathered fresh via the janitor's fail-closed get_all_dlq_object_ids and excluded so
-            # the gauge counts EXACTLY the population the sweep clears — a DLQ-parked orphan the
-            # sweep skips must not read as a phantom leak. On a DLQ-read failure the whole phase is
-            # skipped (gauge holds its prior value) rather than over-counting against an empty set.
-            # Note: the sweep's own DLQ set comes from mpu_cleanup.gather_dlq_object_ids, which is
-            # BEST-EFFORT (a Redis read failure logs and skips that key rather than aborting), so
-            # under a partial Redis failure the two briefly diverge — the sweep proceeds with a
-            # smaller set (clears more) while this gauge deliberately fails closed and stalls.
+            # Aged-pending orphan gauge (A21 soak-gate feed). The DLQ set is gathered fresh via
+            # the fail-closed get_all_dlq_object_ids and excluded so the gauge counts EXACTLY the
+            # population the sweep clears; on a DLQ-read failure the whole phase is skipped (gauge
+            # holds its prior value) rather than over-counting against an empty set.
             aged_orphans = 0
             try:
                 gauge_dlq_object_ids = await get_all_dlq_object_ids(redis_client)
                 aged_orphans = await check_aged_pending_orphans(db_pool, gauge_dlq_object_ids)
             except Exception as e:
-                logger.error(f"Phase 6 (aged-pending orphan gauge) error: {e}", exc_info=True)
+                logger.error(f"Aged-pending orphan gauge error: {e}", exc_info=True)
+
+            # --- FS-walk phases: sharded + budgeted so the cycle ALWAYS completes -------------
+            # Each cycle covers one hash-shard of the tree; a full sweep takes `shards` cycles.
+            # Under disk pressure we walk the whole tree every cycle (shards=1) and, at CRITICAL,
+            # lift the wall-clock budget entirely — freeing space must never be capped by a clock.
+            shards = 1 if pressure > 0 else max(1, config.janitor_walk_shards)
+            walk_shard = _walk_shard % shards
+            publish_sweep = walk_shard == shards - 1  # census publishes when the sweep wraps
+            walk_conc = max(1, config.janitor_walk_concurrency)
+            budget = config.janitor_walk_budget_seconds
+
+            stale_count = 0
+            gc_count = 0
+            tmp_count = 0
+            hard_deleted = 0
+
+            # Phase A: clean stale/orphan/terminally-abandoned parts (each phase gets its OWN
+            # fresh budget so the first walk can't starve the second — the bug we are fixing).
+            try:
+                stale_count = await cleanup_stale_parts(
+                    db_pool,
+                    fs_store,
+                    redis_client,
+                    shard=walk_shard,
+                    shards=shards,
+                    walk_concurrency=walk_conc,
+                    deadline=_walk_deadline(loop, pressure, budget),
+                )
+            except Exception as e:
+                logger.error(f"Stale cleanup error: {e}", exc_info=True)
+
+            # Phase B: replication-gated age GC + census (census published only on a full sweep).
+            try:
+                gc_count = await cleanup_old_parts_by_mtime(
+                    db_pool,
+                    fs_store,
+                    redis_client,
+                    shard=walk_shard,
+                    shards=shards,
+                    walk_concurrency=walk_conc,
+                    deadline=_walk_deadline(loop, pressure, budget),
+                    publish_sweep=publish_sweep,
+                )
+            except Exception as e:
+                logger.error(f"Age-GC error: {e}", exc_info=True)
+
+            # Phase C: orphan .tmp.* files from crashed atomic writes.
+            try:
+                tmp_count = await cleanup_orphan_tmp_files(
+                    fs_store,
+                    shard=walk_shard,
+                    shards=shards,
+                    walk_concurrency=walk_conc,
+                    deadline=_walk_deadline(loop, pressure, budget),
+                )
+            except Exception as e:
+                logger.error(f"Tmp cleanup error: {e}", exc_info=True)
+
+            # Phase D: hard-delete soft-deleted objects where all unpins are confirmed (DB-bound,
+            # batch-capped — cannot starve the cycle).
+            try:
+                hard_deleted = await gc_soft_deleted_objects(db_pool)
+            except Exception as e:
+                logger.error(f"Hard delete error: {e}", exc_info=True)
+
+            _walk_shard += 1  # advance the shard for next cycle
 
             logger.info(
-                f"Janitor cycle complete: stale={stale_count} gc={gc_count} tmp={tmp_count} "
-                f"hard_deleted={hard_deleted} sentinel_violations={sentinel_violations} aged_orphans={aged_orphans}"
+                f"Janitor cycle complete: shard={walk_shard}/{shards} publish_sweep={publish_sweep} "
+                f"stale={stale_count} gc={gc_count} tmp={tmp_count} hard_deleted={hard_deleted} "
+                f"sentinel_violations={sentinel_violations} aged_orphans={aged_orphans}"
             )
 
-            # Pick sleep interval based on current pressure (already probed for Phase 5)
+            # Pick sleep interval based on current pressure.
             sleep_interval = sleep_pressure if pressure > 0 else sleep_normal
             logger.info(f"Janitor sleeping {sleep_interval}s (pressure={pressure})")
             await asyncio.sleep(sleep_interval)

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -604,11 +604,11 @@ async def cleanup_stale_parts(
                 if _janitor_abandoned_deleted_counter is not None:
                     _janitor_abandoned_deleted_counter.add(1)
                 if _janitor_deleted_counter is not None:
-                    _janitor_deleted_counter.add(1, {"reason": "abandoned"})
+                    _janitor_deleted_counter.add(1, attributes={"reason": "abandoned"})
             else:
                 logger.info(f"Cleaned stale part by mtime: object_id={object_id} v={object_version} part={part_number}")
                 if _janitor_deleted_counter is not None:
-                    _janitor_deleted_counter.add(1, {"reason": "stale_mtime"})
+                    _janitor_deleted_counter.add(1, attributes={"reason": "stale_mtime"})
             return True
         except Exception as e:
             logger.warning(f"Failed to clean part: object_id={object_id} v={object_version} part={part_number}: {e}")
@@ -1037,7 +1037,7 @@ async def cleanup_old_parts_by_mtime(
     _fs_pressure_mode = pressure
 
     if parts_cleaned > 0 and _janitor_deleted_counter is not None:
-        _janitor_deleted_counter.add(parts_cleaned, {"reason": "gc_age"})
+        _janitor_deleted_counter.add(parts_cleaned, attributes={"reason": "gc_age"})
 
     logger.info(f"GC cleaned {parts_cleaned=} hot_parts={stats['hot_parts']} pressure={pressure}")
 
@@ -1170,8 +1170,8 @@ async def run_janitor_loop():
             # smaller set (clears more) while this gauge deliberately fails closed and stalls.
             aged_orphans = 0
             try:
-                gauge_dlq_object_ids = await get_all_dlq_object_ids(redis_client)
                 _janitor_phase = 6
+                gauge_dlq_object_ids = await get_all_dlq_object_ids(redis_client)
                 aged_orphans = await check_aged_pending_orphans(db_pool, gauge_dlq_object_ids)
             except Exception as e:
                 logger.error(f"Phase 6 (aged-pending orphan gauge) error: {e}", exc_info=True)

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -447,9 +447,10 @@ def _accumulate_census(stats: dict[str, Any], shard_complete: bool) -> None:
 
 
 def _publish_census(now: float) -> None:
-    """Publish the completed sweep's census to the gauges, then reset for the next sweep.
-    A sweep tainted by a budget truncation is dropped (gauges hold their last complete value)
-    rather than reported as a full census that undercounts. The pressure gauge is owned by
+    """Publish the completed sweep's census to the gauges. A sweep tainted by a budget
+    truncation is dropped (gauges hold their last complete value) rather than reported as a
+    full census that undercounts. The accumulator is reset at the NEXT sweep's shard 0, not
+    here, so a same-cycle re-read stays consistent. The pressure gauge is owned by
     _update_disk_metrics (refreshed every cycle top), so it is not touched here."""
     global _fs_parts_on_disk, _fs_oldest_age_seconds, _fs_age_buckets, _fs_hot_parts
     if _census_accum_complete:
@@ -463,7 +464,6 @@ def _publish_census(now: float) -> None:
             "Census sweep truncated by walk budget — holding last complete census (partial parts_seen=%d)",
             _census_accum["parts_seen"],
         )
-    _reset_census_accum()
 
 
 def _update_disk_metrics(root: Path) -> None:
@@ -1279,6 +1279,12 @@ async def cleanup_old_parts_by_mtime(
     global _fs_pressure_mode
     _fs_pressure_mode = pressure
 
+    # A sweep always starts at shard 0, so reset the accumulator there. This bounds the
+    # accumulator to exactly one sweep even if `shards` changed mid-sweep (e.g. a pressure
+    # transition flips it to 1) — without it the old partial sweep's counts would blend into
+    # the new one and inflate the published census once.
+    if shard == 0:
+        _reset_census_accum()
     _accumulate_census(stats, shard_complete=not walk_state.truncated)
     if publish_sweep:
         _publish_census(now)

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -52,6 +52,7 @@ from hippius_s3.logging_config import setup_loki_logging
 from hippius_s3.otel_setup import build_resource
 from hippius_s3.sentry import init_sentry
 from hippius_s3.utils import get_query
+from hippius_s3.workers.shutdown import run_worker
 
 
 config = get_config()
@@ -1130,4 +1131,4 @@ async def run_janitor_loop():
 
 
 if __name__ == "__main__":
-    asyncio.run(run_janitor_loop())
+    run_worker(run_janitor_loop, "janitor")

--- a/workers/run_mpu_reaper_in_loop.py
+++ b/workers/run_mpu_reaper_in_loop.py
@@ -20,4 +20,4 @@ init_sentry("mpu-reaper", is_worker=True)
 
 
 if __name__ == "__main__":
-    run_worker(run_mpu_reaper_loop, "mpu-reaper")
+    run_worker(run_mpu_reaper_loop, "mpu-reaper", restart_on_crash=True)

--- a/workers/run_mpu_reaper_in_loop.py
+++ b/workers/run_mpu_reaper_in_loop.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-import asyncio
 import logging
 import sys
-import time
 from pathlib import Path
 
 
@@ -12,6 +10,7 @@ from hippius_s3.config import get_config
 from hippius_s3.logging_config import setup_loki_logging
 from hippius_s3.sentry import init_sentry
 from hippius_s3.services.mpu_cleanup import run_mpu_reaper_loop
+from hippius_s3.workers.shutdown import run_worker
 
 
 config = get_config()
@@ -21,12 +20,4 @@ init_sentry("mpu-reaper", is_worker=True)
 
 
 if __name__ == "__main__":
-    while True:
-        try:
-            asyncio.run(run_mpu_reaper_loop())
-        except KeyboardInterrupt:
-            logger.info("MPU reaper stopped by user")
-            break
-        except Exception as e:
-            logger.error(f"MPU reaper crashed, restarting in 5 seconds: {e}", exc_info=True)
-            time.sleep(5)
+    run_worker(run_mpu_reaper_loop, "mpu-reaper")

--- a/workers/run_orphan_checker_in_loop.py
+++ b/workers/run_orphan_checker_in_loop.py
@@ -19,6 +19,7 @@ from hippius_s3.queue import enqueue_unpin_request
 from hippius_s3.queue import initialize_queue_client
 from hippius_s3.sentry import init_sentry
 from hippius_s3.services.hippius_api_service import HippiusApiClient
+from hippius_s3.workers.shutdown import run_worker
 
 
 config = get_config()
@@ -152,20 +153,20 @@ async def run_orphan_checker_loop() -> None:
     else:
         logger.info("Account whitelist: disabled (processing all accounts)")
 
-    while True:
-        ok = await run_orphan_check_cycle(db)
-        sleep_for = config.orphan_checker_loop_sleep if ok else 60
-        logger.info(f"Sleeping for {sleep_for} seconds...")
-        await asyncio.sleep(sleep_for)
+    # Closing on the way out is what tells Postgres and Redis this client is gone. Without
+    # it a cancelled worker leaves its backend behind, which is the orphan this PR exists to
+    # stop — the other workers already had the `finally`, this one did not.
+    try:
+        while True:
+            ok = await run_orphan_check_cycle(db)
+            sleep_for = config.orphan_checker_loop_sleep if ok else 60
+            logger.info(f"Sleeping for {sleep_for} seconds...")
+            await asyncio.sleep(sleep_for)
+    finally:
+        await db.close()
+        await redis_client.aclose()
+        await redis_queues_client.aclose()
 
 
 if __name__ == "__main__":
-    while True:
-        try:
-            asyncio.run(run_orphan_checker_loop())
-        except KeyboardInterrupt:
-            logger.info("Orphan checker service stopped by user")
-            break
-        except Exception as e:
-            logger.error(f"Orphan checker crashed, restarting in 5 seconds: {e}", exc_info=True)
-            time.sleep(5)
+    run_worker(run_orphan_checker_loop, "orphan-checker")

--- a/workers/run_orphan_checker_in_loop.py
+++ b/workers/run_orphan_checker_in_loop.py
@@ -169,4 +169,4 @@ async def run_orphan_checker_loop() -> None:
 
 
 if __name__ == "__main__":
-    run_worker(run_orphan_checker_loop, "orphan-checker")
+    run_worker(run_orphan_checker_loop, "orphan-checker", restart_on_crash=True)


### PR DESCRIPTION
## Summary

Aggregate staging → production release. Rolls up everything on `staging` that isn't yet in `k8s-production`: a janitor GC rewrite that fixes phase starvation, a read-path fail-fast that makes the retryable 503 reachable, graceful worker shutdown on SIGTERM, plus two **inert** additions (a one-time ops script and a staged redis-queues HA manifest that changes nothing until a controlled cutover).

**Deploy impact at a glance** — of the changes here, only the janitor, read-path, and worker-shutdown changes alter running behavior on `kubectl apply`. The redis-queues HA manifest and the MPU sweep script ship as files but do nothing until an operator explicitly acts.

## Changes (largest first)

- **Janitor GC rewrite (#332, #331)** — `run_janitor_in_loop.py` (+834): the whole-cache serial walk (~20h/pass, starving age-GC + the replication-gate sentinel + the A21 aged-orphan gauge behind it) is replaced with a sharded, thread-pooled `os.scandir` descent (`WALK_SHARDS=64`, `WALK_CONCURRENCY=8`, `WALK_BUDGET_SECONDS=240`); DB-only durability phases now run first every cycle. **The per-part delete decision and the replication safety-gate are byte-for-byte unchanged** (verified in review). #331 adds accurate delete counters + cycle-progress gauges + Grafana panels.
- **Worker graceful shutdown (#329)** — new `hippius_s3/workers/shutdown.py` + SIGTERM wiring across every worker loop, so a rolling deploy drains the current item and closes DB/redis/leases instead of orphaning backends. Runs on every deploy.
- **MPU sweep script (#327, inert)** — `sweep_partless_multipart_uploads.py`: one-time operator tool to GC ~875k abandoned partless multipart-upload headers the reaper can't see. Dry-run by default; never auto-invoked.
- **redis-queues HA (#328, inert)** — `k8s/base/redis-queues-ha.yaml` + cutover runbook. Operator-managed RedisReplication + Sentinel to close the single-replica redis-queues SPOF. **Not wired into any kustomization** — apply is a separate controlled cutover (staging-proven end-to-end, incl. a Sentinel failover that preserved the `cephor:epoch` fence).
- **Read-path 503 fail-fast (#330)** — first-chunk wait lowered 90s → 25s so the retryable 503 SlowDown is emitted before the client's 60s read timeout (today it always hung up on a dead socket first).
- **Smoke-alert clarity (#323)** + smoke-test 503 retry helper — human-readable failure alerts; raw-httpx smoke reads now retry 503 like a real S3 client.

## Verification

- All constituent PRs CI-green on staging; each independently reviewed (janitor safety-gate, read-path timing, MPU selection query, graceful-shutdown hang-safety, redis-HA staging failover).
- redis-queues HA validated end-to-end on `hippius-s3-staging` (replication + Sentinel failover + fence survival), then torn down.

## Conclusion

Low-risk aggregate: the two inert additions carry no deploy-time behavior, and the live changes (janitor, read-path, shutdown) are contained, tested, and soaked on staging. The redis-queues HA cutover is deliberately deferred to its own runbook-driven operation after this ships.
