### PR TITLE
fix(postgres-nvme): tune autovacuum for NVMe + 100GB tables

### DIFF
--- a/k8s/production/postgres-nvme-cluster.yaml
+++ b/k8s/production/postgres-nvme-cluster.yaml
@@ -29,6 +29,33 @@ spec:
     shared_preload_libraries:
     - pg_stat_statements
     parameters:
+      # --- autovacuum: tuned for NVMe + 100GB-class tables (2026-07-24) ---
+      # This cluster carries 30-103GB tables. With the stock cost_limit (200, a spinning-disk
+      # value that throttles vacuum to a few MB/s) autovacuum could not finish a 56GB table
+      # before a lock cancelled it, so chunk_backend (43% dead) and object_versions had NEVER
+      # completed an autovacuum, the freeze horizon aged to 188M/200M (~22h from a forced
+      # anti-wraparound storm), and an ordinary vacuum of `parts` at 07:33 UTC saturated the
+      # NVMe enough to make a 24ms ListObjects take 3.5 min and time out the smoke suite.
+      # Full write-up + the one-time manual catch-up in psql-nvme-issue.md.
+      #
+      # 3000 not 200: raises vacuum's I/O budget ~15x so a big-table vacuum finishes rather than
+      # being cancelled mid-run. NVMe here (random_page_cost 1.1), so it absorbs it, and it stays
+      # throttled by autovacuum_vacuum_cost_delay (2ms default) — this is "fast enough to finish",
+      # not "unthrottled". Deliberately NOT raising autovacuum_max_workers: the cost budget is
+      # SHARED across workers, so more workers each run slower.
+      autovacuum_vacuum_cost_limit: '3000'
+      # 100k not the PG18 default of 100M: caps the trigger at an absolute dead-tuple count so a
+      # huge table can't wait for scale_factor*rows (tens of millions) to go dead first. Paired
+      # with per-table autovacuum_vacuum_scale_factor overrides (0.02-0.05) applied via ALTER
+      # TABLE on chunk_backend/object_versions/multipart_uploads/objects/parts/part_chunks — those
+      # are catalog storage params, not postgresql.conf, so they live in the DB, documented in
+      # psql-nvme-issue.md so a cluster rebuild re-applies them.
+      autovacuum_vacuum_max_threshold: '100000'
+      # 0 not 600000 (10min): the old value hid the problem — a vacuum that starts, runs a few
+      # minutes and is cancelled before completing logged NOTHING, so the never-finishing tables
+      # were invisible. Logging every autovacuum makes a still-failing table visible. Can be
+      # dialled up to '1000' (>=1s) once we've confirmed autovacuum is healthy on the big tables.
+      log_autovacuum_min_duration: '0'
       checkpoint_completion_target: '0.9'
       checkpoint_timeout: 15min
       default_statistics_target: '500'


### PR DESCRIPTION
The permanent half of the XID-wraparound / autovacuum fix. The one-time catch-up (Phase 0 + Phase 1) is already applied live; this is what stops it recurring. Full investigation and step-by-step in `psql-nvme-issue.md`.

## What went wrong

The cluster carries 30–103 GB tables against **stock autovacuum defaults**. `autovacuum_vacuum_cost_limit` falls back to **200** — a spinning-disk value that throttles vacuum to a few MB/s. On a 56 GB table that means a single vacuum runs for hours and gets cancelled by a conflicting lock before it finishes, so:

- `chunk_backend` (43% dead) and `object_versions` had **never once completed an autovacuum**
- the freeze horizon aged to **188M / 200M** — ~22 hours from a forced, fleet-wide anti-wraparound vacuum storm
- an ordinary vacuum of `parts` at 07:33 UTC saturated the NVMe enough that a **24 ms `ListObjectsV2` took 3.5 minutes** and timed out the production smoke suite (runs 30076657394, and the 07:53 failure)

## What this changes (3 reloadable params — `sighup`, no restart)

| param | from | to | why |
|---|---|---|---|
| `autovacuum_vacuum_cost_limit` | 200 | **3000** | ~15× I/O budget so a big-table vacuum *finishes* instead of being cancelled. NVMe absorbs it; still throttled by the 2 ms `cost_delay`. |
| `autovacuum_vacuum_max_threshold` (PG18) | 100M | **100k** | caps the trigger at an absolute dead-tuple count so a huge table can't wait for 2% of tens of millions of rows first |
| `log_autovacuum_min_duration` | 600000 (10 min) | **0** | the 10-min value *hid the problem* — a vacuum cancelled after a few minutes logged nothing. Log everything so a still-failing table is visible. |

Deliberately **not** raising `autovacuum_max_workers` (kept at 3): the cost budget is shared across workers, so more workers each run *slower* — unanimous in the research (Azure, Citus, Cybertec).

## Paired per-table settings (already applied live)

`autovacuum_vacuum_scale_factor` overrides — 0.02 on the high-churn `chunk_backend` / `object_versions` / `multipart_uploads`, 0.05 on `objects` / `parts` / `part_chunks`. These are catalog storage params (`ALTER TABLE`), not `postgresql.conf`, so they can't live in this manifest — they're documented in `psql-nvme-issue.md` so a cluster rebuild re-applies them.

## Blast radius

Scoped to `postgres-nvme` only. Verified per-cluster: CNPG `spec.postgresql.parameters` maps to that one cluster's `postgresql.conf` — proven by two clusters on the same operator running wildly different values (`postgres-nvme` `shared_buffers` 12 GB vs `harbor-postgres` 256 MB). The other 11 CNPG clusters, and even the sibling `postgres` cluster in the same namespace, are untouched. Staging's postgres is small and needs no tuning.

## Already done (live, before this PR)

Phase 0 + Phase 1 — manual throttled `VACUUM FREEZE` of the bloated and aged tables:
- horizon **188M → 85.7M** (~22 h → **~9.1 days**)
- `chunk_backend` 36% → 0% dead, `object_versions` 13% → 0% dead, ~44 GB reclaimed to reusable free space
- all big tables frozen; **zero failover, no restart, 5–16 ms query latency throughout** (the throttle avoided the 07:53-style stall)

This PR is what makes autovacuum keep it that way on its own.

## Verification

Valid YAML; `kubectl kustomize k8s/production` builds; all three GUCs confirmed present and `sighup`-reloadable on the live PG 18.1 server. Applied by the production-deploy pipeline (the manifest is in `k8s/production/kustomization.yaml`); CNPG reloads the params with no rollout.