### PR TITLE
perf(janitor): collapse the 3 FS-walk phases into one unified walk

### DIFF
--- a/tests/unit/test_janitor_concurrency.py
+++ b/tests/unit/test_janitor_concurrency.py
@@ -404,12 +404,19 @@ async def test_main_loop_refreshes_disk_metrics_before_phases(monkeypatch):
         order.append(name)
         return 0
 
+    async def _unified_stub(*a, **k):
+        order.append("unified")
+        return {"stale_mtime": 0, "abandoned": 0, "gc": 0, "tmp": 0}
+
     monkeypatch.setattr(
         janitor, "_update_disk_metrics", AsyncMock(side_effect=lambda root: order.append("disk_metrics"))
     )
-    monkeypatch.setattr(janitor, "cleanup_stale_parts", lambda *a, **k: _phase_stub("phase1"))
-    monkeypatch.setattr(janitor, "cleanup_old_parts_by_mtime", lambda *a, **k: _phase_stub("phase2"))
-    monkeypatch.setattr(janitor, "cleanup_orphan_tmp_files", lambda *a, **k: _phase_stub("phase3"))
+    # The three FS-walk phases are now ONE unified walk; patch it (and the DB-only durability
+    # phases) so nothing crawls a real tree.
+    monkeypatch.setattr(janitor, "cleanup_parts_unified", _unified_stub)
+    monkeypatch.setattr(janitor, "check_replication_sentinel", AsyncMock(return_value=0))
+    monkeypatch.setattr(janitor, "get_all_dlq_object_ids", AsyncMock(return_value=set()))
+    monkeypatch.setattr(janitor, "check_aged_pending_orphans", AsyncMock(return_value=0))
     monkeypatch.setattr(janitor, "gc_soft_deleted_objects", lambda *a, **k: _phase_stub("phase4"))
     monkeypatch.setattr(janitor, "_setup_janitor_metrics", lambda: None)
     monkeypatch.setattr(janitor, "create_fs_store", lambda config: MagicMock(root=Path("/tmp")))
@@ -432,4 +439,4 @@ async def test_main_loop_refreshes_disk_metrics_before_phases(monkeypatch):
         await janitor.run_janitor_loop()
 
     assert order[0] == "disk_metrics", f"disk metrics must refresh before any phase; got {order}"
-    assert order[:3] == ["disk_metrics", "phase1", "phase2"]
+    assert order[:3] == ["disk_metrics", "unified", "phase4"]

--- a/tests/unit/test_janitor_sharded_gc.py
+++ b/tests/unit/test_janitor_sharded_gc.py
@@ -251,6 +251,10 @@ async def test_durability_phases_run_before_fs_walks(monkeypatch):
         order.append(name)
         return ret
 
+    async def _rec_unified(*a, **k):
+        order.append("fs_unified")
+        return {"stale_mtime": 0, "abandoned": 0, "gc": 0, "tmp": 0}
+
     monkeypatch.setattr(
         janitor, "_update_disk_metrics", AsyncMock(side_effect=lambda root: order.append("disk_metrics"))
     )
@@ -258,9 +262,7 @@ async def test_durability_phases_run_before_fs_walks(monkeypatch):
     monkeypatch.setattr(janitor, "check_replication_sentinel", lambda *a, **k: _rec("sentinel"))
     monkeypatch.setattr(janitor, "get_all_dlq_object_ids", lambda *a, **k: _rec("dlq", set()))
     monkeypatch.setattr(janitor, "check_aged_pending_orphans", lambda *a, **k: _rec("aged_orphans"))
-    monkeypatch.setattr(janitor, "cleanup_stale_parts", lambda *a, **k: _rec("fs_stale"))
-    monkeypatch.setattr(janitor, "cleanup_old_parts_by_mtime", lambda *a, **k: _rec("fs_gc"))
-    monkeypatch.setattr(janitor, "cleanup_orphan_tmp_files", lambda *a, **k: _rec("fs_tmp"))
+    monkeypatch.setattr(janitor, "cleanup_parts_unified", _rec_unified)
     monkeypatch.setattr(janitor, "gc_soft_deleted_objects", lambda *a, **k: _rec("hard_delete"))
     monkeypatch.setattr(janitor, "_setup_janitor_metrics", lambda: None)
     monkeypatch.setattr(janitor, "create_fs_store", lambda config: MagicMock(root=Path("/tmp")))
@@ -279,10 +281,10 @@ async def test_durability_phases_run_before_fs_walks(monkeypatch):
         await janitor.run_janitor_loop()
 
     assert "sentinel" in order and "aged_orphans" in order
-    # both durability signals must precede every FS-walk phase
-    first_fs = min(order.index(p) for p in ("fs_stale", "fs_gc", "fs_tmp"))
-    assert order.index("sentinel") < first_fs, f"sentinel must run before FS walks; got {order}"
-    assert order.index("aged_orphans") < first_fs, f"aged-orphan gauge must run before FS walks; got {order}"
+    # both durability signals must precede the unified FS walk
+    first_fs = order.index("fs_unified")
+    assert order.index("sentinel") < first_fs, f"sentinel must run before the FS walk; got {order}"
+    assert order.index("aged_orphans") < first_fs, f"aged-orphan gauge must run before the FS walk; got {order}"
 
 
 @pytest.mark.asyncio
