### PR TITLE
fix(redis-ha): pin redis 7.4.8 + operator-safe Phase-2 seed (staging-proven)

### DIFF
--- a/docs/redis-queues-ha-cutover.md
+++ b/docs/redis-queues-ha-cutover.md
@@ -47,6 +47,12 @@ Nothing is repointed yet; the old `redis-queues` still serves all traffic.
    it). Existing `redis-cluster` is unaffected because RedisCluster self-heals via the in-namespace
    :16379 gossip bus; RedisReplication+Sentinel needs ongoing operator→pod connectivity.
 
+3. **The image is pinned to redis 7.4.x** (`quay.io/opstree/redis:v7.4.8`) to match the live
+   `redis-queues` (7.4.x). If someone downgrades it below the live version, the Phase-2 seed fails
+   (`Failed trying to load the MASTER synchronization DB from disk: Invalid argument`). Sanity check
+   before cutover: `kubectl -n $NS exec redis-queues-0 -- redis-cli info server | grep redis_version`
+   must be the same minor as the manifest image.
+
 If Phase 0 shows `connected_slaves:0` or a missing sentinel STS, check these two before anything else.
 
 ## Phase 1 — GATING TEST on staging: does a failover regress the fence? (do this BEFORE prod)
@@ -76,18 +82,34 @@ If Phase 0 shows `connected_slaves:0` or a missing sentinel STS, check these two
 
 ## Phase 2 — Data migration (copy the queue + cephor:* keys into the HA master)
 The HA set comes up empty. To cut over without losing pending uploads or the fence, seed it from
-the live `redis-queues` **before** repointing. Recommended (validate on staging):
+the live `redis-queues` **before** repointing.
+
+**Do NOT use `replicaof` + promote (the obvious approach FAILS here).** Validated on staging
+2026-07-24: making the HA master `replicaof redis-queues` then `replicaof no one` seeds the data,
+but the opstree operator **reconciles the topology and FLUSHES the seed on promote** — the promoted
+node is reverted to a replica and re-synced from an empty peer (dbsize → 0). The operator fights any
+manual topology change.
+
+**Use a logical key-copy into the operator's designated master instead** — these are ordinary client
+writes the reconciler does not touch, and they replicate to the replicas normally:
 ```bash
-# Temporarily make the HA master replicate the live standalone redis-queues to copy ALL keys:
-kubectl -n $NS exec redis-queues-ha-0 -- redis-cli replicaof redis-queues 6379
-kubectl -n $NS exec redis-queues-ha-0 -- redis-cli info replication   # master_link_status:up, sync done
-# Then promote it (keeps every key incl. cephor:* + the queues):
-kubectl -n $NS exec redis-queues-ha-0 -- redis-cli replicaof no one
+# 1. Find the operator's current master (the pod the master service points at):
+MASTER_IP=$(kubectl -n $NS get endpoints redis-queues-ha-master -o jsonpath='{.subsets[0].addresses[0].ip}')
+# 2. MIGRATE COPY every key from the live redis-queues into it (COPY = non-destructive to the source;
+#    REPLACE = idempotent; run via `sh -c` so the empty-key arg survives kubectl's arg parsing):
+KEYS=$(kubectl -n $NS exec redis-queues-0 -- redis-cli --scan | tr -d '\r' | tr '\n' ' ')
+kubectl -n $NS exec redis-queues-0 -- sh -c "redis-cli MIGRATE $MASTER_IP 6379 '' 0 5000 COPY REPLACE KEYS $KEYS"
+# 3. Verify on the master (survives an operator reconcile — wait ~45s — and replicates to ha replicas):
+kubectl -n $NS exec redis-queues-ha-0 -- redis-cli -h redis-queues-ha-master get cephor:epoch   # == live value
+kubectl -n $NS exec redis-queues-ha-0 -- redis-cli -h redis-queues-ha-master dbsize             # == live dbsize
 ```
