### PR TITLE
Gate drain ceiling on per-pool fullness, cap NearFull rate

### DIFF
--- a/crates/hippius-drain-allocator/src/config.rs
+++ b/crates/hippius-drain-allocator/src/config.rs
@@ -220,6 +220,17 @@ impl AllocatorConfig {
             critical_pressure: critical_pressure(&get, "CEPHOR_ALLOC_CRITICAL_PRESSURE_BPS", DEFAULT_CRITICAL_PRESSURE_BPS)?,
             reservation_floor: ByteRate::new(u64_or(&get, "CEPHOR_ALLOC_RESERVATION_FLOOR_BPS", DEFAULT_RESERVATION_FLOOR_BPS)?),
         };
+        let ceph_ceiling = positive_u64(&get, "CEPHOR_CEPH_CEILING_BPS", DEFAULT_CEPH_CEILING_BPS)?;
+        let ceph_nearfull_rate = positive_u64(&get, "CEPHOR_CEPH_NEARFULL_RATE_BPS", DEFAULT_CEPH_NEARFULL_RATE_BPS)?;
+        if ceph_nearfull_rate > ceph_ceiling {
+            // NearFull carrying more budget than Open would invert the "fuller is
+            // never looser" ceiling invariant.
+            return Err(ConfigError::OutOfRange {
+                var: "CEPHOR_CEPH_NEARFULL_RATE_BPS",
+                value: ceph_nearfull_rate,
+                limit: ceph_ceiling,
+            });
+        }
         Ok(Self {
             database_url: required(&get, "CEPHOR_DATABASE_URL")?,
             instance_id: required(&get, "CEPHOR_ALLOCATOR_INSTANCE_ID")?,
@@ -227,14 +238,14 @@ impl AllocatorConfig {
             tick_interval: duration_secs(&get, "CEPHOR_ALLOCATOR_TICK_SECS", DEFAULT_TICK)?,
             redis_queues_url: required(&get, "REDIS_QUEUES_URL")?,
             alloc_ttl: duration_secs(&get, "CEPHOR_ALLOCATION_TTL_SECS", DEFAULT_ALLOCATION_TTL)?,
-            ceph_ceiling: ByteRate::new(positive_u64(&get, "CEPHOR_CEPH_CEILING_BPS", DEFAULT_CEPH_CEILING_BPS)?),
+            ceph_ceiling: ByteRate::new(ceph_ceiling),
             // The first tick starts from the AIMD floor unless overridden, so a
             // fresh leader ramps up from a safe rate rather than a guess.
             initial_total: ByteRate::new(u64_or(&get, "CEPHOR_ALLOC_INITIAL_TOTAL_BPS", min_total)?),
             alloc,
             ceph_mgr_metrics_url: optional(&get, "CEPHOR_CEPH_MGR_METRICS_URL"),
             ceph_thresholds: ceph_thresholds(&get)?,
-            ceph_nearfull_rate: ByteRate::new(positive_u64(&get, "CEPHOR_CEPH_NEARFULL_RATE_BPS", DEFAULT_CEPH_NEARFULL_RATE_BPS)?),
+            ceph_nearfull_rate: ByteRate::new(ceph_nearfull_rate),
             ceph_pools: name_list(&get, "CEPHOR_CEPH_POOLS"),
             ceph_probe_timeout: duration_secs(&get, "CEPHOR_CEPH_PROBE_TIMEOUT_SECS", DEFAULT_PROBE_TIMEOUT)?,
             liveness_file: path_or(&get, "CEPHOR_LIVENESS_FILE", DEFAULT_LIVENESS_FILE),
@@ -417,6 +428,9 @@ mod tests {
     fn tick_config_and_ceiling_reflect_the_config() {
         let mut pairs = required_only();
         pairs.push(("CEPHOR_CEPH_CEILING_BPS", "500000"));
+        // The tiny test ceiling sits below the default near-full rate, which the
+        // ordering check would (correctly) reject; pick a rate under the ceiling.
+        pairs.push(("CEPHOR_CEPH_NEARFULL_RATE_BPS", "100000"));
         let config = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap();
         let tick = config.tick_config();
         assert_eq!(tick.instance_id, "alloc-1");
@@ -585,6 +599,24 @@ mod tests {
         pairs.push(("CEPHOR_CEPH_POOLS", " , ,"));
         let config = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap();
         assert!(config.ceph_pools.is_empty(), "commas and whitespace alone select no pools");
+    }
+
+    #[test]
+    fn a_nearfull_rate_above_the_ceiling_is_rejected() {
+        // NearFull carrying more budget than Open would invert the "fuller is
+        // never looser" invariant the classifier property-tests.
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_CEPH_CEILING_BPS", "1000000000"));
+        pairs.push(("CEPHOR_CEPH_NEARFULL_RATE_BPS", "2000000000"));
+        let err = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::OutOfRange {
+                var: "CEPHOR_CEPH_NEARFULL_RATE_BPS",
+                value: 2_000_000_000,
+                limit: 1_000_000_000,
+            }
+        ));
     }
 
     #[test]

--- a/crates/hippius-drain-allocator/src/config.rs
+++ b/crates/hippius-drain-allocator/src/config.rs
@@ -73,6 +73,13 @@ const DEFAULT_CEPH_FULL_BPS: u16 = 9_500;
 /// Per-scrape timeout for the live mgr probe when `CEPHOR_CEPH_PROBE_TIMEOUT_SECS`
 /// is unset — short relative to the tick so a hung mgr decays rather than stalls.
 const DEFAULT_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+/// The fleet-wide rate a near-full ceiling carries when
+/// `CEPHOR_CEPH_NEARFULL_RATE_BPS` is unset. Deliberately far below any plausible
+/// `min_total`: the 2026-07-24 incident showed the AIMD floor (raised to 50 MB/s
+/// in prod) is an operator latency knob, not a fullness brake, so near-full must
+/// bound the drain through the ceiling clamp instead. 10 MB/s keeps a relief
+/// valve open for SSD pressure while a near-full pool fills in days, not hours.
+const DEFAULT_CEPH_NEARFULL_RATE_BPS: u64 = 10_000_000;
 
 /// How long a terminal (`replicated`/`failed`) replication row is kept before the periodic
 /// GC prunes it, when `CEPHOR_STATUS_RETENTION_SECS` is unset. A week comfortably exceeds
@@ -108,6 +115,13 @@ pub struct AllocatorConfig {
     pub ceph_mgr_metrics_url: Option<String>,
     /// The near-full / full watermarks the live probe classifies against.
     pub ceph_thresholds: CephThresholds,
+    /// The reduced fleet-wide rate a near-full ceiling carries
+    /// (`CEPHOR_CEPH_NEARFULL_RATE_BPS`).
+    pub ceph_nearfull_rate: ByteRate,
+    /// The pools whose `percent_used` additionally gate the live probe's ceiling
+    /// (`CEPHOR_CEPH_POOLS`, comma-separated; the fullest binds). Empty gates on
+    /// cluster-wide signals only.
+    pub ceph_pools: Vec<String>,
     /// Per-scrape timeout for the live probe.
     pub ceph_probe_timeout: Duration,
     /// Path of the liveness file the tick loop touches each iteration; a k8s
@@ -220,6 +234,8 @@ impl AllocatorConfig {
             alloc,
             ceph_mgr_metrics_url: optional(&get, "CEPHOR_CEPH_MGR_METRICS_URL"),
             ceph_thresholds: ceph_thresholds(&get)?,
+            ceph_nearfull_rate: ByteRate::new(positive_u64(&get, "CEPHOR_CEPH_NEARFULL_RATE_BPS", DEFAULT_CEPH_NEARFULL_RATE_BPS)?),
+            ceph_pools: name_list(&get, "CEPHOR_CEPH_POOLS"),
             ceph_probe_timeout: duration_secs(&get, "CEPHOR_CEPH_PROBE_TIMEOUT_SECS", DEFAULT_PROBE_TIMEOUT)?,
             liveness_file: path_or(&get, "CEPHOR_LIVENESS_FILE", DEFAULT_LIVENESS_FILE),
             status_retention: duration_secs(&get, "CEPHOR_STATUS_RETENTION_SECS", DEFAULT_STATUS_RETENTION)?,
@@ -252,6 +268,21 @@ fn required(get: &impl Fn(&str) -> Option<String>, var: &'static str) -> Result<
 /// absent — a blank mgr URL must not select the probe with an unusable endpoint.
 fn optional(get: &impl Fn(&str) -> Option<String>, var: &'static str) -> Option<String> {
     get(var).filter(|value| !value.trim().is_empty())
+}
+
+/// Resolves a comma-separated name list: entries are trimmed, blanks dropped, so
+/// `"a, b,,c "` reads as `["a","b","c"]` and an unset or all-blank variable as empty.
+fn name_list(get: &impl Fn(&str) -> Option<String>, var: &'static str) -> Vec<String> {
+    get(var)
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Resolves an optional path variable, falling back to `default` when unset or blank.
@@ -519,15 +550,56 @@ mod tests {
             osd_full: false,
             osd_nearfull: false,
             used: Some(DiskPressure::try_from(bps).unwrap()),
+            pool_used: None,
         };
         assert_eq!(
-            classify(&report(8_500), config.ceph_ceiling, &config.ceph_thresholds),
-            CephCeiling::NearFull(config.ceph_ceiling)
+            classify(&report(8_500), config.ceph_ceiling, config.ceph_nearfull_rate, &config.ceph_thresholds),
+            CephCeiling::NearFull(config.ceph_nearfull_rate)
         );
         assert_eq!(
-            classify(&report(9_500), config.ceph_ceiling, &config.ceph_thresholds),
+            classify(&report(9_500), config.ceph_ceiling, config.ceph_nearfull_rate, &config.ceph_thresholds),
             CephCeiling::Critical
         );
+    }
+
+    #[test]
+    fn the_pool_gate_and_nearfull_rate_default_off_and_conservative() {
+        let config = AllocatorConfig::from_lookup(lookup(&required_only())).unwrap();
+        assert!(config.ceph_pools.is_empty(), "pool gating is opt-in per deployment");
+        assert_eq!(config.ceph_nearfull_rate, ByteRate::new(10_000_000));
+    }
+
+    #[test]
+    fn the_pools_and_nearfull_rate_are_read_from_the_environment() {
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_CEPH_POOLS", "ceph-filesystem-data0, ceph-filesystem-metadata,ceph-blockpool"));
+        pairs.push(("CEPHOR_CEPH_NEARFULL_RATE_BPS", "5000000"));
+        let config = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(config.ceph_pools, ["ceph-filesystem-data0", "ceph-filesystem-metadata", "ceph-blockpool"]);
+        assert_eq!(config.ceph_nearfull_rate, ByteRate::new(5_000_000));
+    }
+
+    #[test]
+    fn a_blank_pool_list_is_treated_as_absent() {
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_CEPH_POOLS", " , ,"));
+        let config = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap();
+        assert!(config.ceph_pools.is_empty(), "commas and whitespace alone select no pools");
+    }
+
+    #[test]
+    fn a_zero_nearfull_rate_is_rejected() {
+        // Zero would silence the near-full relief valve entirely; a full stop is
+        // Critical's job, so a zero here is a misconfiguration.
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_CEPH_NEARFULL_RATE_BPS", "0"));
+        let err = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::NonPositive {
+                var: "CEPHOR_CEPH_NEARFULL_RATE_BPS"
+            }
+        ));
     }
 
     #[test]

--- a/crates/hippius-drain-allocator/src/main.rs
+++ b/crates/hippius-drain-allocator/src/main.rs
@@ -119,6 +119,15 @@ async fn run_with_ceiling_source(coord: &Coordinator, config: &AllocatorConfig, 
         drive(coord, &probe, config, metrics).await;
         return Ok(());
     }
+    if !config.ceph_pools.is_empty() {
+        // The pool fullness gate only exists inside the live probe; pools configured
+        // without a mgr URL is the silent no-protection state that caused the
+        // 2026-07-24 incident, so it must be loud.
+        tracing::warn!(
+            pools = config.ceph_pools.join(","),
+            "CEPHOR_CEPH_POOLS is set but CEPHOR_CEPH_MGR_METRICS_URL is not; the pool fullness gate is INACTIVE on the static ceiling"
+        );
+    }
     tracing::info!("no ceph mgr url configured; using the static ceiling");
     drive(coord, &config.ceiling(), config, metrics).await;
     Ok(())

--- a/crates/hippius-drain-allocator/src/main.rs
+++ b/crates/hippius-drain-allocator/src/main.rs
@@ -101,14 +101,21 @@ async fn run_with_ceiling_source(coord: &Coordinator, config: &AllocatorConfig, 
     if let Some(url) = config.ceph_mgr_metrics_url.clone() {
         // The decay floor is the AIMD floor: while the probe is blind, the fleet
         // backs off toward the same conservative rate the allocator never drops below.
-        let probe = hippius_drain_allocator::probe::CephProbe::new(
-            url.clone(),
-            config.ceph_ceiling,
-            config.alloc.min_total,
-            config.ceph_thresholds,
-            config.ceph_probe_timeout,
-        )?;
-        tracing::info!(mgr_url = %url, "driving the budget from the live ceph-mgr ceiling probe");
+        let probe = hippius_drain_allocator::probe::CephProbe::new(hippius_drain_allocator::probe::ProbeSettings {
+            url: url.clone(),
+            ceiling_rate: config.ceph_ceiling,
+            nearfull_rate: config.ceph_nearfull_rate,
+            floor: config.alloc.min_total,
+            thresholds: config.ceph_thresholds,
+            timeout: config.ceph_probe_timeout,
+            pools: config.ceph_pools.clone(),
+        })?;
+        tracing::info!(
+            mgr_url = %url,
+            pools = config.ceph_pools.join(","),
+            nearfull_rate_bps = config.ceph_nearfull_rate.get(),
+            "driving the budget from the live ceph-mgr ceiling probe"
+        );
         drive(coord, &probe, config, metrics).await;
         return Ok(());
     }

--- a/crates/hippius-drain-allocator/src/probe.rs
+++ b/crates/hippius-drain-allocator/src/probe.rs
@@ -46,38 +46,54 @@ struct ProbeState {
     consecutive_failures: u32,
 }
 
+/// Everything [`CephProbe::new`] needs. A settings struct rather than positional
+/// parameters: the probe's signal set grows (the target pool and the reduced
+/// near-full rate were added after the 2026-07-24 pool-fill incident), and seven
+/// positional arguments of mostly-`ByteRate` types invite transposition bugs.
+#[derive(Debug, Clone)]
+pub struct ProbeSettings {
+    /// The mgr prometheus exporter URL to scrape.
+    pub url: String,
+    /// The open ceiling handed to the allocator when Ceph is healthy.
+    pub ceiling_rate: ByteRate,
+    /// The reduced rate a near-full cluster or pool carries — this must bound the
+    /// drain below any AIMD floor, so it is deliberately not `ceiling_rate`.
+    pub nearfull_rate: ByteRate,
+    /// The conservative rate the fail-safe decays toward while the probe is blind.
+    pub floor: ByteRate,
+    /// The near-full / full watermarks.
+    pub thresholds: CephThresholds,
+    /// Per-scrape HTTP timeout.
+    pub timeout: Duration,
+    /// The pools whose `percent_used` additionally gate the ceiling (the fullest
+    /// one binds). Empty gates on cluster-wide signals only — the pre-incident
+    /// behavior, kept for clusters with no stable pool names.
+    pub pools: Vec<String>,
+}
+
 /// A [`CephCeilingSource`] backed by the Ceph mgr prometheus exporter.
 #[derive(Debug)]
 pub struct CephProbe {
     client: reqwest::Client,
-    url: String,
-    ceiling_rate: ByteRate,
-    floor: ByteRate,
-    thresholds: CephThresholds,
+    settings: ProbeSettings,
     state: Mutex<ProbeState>,
 }
 
 impl CephProbe {
-    /// Builds a probe for the mgr exporter at `url`.
-    ///
-    /// `ceiling_rate` is the open ceiling handed to the allocator when Ceph is
-    /// healthy; `floor` is the conservative rate the fail-safe decays toward while
-    /// the probe is blind; `thresholds` are the near-full / full watermarks.
+    /// Builds a probe for the mgr exporter described by `settings`.
     ///
     /// # Errors
     ///
     /// [`ProbeError::Http`] if the HTTP client cannot be built (e.g. an invalid TLS
     /// or timeout configuration).
-    pub fn new(url: String, ceiling_rate: ByteRate, floor: ByteRate, thresholds: CephThresholds, timeout: Duration) -> Result<Self, ProbeError> {
-        let client = reqwest::Client::builder().timeout(timeout).build()?;
+    pub fn new(settings: ProbeSettings) -> Result<Self, ProbeError> {
+        let client = reqwest::Client::builder().timeout(settings.timeout).build()?;
+        let last_known = CephCeiling::Open(settings.ceiling_rate);
         Ok(Self {
             client,
-            url,
-            ceiling_rate,
-            floor,
-            thresholds,
+            settings,
             state: Mutex::new(ProbeState {
-                last_known: CephCeiling::Open(ceiling_rate),
+                last_known,
                 consecutive_failures: 0,
             }),
         })
@@ -98,13 +114,14 @@ impl CephProbe {
     ///
     /// [`ProbeError`] on transport failure, a non-success status, or unparseable body.
     async fn probe(&self) -> Result<CephReport, ProbeError> {
-        let response = self.client.get(&self.url).send().await?;
+        let response = self.client.get(&self.settings.url).send().await?;
         let status = response.status();
         if !status.is_success() {
             return Err(ProbeError::Status { code: status.as_u16() });
         }
         let body = response.text().await?;
-        Ok(parse_prometheus_metrics(&body)?)
+        let pools: Vec<&str> = self.settings.pools.iter().map(String::as_str).collect();
+        Ok(parse_prometheus_metrics(&body, &pools)?)
     }
 
     /// Locks the state, recovering the guard if a previous holder poisoned it. The
@@ -124,7 +141,12 @@ impl CephCeilingSource for CephProbe {
 
         match self.probe().await {
             Ok(report) => {
-                let ceiling = classify(&report, self.ceiling_rate, &self.thresholds);
+                let ceiling = classify(
+                    &report,
+                    self.settings.ceiling_rate,
+                    self.settings.nearfull_rate,
+                    &self.settings.thresholds,
+                );
                 let mut state = self.lock();
                 state.last_known = ceiling;
                 state.consecutive_failures = 0;
@@ -135,7 +157,7 @@ impl CephCeilingSource for CephProbe {
                 // Decay the last *successful* ceiling by the new failure count — never
                 // the already-decayed value, so the back-off is geometric in failures,
                 // not compounded per tick. `last_known` is deliberately left intact.
-                let ceiling = decay(last_known, failures, self.floor);
+                let ceiling = decay(last_known, failures, self.settings.floor);
                 self.lock().consecutive_failures = failures;
                 tracing::warn!(error = %err, consecutive_failures = failures, ?ceiling, "ceph mgr probe failed; using decayed ceiling");
                 ceiling
@@ -147,7 +169,7 @@ impl CephCeilingSource for CephProbe {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::CephProbe;
+    use super::{CephProbe, ProbeSettings};
     use hippius_drain_core::DiskPressure;
     use hippius_drain_core::{ByteRate, CephCeiling, CephCeilingSource, CephThresholds};
     use std::time::Duration;
@@ -155,6 +177,7 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     const CEILING: ByteRate = ByteRate::new(1_000_000_000);
+    const NEARFULL_RATE: ByteRate = ByteRate::new(10_000_000);
     const FLOOR: ByteRate = ByteRate::new(1_000_000);
 
     /// The trimmed-but-real healthy scrape captured from the live mgr exporter.
@@ -169,8 +192,28 @@ ceph_health_detail{name=\"MON_DISK_LOW\",severity=\"HEALTH_WARN\"} 1.0
         CephThresholds::new(DiskPressure::try_from(8_500).unwrap(), DiskPressure::try_from(9_500).unwrap()).unwrap()
     }
 
+    fn settings(url: String) -> ProbeSettings {
+        ProbeSettings {
+            url,
+            ceiling_rate: CEILING,
+            nearfull_rate: NEARFULL_RATE,
+            floor: FLOOR,
+            thresholds: thresholds(),
+            timeout: Duration::from_secs(2),
+            pools: Vec::new(),
+        }
+    }
+
     fn probe(url: String) -> CephProbe {
-        CephProbe::new(url, CEILING, FLOOR, thresholds(), Duration::from_secs(2)).unwrap()
+        CephProbe::new(settings(url)).unwrap()
+    }
+
+    fn pool_probe(url: String, pools: &[&str]) -> CephProbe {
+        CephProbe::new(ProbeSettings {
+            pools: pools.iter().map(|&p| p.to_owned()).collect(),
+            ..settings(url)
+        })
+        .unwrap()
     }
 
     async fn server_returning(status: u16, body: &str) -> MockServer {
@@ -191,11 +234,69 @@ ceph_health_detail{name=\"MON_DISK_LOW\",severity=\"HEALTH_WARN\"} 1.0
     }
 
     #[tokio::test]
-    async fn an_osd_nearfull_scrape_yields_a_nearfull_ceiling() {
+    async fn an_osd_nearfull_scrape_yields_a_nearfull_ceiling_at_the_reduced_rate() {
         let body = format!("{HEALTHY}ceph_health_detail{{name=\"OSD_NEARFULL\",severity=\"HEALTH_WARN\"}} 1.0\n");
         let server = server_returning(200, &body).await;
         let probe = probe(format!("{}/metrics", server.uri()));
-        assert_eq!(probe.ceiling().await, CephCeiling::NearFull(CEILING));
+        // The reduced rate, not the open ceiling: the ceiling clamp must bound the
+        // drain below any operator-raised AIMD floor (2026-07-24 incident).
+        assert_eq!(probe.ceiling().await, CephCeiling::NearFull(NEARFULL_RATE));
+    }
+
+    #[tokio::test]
+    async fn a_full_target_pool_yields_critical_on_an_otherwise_healthy_scrape() {
+        // The 2026-07-24 incident shape end-to-end: cluster ~27% used, no OSD checks
+        // firing, but the drain's target pool at 98%.
+        let body = format!(
+            "{HEALTHY}\
+ceph_pool_metadata{{pool_id=\"5\",name=\"ceph-filesystem-data0\",type=\"replicated\"}} 1.0\n\
+ceph_pool_percent_used{{pool_id=\"5\"}} 0.98\n"
+        );
+        let server = server_returning(200, &body).await;
+        let probe = pool_probe(format!("{}/metrics", server.uri()), &["ceph-filesystem-data0"]);
+        assert_eq!(probe.ceiling().await, CephCeiling::Critical);
+    }
+
+    #[tokio::test]
+    async fn a_nearfull_target_pool_yields_the_reduced_nearfull_rate() {
+        let body = format!(
+            "{HEALTHY}\
+ceph_pool_metadata{{pool_id=\"5\",name=\"ceph-filesystem-data0\",type=\"replicated\"}} 1.0\n\
+ceph_pool_percent_used{{pool_id=\"5\"}} 0.88\n"
+        );
+        let server = server_returning(200, &body).await;
+        let probe = pool_probe(format!("{}/metrics", server.uri()), &["ceph-filesystem-data0"]);
+        assert_eq!(probe.ceiling().await, CephCeiling::NearFull(NEARFULL_RATE));
+    }
+
+    #[tokio::test]
+    async fn the_fullest_of_several_configured_pools_gates_through_the_probe() {
+        // Both CephFS pools plus the blockpool are configured; the fullest (the
+        // metadata pool here) drives the band even though the others are healthy.
+        let body = format!(
+            "{HEALTHY}\
+ceph_pool_metadata{{pool_id=\"2\",name=\"ceph-blockpool\",type=\"replicated\"}} 1.0\n\
+ceph_pool_metadata{{pool_id=\"3\",name=\"ceph-filesystem-metadata\",type=\"replicated\"}} 1.0\n\
+ceph_pool_metadata{{pool_id=\"5\",name=\"ceph-filesystem-data0\",type=\"replicated\"}} 1.0\n\
+ceph_pool_percent_used{{pool_id=\"2\"}} 0.10\n\
+ceph_pool_percent_used{{pool_id=\"3\"}} 0.97\n\
+ceph_pool_percent_used{{pool_id=\"5\"}} 0.20\n"
+        );
+        let server = server_returning(200, &body).await;
+        let probe = pool_probe(
+            format!("{}/metrics", server.uri()),
+            &["ceph-blockpool", "ceph-filesystem-metadata", "ceph-filesystem-data0"],
+        );
+        assert_eq!(probe.ceiling().await, CephCeiling::Critical);
+    }
+
+    #[tokio::test]
+    async fn a_scrape_missing_the_configured_pool_decays_rather_than_reading_healthy() {
+        // A renamed/deleted target pool must fail safe like any other parse failure.
+        let server = server_returning(200, HEALTHY).await;
+        let probe = pool_probe(format!("{}/metrics", server.uri()), &["ceph-filesystem-data0"]);
+        assert_eq!(probe.ceiling().await, CephCeiling::Open(ByteRate::new(500_000_000)));
+        assert_eq!(probe.consecutive_failures(), 1);
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-core/src/alloc.rs
+++ b/crates/hippius-drain-core/src/alloc.rs
@@ -385,6 +385,42 @@ mod tests {
     }
 
     #[test]
+    fn a_nearfull_budget_caps_capacity_below_the_aimd_floor() {
+        // Regression for the 2026-07-24 incident: ops had raised min_total to 50 MB/s
+        // (for latency reasons), and NearFull carried the full open rate, so the only
+        // brake was the AIMD floor — five nodes kept flushing 10 MB/s each into a
+        // ~98%-full pool. The NearFull budget must bound the distributed total even
+        // when the AIMD estimate is pinned at a floor far above it.
+        let min_total = ByteRate::new(50_000_000);
+        let cfg = AllocConfig { min_total, ..config() };
+        let nearfull_rate = ByteRate::new(10_000_000);
+        let fleet = fleet_of(&[
+            node("a", 5_000, 10_000_000_000, 1_000_000_000),
+            node("b", 5_000, 10_000_000_000, 1_000_000_000),
+            node("c", 5_000, 10_000_000_000, 1_000_000_000),
+            node("d", 5_000, 10_000_000_000, 1_000_000_000),
+            node("e", 5_000, 10_000_000_000, 1_000_000_000),
+        ]);
+        let plan = allocate(
+            &fleet,
+            CephCeiling::NearFull(nearfull_rate),
+            BudgetController::new(ByteRate::new(1_000_000_000)),
+            &cfg,
+        );
+        let distributed: u64 = plan.allocations.iter().map(|a| a.budget.get()).sum();
+        assert!(
+            distributed <= nearfull_rate.get(),
+            "NearFull({nearfull}) must bound the fleet total; got {distributed} (AIMD floor {floor})",
+            nearfull = nearfull_rate.get(),
+            floor = min_total.get(),
+        );
+        assert!(
+            plan.controller.total().get() >= min_total.get(),
+            "the carried AIMD estimate keeps its floor so the fleet resumes promptly when the ceiling reopens",
+        );
+    }
+
+    #[test]
     fn a_healthy_slow_fleet_ramps_the_estimate_up() {
         // Regression for the drain throttle deadlock: a whole-part SSD->CephFS drain has a p99 of
         // hundreds of ms even when perfectly healthy (measured ~330-410 ms on staging). With a

--- a/crates/hippius-drain-core/src/mgr.rs
+++ b/crates/hippius-drain-core/src/mgr.rs
@@ -5,12 +5,15 @@
 //! that fetches `/metrics` lives in `hippius-drain-allocator` — so the parse,
 //! classify, and fail-safe-decay logic is testable as pure functions.
 //!
-//! Only the **near-full** signal is read (the first cut, ratified 2026-06-18 against
-//! the live cluster): the exporter on the target cluster runs with
-//! `exclude_perf_counters=true`, so per-OSD bytes and MDS-load counters are absent.
-//! The signals that ARE present and authoritative are Ceph's own `OSD_NEARFULL` /
-//! `OSD_FULL` health checks (per-OSD-aware, computed by Ceph) plus the always-present
-//! `ceph_cluster_total_bytes` / `ceph_cluster_total_used_bytes` fleet ratio.
+//! Three fullness signals gate the ceiling: Ceph's own `OSD_NEARFULL` / `OSD_FULL`
+//! health checks (per-OSD-aware, computed by Ceph), the always-present
+//! `ceph_cluster_total_bytes` / `ceph_cluster_total_used_bytes` fleet ratio, and —
+//! when a target pool is configured — that pool's `ceph_pool_percent_used`. The pool
+//! signal exists because of the 2026-07-24 incident: the drain's target pool
+//! (`CephFS` data) hit ~98% `%USED` while the cluster ratio sat at 72% and no OSD had
+//! crossed its near-full ratio, so the ceiling stayed `Open` while the pool filled.
+//! Pool `%USED` (`stored / (stored + max_avail)`) is the earliest fullness signal for
+//! a pool whose CRUSH subtree fills ahead of the fleet average.
 
 use crate::error::Error;
 use crate::state::CephCeiling;
@@ -23,6 +26,11 @@ use thiserror::Error as ThisError;
 const METRIC_TOTAL_BYTES: &str = "ceph_cluster_total_bytes";
 /// The used-capacity counterpart of [`METRIC_TOTAL_BYTES`].
 const METRIC_USED_BYTES: &str = "ceph_cluster_total_used_bytes";
+/// Per-pool identity series; its `name`/`pool_id` labels map a pool name to the id
+/// the capacity series are keyed by.
+const METRIC_POOL_METADATA: &str = "ceph_pool_metadata";
+/// Per-pool fullness fraction (`stored / (stored + max_avail)`, `0.0..=1.0`).
+const METRIC_POOL_PERCENT_USED: &str = "ceph_pool_percent_used";
 
 /// The parsed, flavor-agnostic near-full signal set from one mgr scrape.
 ///
@@ -40,6 +48,12 @@ pub struct CephReport {
     pub osd_nearfull: bool,
     /// Fleet-wide used fraction, when the capacity metrics were present.
     pub used: Option<DiskPressure>,
+    /// The *fullest* requested pool's used fraction (the binding constraint —
+    /// classification cares only about the pool closest to full). `None` only when
+    /// no pools were requested — a requested pool that cannot be resolved is a
+    /// parse error, so a missing pool signal fails safe instead of reading as
+    /// healthy.
+    pub pool_used: Option<DiskPressure>,
 }
 
 /// A failure turning mgr exporter text into a [`CephReport`].
@@ -64,21 +78,38 @@ pub enum ProbeParseError {
         /// The offending raw value.
         value: String,
     },
+    /// The requested target pool had no `ceph_pool_metadata` series — the pool does
+    /// not exist on this cluster (or was renamed), so its fullness cannot be read.
+    #[error("target pool `{pool}` was absent from the mgr exporter output")]
+    MissingPool {
+        /// The pool name that was requested but not found.
+        pool: String,
+    },
 }
 
 /// Parses Ceph mgr prometheus exporter text into a [`CephReport`].
 ///
+/// Every pool named in `target_pools` is resolved to its
+/// [`METRIC_POOL_PERCENT_USED`] via its [`METRIC_POOL_METADATA`] `pool_id`; the
+/// report carries the fullest one. An empty slice skips pool gating.
+///
 /// # Errors
 ///
 /// [`ProbeParseError::MissingMetric`] if [`METRIC_TOTAL_BYTES`] is absent (the body
-/// is not a mgr scrape), or [`ProbeParseError::MalformedValue`] if a recognized
-/// metric carries a value that is not a finite number forming a valid `0.0..=1.0`
-/// ratio.
-pub fn parse_prometheus_metrics(text: &str) -> Result<CephReport, ProbeParseError> {
+/// is not a mgr scrape) or a requested pool has no percent-used series,
+/// [`ProbeParseError::MissingPool`] if a requested pool has no metadata series, or
+/// [`ProbeParseError::MalformedValue`] if a recognized metric carries a value that
+/// is not a finite number forming a valid `0.0..=1.0` ratio.
+pub fn parse_prometheus_metrics(text: &str, target_pools: &[&str]) -> Result<CephReport, ProbeParseError> {
     let mut total: Option<f64> = None;
     let mut used: Option<f64> = None;
     let mut osd_full = false;
     let mut osd_nearfull = false;
+    // Name->id pairs for requested pools, and all percent-used series, collected
+    // before resolution because the exporter does not guarantee the metadata series
+    // (which names a pool) precedes its capacity series.
+    let mut pool_ids: Vec<(String, String)> = Vec::new();
+    let mut pool_percents: Vec<(String, f64)> = Vec::new();
 
     for line in text.lines() {
         let line = line.trim();
@@ -101,6 +132,20 @@ pub fn parse_prometheus_metrics(text: &str) -> Result<CephReport, ProbeParseErro
             if health_check_firing(line, "name=\"OSD_NEARFULL\"") || health_check_firing(line, "name=\"OSD_BACKFILLFULL\"") {
                 osd_nearfull = true;
             }
+        } else if family == METRIC_POOL_METADATA
+            && !target_pools.is_empty()
+            // The extracted label value runs to the closing quote, so the match is
+            // exact: a target `data` never matches a `name="data0"` series.
+            && let Some(name) = label_value(line, "name=\"")
+            && target_pools.contains(&name)
+            && let Some(id) = label_value(line, "pool_id=\"")
+        {
+            pool_ids.push((name.to_owned(), id.to_owned()));
+        } else if family == METRIC_POOL_PERCENT_USED
+            && !target_pools.is_empty()
+            && let Some(id) = label_value(line, "pool_id=\"")
+        {
+            pool_percents.push((id.to_owned(), finite_value(line, METRIC_POOL_PERCENT_USED)?));
         }
     }
 
@@ -108,11 +153,49 @@ pub fn parse_prometheus_metrics(text: &str) -> Result<CephReport, ProbeParseErro
         return Err(ProbeParseError::MissingMetric { metric: METRIC_TOTAL_BYTES });
     };
     let used = used_fraction(total, used)?;
+    let pool_used = resolve_pool_used(target_pools, &pool_ids, &pool_percents)?;
     Ok(CephReport {
         osd_full,
         osd_nearfull,
         used,
+        pool_used,
     })
+}
+
+/// Resolves the fullest requested pool's used fraction from the collected series.
+///
+/// Any requested pool that cannot be resolved is an error, never a skip: the pool
+/// gate exists to fail safe, so a missing pool must decay the ceiling rather than
+/// silently drop out of the max. A fraction just past `1.0` (exporter rounding)
+/// clamps to fully-used, mirroring [`used_fraction`].
+fn resolve_pool_used(
+    target_pools: &[&str],
+    pool_ids: &[(String, String)],
+    pool_percents: &[(String, f64)],
+) -> Result<Option<DiskPressure>, ProbeParseError> {
+    let mut fullest: Option<DiskPressure> = None;
+    for pool in target_pools {
+        let Some((_, id)) = pool_ids.iter().find(|(name, _)| name == pool) else {
+            return Err(ProbeParseError::MissingPool { pool: (*pool).to_owned() });
+        };
+        let Some((_, fraction)) = pool_percents.iter().find(|(pool_id, _)| pool_id == id) else {
+            return Err(ProbeParseError::MissingMetric {
+                metric: METRIC_POOL_PERCENT_USED,
+            });
+        };
+        let pressure = DiskPressure::from_fraction(fraction.clamp(0.0, 1.0)).map_err(|_| ProbeParseError::MalformedValue {
+            metric: METRIC_POOL_PERCENT_USED,
+            value: fraction.to_string(),
+        })?;
+        fullest = Some(fullest.map_or(pressure, |current| current.max(pressure)));
+    }
+    Ok(fullest)
+}
+
+/// The label value following `needle` (e.g. `pool_id="`), up to its closing quote.
+fn label_value<'a>(line: &'a str, needle: &str) -> Option<&'a str> {
+    let start = line.find(needle)? + needle.len();
+    line[start..].split('"').next()
 }
 
 /// The metric family name: everything before the label block `{` or the value.
@@ -202,17 +285,19 @@ impl CephThresholds {
 /// at/above the near-full watermark yields [`CephCeiling::NearFull`]; otherwise
 /// [`CephCeiling::Open`].
 ///
-/// `NearFull` carries the same `ceiling_rate` as `Open`: the allocator's AIMD reads
-/// the *variant* (any non-`Open` ceiling forces a multiplicative back-off in
-/// `next_capacity`), so the throttle comes from the band, not a reduced rate — the
-/// prometheus near-full signal gives no principled lower target (deferred tuning).
+/// `NearFull` carries `nearfull_rate`, not the open `ceiling_rate`: the AIMD's
+/// multiplicative back-off alone proved insufficient in the 2026-07-24 incident —
+/// its estimate is clamped at the operator-tuned `min_total` floor (raised to
+/// 50 MB/s in prod for latency reasons), so the fleet kept draining at the floor
+/// into a near-full pool indefinitely. Carrying a reduced rate lets the ceiling
+/// clamp (`estimate.min(budget)`) bound the drain below any AIMD floor.
 #[must_use]
-pub fn classify(report: &CephReport, ceiling_rate: ByteRate, thresholds: &CephThresholds) -> CephCeiling {
-    let used_at = |watermark: DiskPressure| report.used.is_some_and(|u| u >= watermark);
-    if report.osd_full || used_at(thresholds.full) {
+pub fn classify(report: &CephReport, ceiling_rate: ByteRate, nearfull_rate: ByteRate, thresholds: &CephThresholds) -> CephCeiling {
+    let at = |fraction: Option<DiskPressure>, watermark: DiskPressure| fraction.is_some_and(|f| f >= watermark);
+    if report.osd_full || at(report.used, thresholds.full) || at(report.pool_used, thresholds.full) {
         CephCeiling::Critical
-    } else if report.osd_nearfull || used_at(thresholds.nearfull) {
-        CephCeiling::NearFull(ceiling_rate)
+    } else if report.osd_nearfull || at(report.used, thresholds.nearfull) || at(report.pool_used, thresholds.nearfull) {
+        CephCeiling::NearFull(nearfull_rate)
     } else {
         CephCeiling::Open(ceiling_rate)
     }
@@ -267,9 +352,18 @@ ceph_health_detail{name=\"MON_DISK_LOW\",severity=\"HEALTH_WARN\"} 1.0
 ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
 ";
 
+    /// The pool series shape captured live from `rook-ceph-mgr:9283/metrics` on
+    /// 2026-07-24 (the incident cluster: pool 5 at ~95% while the fleet sat at 74%).
+    const POOL_SERIES: &str = "\
+ceph_pool_metadata{pool_id=\"2\",name=\"ceph-blockpool\",type=\"replicated\",description=\"replica:3\",compression_mode=\"none\"} 1.0
+ceph_pool_metadata{pool_id=\"5\",name=\"ceph-filesystem-data0\",type=\"replicated\",description=\"replica:3\",compression_mode=\"none\"} 1.0
+ceph_pool_percent_used{pool_id=\"2\"} 0.6975
+ceph_pool_percent_used{pool_id=\"5\"} 0.9507322907447815
+";
+
     #[test]
     fn healthy_scrape_reports_no_nearfull_and_the_used_fraction() {
-        let report = parse_prometheus_metrics(HEALTHY).unwrap();
+        let report = parse_prometheus_metrics(HEALTHY, &[]).unwrap();
         // ~27.59% used -> 2759 bps (rounded), and neither OSD health check firing.
         let expected_used = DiskPressure::from_fraction(31_791_022_084_096.0 / 115_222_679_470_080.0).unwrap();
         assert_eq!(
@@ -278,14 +372,107 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
                 osd_full: false,
                 osd_nearfull: false,
                 used: Some(expected_used),
+                pool_used: None,
             }
         );
     }
 
     #[test]
+    fn the_target_pools_used_fraction_is_resolved_via_its_metadata_id() {
+        let scrape = format!("{HEALTHY}{POOL_SERIES}");
+        let report = parse_prometheus_metrics(&scrape, &["ceph-filesystem-data0"]).unwrap();
+        let expected = DiskPressure::from_fraction(0.950_732_290_744_781_5).unwrap();
+        assert_eq!(report.pool_used, Some(expected), "pool 5's fraction, not pool 2's");
+    }
+
+    #[test]
+    fn pool_series_order_does_not_matter() {
+        // The exporter may emit percent-used series before the metadata that names
+        // the pool; resolution must be order-independent.
+        let scrape = format!(
+            "{HEALTHY}\
+ceph_pool_percent_used{{pool_id=\"5\"}} 0.5\n\
+ceph_pool_metadata{{pool_id=\"5\",name=\"data\",type=\"replicated\"}} 1.0\n"
+        );
+        let report = parse_prometheus_metrics(&scrape, &["data"]).unwrap();
+        assert_eq!(report.pool_used, Some(DiskPressure::from_fraction(0.5).unwrap()));
+    }
+
+    #[test]
+    fn a_pool_name_that_prefixes_the_target_is_not_matched() {
+        // `name="data0"` must not resolve for target `data` (nor vice versa): the
+        // match is on the full quoted label value.
+        let scrape = format!(
+            "{HEALTHY}\
+ceph_pool_metadata{{pool_id=\"7\",name=\"data0\",type=\"replicated\"}} 1.0\n\
+ceph_pool_percent_used{{pool_id=\"7\"}} 0.99\n"
+        );
+        let err = parse_prometheus_metrics(&scrape, &["data"]).unwrap_err();
+        assert!(matches!(err, ProbeParseError::MissingPool { ref pool } if pool == "data"));
+    }
+
+    #[test]
+    fn the_fullest_of_several_requested_pools_gates() {
+        // The gate covers every pool the stack writes (CephFS data + metadata,
+        // the RBD blockpool); the binding constraint is whichever is fullest —
+        // here the metadata pool, deliberately listed second.
+        let report = parse_prometheus_metrics(&format!("{HEALTHY}{POOL_SERIES}"), &["ceph-blockpool", "ceph-filesystem-data0"]).unwrap();
+        let expected = DiskPressure::from_fraction(0.950_732_290_744_781_5).unwrap();
+        assert_eq!(report.pool_used, Some(expected), "the fullest pool wins, regardless of list order");
+    }
+
+    #[test]
+    fn any_missing_pool_of_several_is_an_error() {
+        // A typo'd or renamed pool anywhere in the list must fail safe, not
+        // silently shrink the gate to the pools that did resolve.
+        let scrape = format!("{HEALTHY}{POOL_SERIES}");
+        let err = parse_prometheus_metrics(&scrape, &["ceph-filesystem-data0", "nonexistent"]).unwrap_err();
+        assert!(matches!(err, ProbeParseError::MissingPool { ref pool } if pool == "nonexistent"));
+    }
+
+    #[test]
+    fn a_requested_pool_with_no_metadata_is_a_missing_pool_error() {
+        // Fail safe: a configured pool the exporter does not know cannot silently
+        // read as healthy while that pool fills.
+        let err = parse_prometheus_metrics(HEALTHY, &["ceph-filesystem-data0"]).unwrap_err();
+        assert!(matches!(err, ProbeParseError::MissingPool { ref pool } if pool == "ceph-filesystem-data0"));
+    }
+
+    #[test]
+    fn a_requested_pool_with_no_percent_series_is_a_missing_metric_error() {
+        let scrape = format!("{HEALTHY}ceph_pool_metadata{{pool_id=\"5\",name=\"data\",type=\"replicated\"}} 1.0\n");
+        let err = parse_prometheus_metrics(&scrape, &["data"]).unwrap_err();
+        assert!(matches!(err, ProbeParseError::MissingMetric { metric } if metric == "ceph_pool_percent_used"));
+    }
+
+    #[test]
+    fn a_malformed_pool_percent_value_is_rejected() {
+        let scrape = format!(
+            "{HEALTHY}\
+ceph_pool_metadata{{pool_id=\"5\",name=\"data\",type=\"replicated\"}} 1.0\n\
+ceph_pool_percent_used{{pool_id=\"5\"}} NaN\n"
+        );
+        let err = parse_prometheus_metrics(&scrape, &["data"]).unwrap_err();
+        assert!(matches!(err, ProbeParseError::MalformedValue { metric, .. } if metric == "ceph_pool_percent_used"));
+    }
+
+    #[test]
+    fn a_pool_percent_above_one_clamps_to_fully_used() {
+        // Rounding artifacts can push the exporter fraction past 1.0; clamp rather
+        // than reject, mirroring the cluster ratio's behavior.
+        let scrape = format!(
+            "{HEALTHY}\
+ceph_pool_metadata{{pool_id=\"5\",name=\"data\",type=\"replicated\"}} 1.0\n\
+ceph_pool_percent_used{{pool_id=\"5\"}} 1.0000001\n"
+        );
+        let report = parse_prometheus_metrics(&scrape, &["data"]).unwrap();
+        assert_eq!(report.pool_used, Some(DiskPressure::from_fraction(1.0).unwrap()));
+    }
+
+    #[test]
     fn an_osd_nearfull_health_check_sets_nearfull() {
         let scrape = format!("{HEALTHY}ceph_health_detail{{name=\"OSD_NEARFULL\",severity=\"HEALTH_WARN\"}} 1.0\n");
-        let report = parse_prometheus_metrics(&scrape).unwrap();
+        let report = parse_prometheus_metrics(&scrape, &[]).unwrap();
         assert!(report.osd_nearfull, "the OSD_NEARFULL series is firing");
         assert!(!report.osd_full, "no OSD_FULL series present");
     }
@@ -295,7 +482,7 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
         // BACKFILLFULL is the earlier-warning band; treat it as near-full too. The
         // substring guard must not let OSD_BACKFILLFULL trip the OSD_FULL branch.
         let scrape = format!("{HEALTHY}ceph_health_detail{{name=\"OSD_BACKFILLFULL\",severity=\"HEALTH_WARN\"}} 1.0\n");
-        let report = parse_prometheus_metrics(&scrape).unwrap();
+        let report = parse_prometheus_metrics(&scrape, &[]).unwrap();
         assert!(report.osd_nearfull);
         assert!(!report.osd_full, "BACKFILLFULL must not be misread as OSD_FULL");
     }
@@ -303,7 +490,7 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
     #[test]
     fn an_osd_full_health_check_sets_full() {
         let scrape = format!("{HEALTHY}ceph_health_detail{{name=\"OSD_FULL\",severity=\"HEALTH_ERR\"}} 1.0\n");
-        let report = parse_prometheus_metrics(&scrape).unwrap();
+        let report = parse_prometheus_metrics(&scrape, &[]).unwrap();
         assert!(report.osd_full, "the OSD_FULL series is firing");
     }
 
@@ -312,7 +499,7 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
         // The exporter can emit a known check at 0.0 when not active; absence of
         // value >= 1.0 must read as not-firing.
         let scrape = format!("{HEALTHY}ceph_health_detail{{name=\"OSD_NEARFULL\",severity=\"HEALTH_WARN\"}} 0.0\n");
-        let report = parse_prometheus_metrics(&scrape).unwrap();
+        let report = parse_prometheus_metrics(&scrape, &[]).unwrap();
         assert!(!report.osd_nearfull, "a 0.0 value is not a firing check");
     }
 
@@ -320,14 +507,14 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
     fn a_body_without_the_capacity_metric_is_a_missing_metric_error() {
         // An error page or the wrong endpoint: no ceph_cluster_total_bytes. Must fail
         // safe rather than read the absent near-full series as healthy.
-        let err = parse_prometheus_metrics("not a ceph scrape\nrandom 1\n").unwrap_err();
+        let err = parse_prometheus_metrics("not a ceph scrape\nrandom 1\n", &[]).unwrap_err();
         assert!(matches!(err, ProbeParseError::MissingMetric { metric } if metric == "ceph_cluster_total_bytes"));
     }
 
     #[test]
     fn a_nonnumeric_capacity_value_is_a_malformed_value_error() {
         let scrape = "ceph_cluster_total_bytes oops\nceph_cluster_total_used_bytes 1.0\n";
-        let err = parse_prometheus_metrics(scrape).unwrap_err();
+        let err = parse_prometheus_metrics(scrape, &[]).unwrap_err();
         assert!(matches!(
             err,
             ProbeParseError::MalformedValue { metric, ref value } if metric == "ceph_cluster_total_bytes" && value == "oops"
@@ -339,14 +526,14 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
         // f64::parse accepts "NaN"/"inf"; a capacity that is not finite cannot form a
         // ratio and must be a malformed value, not a silently-dropped signal.
         let scrape = "ceph_cluster_total_bytes NaN\nceph_cluster_total_used_bytes 1.0\n";
-        let err = parse_prometheus_metrics(scrape).unwrap_err();
+        let err = parse_prometheus_metrics(scrape, &[]).unwrap_err();
         assert!(matches!(err, ProbeParseError::MalformedValue { metric, .. } if metric == "ceph_cluster_total_bytes"));
     }
 
     #[test]
     fn zero_total_bytes_yields_no_used_fraction_without_dividing_by_zero() {
         let scrape = "ceph_cluster_total_bytes 0.0\nceph_cluster_total_used_bytes 0.0\n";
-        let report = parse_prometheus_metrics(scrape).unwrap();
+        let report = parse_prometheus_metrics(scrape, &[]).unwrap();
         assert_eq!(report.used, None, "a zero-capacity cluster yields no ratio");
     }
 
@@ -356,6 +543,7 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
     use crate::units::ByteRate;
 
     const CEILING: ByteRate = ByteRate::new(1_000_000_000);
+    const NEARFULL_RATE: ByteRate = ByteRate::new(10_000_000);
     const FLOOR: ByteRate = ByteRate::new(1_000_000);
 
     fn thresholds() -> CephThresholds {
@@ -368,6 +556,16 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
             osd_full,
             osd_nearfull,
             used: used_bps.map(|b| DiskPressure::try_from(b).unwrap()),
+            pool_used: None,
+        }
+    }
+
+    fn pool_report(pool_bps: u16) -> CephReport {
+        CephReport {
+            osd_full: false,
+            osd_nearfull: false,
+            used: Some(DiskPressure::try_from(2_000).unwrap()),
+            pool_used: Some(DiskPressure::try_from(pool_bps).unwrap()),
         }
     }
 
@@ -382,68 +580,108 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
 
     #[test]
     fn a_healthy_report_is_open() {
-        let ceiling = classify(&report(false, false, Some(2_759)), CEILING, &thresholds());
+        let ceiling = classify(&report(false, false, Some(2_759)), CEILING, NEARFULL_RATE, &thresholds());
         assert_eq!(ceiling, CephCeiling::Open(CEILING));
     }
 
     #[test]
     fn an_osd_full_flag_is_critical() {
-        let ceiling = classify(&report(true, false, Some(2_000)), CEILING, &thresholds());
+        let ceiling = classify(&report(true, false, Some(2_000)), CEILING, NEARFULL_RATE, &thresholds());
         assert_eq!(ceiling, CephCeiling::Critical, "OSD_FULL blocks writes regardless of the ratio");
     }
 
     #[test]
     fn used_at_or_above_full_is_critical() {
         assert_eq!(
-            classify(&report(false, false, Some(9_500)), CEILING, &thresholds()),
+            classify(&report(false, false, Some(9_500)), CEILING, NEARFULL_RATE, &thresholds()),
             CephCeiling::Critical
         );
         assert_eq!(
-            classify(&report(false, false, Some(9_999)), CEILING, &thresholds()),
+            classify(&report(false, false, Some(9_999)), CEILING, NEARFULL_RATE, &thresholds()),
             CephCeiling::Critical
         );
     }
 
     #[test]
     fn an_osd_nearfull_flag_is_nearfull() {
-        let ceiling = classify(&report(false, true, Some(1_000)), CEILING, &thresholds());
-        assert_eq!(ceiling, CephCeiling::NearFull(CEILING));
+        let ceiling = classify(&report(false, true, Some(1_000)), CEILING, NEARFULL_RATE, &thresholds());
+        assert_eq!(ceiling, CephCeiling::NearFull(NEARFULL_RATE));
     }
 
     #[test]
     fn used_between_nearfull_and_full_is_nearfull() {
         assert_eq!(
-            classify(&report(false, false, Some(8_500)), CEILING, &thresholds()),
-            CephCeiling::NearFull(CEILING)
+            classify(&report(false, false, Some(8_500)), CEILING, NEARFULL_RATE, &thresholds()),
+            CephCeiling::NearFull(NEARFULL_RATE)
         );
         assert_eq!(
-            classify(&report(false, false, Some(9_499)), CEILING, &thresholds()),
-            CephCeiling::NearFull(CEILING)
+            classify(&report(false, false, Some(9_499)), CEILING, NEARFULL_RATE, &thresholds()),
+            CephCeiling::NearFull(NEARFULL_RATE)
         );
     }
 
     #[test]
     fn full_takes_precedence_over_nearfull() {
         // Both flags firing: Critical wins (a full OSD blocks writes).
-        let ceiling = classify(&report(true, true, Some(9_900)), CEILING, &thresholds());
+        let ceiling = classify(&report(true, true, Some(9_900)), CEILING, NEARFULL_RATE, &thresholds());
         assert_eq!(ceiling, CephCeiling::Critical);
     }
 
     #[test]
     fn absent_used_fraction_classifies_on_flags_alone() {
-        assert_eq!(classify(&report(false, false, None), CEILING, &thresholds()), CephCeiling::Open(CEILING));
         assert_eq!(
-            classify(&report(false, true, None), CEILING, &thresholds()),
-            CephCeiling::NearFull(CEILING)
+            classify(&report(false, false, None), CEILING, NEARFULL_RATE, &thresholds()),
+            CephCeiling::Open(CEILING)
         );
-        assert_eq!(classify(&report(true, false, None), CEILING, &thresholds()), CephCeiling::Critical);
+        assert_eq!(
+            classify(&report(false, true, None), CEILING, NEARFULL_RATE, &thresholds()),
+            CephCeiling::NearFull(NEARFULL_RATE)
+        );
+        assert_eq!(
+            classify(&report(true, false, None), CEILING, NEARFULL_RATE, &thresholds()),
+            CephCeiling::Critical
+        );
+    }
+
+    #[test]
+    fn a_full_target_pool_is_critical_even_when_cluster_and_osds_read_healthy() {
+        // The 2026-07-24 incident shape: pool ~98% while the cluster ratio is ~72%
+        // and no OSD health check fires. The pool signal alone must go Critical.
+        let ceiling = classify(&pool_report(9_800), CEILING, NEARFULL_RATE, &thresholds());
+        assert_eq!(ceiling, CephCeiling::Critical);
+    }
+
+    #[test]
+    fn a_nearfull_target_pool_is_nearfull() {
+        let ceiling = classify(&pool_report(8_600), CEILING, NEARFULL_RATE, &thresholds());
+        assert_eq!(ceiling, CephCeiling::NearFull(NEARFULL_RATE));
+    }
+
+    #[test]
+    fn a_healthy_target_pool_leaves_the_ceiling_open() {
+        let ceiling = classify(&pool_report(5_000), CEILING, NEARFULL_RATE, &thresholds());
+        assert_eq!(ceiling, CephCeiling::Open(CEILING));
+    }
+
+    #[test]
+    fn nearfull_carries_the_reduced_rate_not_the_open_ceiling() {
+        // Regression for 2026-07-24: NearFull used to carry the open ceiling rate,
+        // so the AIMD's min_total floor (50 MB/s in prod) was the only brake and the
+        // drain kept flushing into a near-full pool. The reduced rate must win the
+        // `estimate.min(budget)` clamp regardless of any AIMD floor.
+        let ceiling = classify(&report(false, true, Some(1_000)), CEILING, NEARFULL_RATE, &thresholds());
+        assert_eq!(ceiling, CephCeiling::NearFull(NEARFULL_RATE));
+        assert_ne!(NEARFULL_RATE, CEILING, "the test is vacuous if the rates coincide");
     }
 
     #[test]
     fn decay_is_identity_at_zero_failures() {
         let open = CephCeiling::Open(CEILING);
         assert_eq!(decay(open, 0, FLOOR), open);
-        assert_eq!(decay(CephCeiling::NearFull(CEILING), 0, FLOOR), CephCeiling::NearFull(CEILING));
+        assert_eq!(
+            decay(CephCeiling::NearFull(NEARFULL_RATE), 0, FLOOR),
+            CephCeiling::NearFull(NEARFULL_RATE)
+        );
     }
 
     #[test]
@@ -452,8 +690,8 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
         assert_eq!(decay(CephCeiling::Open(CEILING), 1, FLOOR), CephCeiling::Open(ByteRate::new(500_000_000)));
         assert_eq!(decay(CephCeiling::Open(CEILING), 2, FLOOR), CephCeiling::Open(ByteRate::new(250_000_000)));
         assert_eq!(
-            decay(CephCeiling::NearFull(CEILING), 1, FLOOR),
-            CephCeiling::NearFull(ByteRate::new(500_000_000))
+            decay(CephCeiling::NearFull(NEARFULL_RATE), 1, FLOOR),
+            CephCeiling::NearFull(ByteRate::new(5_000_000))
         );
     }
 
@@ -495,16 +733,32 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
                 CephCeiling::NearFull(_) => 1,
                 CephCeiling::Critical => 2,
             };
-            let low = rank(classify(&report(false, false, Some(lo)), CEILING, &t));
-            let high = rank(classify(&report(false, false, Some(hi)), CEILING, &t));
+            let low = rank(classify(&report(false, false, Some(lo)), CEILING, NEARFULL_RATE, &t));
+            let high = rank(classify(&report(false, false, Some(hi)), CEILING, NEARFULL_RATE, &t));
             prop_assert!(high >= low, "more-full ({hi}bps) must not be looser than less-full ({lo}bps)");
+        }
+
+        /// Pool monotonicity: a fuller target pool never yields a *looser* ceiling.
+        #[test]
+        fn fuller_pool_never_loosens_the_ceiling(lo in 0u16..=10_000, hi in 0u16..=10_000) {
+            prop_assume!(lo <= hi);
+            let t = thresholds();
+            let rank = |c: CephCeiling| match c {
+                CephCeiling::Open(_) => 0u8,
+                CephCeiling::NearFull(_) => 1,
+                CephCeiling::Critical => 2,
+            };
+            let low = rank(classify(&pool_report(lo), CEILING, NEARFULL_RATE, &t));
+            let high = rank(classify(&pool_report(hi), CEILING, NEARFULL_RATE, &t));
+            prop_assert!(high >= low, "a fuller pool ({hi}bps) must not be looser than a less-full one ({lo}bps)");
         }
 
         /// The parser is a boundary over untrusted bytes: it must never panic on
         /// arbitrary input, only return a report or a typed error.
         #[test]
         fn never_panics_on_arbitrary_text(text in ".*") {
-            let _ = parse_prometheus_metrics(&text);
+            let _ = parse_prometheus_metrics(&text, &[]);
+            let _ = parse_prometheus_metrics(&text, &["pool"]);
         }
 
         /// Any well-formed capacity pair yields a used fraction matching the ratio
@@ -514,7 +768,7 @@ ceph_osd_up{ceph_daemon=\"osd.0\"} 1.0
             let total_f = f64::from(total);
             let used_f = (used_frac * total_f).floor();
             let scrape = format!("ceph_cluster_total_bytes {total_f}\nceph_cluster_total_used_bytes {used_f}\n");
-            let report = parse_prometheus_metrics(&scrape).unwrap();
+            let report = parse_prometheus_metrics(&scrape, &[]).unwrap();
             let used = report.used.expect("a positive total with a used value forms a fraction");
             let expected = DiskPressure::from_fraction((used_f / total_f).clamp(0.0, 1.0)).unwrap();
             prop_assert_eq!(used, expected);

--- a/k8s/production/drain-allocator-deployment.yaml
+++ b/k8s/production/drain-allocator-deployment.yaml
@@ -93,6 +93,16 @@ spec:
             # its static fallback ceiling. Cross-namespace reach to rook-ceph confirmed.
             - name: CEPHOR_CEPH_MGR_METRICS_URL
               value: "http://rook-ceph-mgr.rook-ceph.svc.cluster.local:9283/metrics"
+            # Pool-level fullness gate (2026-07-24 incident). The drain's target pool
+            # filled to ~98% while the cluster ratio sat at 72% and no OSD had crossed
+            # near-full, so the ceiling stayed Open all night. Every pool this stack
+            # writes is listed (CephFS data + metadata, and the RBD blockpool backing
+            # the Postgres/Redis PVCs); the fullest one gates: NearFull at 85% caps
+            # the drain at CEPHOR_CEPH_NEARFULL_RATE_BPS (default 10 MB/s fleet-wide —
+            # deliberately below the min_total floor above, which is a latency knob,
+            # not a fullness brake), Critical at 95% stops it.
+            - name: CEPHOR_CEPH_POOLS
+              value: "ceph-filesystem-data0,ceph-filesystem-metadata,ceph-blockpool"
           resources:
             requests:
               cpu: 50m

--- a/k8s/staging/drain-allocator-deployment.yaml
+++ b/k8s/staging/drain-allocator-deployment.yaml
@@ -93,6 +93,16 @@ spec:
             # its static fallback ceiling. Cross-namespace reach to rook-ceph confirmed.
             - name: CEPHOR_CEPH_MGR_METRICS_URL
               value: "http://rook-ceph-mgr.rook-ceph.svc.cluster.local:9283/metrics"
+            # Pool-level fullness gate (2026-07-24 incident). The drain's target pool
+            # filled to ~98% while the cluster ratio sat at 72% and no OSD had crossed
+            # near-full, so the ceiling stayed Open all night. Every pool this stack
+            # writes is listed (CephFS data + metadata, and the RBD blockpool backing
+            # the Postgres/Redis PVCs); the fullest one gates: NearFull at 85% caps
+            # the drain at CEPHOR_CEPH_NEARFULL_RATE_BPS (default 10 MB/s fleet-wide —
+            # deliberately below the min_total floor above, which is a latency knob,
+            # not a fullness brake), Critical at 95% stops it.
+            - name: CEPHOR_CEPH_POOLS
+              value: "ceph-filesystem-data0,ceph-filesystem-metadata,ceph-blockpool"
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## Why

2026-07-24 incident: the drain flushed the SSD backlog into `ceph-filesystem-data0` while that pool sat at ~98% `%USED`. Two gaps:

1. The mgr ceiling probe read only the cluster-wide used ratio (72%) and the `OSD_NEARFULL`/`OSD_FULL` health checks (not yet firing) — pool-level fullness was invisible. `drain_fleet_estimate_bps` was pinned at 1000 MB/s until 07:15Z.
2. When `OSD_NEARFULL` finally fired, `NearFull` carried the full open rate; the only brake was the AIMD multiplicative back-off, clamped at the operator-raised `min_total` floor (50 MB/s prod) — 10 MB/s x 5 nodes into a near-full pool, indefinitely.

## Changes (biggest to smallest)

- `hippius-drain-core/mgr.rs`: parse `ceph_pool_metadata` + `ceph_pool_percent_used` for the pools named in `CEPHOR_CEPH_POOLS`; `classify` gates on the fullest one against the same 85%/95% watermarks. A configured pool that cannot be resolved is a parse error (probe decays; never reads healthy). `NearFull` now carries a reduced rate instead of the open ceiling.
- `hippius-drain-allocator`: `ProbeSettings` struct (constructor was at 5 positional params), `CEPHOR_CEPH_POOLS` (comma-separated) and `CEPHOR_CEPH_NEARFULL_RATE_BPS` (default 10 MB/s fleet-wide) env vars, wired in `main.rs`.
- `hippius-drain-core/alloc.rs`: regression test — `NearFull(10MB/s)` bounds the distributed total below a 50 MB/s `min_total`.
- k8s staging + production: `CEPHOR_CEPH_POOLS=ceph-filesystem-data0,ceph-filesystem-metadata,ceph-blockpool` (every pool this stack writes: CephFS data + metadata, RBD blockpool backing the DB PVCs).

## Behavior after deploy

Fullest gated pool >= 85% -> `NearFull`, drain capped at 10 MB/s fleet-wide; >= 95% -> `Critical`, drain stops. Note `ceph-filesystem-data0` is at 95.07% right now, so the drain will go Critical immediately on deploy — that is the intended fail-safe until space is freed.

386 workspace tests pass; clippy clean; kustomize builds for both overlays.