@@ -295,22 +297,16 @@ async def test_disk_pressure_collapses_the_walk_to_a_single_whole_tree_shard(mon
     async def _shards_passed_at_pressure(pressure: int) -> dict:
         captured: dict = {}
 
-        async def _capture_stale(*a, **k):
-            captured["stale"] = k.get("shards")
-            return 0
-
-        async def _capture_gc(*a, **k):
-            captured["gc"] = k.get("shards")
-            return 0
+        async def _capture_unified(*a, **k):
+            captured["unified"] = k.get("shards")
+            return {"stale_mtime": 0, "abandoned": 0, "gc": 0, "tmp": 0}
 
         monkeypatch.setattr(janitor, "_update_disk_metrics", AsyncMock(return_value=None))
         monkeypatch.setattr(janitor, "_pressure_mode", lambda root: pressure)
         monkeypatch.setattr(janitor, "check_replication_sentinel", AsyncMock(return_value=0))
         monkeypatch.setattr(janitor, "get_all_dlq_object_ids", AsyncMock(return_value=set()))
         monkeypatch.setattr(janitor, "check_aged_pending_orphans", AsyncMock(return_value=0))
-        monkeypatch.setattr(janitor, "cleanup_stale_parts", _capture_stale)
-        monkeypatch.setattr(janitor, "cleanup_old_parts_by_mtime", _capture_gc)
-        monkeypatch.setattr(janitor, "cleanup_orphan_tmp_files", AsyncMock(return_value=0))
+        monkeypatch.setattr(janitor, "cleanup_parts_unified", _capture_unified)
         monkeypatch.setattr(janitor, "gc_soft_deleted_objects", AsyncMock(return_value=0))
         monkeypatch.setattr(janitor, "_setup_janitor_metrics", lambda: None)
         monkeypatch.setattr(janitor, "create_fs_store", lambda config: MagicMock(root=Path("/tmp")))
@@ -331,11 +327,9 @@ async def test_disk_pressure_collapses_the_walk_to_a_single_whole_tree_shard(mon
     # Elevated (1) AND critical (2) both force the whole-tree single-shard walk.
     for pressure in (1, 2):
         captured = await _shards_passed_at_pressure(pressure)
-        assert captured["stale"] == 1, f"pressure={pressure} must force shards=1 (stale phase), got {captured}"
-        assert captured["gc"] == 1, f"pressure={pressure} must force shards=1 (age-GC phase), got {captured}"
+        assert captured["unified"] == 1, f"pressure={pressure} must force shards=1 (unified walk), got {captured}"
 
     # Normal pressure keeps the configured sharded sweep.
     normal = await _shards_passed_at_pressure(0)
     expected = max(1, janitor.config.janitor_walk_shards)
-    assert normal["stale"] == expected, f"normal pressure must use the configured shard count, got {normal}"
-    assert normal["gc"] == expected, f"normal pressure must use the configured shard count, got {normal}"
+    assert normal["unified"] == expected, f"normal pressure must use the configured shard count, got {normal}"

--- a/tests/unit/test_janitor_unified_walk.py
+++ b/tests/unit/test_janitor_unified_walk.py
@@ -1,0 +1,315 @@
+"""Union-equivalence tests for the unified janitor FS walk.
+
+The janitor used to run THREE separate full-tree FS walks per cycle — `cleanup_stale_parts`,
+`cleanup_old_parts_by_mtime` (age-GC + census), `cleanup_orphan_tmp_files` — each independently
+crawling the shard via `iter_part_dirs`. On prod that metadata-crawled a ~15.6M-object CephFS tree
+3× per cycle over the same MDS that serves live GET/PUT. `cleanup_parts_unified` merges them into
+ONE walk, applying every phase's rule per part dir.
+
+The safety-critical property these tests pin: the WALK is unified but the deletion RULES are
+byte-for-byte identical. The union of what the unified walk deletes must EXACTLY equal what the
+three old phases delete when run in sequence — across every category (stale orphans,
+terminally-abandoned parts, replicated-cold age-GC deletes, hot-protected, under-replicated,
+DLQ-protected, and orphan `.tmp.*` files) and under sharding.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import time
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from workers import run_janitor_in_loop as janitor
+
+
+# ---- object-id catalogue (well-formed 32-hex names so the walk yields them) ----
+
+ORPHAN_STALE = f"{0x01:032x}"  # stale-eligible, no parts row -> reap (stale_mtime)
+ABANDONED = f"{0x02:032x}"  # stale-eligible, failed+unservable -> reap (abandoned)
+PROTECTED_PENDING = f"{0x03:032x}"  # stale-eligible, old row, not replicated, not abandoned -> keep
+GC_REPLICATED_COLD = f"{0x04:032x}"  # gc-eligible, replicated, cold -> delete (gc_age)
+HOT_PROTECTED = f"{0x05:032x}"  # gc-aged mtime but recently read -> hot -> keep
+UNDER_REPLICATED = f"{0x06:032x}"  # gc-eligible but NOT replicated -> replication gate -> keep
+DLQ_PROTECTED = f"{0x07:032x}"  # stale+gc eligible but in DLQ -> keep (both rules honour DLQ)
+TMP_SURVIVOR = f"{0x08:032x}"  # recent, ineligible; carries an orphan tmp that must be reaped
+
+EXPECTED_DELETED = {(ORPHAN_STALE, 1, 1), (ABANDONED, 1, 1), (GC_REPLICATED_COLD, 1, 1)}
+EXPECTED_TMP = 3  # tmp files live ONLY in surviving dirs (PROTECTED_PENDING, UNDER_REPLICATED, TMP_SURVIVOR)
+
+REPLICATED_OIDS = {GC_REPLICATED_COLD, DLQ_PROTECTED}
+ABANDONED_OIDS = {ABANDONED}
+# parts-row state for the stale query: object_id -> None (no row) | {"recent": bool}
+PARTS_ROWS: dict[str, dict | None] = {ABANDONED: {"recent": False}, PROTECTED_PENDING: {"recent": False}}
+
+
+def _make_part(root: Path, oid: str, *, mtime_ago: float, atime_ago: float, tmp_ago: float | None = None) -> None:
+    d = root / oid / "v1" / "part_1"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "chunk_0.bin").write_bytes(b"payload")
+    (d / "meta.json").write_text('{"chunk_size": 7, "num_chunks": 1, "size_bytes": 7}')
+    now = time.time()
+    os.utime(d / "meta.json", (now - atime_ago, now - mtime_ago))
+    if tmp_ago is not None:
+        t = d / f"chunk_0.bin.tmp.{uuid.uuid4()}"
+        t.write_bytes(b"partial")
+        os.utime(t, (now - tmp_ago, now - tmp_ago))
+
+
+def _build_catalogue(root: Path) -> None:
+    old = 200_000  # older than the 86_400 stale threshold
+    gc_aged = 3600  # older than the 60s gc cutoff, younger than the stale threshold
+    recent = 30  # younger than everything
+    tmp_old = 3600  # older than TMP_FILE_MAX_AGE_SECONDS (1800)
+
+    _make_part(root, ORPHAN_STALE, mtime_ago=old, atime_ago=old)
+    _make_part(root, ABANDONED, mtime_ago=old, atime_ago=old)
+    _make_part(root, PROTECTED_PENDING, mtime_ago=old, atime_ago=old, tmp_ago=tmp_old)
+    _make_part(root, GC_REPLICATED_COLD, mtime_ago=gc_aged, atime_ago=gc_aged)
+    _make_part(root, HOT_PROTECTED, mtime_ago=gc_aged, atime_ago=0)  # atime now -> hot
+    _make_part(root, UNDER_REPLICATED, mtime_ago=gc_aged, atime_ago=gc_aged, tmp_ago=tmp_old)
+    _make_part(root, DLQ_PROTECTED, mtime_ago=old, atime_ago=old)
+    _make_part(root, TMP_SURVIVOR, mtime_ago=recent, atime_ago=recent, tmp_ago=tmp_old)
+
+
+class _PoolCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _PoolCtx(self._conn)
+
+
+class _FakeConn:
+    """Answers only the stale-phase `parts` recency query; replication / abandoned checks are
+    patched at module level so they never touch this conn."""
+
+    async def fetchrow(self, query, *args):
+        object_id = args[0]
+        return PARTS_ROWS.get(object_id)
+
+
+class _FakeFsStore:
+    def __init__(self, root: Path):
+        self.root = root
+        self.deleted: list[tuple[str, int, int]] = []
+
+    async def delete_part(self, object_id: str, object_version: int, part_number: int) -> None:
+        self.deleted.append((object_id, int(object_version), int(part_number)))
+        p = self.root / object_id / f"v{object_version}" / f"part_{part_number}"
+        if p.exists():
+            shutil.rmtree(p)
+
+
+def _redis(dlq_oids: tuple[str, ...] = ()):
+    r = MagicMock()
+    entries = [json.dumps({"object_id": o}) for o in dlq_oids]
+
+    async def _lrange(key, start, end):
+        return entries if key == "arion_upload_requests:dlq" else []
+
+    r.lrange = AsyncMock(side_effect=_lrange)
+    return r
+
+
+async def _fake_replicated(conn, oid, ov, pn):
+    return oid in REPLICATED_OIDS
+
+
+async def _fake_abandoned(conn, oid, ov, pn):
+    return oid in ABANDONED_OIDS
+
+
+@pytest.fixture(autouse=True)
+def _cfg():
+    janitor.config.fs_cache_hot_retention_seconds = 1  # tight window: only atime==now is "hot"
+    janitor.config.fs_cache_gc_max_age_seconds = 60
+    janitor.config.mpu_stale_seconds = 86_400
+    janitor.config.upload_backends = ["arion"]
+    janitor.config.backup_backends = []
+    janitor._reset_census_accum()
+    janitor._walk_shard = 0
+    yield
+
+
+async def _run_three_phases_sequential(store, redis, **walk_kw) -> int:
+    """The OLD loop body: stale -> age-GC -> orphan-tmp, in sequence, on one tree."""
+    await janitor.cleanup_stale_parts(_FakePool(_FakeConn()), store, redis, **walk_kw)
+    await janitor.cleanup_old_parts_by_mtime(_FakePool(_FakeConn()), store, redis, **walk_kw)
+    return await janitor.cleanup_orphan_tmp_files(store, **walk_kw)
+
+
+# --------------------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unified_walk_deletes_exactly_the_three_phase_union(tmp_path: Path, monkeypatch):
+    """The core property: one walk deletes EXACTLY the set (and reaps exactly the tmp files) that
+    the three separate phases delete when run in sequence — across every category."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+
+    walk_kw = {"shard": 0, "shards": 1, "walk_concurrency": 4, "deadline": None}
+
+    # Reference: run the three old phases sequentially.
+    ref_root = tmp_path / "ref"
+    _build_catalogue(ref_root)
+    ref_store = _FakeFsStore(ref_root)
+    with (
+        patch.object(janitor, "is_replicated_on_all_backends", _fake_replicated),
+        patch.object(janitor, "is_terminally_abandoned", _fake_abandoned),
+    ):
+        ref_tmp = await _run_three_phases_sequential(ref_store, _redis((DLQ_PROTECTED,)), **walk_kw)
+
+    assert set(ref_store.deleted) == EXPECTED_DELETED
+    assert ref_tmp == EXPECTED_TMP
+
+    # Unified: one walk over an identical tree.
+    uni_root = tmp_path / "uni"
+    _build_catalogue(uni_root)
+    uni_store = _FakeFsStore(uni_root)
+    with (
+        patch.object(janitor, "is_replicated_on_all_backends", _fake_replicated),
+        patch.object(janitor, "is_terminally_abandoned", _fake_abandoned),
+    ):
+        res = await janitor.cleanup_parts_unified(
+            _FakePool(_FakeConn()), uni_store, _redis((DLQ_PROTECTED,)), pressure=0, **walk_kw
+        )
+
+    assert set(uni_store.deleted) == set(ref_store.deleted), "unified deletions must equal the 3-phase union"
+    assert res["tmp"] == ref_tmp
+    # And the reason attribution is correct.
+    assert res["stale_mtime"] == 1  # ORPHAN_STALE
+    assert res["abandoned"] == 1  # ABANDONED
+    assert res["gc"] == 1  # GC_REPLICATED_COLD
+
+    # The survivors really survive on disk.
+    for oid in (PROTECTED_PENDING, HOT_PROTECTED, UNDER_REPLICATED, DLQ_PROTECTED, TMP_SURVIVOR):
+        assert (uni_root / oid / "v1" / "part_1").exists(), f"{oid} must not be deleted"
+    # Orphan tmp files are gone from the survivors that carried them.
+    for oid in (PROTECTED_PENDING, UNDER_REPLICATED, TMP_SURVIVOR):
+        remaining = list((uni_root / oid / "v1" / "part_1").glob("*.tmp.*"))
+        assert remaining == [], f"{oid} orphan tmp must be reaped by the unified walk"
+
+
+@pytest.mark.asyncio
+async def test_unified_walk_dlq_unavailable_skips_stale_but_still_age_gcs(tmp_path: Path, monkeypatch):
+    """Invariant 2 & 3: on a DLQ-read failure the unified walk SKIPS the (non-replication-gated)
+    stale-reap entirely (fail-closed), but STILL performs replication-gated age-GC eviction
+    (fail-open) — a fully-replicated part is safe to evict regardless of DLQ availability."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+
+    root = tmp_path / "t"
+    _build_catalogue(root)
+    store = _FakeFsStore(root)
+
+    async def _raise(_redis):
+        raise janitor.DLQProtectionUnavailable("redis-queues down")
+
+    with (
+        patch.object(janitor, "is_replicated_on_all_backends", _fake_replicated),
+        patch.object(janitor, "is_terminally_abandoned", _fake_abandoned),
+        patch.object(janitor, "get_all_dlq_object_ids", _raise),
+    ):
+        res = await janitor.cleanup_parts_unified(
+            _FakePool(_FakeConn()), store, _redis(), pressure=0, shard=0, shards=1, walk_concurrency=4
+        )
+
+    deleted = set(store.deleted)
+    # Stale-reap is skipped: ORPHAN_STALE and ABANDONED (both non-replicated) survive.
+    assert (ORPHAN_STALE, 1, 1) not in deleted
+    assert (ABANDONED, 1, 1) not in deleted
+    assert res["stale_mtime"] == 0 and res["abandoned"] == 0
+    # Age-GC still runs replication-gate-only: the replicated-cold part is evicted.
+    assert (GC_REPLICATED_COLD, 1, 1) in deleted
+    # DLQ set is empty (unavailable) but DLQ_PROTECTED is replicated + gc-aged, so age-GC evicts it
+    # too — proving age-GC no longer depends on the DLQ dimension when it is down.
+    assert (DLQ_PROTECTED, 1, 1) in deleted
+    assert res["gc"] == 2  # GC_REPLICATED_COLD + DLQ_PROTECTED (no longer DLQ-shielded when DLQ is down)
+    # tmp cleanup is independent of the DB/DLQ and still runs.
+    assert res["tmp"] == EXPECTED_TMP
+
+
+@pytest.mark.asyncio
+async def test_unified_shard_union_equals_unsharded(tmp_path: Path, monkeypatch):
+    """Invariant 9: sharding changes only WHICH objects a cycle visits, never the per-part
+    decision — the union of unified deletions over all shards equals the unsharded unified run."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+
+    # Unsharded reference.
+    ref_root = tmp_path / "ref"
+    _build_catalogue(ref_root)
+    ref_store = _FakeFsStore(ref_root)
+    with (
+        patch.object(janitor, "is_replicated_on_all_backends", _fake_replicated),
+        patch.object(janitor, "is_terminally_abandoned", _fake_abandoned),
+    ):
+        await janitor.cleanup_parts_unified(
+            _FakePool(_FakeConn()), ref_store, _redis((DLQ_PROTECTED,)), pressure=0, shards=1, walk_concurrency=4
+        )
+    ref_deleted = set(ref_store.deleted)
+    assert ref_deleted == EXPECTED_DELETED
+
+    # Sharded: same tree, every shard, deletions accumulated.
+    sh_root = tmp_path / "sh"
+    _build_catalogue(sh_root)
+    sh_store = _FakeFsStore(sh_root)
+    shards = 5
+    with (
+        patch.object(janitor, "is_replicated_on_all_backends", _fake_replicated),
+        patch.object(janitor, "is_terminally_abandoned", _fake_abandoned),
+    ):
+        for s in range(shards):
+            await janitor.cleanup_parts_unified(
+                _FakePool(_FakeConn()),
+                sh_store,
+                _redis((DLQ_PROTECTED,)),
+                pressure=0,
+                shard=s,
+                shards=shards,
+                walk_concurrency=4,
+                publish_sweep=(s == shards - 1),
+            )
+
+    assert set(sh_store.deleted) == ref_deleted, "unified shard union must equal the unsharded unified run"
+
+
+@pytest.mark.asyncio
+async def test_unified_tmp_only_no_part_deletes(tmp_path: Path, monkeypatch):
+    """A tree with nothing deletable but stale orphan tmp files: the unified walk deletes no part
+    yet still reaps the tmp files in the SAME pass (no separate tmp crawl)."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+
+    root = tmp_path / "t"
+    # A single recent, ineligible part carrying an old orphan tmp file.
+    _make_part(root, TMP_SURVIVOR, mtime_ago=10, atime_ago=10, tmp_ago=3600)
+    store = _FakeFsStore(root)
+
+    with (
+        patch.object(janitor, "is_replicated_on_all_backends", _fake_replicated),
+        patch.object(janitor, "is_terminally_abandoned", _fake_abandoned),
+    ):
+        res = await janitor.cleanup_parts_unified(
+            _FakePool(_FakeConn()), store, _redis(), pressure=0, shard=0, shards=1, walk_concurrency=2
+        )
+
+    assert store.deleted == []
+    assert res == {"stale_mtime": 0, "abandoned": 0, "gc": 0, "tmp": 1}
+    assert list((root / TMP_SURVIVOR / "v1" / "part_1").glob("*.tmp.*")) == []

--- a/tests/unit/test_janitor_unified_walk.py
+++ b/tests/unit/test_janitor_unified_walk.py
@@ -313,3 +313,53 @@ async def test_unified_tmp_only_no_part_deletes(tmp_path: Path, monkeypatch):
     assert store.deleted == []
     assert res == {"stale_mtime": 0, "abandoned": 0, "gc": 0, "tmp": 1}
     assert list((root / TMP_SURVIVOR / "v1" / "part_1").glob("*.tmp.*")) == []
+
+
+@pytest.mark.asyncio
+async def test_unified_walk_publishes_census_only_on_full_sweep(tmp_path: Path, monkeypatch):
+    """The unified walk carries the census the old age-GC phase did: `parts_on_disk` + `hot_parts`
+    accumulate across the sharded sweep and publish ONLY on the final untruncated shard. This is
+    the prod path now (the pre-existing census tests exercise the retained standalone age-GC fn),
+    so pin it directly.
+
+    Note a deliberate semantic: the census counts every part the producer SEES, before any delete —
+    so `parts_on_disk` reflects the whole tree (all 8 catalogue parts), including the stale-reapable
+    orphans. The old split census ran age-GC's count AFTER the separate stale phase had already
+    deleted those orphans, so it read lower. Counting at walk-start is the more accurate on-disk
+    figure; the difference is only the (small) stale-reapable set.
+    """
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    root = tmp_path / "t"
+    _build_catalogue(root)  # 8 parts; HOT_PROTECTED is the single hot one (atime==now)
+    store = _FakeFsStore(root)
+    janitor._fs_parts_on_disk = -1  # sentinel: unchanged means "not published"
+    janitor._fs_hot_parts = -1
+    shards = 3
+    with (
+        patch.object(janitor, "is_replicated_on_all_backends", _fake_replicated),
+        patch.object(janitor, "is_terminally_abandoned", _fake_abandoned),
+    ):
+        for s in range(shards - 1):
+            await janitor.cleanup_parts_unified(
+                _FakePool(_FakeConn()),
+                store,
+                _redis((DLQ_PROTECTED,)),
+                pressure=0,
+                shard=s,
+                shards=shards,
+                walk_concurrency=4,
+                publish_sweep=False,
+            )
+        assert janitor._fs_parts_on_disk == -1, "census must not publish mid-sweep"
+        await janitor.cleanup_parts_unified(
+            _FakePool(_FakeConn()),
+            store,
+            _redis((DLQ_PROTECTED,)),
+            pressure=0,
+            shard=shards - 1,
+            shards=shards,
+            walk_concurrency=4,
+            publish_sweep=True,
+        )
+    assert janitor._fs_parts_on_disk == 8, "a completed sweep must publish the whole-tree part count"
+    assert janitor._fs_hot_parts == 1, "the one hot part (HOT_PROTECTED) must be counted"

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -145,9 +145,7 @@ _janitor_cycle_seconds = 0.0
 
 JANITOR_PHASES = (
     "idle",
-    "stale_parts",
-    "gc_age",
-    "orphan_tmp",
+    "parts_unified",
     "soft_deleted",
     "sentinel",
     "aged_orphans",
@@ -379,12 +377,15 @@ class PartDirInfo:
 
 @dataclass
 class WalkState:
-    """Out-of-band result of a walk: whether the wall-clock budget truncated it, and how
-    many object dirs (in this shard) it reached. The census is only trustworthy for a full
-    (untruncated) sweep, so callers check `truncated` before publishing gauges."""
+    """Out-of-band result of a walk: whether the wall-clock budget truncated it, how
+    many object dirs (in this shard) it reached, and how many orphan `.tmp.*` files it
+    unlinked (only when the walk was asked to clean tmp — see `iter_part_dirs`'s
+    `tmp_cutoff`). The census is only trustworthy for a full (untruncated) sweep, so
+    callers check `truncated` before publishing gauges."""
 
     truncated: bool = False
     objects_scanned: int = 0
+    tmp_removed: int = 0
 
 
 def _object_in_shard(object_id: str, shard: int, shards: int) -> bool:
@@ -415,18 +416,48 @@ def _read_dir_batch(scan_it: Any, n: int) -> tuple[list[str], bool]:
     return names, False
 
 
-def _descend_object(root_str: str, object_name: str) -> list[PartDirInfo]:
+def _unlink_old_tmp_files(part_path: str, cutoff: float) -> int:
+    """Unlink `*.tmp.*` files older than `cutoff` directly under one part dir. Returns how many
+    were removed. Every FS error is a skip — the tree mutates underneath us. This is the
+    per-part-dir tmp-reap the standalone tmp walk used, extracted so the unified walk can apply
+    it in the SAME descent that gathers part stats (one visit per part dir, not two)."""
+    removed = 0
+    try:
+        file_scan = os.scandir(part_path)  # noqa: PTH208
+    except OSError:
+        return 0
+    with file_scan:
+        for f in file_scan:
+            if ".tmp." not in f.name:
+                continue
+            try:
+                if not f.is_file():
+                    continue
+                if f.stat().st_mtime > cutoff:
+                    continue
+                os.unlink(f.path)  # noqa: PTH108
+                removed += 1
+            except OSError:
+                continue
+    return removed
+
+
+def _descend_object(root_str: str, object_name: str, tmp_cutoff: float | None = None) -> tuple[list[PartDirInfo], int]:
     """Blocking descent of ONE object dir → its part dirs, run in a walk thread.
 
     Mirrors the serial walk exactly: `v<n>` version dirs, `part_<n>` part dirs, stat
     `meta.json` if present else the part dir. Every FS error is swallowed to a skip — the
-    tree is mutating underneath us. Returns the parts found (possibly empty)."""
+    tree is mutating underneath us. Returns `(parts, tmp_removed)`: the parts found (possibly
+    empty), and — when `tmp_cutoff` is not None — the count of orphan `.tmp.*` files older than
+    the cutoff unlinked from those part dirs (0 when `tmp_cutoff` is None; that keeps the legacy
+    stat-only callers byte-for-byte unchanged)."""
     out: list[PartDirInfo] = []
+    tmp_removed = 0
     obj_path = os.path.join(root_str, object_name)  # noqa: PTH118 — hot walk path, os.* avoids per-entry Path alloc
     try:
-        version_scan = os.scandir(obj_path)
+        version_scan = os.scandir(obj_path)  # noqa: PTH208
     except OSError:
-        return out
+        return out, tmp_removed
     with version_scan:
         for vd in version_scan:
             name = vd.name
@@ -442,7 +473,7 @@ def _descend_object(root_str: str, object_name: str) -> list[PartDirInfo]:
             except ValueError:
                 continue
             try:
-                part_scan = os.scandir(vd.path)
+                part_scan = os.scandir(vd.path)  # noqa: PTH208
             except OSError:
                 continue
             with part_scan:
@@ -455,6 +486,10 @@ def _descend_object(root_str: str, object_name: str) -> list[PartDirInfo]:
                             continue
                     except OSError:
                         continue
+                    # tmp reap runs on every valid part dir, BEFORE the part-number parse guard,
+                    # so it covers the same part dirs the standalone tmp walk did.
+                    if tmp_cutoff is not None:
+                        tmp_removed += _unlink_old_tmp_files(pd.path, tmp_cutoff)
                     try:
                         part_number = int(pname.split("_")[1])
                     except (ValueError, IndexError):
@@ -468,7 +503,7 @@ def _descend_object(root_str: str, object_name: str) -> list[PartDirInfo]:
                         except OSError:
                             continue
                     out.append(PartDirInfo(object_name, object_version, part_number, st.st_mtime, st.st_atime))
-    return out
+    return out, tmp_removed
 
 
 async def _stream_shard_object_names(
@@ -508,6 +543,7 @@ async def iter_part_dirs(
     shards: int,
     deadline: float | None,
     state: WalkState,
+    tmp_cutoff: float | None = None,
 ) -> AsyncIterator[PartDirInfo]:
     """Walk `root` and yield every part dir in the current shard, descending object dirs
     across a bounded thread pool so many CephFS metadata roundtrips are in flight at once.
@@ -517,25 +553,34 @@ async def iter_part_dirs(
     on prod). Callers apply their own per-part gating + census to the yielded records; the
     deletion logic downstream is unchanged.
 
+    When `tmp_cutoff` is not None the SAME descent also unlinks orphan `.tmp.*` files older
+    than the cutoff from every part dir it visits, accumulating the count into
+    `state.tmp_removed` — so the unified walk folds the old standalone tmp sweep into this one
+    pass instead of a third full-tree crawl. `None` leaves the walk stat-only (legacy callers).
+
     `concurrency<=1` degrades to a serial descent (legacy behaviour, one object at a time).
     """
     concurrency = max(1, concurrency)
     root_str = str(root)
     loop = asyncio.get_running_loop()
     executor = ThreadPoolExecutor(max_workers=concurrency, thread_name_prefix="janitor-walk")
-    inflight: set[asyncio.Future[list[PartDirInfo]]] = set()
+    inflight: set[asyncio.Future[tuple[list[PartDirInfo], int]]] = set()
     try:
         async for name in _stream_shard_object_names(root_str, shard, shards, deadline, state):
-            inflight.add(loop.run_in_executor(executor, _descend_object, root_str, name))
+            inflight.add(loop.run_in_executor(executor, _descend_object, root_str, name, tmp_cutoff))
             if len(inflight) >= concurrency:
                 done, inflight = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
                 for fut in done:
-                    for info in fut.result():
+                    parts, tmp_removed = fut.result()
+                    state.tmp_removed += tmp_removed
+                    for info in parts:
                         yield info
         while inflight:
             done, inflight = await asyncio.wait(inflight, return_when=asyncio.FIRST_COMPLETED)
             for fut in done:
-                for info in fut.result():
+                parts, tmp_removed = fut.result()
+                state.tmp_removed += tmp_removed
+                for info in parts:
                     yield info
     finally:
         for fut in inflight:
@@ -818,6 +863,81 @@ async def get_all_dlq_object_ids(redis_client: Redis) -> set[str]:
     return object_ids
 
 
+def _stale_fs_eligible(
+    mtime: float,
+    mtime_cutoff: float,
+    object_id: str,
+    dlq_available: bool,
+    dlq_object_ids: set[str],
+) -> bool:
+    """FS-level stale-reap gate (byte-for-byte the stale phase's producer filter).
+
+    A part is a stale-reap candidate iff the DLQ protection set is available (fail-CLOSED:
+    with no complete DLQ set we never reap the non-replication-gated stale path), its
+    meta/dir mtime is older than the stale threshold, and its object is not DLQ-protected.
+    The DB 3-state decision (`_stale_reap_decision`) is only consulted for parts that pass here.
+    """
+    if not dlq_available:
+        return False
+    if mtime > mtime_cutoff:
+        return False
+    return object_id not in dlq_object_ids
+
+
+async def _stale_reap_decision(
+    conn: asyncpg.Connection,
+    object_id: str,
+    object_version: int,
+    part_number: int,
+    stale_threshold_seconds: int,
+) -> tuple[bool, bool]:
+    """The stale phase's DB-side 3-state decision, extracted VERBATIM so the unified walk and
+    the standalone `cleanup_stale_parts` share one implementation.
+
+    Returns `(should_delete, abandoned)`:
+      row is None        → no `parts` row → orphan → reap  → (True, False).
+      row["recent"] true → row exists, recently written    → keep → (False, False).
+      row old + replicated → safe to reap (fully backed up)→ (True, False).
+      row old + not replicated:
+          terminally-abandoned (failed + unservable)       → reclaim → (True, True).
+          otherwise (pending/in-flight/aborted)            → protect → (False, False).
+    Any DB error is conservative: (False, False) — never delete on an incomplete read.
+    """
+    cutoff_sql = "NOW() - INTERVAL '1 second' * $4"
+    abandoned = False
+    try:
+        row = await conn.fetchrow(
+            """
+            SELECT (uploaded_at > """
+            + cutoff_sql
+            + """) AS recent
+            FROM parts
+            WHERE object_id = $1 AND object_version = $2 AND part_number = $3
+            LIMIT 1""",
+            object_id,
+            object_version,
+            part_number,
+            stale_threshold_seconds,
+        )
+        if row is not None:
+            if row["recent"]:
+                return (False, False)
+            if not await is_replicated_on_all_backends(conn, object_id, object_version, part_number):
+                # Not replicated → normally protect (pending / in-flight / aborted).
+                # The ONE exception: a terminally-abandoned upload — the reaper or an
+                # abort marked the part 'failed' AND its version is unservable. The
+                # drain never re-claims a 'failed' part, so its pool bytes leak
+                # forever otherwise; an unservable version can never be served by a
+                # GET, so reclaiming is safe (see is_terminally_abandoned).
+                if not await is_terminally_abandoned(conn, object_id, object_version, part_number):
+                    return (False, False)
+                abandoned = True
+    except Exception:
+        # If any DB check fails, be extra conservative: skip deletion
+        return (False, False)
+    return (True, abandoned)
+
+
 async def cleanup_stale_parts(
     pool: asyncpg.Pool,
     fs_store: FileSystemPartsStore,
@@ -841,7 +961,6 @@ async def cleanup_stale_parts(
     it descends only this cycle's shard and stops at `deadline`. Deletion logic is unchanged.
     """
     stale_threshold_seconds = config.mpu_stale_seconds
-    cutoff_sql = "NOW() - INTERVAL '1 second' * $4"
 
     try:
         dlq_object_ids = await get_all_dlq_object_ids(redis_client)
@@ -871,69 +990,22 @@ async def cleanup_stale_parts(
             deadline=deadline,
             state=walk_state,
         ):
-            if part.mtime > mtime_cutoff:
-                # Recently touched, skip
+            # dlq_available=True: we only reach here when get_all_dlq_object_ids succeeded
+            # (the fail-closed early-return above handles the unavailable case).
+            if not _stale_fs_eligible(part.mtime, mtime_cutoff, part.object_id, True, dlq_object_ids):
                 continue
-
-            # Skip deletion if object is in DLQ
-            if part.object_id in dlq_object_ids:
-                logger.debug(
-                    f"Skipping DLQ-protected part: object_id={part.object_id} "
-                    f"v={part.object_version} part={part.part_number}"
-                )
-                continue
-
             yield (part.object_id, part.object_version, part.part_number)
 
     async def handle(conn: asyncpg.Connection, item: tuple[str, int, int]) -> bool:
         object_id, object_version, part_number = item
 
-        # Decide, in one query, which of three states this part is in:
-        #   row is None        → no `parts` row at all. The object's DB rows are
-        #                        gone (Phase 4 hard-delete cascades parts →
-        #                        part_chunks → chunk_backend) or this is orphaned
-        #                        FS with no record. mtime>1d already rules out an
-        #                        in-flight write (chunks land before the parts
-        #                        row), so it is safe to reap → fall through.
-        #   row["recent"] true → row exists and was (re)written recently → leave it.
-        #   row["recent"] false→ row exists but is old → only reap once every chunk
-        #                        is replicated to every required backend. A
-        #                        not-yet-replicated part is a pending or aborted
-        #                        upload and must be protected (no data loss) — with
-        #                        ONE exception, the terminally-abandoned upload below.
-        # Distinguishing "no DB row" (orphan, reap) from "DB row but not replicated"
-        # (pending, protect) is what keeps deleted-object cache cleanup working
-        # without ever deleting data that hasn't been backed up.
-        abandoned = False
-        try:
-            row = await conn.fetchrow(
-                """
-                SELECT (uploaded_at > """
-                + cutoff_sql
-                + """) AS recent
-                FROM parts
-                WHERE object_id = $1 AND object_version = $2 AND part_number = $3
-                LIMIT 1""",
-                object_id,
-                object_version,
-                part_number,
-                stale_threshold_seconds,
-            )
-            if row is not None:
-                if row["recent"]:
-                    return False
-                if not await is_replicated_on_all_backends(conn, object_id, object_version, part_number):
-                    # Not replicated → normally protect (pending / in-flight / aborted).
-                    # The ONE exception: a terminally-abandoned upload — the reaper or an
-                    # abort marked the part 'failed' AND its version is unservable. The
-                    # drain never re-claims a 'failed' part, so its pool bytes leak
-                    # forever otherwise; an unservable version can never be served by a
-                    # GET, so reclaiming is safe (see is_terminally_abandoned).
-                    if not await is_terminally_abandoned(conn, object_id, object_version, part_number):
-                        return False
-                    abandoned = True
-        except Exception:
-            # If any DB check fails, be extra conservative: skip deletion
+        # Decide, in one query, which of three states this part is in (see
+        # _stale_reap_decision): no `parts` row → orphan → reap; recent row → keep;
+        # old row → reap only if fully replicated, or terminally-abandoned when not.
+        should_delete, abandoned = await _stale_reap_decision(
+            conn, object_id, object_version, part_number, stale_threshold_seconds
+        )
+        if not should_delete:
             return False
 
         try:
@@ -1167,23 +1239,7 @@ def _descend_object_tmp(root_str: str, object_name: str, cutoff: float) -> int:
                             continue
                     except OSError:
                         continue
-                    try:
-                        file_scan = os.scandir(pd.path)
-                    except OSError:
-                        continue
-                    with file_scan:
-                        for f in file_scan:
-                            if ".tmp." not in f.name:
-                                continue
-                            try:
-                                if not f.is_file():
-                                    continue
-                                if f.stat().st_mtime > cutoff:
-                                    continue
-                                os.unlink(f.path)  # noqa: PTH108
-                                removed += 1
-                            except OSError:
-                                continue
+                    removed += _unlink_old_tmp_files(pd.path, cutoff)
     return removed
 
 
@@ -1235,6 +1291,45 @@ async def cleanup_orphan_tmp_files(
     if removed > 0:
         logger.info(f"Janitor removed {removed} orphan tmp files (shard={shard}/{shards} truncated={state.truncated})")
     return removed
+
+
+def _age_gc_decision(
+    mtime: float,
+    atime: float,
+    now: float,
+    hot_window: float,
+    cutoff_time: float,
+    pressure: int,
+    is_dlq_protected: bool,
+) -> tuple[bool, bool, bool]:
+    """The age-GC phase's FS-level eligibility gate, extracted VERBATIM so the unified walk and
+    the standalone `cleanup_old_parts_by_mtime` share one rule.
+
+    Returns `(is_hot, gc_candidate, old_enough)`:
+    - is_hot: atime within the pressure-adjusted hot-retention window (computed for census even
+      when the part is skipped — hot parts are counted regardless of DLQ/eligibility).
+    - gc_candidate: passes all FS gates → hand to the worker's replication check. False when
+      DLQ-protected, hot, or (under normal pressure) not yet old enough.
+    - old_enough: mtime older than the GC max-age cutoff (for logging).
+
+    The replication gate itself is NOT here — it is the absolute DB check the worker applies to
+    every gc_candidate. This gate only decides which replicated parts are ELIGIBLE, never
+    overriding replication.
+    """
+    is_hot = hot_window > 0 and atime > (now - hot_window)
+    if is_dlq_protected:
+        return (is_hot, False, False)
+    # Hot files are protected. Under critical pressure hot_window is 0, which forces
+    # is_hot=False, letting fully-replicated parts become eligible even if recently read.
+    if is_hot:
+        return (is_hot, False, False)
+    # A fully-replicated, cold, non-DLQ part is safe to evict. Under normal pressure we
+    # additionally require age > cutoff so we don't thrash; under any pressure level we evict
+    # replicated cold parts regardless of age. The replication gate is enforced in the worker.
+    old_enough = mtime < cutoff_time
+    if pressure == 0 and not old_enough:
+        return (is_hot, False, False)
+    return (is_hot, True, old_enough)
 
 
 async def cleanup_old_parts_by_mtime(
@@ -1374,27 +1469,12 @@ async def cleanup_old_parts_by_mtime(
                 part_age = now - mtime
                 stats["age_counts"][_classify_age_bucket(part_age)] += 1
 
-                is_hot = hot_window > 0 and atime > (now - hot_window)
+                is_hot, gc_candidate, old_enough = _age_gc_decision(
+                    mtime, atime, now, hot_window, cutoff_time, pressure, is_dlq_protected
+                )
                 if is_hot:
                     stats["hot_parts"] += 1
-
-                # Don't clean DLQ-protected parts (only count them for metrics)
-                if is_dlq_protected:
-                    continue
-
-                # Hot files are protected. Under critical pressure
-                # hot_window is 0, which forces is_hot=False, letting
-                # fully-replicated parts become eligible even if recently read.
-                if is_hot:
-                    continue
-
-                # A fully-replicated, cold, non-DLQ part is safe to evict.
-                # Under normal pressure we additionally require age > cutoff
-                # so we don't thrash. Under any pressure level we evict
-                # replicated cold parts regardless of age. The replication
-                # gate itself is enforced in the worker below.
-                old_enough = mtime < cutoff_time
-                if pressure == 0 and not old_enough:
+                if not gc_candidate:
                     continue
             except Exception as e:
                 logger.warning(
@@ -1467,6 +1547,270 @@ async def cleanup_old_parts_by_mtime(
         )
 
     return parts_cleaned
+
+
+@dataclass(frozen=True)
+class _UnifiedCandidate:
+    """One part the unified walk found that qualifies for AT LEAST one deletion rule. The two
+    `*_candidate` flags carry the FS-level pre-decision so the worker only runs the DB checks a
+    part actually needs; a part can qualify for both (deleted once, stale attributed first)."""
+
+    object_id: str
+    object_version: int
+    part_number: int
+    stale_candidate: bool
+    gc_candidate: bool
+    gc_old_enough: bool
+
+
+async def cleanup_parts_unified(
+    pool: asyncpg.Pool,
+    fs_store: FileSystemPartsStore,
+    redis_client: Redis,
+    *,
+    pressure: int,
+    shard: int = 0,
+    shards: int = 1,
+    walk_concurrency: int = 1,
+    deadline: float | None = None,
+    publish_sweep: bool = True,
+) -> dict[str, int]:
+    """ONE FS walk that applies all three old FS-walk phases per part dir.
+
+    This collapses `cleanup_stale_parts` + `cleanup_old_parts_by_mtime` + `cleanup_orphan_tmp_files`
+    — which each independently crawled the whole shard via `iter_part_dirs` — into a single pass.
+    On prod that turned a 3× metadata crawl of a ~15.6M-object CephFS tree (contending with live
+    GET/PUT on the MDS) into 1×, for the same coverage. The WALK is unified; the deletion RULES are
+    the SAME byte-for-byte helpers the standalone phases use:
+      - stale-reap:  `_stale_fs_eligible` (producer) + `_stale_reap_decision` (worker).
+      - age-GC:      `_age_gc_decision` (producer) + `is_replicated_on_all_backends` (worker).
+      - tmp:         `_unlink_old_tmp_files`, folded into the walk via `iter_part_dirs(tmp_cutoff=)`.
+      - census:      accumulated in the producer, published only on an untruncated full sweep.
+
+    A part is deleted if EITHER the stale rule OR the age-GC rule fires; both are evaluated and it
+    is deleted once, attributing the correct reason (abandoned / stale_mtime / gc_age). The one
+    walk gets ONE budget (`deadline`), unbounded at Critical — that is the ~3× cycle-time win.
+
+    DLQ semantics (invariants 2 & 3): the protection set is fetched ONCE.
+      - On success: stale-reap requires the object be absent from it; age-GC honours it too.
+      - On DLQProtectionUnavailable: stale-reap is SKIPPED entirely this cycle (fail-CLOSED),
+        while age-GC still runs replication-gate-only (fail-OPEN) — a fully-replicated part is
+        safe to evict regardless of any DLQ entry.
+
+    Returns a dict of per-reason delete counts plus tmp: {stale_mtime, abandoned, gc, tmp}.
+    """
+    root = fs_store.root
+    if not root.exists():
+        return {"stale_mtime": 0, "abandoned": 0, "gc": 0, "tmp": 0}
+
+    stale_threshold_seconds = config.mpu_stale_seconds
+    max_age_seconds = config.fs_cache_gc_max_age_seconds
+    logger.info(
+        "Unified janitor walk: stale_threshold=%ds gc_max_age=%ds tmp_max_age=%ds pressure=%d (replication-gated)",
+        stale_threshold_seconds,
+        max_age_seconds,
+        TMP_FILE_MAX_AGE_SECONDS,
+        pressure,
+    )
+
+    # A15/C1: one DLQ fetch drives both rules. dlq_available=False means the stale-reap path is
+    # skipped this cycle (fail-closed); age-GC proceeds against an empty set (fail-open) — its
+    # replication gate is the hard safety net.
+    dlq_available = True
+    try:
+        dlq_object_ids = await get_all_dlq_object_ids(redis_client)
+    except DLQProtectionUnavailable as exc:
+        logger.error(
+            "DLQ protection unavailable — stale-reap SKIPPED this cycle (fail-closed); "
+            "age-GC falls back to replication-gate-only eviction: %s",
+            exc,
+        )
+        dlq_object_ids = set()
+        dlq_available = False
+    if dlq_object_ids:
+        logger.info(f"Protecting {len(dlq_object_ids)} DLQ objects from the unified walk")
+
+    now = time.time()
+    mtime_cutoff = now - stale_threshold_seconds
+    cutoff_time = now - max_age_seconds
+    tmp_cutoff = now - TMP_FILE_MAX_AGE_SECONDS
+    hot_window = _effective_hot_retention(pressure)
+    if pressure > 0:
+        logger.warning(
+            f"Disk pressure={pressure} ({'elevated' if pressure == 1 else 'critical'}); hot_window={hot_window}s"
+        )
+
+    stats: dict[str, Any] = {
+        "parts_seen": 0,
+        "hot_parts": 0,
+        "oldest_mtime": None,
+        "age_counts": dict.fromkeys(AGE_BUCKET_NAMES, 0),
+    }
+    reason_counts = {"stale_mtime": 0, "abandoned": 0, "gc": 0}
+    walk_state = WalkState()
+
+    async def candidates() -> AsyncIterator[_UnifiedCandidate]:
+        async for part in iter_part_dirs(
+            root,
+            concurrency=walk_concurrency,
+            shard=shard,
+            shards=shards,
+            deadline=deadline,
+            state=walk_state,
+            tmp_cutoff=tmp_cutoff,  # folds the old orphan-tmp sweep into this one walk
+        ):
+            object_id = part.object_id
+            object_version = part.object_version
+            part_number = part.part_number
+            is_dlq_protected = object_id in dlq_object_ids
+
+            stats["parts_seen"] += 1
+            try:
+                mtime = part.mtime
+                atime = part.atime
+                if stats["oldest_mtime"] is None or mtime < stats["oldest_mtime"]:
+                    stats["oldest_mtime"] = mtime
+                stats["age_counts"][_classify_age_bucket(now - mtime)] += 1
+
+                # Age-GC gate (also yields is_hot for the census — counted for every part,
+                # even DLQ-protected/hot ones, exactly as the standalone census did).
+                is_hot, gc_candidate, gc_old_enough = _age_gc_decision(
+                    mtime, atime, now, hot_window, cutoff_time, pressure, is_dlq_protected
+                )
+                if is_hot:
+                    stats["hot_parts"] += 1
+
+                # Stale-reap gate (mtime-only; does NOT honour hot retention, matching the
+                # standalone stale phase). Skipped wholesale when the DLQ set is unavailable.
+                stale_candidate = _stale_fs_eligible(mtime, mtime_cutoff, object_id, dlq_available, dlq_object_ids)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to classify part object_id={object_id} v={object_version} part={part_number}: {e}"
+                )
+                continue
+
+            if not stale_candidate and not gc_candidate:
+                continue
+            yield _UnifiedCandidate(
+                object_id, object_version, part_number, stale_candidate, gc_candidate, gc_old_enough
+            )
+
+    async def handle(conn: asyncpg.Connection, item: _UnifiedCandidate) -> bool:
+        # Evaluate stale-reap FIRST (matches the old serial order: stale phase ran before age-GC,
+        # so a part deletable by both is attributed to stale). If stale protects it, fall through
+        # to age-GC — a not-replicated part is protected by both, a stale-recent-but-replicated
+        # part is still an age-GC delete.
+        if item.stale_candidate:
+            should_delete, abandoned = await _stale_reap_decision(
+                conn, item.object_id, item.object_version, item.part_number, stale_threshold_seconds
+            )
+            if should_delete:
+                try:
+                    await fs_store.delete_part(item.object_id, item.object_version, item.part_number)
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to clean part: object_id={item.object_id} "
+                        f"v={item.object_version} part={item.part_number}: {e}"
+                    )
+                    return False
+                if abandoned:
+                    logger.info(
+                        "Reclaimed terminally-abandoned part (failed+unservable): "
+                        f"object_id={item.object_id} v={item.object_version} part={item.part_number}"
+                    )
+                    reason_counts["abandoned"] += 1
+                    if _janitor_abandoned_deleted_counter is not None:
+                        _janitor_abandoned_deleted_counter.add(1)
+                    if _janitor_deleted_counter is not None:
+                        _janitor_deleted_counter.add(1, attributes={"reason": "abandoned"})
+                else:
+                    logger.info(
+                        f"Cleaned stale part by mtime: object_id={item.object_id} "
+                        f"v={item.object_version} part={item.part_number}"
+                    )
+                    reason_counts["stale_mtime"] += 1
+                    if _janitor_deleted_counter is not None:
+                        _janitor_deleted_counter.add(1, attributes={"reason": "stale_mtime"})
+                return True
+
+        if item.gc_candidate:
+            # ABSOLUTE safety gate: never delete non-replicated data.
+            try:
+                fully_replicated = await is_replicated_on_all_backends(
+                    conn, item.object_id, item.object_version, item.part_number
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Replication check failed for {item.object_id} v{item.object_version} part{item.part_number}: {e}"
+                )
+                return False
+            if not fully_replicated:
+                return False
+            try:
+                await fs_store.delete_part(item.object_id, item.object_version, item.part_number)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to clean part: object_id={item.object_id} "
+                    f"v={item.object_version} part={item.part_number}: {e}"
+                )
+                return False
+            logger.info(
+                f"GC cleaned part: object_id={item.object_id} v={item.object_version} part={item.part_number} "
+                f"replicated=True pressure={pressure} old_enough={item.gc_old_enough}"
+            )
+            reason_counts["gc"] += 1
+            if _janitor_deleted_counter is not None:
+                _janitor_deleted_counter.add(1, attributes={"reason": "gc_age"})
+            return True
+
+        return False
+
+    parts_cleaned = await _run_worker_pool(pool, candidates(), handle, config.janitor_concurrency)
+
+    # Census: accumulated across the sharded sweep, published only on an untruncated full sweep.
+    # A sweep starts at shard 0, so reset the accumulator there (bounds it to one sweep even if
+    # `shards` changed mid-sweep). Pressure is a per-cycle fact — publish it every call.
+    global _fs_pressure_mode
+    _fs_pressure_mode = pressure
+    if shard == 0:
+        _reset_census_accum()
+    _accumulate_census(stats, shard_complete=not walk_state.truncated)
+    if publish_sweep:
+        _publish_census(now)
+
+    tmp_removed = walk_state.tmp_removed
+    if tmp_removed > 0 and _janitor_tmp_deleted_counter is not None:
+        _janitor_tmp_deleted_counter.add(tmp_removed)
+
+    logger.info(
+        "Unified walk cleaned: stale=%d abandoned=%d gc=%d tmp=%d hot_parts=%d parts_seen=%d "
+        "(shard=%d/%d objects_scanned=%d truncated=%s pressure=%d)",
+        reason_counts["stale_mtime"],
+        reason_counts["abandoned"],
+        reason_counts["gc"],
+        tmp_removed,
+        stats["hot_parts"],
+        stats["parts_seen"],
+        shard,
+        shards,
+        walk_state.objects_scanned,
+        walk_state.truncated,
+        pressure,
+    )
+
+    # Critical pressure but nothing freed: every remaining part is hot (ignored under critical —
+    # nothing to free) or non-replicated (we refuse to delete). parts_cleaned counts BOTH stale
+    # and age-GC part deletions, so this fires only when the walk genuinely freed no part space.
+    if pressure == 2 and parts_cleaned == 0 and stats["parts_seen"] > 0:
+        logger.error(
+            "JANITOR_CRITICAL_PRESSURE_BLOCKED parts_seen=%d hot_parts=%d — "
+            "disk is >=95%% full but all remaining parts are non-replicated. "
+            "Operator action required; refusing to delete unreplicated data.",
+            stats["parts_seen"],
+            stats["hot_parts"],
+        )
+
+    return {**reason_counts, "tmp": tmp_removed}
 
 
 async def gc_soft_deleted_objects(pool: asyncpg.Pool) -> int:
@@ -1546,7 +1890,7 @@ async def run_janitor_loop():
             # They are single indexed DB reads; nothing about the FS cache should gate them.
             sentinel_violations = 0
             try:
-                _janitor_phase = 5  # sentinel
+                _janitor_phase = 3  # sentinel
                 sentinel_violations = await check_replication_sentinel(db_pool, pressure)
             except Exception as e:
                 logger.error(f"Replication sentinel error: {e}", exc_info=True)
@@ -1557,7 +1901,7 @@ async def run_janitor_loop():
             # holds its prior value) rather than over-counting against an empty set.
             aged_orphans = 0
             try:
-                _janitor_phase = 6  # aged_orphans
+                _janitor_phase = 4  # aged_orphans
                 gauge_dlq_object_ids = await get_all_dlq_object_ids(redis_client)
                 aged_orphans = await check_aged_pending_orphans(db_pool, gauge_dlq_object_ids)
             except Exception as e:
@@ -1574,59 +1918,40 @@ async def run_janitor_loop():
             budget = config.janitor_walk_budget_seconds
 
             stale_count = 0
+            abandoned_count = 0
             gc_count = 0
             tmp_count = 0
             hard_deleted = 0
 
-            # Phase A: clean stale/orphan/terminally-abandoned parts (each phase gets its OWN
-            # fresh budget so the first walk can't starve the second — the bug we are fixing).
+            # Phase A (UNIFIED): ONE FS walk applies stale-reap + age-GC + census + orphan-tmp per
+            # part dir. This replaces the three separate full-tree walks that each independently
+            # crawled the shard (3× the CephFS MDS metadata load, ~3× the cycle time); the deletion
+            # RULES are unchanged (shared helpers), only the WALK is merged. The single walk gets
+            # ONE budget, unbounded at Critical — that is the ~3× cycle-time win.
             try:
-                _janitor_phase = 1  # stale_parts
-                stale_count = await cleanup_stale_parts(
+                _janitor_phase = 1  # parts_unified
+                unified = await cleanup_parts_unified(
                     db_pool,
                     fs_store,
                     redis_client,
-                    shard=walk_shard,
-                    shards=shards,
-                    walk_concurrency=walk_conc,
-                    deadline=_walk_deadline(loop, pressure, budget),
-                )
-            except Exception as e:
-                logger.error(f"Stale cleanup error: {e}", exc_info=True)
-
-            # Phase B: replication-gated age GC + census (census published only on a full sweep).
-            try:
-                _janitor_phase = 2  # gc_age
-                gc_count = await cleanup_old_parts_by_mtime(
-                    db_pool,
-                    fs_store,
-                    redis_client,
+                    pressure=pressure,
                     shard=walk_shard,
                     shards=shards,
                     walk_concurrency=walk_conc,
                     deadline=_walk_deadline(loop, pressure, budget),
                     publish_sweep=publish_sweep,
                 )
+                stale_count = unified["stale_mtime"]
+                abandoned_count = unified["abandoned"]
+                gc_count = unified["gc"]
+                tmp_count = unified["tmp"]
             except Exception as e:
-                logger.error(f"Age-GC error: {e}", exc_info=True)
-
-            # Phase C: orphan .tmp.* files from crashed atomic writes.
-            try:
-                _janitor_phase = 3  # orphan_tmp
-                tmp_count = await cleanup_orphan_tmp_files(
-                    fs_store,
-                    shard=walk_shard,
-                    shards=shards,
-                    walk_concurrency=walk_conc,
-                    deadline=_walk_deadline(loop, pressure, budget),
-                )
-            except Exception as e:
-                logger.error(f"Tmp cleanup error: {e}", exc_info=True)
+                logger.error(f"Unified parts cleanup error: {e}", exc_info=True)
 
             # Phase D: hard-delete soft-deleted objects where all unpins are confirmed (DB-bound,
             # batch-capped — cannot starve the cycle).
             try:
-                _janitor_phase = 4  # soft_deleted
+                _janitor_phase = 2  # soft_deleted
                 hard_deleted = await gc_soft_deleted_objects(db_pool)
             except Exception as e:
                 logger.error(f"Hard delete error: {e}", exc_info=True)
@@ -1635,8 +1960,9 @@ async def run_janitor_loop():
 
             logger.info(
                 f"Janitor cycle complete: shard={walk_shard}/{shards} publish_sweep={publish_sweep} "
-                f"stale={stale_count} gc={gc_count} tmp={tmp_count} hard_deleted={hard_deleted} "
-                f"sentinel_violations={sentinel_violations} aged_orphans={aged_orphans}"
+                f"stale={stale_count} abandoned={abandoned_count} gc={gc_count} tmp={tmp_count} "
+                f"hard_deleted={hard_deleted} sentinel_violations={sentinel_violations} "
+                f"aged_orphans={aged_orphans}"
             )
 
             _janitor_cycle_seconds = time.time() - _cycle_started


### PR DESCRIPTION
## Summary

The janitor ran **three** separate full-tree FS walks per cycle — `cleanup_stale_parts`, `cleanup_old_parts_by_mtime` (age-GC + census), and `cleanup_orphan_tmp_files` — and **each** independently crawled the shard via `iter_part_dirs`. On prod that metadata-crawls a ~15.6M-object CephFS tree **3× per cycle** over the same MDS that also serves live GET/PUT (cycle ~26 min).

This PR merges them into a single `cleanup_parts_unified()` that walks each part dir **once** and applies all three phases' logic per part — targeting **~3× less MDS load** and **~3× shorter cycle** for identical coverage.

## The walk is unified; the deletion rules are byte-for-byte identical

The per-part decision logic of each phase was extracted into small helpers and reused **verbatim** by both the standalone phase functions (kept, for their existing direct unit tests) and the unified path:

- **stale-reap:** `_stale_fs_eligible` (producer gate) + `_stale_reap_decision` (DB 3-state).
- **age-GC:** `_age_gc_decision` (FS gate) + `is_replicated_on_all_backends` (absolute replication gate).
- **tmp:** `_unlink_old_tmp_files`, folded into the walk via a new `tmp_cutoff` param on `iter_part_dirs`/`_descend_object` (accumulated into `WalkState.tmp_removed`) — unlinked during the walk, before the delete worker pool runs.

A part is deleted if **either** the stale rule **or** the age-GC rule fires; both are evaluated, it is deleted **once**, and the correct reason is attributed to the counter (`abandoned` / `stale_mtime` / `gc_age`). Stale is evaluated first, matching the old serial phase order. The single walk gets **one** budget (`janitor_walk_budget_seconds`), unbounded at Critical — that is the cycle-time win.

## Invariants preserved

- Replication gate **absolute** for age-GC (never delete un-replicated data; terminally-abandoned exception unchanged).
- Stale-reap DLQ = **fail-closed**; age-GC DLQ = **fail-open** (replication-gate-only) — threaded via a single `dlq_available` flag off one DLQ fetch.
- Stale 3-state DB logic, hot-retention pressure adjustment, sweep-scoped census (publish only on an untruncated full sweep, reset at shard 0), sharding-union, bounded worker-pool deletes, and all reason counters — all unchanged.
- The DB-only durability phases (sentinel, aged-orphan gauge) still run first, untouched. `JANITOR_PHASES` renumbered (idle=0, parts_unified=1, soft_deleted=2, sentinel=3, aged_orphans=4).

## Changes (largest first)

- `workers/run_janitor_in_loop.py`: new `cleanup_parts_unified()`; extracted `_stale_fs_eligible`, `_stale_reap_decision`, `_age_gc_decision`, `_unlink_old_tmp_files`; `tmp_cutoff` threaded through `iter_part_dirs`/`_descend_object`; `WalkState.tmp_removed`; refactored the 3 old phase functions onto the shared helpers; `run_janitor_loop` now makes one unified call.
- `tests/unit/test_janitor_unified_walk.py` (new): **union-equivalence** test — the unified walk deletes EXACTLY the set (and reaps exactly the tmp files) the three phases delete when run in sequence, across stale orphans, terminally-abandoned, replicated-cold age-GC, hot-protected (kept), under-replicated (protected), DLQ-protected (kept), and `.tmp.*` files. Plus a DLQ-unavailable test (stale skipped, age-GC still evicts), a shard-union test, and a tmp-only test.
- `tests/unit/test_janitor_sharded_gc.py`, `tests/unit/test_janitor_concurrency.py`: adapted the loop-level tests to the single unified call.

## Tests

`pytest tests/unit/ -k janitor` → **114 passed**. `ruff check`/`format` clean on changed files; `ty check` clean apart from the pre-existing `redis.lrange`/`wait_for` diagnostic.

## Impact

~3× reduction in janitor CephFS MDS metadata load and ~3× shorter cycle for the same coverage; deletion behavior is unchanged and pinned by the union-equivalence test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)