-**Caveat to validate on staging:** the OT operator reconciler manages `replicaof`; confirm it
-does not fight the manual `replicaof` mid-migration (if it does, use a one-shot `redis-cli --rdb`
-dump of the old + `redis-cli -x restore`/`--pipe` load into the new master instead, during a
-brief writer quiesce). Pick whichever staging proves clean; document it here before prod.
+For a large keyspace, batch the `KEYS` list (a few hundred per MIGRATE). Both redis versions must be
+the **same minor** (7.4.x ↔ 7.4.x) or MIGRATE's serialization is rejected — the same version rule the
+manifest's image pin enforces. **Quiesce note:** MIGRATE is a point-in-time copy; any queue entry
+written to the live redis *after* the copy and *before* the Phase-3 repoint won't be on the HA master.
+The drain re-enqueues on transient error so this is tolerable, but do Phase 2 → Phase 3 back-to-back
+(minimize the gap), or briefly pause the producers, to avoid stranding in-flight uploads on the old
+redis.
 
 ## Phase 3 — Repoint + roll consumers (the actual cutover; seconds)
 ```bash

--- a/docs/redis-queues-ha-cutover.md
+++ b/docs/redis-queues-ha-cutover.md
@@ -112,8 +112,22 @@ The drain re-enqueues on transient error so this is tolerable, but do Phase 2 �
 redis.
 
 ## Phase 3 — Repoint + roll consumers (the actual cutover; seconds)
+
+**CRITICAL — `REDIS_QUEUES_URL` is NOT a GitHub Actions secret; it is a plaintext literal in the
+deploy workflow.** The deploy's "Update secrets" step (`.github/workflows/production-deploy.yaml`,
+`kubectl create secret generic hippius-s3-secrets --from-literal=REDIS_QUEUES_URL=...`) **recreates
+`hippius-s3-secrets` on every deploy from that literal**. So a live `kubectl patch` of the secret is
+**silently reverted on the very next deploy**. The durable change is editing the workflow literal.
+Do BOTH:
+
+1. **Durable repoint (source of truth):** change the literal in `production-deploy.yaml`
+   (`redis://redis-queues:6379/0` → `redis://redis-queues-ha-master:6379/0`) and merge to
+   `k8s-production`. Prepared as a held PR (see the "cutover repoint" PR). **Merge it only AFTER
+   Phase 0** (the `redis-queues-ha-master` service must exist, or that deploy breaks the queue path).
+   `staging-deploy.yaml` has the analogous literal — edit it on `staging` for a staging cutover.
+2. **Immediate repoint + roll** (the live switch; the merge in step 1 recreates the secret but does
+   NOT restart pods without an image change, so you roll them explicitly):
 ```bash
-# Patch the secret key (base64) and roll every workload that reads REDIS_QUEUES_URL:
 NEW=$(printf 'redis://redis-queues-ha-master:6379/0' | base64)
 kubectl -n $NS patch secret hippius-s3-secrets --type merge -p "{\"data\":{\"REDIS_QUEUES_URL\":\"$NEW\"}}"
 kubectl -n $NS rollout restart ds/drain-agent ds/api-local deploy/drain-allocator deploy/mpu-reaper \
@@ -132,7 +146,9 @@ OLD=$(printf 'redis://redis-queues:6379/0' | base64)
 kubectl -n <ns> patch secret hippius-s3-secrets --type merge -p "{\"data\":{\"REDIS_QUEUES_URL\":\"$OLD\"}}"
 kubectl -n <ns> rollout restart ds/drain-agent ds/api-local deploy/drain-allocator deploy/mpu-reaper ...
 ```
-If the HA master accumulated new queue entries after cutover, drain them back or accept the
+**If the durable repoint (Phase 3 step 1) was already merged, also `git revert` that workflow commit**
+— otherwise the next deploy recreates the secret pointing back at the HA master and undoes this
+rollback. If the HA master accumulated new queue entries after cutover, drain them back or accept the
 drain's re-enqueue (idempotent). Instant, no data loss (both redises are CephFS-durable).
 
 ## Decommission (after soak)

--- a/k8s/base/redis-queues-ha.yaml
+++ b/k8s/base/redis-queues-ha.yaml
@@ -46,7 +46,12 @@ spec:
     runAsGroup: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis:v7.0.15
+    # MUST be >= the live redis-queues version (redis:7-alpine → 7.4.x; prod 7.4.8, staging 7.4.9).
+    # Redis replication is forward-incompatible: an older replica cannot load a newer master's RDB —
+    # a v7.0.15 node fails the Phase-2 seed from a 7.4.x source with "Failed trying to load the MASTER
+    # synchronization DB from disk: Invalid argument". v7.4.8 is opstree's newest 7.4 tag and shares
+    # the 7.4 RDB format with the live 7.4.9 (verified on staging 2026-07-24).
+    image: quay.io/opstree/redis:v7.4.8
     imagePullPolicy: IfNotPresent
     resources:
       requests:
@@ -81,7 +86,7 @@ spec:
     runAsGroup: 1000
     fsGroup: 1000
   kubernetesConfig:
-    image: quay.io/opstree/redis-sentinel:v7.0.15
+    image: quay.io/opstree/redis-sentinel:v7.4.8 # keep in lockstep with the redis image above
     imagePullPolicy: IfNotPresent
     resources:
       requests:


### PR DESCRIPTION
## Summary

The Phase-2 `replicaof` seed was the one unvalidated step of the redis-queues HA cutover. A staging dry-run (2026-07-24) hit **two blockers**; both are fixed here. The manifest stays **inert** (in no kustomization), so this has zero deploy impact — it corrects the staged files for the eventual cutover.

## Findings (both validated live on staging)

1. **Version mismatch → seed fails.** The HA manifest pinned opstree `v7.0.15`, but the live `redis-queues` runs 7.4.x (**prod 7.4.8**, staging 7.4.9). Redis replication is forward-incompatible — a 7.0.15 node can't load a 7.4.x master's RDB, failing with `Failed trying to load the MASTER synchronization DB from disk: Invalid argument`. **Fix:** bump redis + redis-sentinel images to `v7.4.8` (opstree's newest 7.4, same RDB format as live). After the bump the seed link came up (`master_link_status:up`, dbsize matched, keys copied).

2. **The operator flushes a `replicaof`-based seed.** The runbook's Phase 2 (`replicaof redis-queues` → `replicaof no one`) seeds the data, but the opstree reconciler reverts the promoted node to a replica and re-syncs it from an empty peer → **dbsize 0, seed lost**. **Fix:** rewrote Phase 2 to a logical key-copy (`MIGRATE COPY` into the operator's designated master) — ordinary client writes the reconciler leaves alone. Verified they persist through a reconcile and replicate to both replicas.

## Changes
- `k8s/base/redis-queues-ha.yaml`: image `v7.0.15` → `v7.4.8` (both CRs) + a comment explaining the version rule.
- `docs/redis-queues-ha-cutover.md`: Phase 2 rewritten to the MIGRATE approach; added a Phase-0 version-match prereq.

## Verification
Full HA set stood up on staging on v7.4.8 (master + 2 replicas + 3 sentinels healthy), seed copied `cephor:epoch` + queue keys into the operator master, survived a 45s reconcile, replicated to both replicas. Test set torn down; live `redis-queues` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)