### PR TITLE
Promote to prod: janitor pool-fullness gate + faster eviction (#338)

### DIFF
--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -240,8 +240,10 @@ class Config:
     stream_chunk_timeout_seconds: int = env("HIPPIUS_STREAM_CHUNK_TIMEOUT_SECONDS:300", convert=int)
     # Hot-retention window for the FS cache: chunks read within this window
     # are protected from janitor deletion so frequently-accessed content
-    # stays on NVMe. Touched on every read by the API/streamer.
-    fs_cache_hot_retention_seconds: int = env("HIPPIUS_FS_CACHE_HOT_RETENTION_SECONDS:10800", convert=int)
+    # stays on NVMe. Touched on every read by the API/streamer. Tightened from
+    # 3h to 1h (2026-07-24): a fuller default eviction floor clears cold cache
+    # sooner; a missed re-fetch is one backend read, cheap next to a full pool.
+    fs_cache_hot_retention_seconds: int = env("HIPPIUS_FS_CACHE_HOT_RETENTION_SECONDS:3600", convert=int)
     # Unified object part chunk size (bytes) for cache and range math
     object_chunk_size_bytes: int = env("HIPPIUS_CHUNK_SIZE_BYTES:4194304", convert=int)
     # Downloader behavior (default: no whole-part backfill)
@@ -402,7 +404,7 @@ class Config:
     # Bounded concurrency for the janitor's per-part DB checks + deletes. The
     # cleanup loops are DB-roundtrip bound; this is how many parts are processed
     # in parallel (each over its own pooled connection).
-    janitor_concurrency: int = env("HIPPIUS_JANITOR_CONCURRENCY:16", convert=int)
+    janitor_concurrency: int = env("HIPPIUS_JANITOR_CONCURRENCY:32", convert=int)
     # Concurrency for the FS *walk* itself (distinct from janitor_concurrency, which is the
     # per-part DB roundtrip fan-out). The cache root is a single flat directory of millions of
     # object dirs on CephFS; a single-threaded walk is metadata-latency bound (~40 objects/s
@@ -417,7 +419,7 @@ class Config:
     # completes and the phases after it — plus the DB-only durability sentinel + aged-orphan
     # gauge which now run FIRST regardless — keep ticking. 0 = unbounded. Automatically lifted to
     # unbounded under CRITICAL disk pressure — freeing space must never be capped by a clock.
-    janitor_walk_budget_seconds: int = env("HIPPIUS_JANITOR_WALK_BUDGET_SECONDS:240", convert=int)
+    janitor_walk_budget_seconds: int = env("HIPPIUS_JANITOR_WALK_BUDGET_SECONDS:480", convert=int)
     # Number of hash-shards the FS walk rotates through, one per cycle, for FAIR coverage: each
     # cycle descends only into object dirs where crc32(object_id) % shards == cycle_shard, so a
     # full sweep of the tree takes `shards` cycles and no object waits behind an always-truncated
@@ -428,6 +430,20 @@ class Config:
     # normal sleep). Raise it if the cache grows or the walk logs truncated=True; 1 = walk the
     # whole tree every cycle. Forced to 1 under disk pressure so eviction sees the whole tree.
     janitor_walk_shards: int = env("HIPPIUS_JANITOR_WALK_SHARDS:64", convert=int)
+    # Pool-fullness gate for the janitor's disk-pressure probe. _pressure_mode reads statvfs on the
+    # cache mount, which sees the CephFS *PVC quota* — NOT the backing pool. On 2026-07-24 statvfs
+    # read 69% while ceph-filesystem-data0 sat at 94%, so the janitor stayed in Normal mode (10min
+    # sleep, 64-shard sweep, hot retention honored) while the pool filled to the read-only cliff.
+    # When BOTH are set, the janitor also scrapes ceph_pool_percent_used for these pools from the
+    # mgr exporter (the same signal PR #337 gave the drain allocator) and takes the MAX of that and
+    # the local statvfs ratio: the pool signal can only ever RAISE pressure, never mask it. Empty =
+    # statvfs-only (pre-incident behavior). Point the URL at the mgr exporter and list the same
+    # pools as the drain's CEPHOR_CEPH_POOLS.
+    janitor_ceph_mgr_metrics_url: str = env("HIPPIUS_JANITOR_CEPH_MGR_METRICS_URL:")
+    janitor_ceph_pools: str = env("HIPPIUS_JANITOR_CEPH_POOLS:")
+    # Per-scrape timeout for the pool-fullness probe; short relative to the cycle so a hung mgr
+    # falls back to statvfs rather than stalling the loop.
+    janitor_ceph_probe_timeout_seconds: float = env("HIPPIUS_JANITOR_CEPH_PROBE_TIMEOUT_SECONDS:5", convert=float)
     # Max soft-deleted objects hard-deleted per janitor cycle. The find query is
     # an index-probe over this many candidates; keep it bounded so a large
     # backlog drains gradually instead of in one DELETE-cascade burst.

--- a/k8s/base/workers-deployments.yaml
+++ b/k8s/base/workers-deployments.yaml
@@ -608,6 +608,15 @@ spec:
               value: "hippius-s3-janitor"
             - name: WORKER_SCRIPT
               value: "workers/run_janitor_in_loop.py"
+            # Pool-fullness gate (2026-07-24 incident). statvfs on the cache PVC sees the CephFS
+            # quota (~69%), not the backing pool (~94%), so the janitor stayed in Normal mode as
+            # the pool filled to the read-only cliff. These make _pressure_mode take max(statvfs,
+            # fullest pool %USED) from the mgr exporter — the same signal + pools the drain
+            # allocator uses (CEPHOR_CEPH_*). Cross-namespace reach to rook-ceph confirmed.
+            - name: HIPPIUS_JANITOR_CEPH_MGR_METRICS_URL
+              value: "http://rook-ceph-mgr.rook-ceph.svc.cluster.local:9283/metrics"
+            - name: HIPPIUS_JANITOR_CEPH_POOLS
+              value: "ceph-filesystem-data0,ceph-filesystem-metadata,ceph-blockpool"
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -20,3 +20,24 @@ def _reset_config_singleton() -> "object":
     _config.reset_config()
     yield
     _config.reset_config()
+
+
+@pytest.fixture(autouse=True)
+def _reset_janitor_pressure_globals() -> "object":
+    # _pressure_mode reads module-global disk/pool state. The pool-fullness gate added
+    # _fs_pool_percent_used, which _update_disk_metrics writes DIRECTLY (not via monkeypatch), so a
+    # test that drives the pool high would bleed Critical into later pressure cases — across files.
+    # Reset the pressure globals around every test that imported the janitor. Guarded on sys.modules
+    # so non-janitor unit tests don't pay the import.
+    import sys
+
+    def _reset() -> None:
+        mod = sys.modules.get("workers.run_janitor_in_loop")
+        if mod is not None:
+            mod._fs_pool_percent_used = None
+            mod._prev_pressure_mode = 0
+            mod._fs_pressure_mode = 0
+
+    _reset()
+    yield
+    _reset()

--- a/tests/unit/test_janitor_concurrency.py
+++ b/tests/unit/test_janitor_concurrency.py
@@ -199,7 +199,8 @@ async def test_worker_pool_clamps_nonpositive_concurrency():
 # --------------------------------------------------------- _update_disk_metrics
 
 
-def test_update_disk_metrics_populates_gauges_without_cleanup(monkeypatch):
+@pytest.mark.asyncio
+async def test_update_disk_metrics_populates_gauges_without_cleanup(monkeypatch):
     """Disk + pressure gauges are set from a single statvfs, not from a GC pass."""
 
     class FakeUsage:
@@ -207,36 +208,59 @@ def test_update_disk_metrics_populates_gauges_without_cleanup(monkeypatch):
         total = 1000  # 85% → elevated
 
     monkeypatch.setattr(janitor.shutil, "disk_usage", lambda p: FakeUsage())
+    # Pool gating off (default) → no mgr scrape; pressure keyed on statvfs alone.
+    monkeypatch.setattr(janitor, "_fetch_pool_percent_used", AsyncMock(return_value=None))
 
     janitor._fs_disk_used_bytes = 0
     janitor._fs_disk_total_bytes = 0
     janitor._fs_pressure_mode = 0
 
-    janitor._update_disk_metrics(Path("/tmp"))
+    await janitor._update_disk_metrics(Path("/tmp"))
 
     assert janitor._fs_disk_used_bytes == 850
     assert janitor._fs_disk_total_bytes == 1000
     assert janitor._fs_pressure_mode == 1  # 85% == elevated boundary
 
 
-def test_update_disk_metrics_critical(monkeypatch):
+@pytest.mark.asyncio
+async def test_update_disk_metrics_critical(monkeypatch):
     class FakeUsage:
         used = 990
         total = 1000  # 99% → critical
 
     monkeypatch.setattr(janitor.shutil, "disk_usage", lambda p: FakeUsage())
-    janitor._update_disk_metrics(Path("/tmp"))
+    monkeypatch.setattr(janitor, "_fetch_pool_percent_used", AsyncMock(return_value=None))
+    await janitor._update_disk_metrics(Path("/tmp"))
     assert janitor._fs_pressure_mode == 2
 
 
-def test_update_disk_metrics_normal(monkeypatch):
+@pytest.mark.asyncio
+async def test_update_disk_metrics_normal(monkeypatch):
     class FakeUsage:
         used = 100
         total = 1000  # 10% → normal
 
     monkeypatch.setattr(janitor.shutil, "disk_usage", lambda p: FakeUsage())
-    janitor._update_disk_metrics(Path("/tmp"))
+    monkeypatch.setattr(janitor, "_fetch_pool_percent_used", AsyncMock(return_value=None))
+    await janitor._update_disk_metrics(Path("/tmp"))
     assert janitor._fs_pressure_mode == 0
+
+
+@pytest.mark.asyncio
+async def test_update_disk_metrics_pool_gate_raises_pressure_above_statvfs(monkeypatch):
+    """The pool signal (94%) drives Critical even when local statvfs (the PVC quota) reads a calm
+    10% — the 2026-07-24 blind spot. max(statvfs, pool) is what _pressure_mode must key on."""
+
+    class FakeUsage:
+        used = 100
+        total = 1000  # 10% locally (PVC quota) → would be Normal on statvfs alone
+
+    monkeypatch.setattr(janitor.shutil, "disk_usage", lambda p: FakeUsage())
+    monkeypatch.setattr(janitor, "_fetch_pool_percent_used", AsyncMock(return_value=0.96))
+    janitor._prev_pressure_mode = 0
+    await janitor._update_disk_metrics(Path("/tmp"))
+    assert janitor._fs_pressure_mode == 2, "pool at 96% must force Critical despite statvfs at 10%"
+    assert janitor._fs_pool_percent_used == 0.96
 
 
 class _RmtreeFsStore:
@@ -380,7 +404,9 @@ async def test_main_loop_refreshes_disk_metrics_before_phases(monkeypatch):
         order.append(name)
         return 0
 
-    monkeypatch.setattr(janitor, "_update_disk_metrics", lambda root: order.append("disk_metrics"))
+    monkeypatch.setattr(
+        janitor, "_update_disk_metrics", AsyncMock(side_effect=lambda root: order.append("disk_metrics"))
+    )
     monkeypatch.setattr(janitor, "cleanup_stale_parts", lambda *a, **k: _phase_stub("phase1"))
     monkeypatch.setattr(janitor, "cleanup_old_parts_by_mtime", lambda *a, **k: _phase_stub("phase2"))
     monkeypatch.setattr(janitor, "cleanup_orphan_tmp_files", lambda *a, **k: _phase_stub("phase3"))

--- a/tests/unit/test_janitor_pool_gate.py
+++ b/tests/unit/test_janitor_pool_gate.py
@@ -1,0 +1,172 @@
+"""Tests for the janitor's Ceph pool-fullness gate (2026-07-24 incident, handoff item #3).
+
+statvfs on the cache mount sees the CephFS *PVC quota*, not the backing pool, so the janitor's
+disk-pressure probe stayed in Normal mode (10min sleep, 64-shard sweep, hot retention honored)
+while `ceph-filesystem-data0` filled to the read-only cliff. The gate makes _pressure_mode key on
+max(statvfs ratio, fullest configured pool's %USED) from the mgr exporter — the same signal the
+drain allocator got in PR #337. These cover the parse, the fail-safe fallbacks, and the max.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from workers import run_janitor_in_loop as janitor
+
+
+# The pool series shape captured live from rook-ceph-mgr:9283/metrics (pool 5 fullest at ~95%).
+HEALTHY = "ceph_cluster_total_bytes 115222679470080.0\nceph_cluster_total_used_bytes 31791022084096.0\n"
+POOL_SERIES = (
+    'ceph_pool_metadata{pool_id="2",name="ceph-blockpool",type="replicated"} 1.0\n'
+    'ceph_pool_metadata{pool_id="3",name="ceph-filesystem-metadata",type="replicated"} 1.0\n'
+    'ceph_pool_metadata{pool_id="5",name="ceph-filesystem-data0",type="replicated"} 1.0\n'
+    'ceph_pool_percent_used{pool_id="2"} 0.6975\n'
+    'ceph_pool_percent_used{pool_id="3"} 0.0072\n'
+    'ceph_pool_percent_used{pool_id="5"} 0.9507322907447815\n'
+)
+
+
+# ------------------------------------------------------------------ _label_value
+
+
+def test_label_value_extracts_up_to_the_closing_quote() -> None:
+    line = 'ceph_pool_metadata{pool_id="5",name="ceph-filesystem-data0",type="replicated"} 1.0'
+    assert janitor._label_value(line, 'pool_id="') == "5"
+    assert janitor._label_value(line, 'name="') == "ceph-filesystem-data0"
+
+
+def test_label_value_absent_needle_is_none() -> None:
+    assert janitor._label_value("ceph_pool_percent_used 0.5", 'pool_id="') is None
+
+
+# --------------------------------------------------------- _parse_pool_percent_used
+
+
+def test_parse_resolves_the_pool_fraction_via_its_metadata_id() -> None:
+    got = janitor._parse_pool_percent_used(HEALTHY + POOL_SERIES, ["ceph-filesystem-data0"])
+    assert got == pytest.approx(0.9507322907447815), "pool 5's fraction, not pool 2's"
+
+
+def test_parse_fullest_of_several_pools_wins_regardless_of_order() -> None:
+    # data0 (95%) is fuller than blockpool (70%) and metadata (0.7%); order must not matter.
+    got = janitor._parse_pool_percent_used(
+        HEALTHY + POOL_SERIES, ["ceph-blockpool", "ceph-filesystem-data0", "ceph-filesystem-metadata"]
+    )
+    assert got == pytest.approx(0.9507322907447815)
+
+
+def test_parse_series_order_does_not_matter() -> None:
+    # percent-used emitted BEFORE the metadata that names the pool must still resolve.
+    body = HEALTHY + 'ceph_pool_percent_used{pool_id="5"} 0.5\nceph_pool_metadata{pool_id="5",name="data"} 1.0\n'
+    assert janitor._parse_pool_percent_used(body, ["data"]) == pytest.approx(0.5)
+
+
+def test_parse_missing_pool_is_none_fail_safe() -> None:
+    # A typo'd/renamed pool anywhere in the list must fail safe (fall back to statvfs), never
+    # silently shrink the gate to the pools that did resolve.
+    assert janitor._parse_pool_percent_used(HEALTHY + POOL_SERIES, ["ceph-filesystem-data0", "nope"]) is None
+
+
+def test_parse_pool_absent_entirely_is_none() -> None:
+    assert janitor._parse_pool_percent_used(HEALTHY, ["ceph-filesystem-data0"]) is None
+
+
+def test_parse_prefix_name_is_not_matched() -> None:
+    # name="data0" must not resolve for target "data": the label match is exact.
+    body = HEALTHY + 'ceph_pool_metadata{pool_id="7",name="data0"} 1.0\nceph_pool_percent_used{pool_id="7"} 0.99\n'
+    assert janitor._parse_pool_percent_used(body, ["data"]) is None
+
+
+def test_parse_fraction_above_one_clamps() -> None:
+    body = HEALTHY + 'ceph_pool_metadata{pool_id="5",name="data"} 1.0\nceph_pool_percent_used{pool_id="5"} 1.0000001\n'
+    assert janitor._parse_pool_percent_used(body, ["data"]) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("bad", ["NaN", "inf", "garbage"])
+def test_parse_non_finite_or_garbage_percent_reads_missing(bad: str) -> None:
+    # A NaN/inf/garbage value is not a ratio — it is dropped, so the pool has no valid percent and
+    # the whole probe reads "missing" → None (fail safe to statvfs), never a silent healthy read.
+    body = HEALTHY + f'ceph_pool_metadata{{pool_id="5",name="data"}} 1.0\nceph_pool_percent_used{{pool_id="5"}} {bad}\n'
+    assert janitor._parse_pool_percent_used(body, ["data"]) is None
+
+
+# --------------------------------------------------------- _fetch_pool_percent_used
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_none_when_unconfigured(monkeypatch) -> None:
+    monkeypatch.setattr(janitor.config, "janitor_ceph_mgr_metrics_url", "")
+    monkeypatch.setattr(janitor.config, "janitor_ceph_pools", "")
+    assert await janitor._fetch_pool_percent_used() is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_scrapes_and_parses_the_fullest_pool(monkeypatch) -> None:
+    url = "http://mgr.test/metrics"
+    monkeypatch.setattr(janitor.config, "janitor_ceph_mgr_metrics_url", url)
+    monkeypatch.setattr(janitor.config, "janitor_ceph_pools", "ceph-filesystem-data0, ceph-blockpool")
+    monkeypatch.setattr(janitor.config, "janitor_ceph_probe_timeout_seconds", 2.0)
+    respx.get(url).mock(return_value=httpx.Response(200, text=HEALTHY + POOL_SERIES))
+    assert await janitor._fetch_pool_percent_used() == pytest.approx(0.9507322907447815)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_falls_back_to_none_on_http_error(monkeypatch) -> None:
+    url = "http://mgr.test/metrics"
+    monkeypatch.setattr(janitor.config, "janitor_ceph_mgr_metrics_url", url)
+    monkeypatch.setattr(janitor.config, "janitor_ceph_pools", "ceph-filesystem-data0")
+    monkeypatch.setattr(janitor.config, "janitor_ceph_probe_timeout_seconds", 2.0)
+    respx.get(url).mock(return_value=httpx.Response(503))
+    assert await janitor._fetch_pool_percent_used() is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_falls_back_to_none_on_connect_error(monkeypatch) -> None:
+    url = "http://mgr.test/metrics"
+    monkeypatch.setattr(janitor.config, "janitor_ceph_mgr_metrics_url", url)
+    monkeypatch.setattr(janitor.config, "janitor_ceph_pools", "ceph-filesystem-data0")
+    monkeypatch.setattr(janitor.config, "janitor_ceph_probe_timeout_seconds", 2.0)
+    respx.get(url).mock(side_effect=httpx.ConnectError("refused"))
+    assert await janitor._fetch_pool_percent_used() is None
+
+
+# ------------------------------------------------------------------ _pressure_mode max
+
+
+@pytest.mark.parametrize(
+    ("pool_pct", "expected"),
+    [
+        (None, 0),  # gate off → statvfs (10%) alone → Normal
+        (0.50, 0),  # pool calm → still Normal
+        (0.88, 1),  # pool near-full → Elevated even though statvfs says 10%
+        (0.96, 2),  # pool at cliff → Critical (the incident: statvfs blind at 10%)
+    ],
+)
+def test_pressure_mode_takes_the_max_of_statvfs_and_pool(monkeypatch, pool_pct, expected) -> None:
+    class FakeUsage:
+        used = 100
+        total = 1000  # 10% locally → Normal on statvfs alone
+
+    monkeypatch.setattr(janitor.shutil, "disk_usage", lambda p: FakeUsage())
+    monkeypatch.setattr(janitor, "_fs_pool_percent_used", pool_pct)
+    janitor._prev_pressure_mode = 0
+    assert janitor._pressure_mode(Path("/tmp")) == expected
+
+
+def test_pressure_mode_local_statvfs_still_drives_when_pool_gate_off(monkeypatch) -> None:
+    # Gate unconfigured (pool None): a genuinely full local disk must still escalate.
+    class FakeUsage:
+        used = 970
+        total = 1000  # 97% locally → Critical
+
+    monkeypatch.setattr(janitor.shutil, "disk_usage", lambda p: FakeUsage())
+    monkeypatch.setattr(janitor, "_fs_pool_percent_used", None)
+    janitor._prev_pressure_mode = 0
+    assert janitor._pressure_mode(Path("/tmp")) == 2

--- a/tests/unit/test_janitor_sharded_gc.py
+++ b/tests/unit/test_janitor_sharded_gc.py
@@ -251,7 +251,9 @@ async def test_durability_phases_run_before_fs_walks(monkeypatch):
         order.append(name)
         return ret
 
-    monkeypatch.setattr(janitor, "_update_disk_metrics", lambda root: order.append("disk_metrics"))
+    monkeypatch.setattr(
+        janitor, "_update_disk_metrics", AsyncMock(side_effect=lambda root: order.append("disk_metrics"))
+    )
     monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
     monkeypatch.setattr(janitor, "check_replication_sentinel", lambda *a, **k: _rec("sentinel"))
     monkeypatch.setattr(janitor, "get_all_dlq_object_ids", lambda *a, **k: _rec("dlq", set()))
@@ -301,7 +303,7 @@ async def test_disk_pressure_collapses_the_walk_to_a_single_whole_tree_shard(mon
             captured["gc"] = k.get("shards")
             return 0
 
-        monkeypatch.setattr(janitor, "_update_disk_metrics", lambda root: None)
+        monkeypatch.setattr(janitor, "_update_disk_metrics", AsyncMock(return_value=None))
         monkeypatch.setattr(janitor, "_pressure_mode", lambda root: pressure)
         monkeypatch.setattr(janitor, "check_replication_sentinel", AsyncMock(return_value=0))
         monkeypatch.setattr(janitor, "get_all_dlq_object_ids", AsyncMock(return_value=set()))

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -24,6 +24,7 @@ Disk-pressure modes (all still replication-gated):
 import asyncio
 import json
 import logging
+import math
 import os
 import shutil
 import sys
@@ -39,6 +40,7 @@ from pathlib import Path
 from typing import Any
 
 import asyncpg
+import httpx
 from opentelemetry import metrics as otel_metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
 from opentelemetry.sdk.metrics import MeterProvider
@@ -84,7 +86,9 @@ PRESSURE_CRITICAL_EXIT = 0.93
 
 # Maximum age of an orphan `.tmp.*` file before we delete it. Atomic writes
 # finish in milliseconds; anything older than this is a crashed-write orphan.
-TMP_FILE_MAX_AGE_SECONDS = 3600  # 1h
+# 30min: atomic writes complete in ms, so half an hour is already many orders of
+# magnitude of slack — no reason to sit on crashed-write bytes for a full hour.
+TMP_FILE_MAX_AGE_SECONDS = 1800  # 30m
 # Cap on the G2 sentinel scan: it needs only to DETECT a durability gap and sample a few
 # offenders, not enumerate every one, so a bounded page keeps the read-only query cheap.
 SENTINEL_SCAN_LIMIT = 500
@@ -102,6 +106,10 @@ _fs_disk_total_bytes = 0
 _fs_hot_parts = 0
 _fs_pressure_mode = 0  # 0 = normal, 1 = elevated, 2 = critical
 _prev_pressure_mode = 0  # C2: last mode returned by _pressure_mode, for hysteresis (single-instance janitor)
+# Fullest configured Ceph pool's %USED (0.0-1.0), refreshed once per cycle by _update_disk_metrics
+# from the mgr exporter. None when pool gating is unconfigured or the probe failed this cycle — in
+# which case _pressure_mode falls back to statvfs alone. See _fetch_pool_percent_used.
+_fs_pool_percent_used: float | None = None
 _fs_age_buckets: dict[str, int] = dict.fromkeys(AGE_BUCKET_NAMES, 0)
 # Census is now accumulated across a full sharded sweep (the age-GC walk covers 1/shards of
 # the tree per cycle), then published to the gauges above only when a sweep completes without
@@ -174,6 +182,12 @@ def _obs_pressure_mode(_: object) -> list[otel_metrics.Observation]:
     return [otel_metrics.Observation(_fs_pressure_mode, {})]
 
 
+def _obs_pool_percent_used(_: object) -> list[otel_metrics.Observation]:
+    # -1 = pool gating unconfigured or the probe failed this cycle (falling back to statvfs).
+    value = _fs_pool_percent_used if _fs_pool_percent_used is not None else -1.0
+    return [otel_metrics.Observation(value, {})]
+
+
 def _obs_age_buckets(_: object) -> list[otel_metrics.Observation]:
     return [otel_metrics.Observation(count, {"age_bucket": bucket}) for bucket, count in _fs_age_buckets.items()]
 
@@ -209,6 +223,80 @@ def _classify_age_bucket(age_seconds: float) -> str:
     return "7d+"
 
 
+def _label_value(line: str, needle: str) -> str | None:
+    """The prometheus label value following `needle` (e.g. `pool_id="`), up to its closing quote."""
+    start = line.find(needle)
+    if start < 0:
+        return None
+    start += len(needle)
+    end = line.find('"', start)
+    return line[start:end] if end >= 0 else None
+
+
+def _parse_pool_percent_used(body: str, pools: list[str]) -> float | None:
+    """The fullest of `pools` from a mgr prometheus scrape, resolving each name to its id via
+    `ceph_pool_metadata` then reading `ceph_pool_percent_used`. Returns None if ANY pool is absent
+    — a missing pool must fail safe (fall back to statvfs), never silently shrink the gate. Pure so
+    the parse is unit-testable without a live exporter."""
+    name_to_id: dict[str, str] = {}
+    id_to_pct: dict[str, float] = {}
+    for line in body.splitlines():
+        if line.startswith("ceph_pool_metadata{"):
+            name = _label_value(line, 'name="')
+            pool_id = _label_value(line, 'pool_id="')
+            if name is not None and pool_id is not None and name in pools:
+                name_to_id[name] = pool_id
+        elif line.startswith("ceph_pool_percent_used{"):
+            pool_id = _label_value(line, 'pool_id="')
+            if pool_id is None:
+                continue
+            try:
+                value = float(line.rsplit(" ", 1)[1])
+            except (ValueError, IndexError):
+                continue
+            if math.isfinite(value):  # a NaN/inf is not a ratio — drop it so the pool reads missing
+                id_to_pct[pool_id] = value
+
+    fullest: float | None = None
+    for pool in pools:
+        pool_id = name_to_id.get(pool)
+        pct = id_to_pct.get(pool_id) if pool_id is not None else None
+        if pct is None:
+            logger.warning("janitor pool-fullness probe: pool %r absent from mgr output; falling back to statvfs", pool)
+            return None
+        pct = min(max(pct, 0.0), 1.0)  # exporter rounding can nudge just past 1.0
+        fullest = pct if fullest is None else max(fullest, pct)
+    return fullest
+
+
+async def _fetch_pool_percent_used() -> float | None:
+    """The fullest configured Ceph pool's %USED (0.0-1.0) from the mgr exporter, or None.
+
+    statvfs on the cache mount (what _pressure_mode reads locally) sees the CephFS *PVC quota*,
+    not the backing pool: on 2026-07-24 statvfs read 0.69 while ceph-filesystem-data0 sat at 0.94,
+    so the janitor never left Normal mode as the pool filled to the read-only cliff. This reads the
+    same `ceph_pool_percent_used` signal PR #337 gave the drain allocator.
+
+    Returns None — the caller then falls back to statvfs alone — when pool gating is unconfigured,
+    the mgr is unreachable, or any configured pool is absent (a missing pool must not silently
+    shrink the gate). The pool signal only ever RAISES pressure via the max in _pressure_mode; on
+    failure the janitor is no worse off than its pre-incident statvfs-only behavior, but it logs.
+    """
+    url = config.janitor_ceph_mgr_metrics_url
+    pools = [p.strip() for p in config.janitor_ceph_pools.split(",") if p.strip()]
+    if not url or not pools:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=config.janitor_ceph_probe_timeout_seconds) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            body = resp.text
+    except httpx.HTTPError as exc:
+        logger.warning("janitor pool-fullness probe failed (%s); falling back to statvfs", exc)
+        return None
+    return _parse_pool_percent_used(body, pools)
+
+
 def _pressure_mode(root: Path) -> int:
     """Return the current disk-pressure mode (0/1/2) with hysteresis.
 
@@ -217,13 +305,20 @@ def _pressure_mode(root: Path) -> int:
     0.85 or 0.95 from oscillating the mode — and the hot-retention window and loop sleep that key
     off it — on every cycle. The janitor is single-instance, so a module-global previous-mode is
     safe. On a stat error we hold the previous mode rather than snapping to normal.
+
+    The ratio is the MAX of the local statvfs used-fraction and the backing Ceph pool's %USED
+    (`_fs_pool_percent_used`, refreshed once per cycle). statvfs alone sees the CephFS PVC quota,
+    not the pool, so it under-reports fullness for a pool whose CRUSH subtree fills ahead of the
+    quota — the 2026-07-24 incident. `None` (pool gating off / probe failed) uses statvfs alone.
     """
     global _prev_pressure_mode
     try:
         usage = shutil.disk_usage(root)
-        ratio = usage.used / usage.total if usage.total else 0.0
+        local_ratio = usage.used / usage.total if usage.total else 0.0
     except OSError:
         return _prev_pressure_mode
+    pool_ratio = _fs_pool_percent_used if _fs_pool_percent_used is not None else 0.0
+    ratio = max(local_ratio, pool_ratio)
     prev = _prev_pressure_mode
     if ratio >= PRESSURE_CRITICAL or (prev == 2 and ratio >= PRESSURE_CRITICAL_EXIT):
         mode = 2
@@ -502,14 +597,19 @@ def _publish_census(now: float) -> None:
         )
 
 
-def _update_disk_metrics(root: Path) -> None:
+async def _update_disk_metrics(root: Path) -> None:
     """Refresh disk-usage + pressure gauges from a single statvfs.
 
     Called at the top of every cycle so disk visibility never depends on a full
     GC pass completing — the GC walk over millions of parts can take hours, and
     operators need to see a filling disk long before then.
+
+    The pool-fullness probe is refreshed HERE (once per cycle) into a module global that
+    _pressure_mode reads, so the many per-cycle _pressure_mode calls (each GC phase re-reads it)
+    share one mgr scrape rather than hammering the exporter.
     """
-    global _fs_disk_used_bytes, _fs_disk_total_bytes, _fs_pressure_mode
+    global _fs_disk_used_bytes, _fs_disk_total_bytes, _fs_pressure_mode, _fs_pool_percent_used
+    _fs_pool_percent_used = await _fetch_pool_percent_used()
     usage = shutil.disk_usage(root)
     _fs_disk_used_bytes = usage.used
     _fs_disk_total_bytes = usage.total
@@ -624,6 +724,11 @@ def _setup_janitor_metrics() -> None:
         name="fs_cache_pressure_mode",
         callbacks=[_obs_pressure_mode],
         description="0=normal, 1=elevated, 2=critical",
+    )
+    meter.create_observable_gauge(
+        name="fs_cache_pool_percent_used",
+        callbacks=[_obs_pool_percent_used],
+        description="Backing Ceph pool %USED (0.0-1.0) from the mgr exporter; -1 = pool gating off or probe failed (statvfs fallback). The real fullness signal statvfs misses.",
     )
     meter.create_observable_gauge(
         name="fs_cache_age_bucket_parts",
@@ -1408,6 +1513,16 @@ async def run_janitor_loop():
     logger.info(f"FS GC max age: {config.fs_cache_gc_max_age_seconds}s")
     logger.info(f"FS hot retention: {getattr(config, 'fs_cache_hot_retention_seconds', 10800)}s")
     logger.info(f"Cleanup concurrency: {concurrency}")
+    if config.janitor_ceph_mgr_metrics_url and config.janitor_ceph_pools:
+        logger.info(
+            f"Pool-fullness gate ACTIVE: pools={config.janitor_ceph_pools} via {config.janitor_ceph_mgr_metrics_url} "
+            f"(pressure = max(statvfs, fullest pool %USED))"
+        )
+    else:
+        logger.warning(
+            "Pool-fullness gate INACTIVE (HIPPIUS_JANITOR_CEPH_MGR_METRICS_URL / _POOLS unset); "
+            "pressure keyed on statvfs, which sees the PVC quota not the backing pool — the 2026-07-24 blind spot"
+        )
 
     # Sleep intervals: shorter under disk pressure to catch up
     sleep_normal = 600  # 10m
@@ -1421,7 +1536,7 @@ async def run_janitor_loop():
             _cycle_started = time.time()
             logger.info("Janitor cycle starting...")
             # Refresh disk/pressure gauges up front, and read pressure ONCE for the whole cycle.
-            _update_disk_metrics(fs_store.root)
+            await _update_disk_metrics(fs_store.root)
             pressure = _pressure_mode(fs_store.root)
 
             # --- DB-only DURABILITY phases run FIRST ------------------------------------------


### PR DESCRIPTION
Promotes **#338** (merged to staging, verified live on staging) to production.

## What it is
The janitor twin of #337: `_pressure_mode` was reading `statvfs` on the cache mount (the CephFS **PVC quota**, ~69%) instead of the backing pool (~94%), so during the 2026-07-24 incident it stayed in Normal mode — 10-min sleeps, 64-shard sweep, hot retention honored — while the pool filled to the read-only cliff. This makes the janitor key on `max(statvfs, fullest configured pool %USED)` from the mgr exporter (async httpx, fail-safe to statvfs), plus raises eviction throughput and tightens TTLs.

## Delta vs k8s-production
Exactly #338 — 7 files, no other staging changes:
- `workers/run_janitor_in_loop.py` — pool-fullness gate + `fs_cache_pool_percent_used` gauge
- `hippius_s3/config.py` — pool-gate config, `janitor_concurrency` 16→32, walk budget 240→480s, hot retention 3h→1h
- `k8s/base/workers-deployments.yaml` — wire `HIPPIUS_JANITOR_CEPH_{MGR_METRICS_URL,POOLS}`
- tests: new `test_janitor_pool_gate.py` + async `_update_disk_metrics` fixups + conftest reset

## Staging verification (before this promotion)
- `deploy-staging` succeeded; janitor rolled to `workers:46e892f`, pod 1/1 Running, 0 restarts.
- Logs: `Pool-fullness gate ACTIVE: pools=...`, `Cleanup concurrency: 32`, `FS hot retention: 3600s`.
- The httpx scrape to ceph-mgr returns 200; **the staging janitor now reports pressure=1 (elevated)** — it's seeing the real ~92% pool instead of the 69% PVC quota. Fix confirmed working.
- CI on #338: ruff, ty, pip-audit, Unit & Integration Tests all green.

## Rollout note
`ceph-filesystem-data0` is ~92% on prod right now, so on deploy the prod janitor will correctly read Elevated/Critical immediately and evict harder — the intended behavior until the pool recovers below 85%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)