### PR TITLE
Fix System Resources cache metrics; add Gateway Type/s + Ceph pool usage

### DIFF
--- a/hippius_s3/metrics_collector_task.py
+++ b/hippius_s3/metrics_collector_task.py
@@ -14,6 +14,22 @@ from hippius_s3.monitoring import MetricsCollector
 logger = logging.getLogger(__name__)
 
 
+def _redis_memory(info: dict) -> tuple[int, int]:
+    """`(used_memory, maxmemory)` from an INFO reply, for a single node OR a cluster.
+
+    A single `Redis` returns a flat mapping. A `RedisCluster` fans INFO out to every primary and
+    returns one mapping PER NODE, keyed by node name — so the flat `info["used_memory"]` lookup
+    silently yielded 0 and the redis-memory gauge read empty for every cluster-backed pod. Sum the
+    per-node values so the gauge reports the cluster as a whole; `maxmemory` sums too, since the
+    cap that matters is the cluster's aggregate headroom. Nodes missing the field contribute 0.
+    """
+    per_node = bool(info) and all(isinstance(v, dict) for v in info.values())
+    nodes = list(info.values()) if per_node else [info]
+    used = sum(int(n.get("used_memory", 0) or 0) for n in nodes)
+    cap = sum(int(n.get("maxmemory", 0) or 0) for n in nodes)
+    return used, cap
+
+
 class BackgroundMetricsCollector:
     """Background task for collecting custom metrics from Redis and other sources."""
 
@@ -101,9 +117,7 @@ class BackgroundMetricsCollector:
             # `noeviction`, so once it fills EVERY write fails — the sole-producer upload LPUSH,
             # the chunk pub/sub, and the cephor:* coordination keys — a pipeline-wide cascade.
             # (The old code read the main redis, whose fullness is harmless — it just evicts.)
-            info = await rc.info("memory")
-            used_mem = int(info.get("used_memory", 0) or 0)
-            max_mem = int(info.get("maxmemory", 0) or 0)
+            used_mem, max_mem = _redis_memory(await rc.info("memory"))
             self.metrics_collector._used_mem = used_mem
             self.metrics_collector._max_mem = max_mem
             if max_mem > 0:

--- a/k8s/base/grafana-dashboards.yaml
+++ b/k8s/base/grafana-dashboards.yaml
@@ -28,6 +28,164 @@ data:
       "links": [],
       "panels": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 8,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "2xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "3xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#EAB839",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "4xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "5xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 96,
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "expr": "sum by (class) (label_replace(rate(http_requests_total{service_namespace=\"$namespace\", handler=~\"gateway.*\"}[5m]), \"class\", \"${1}xx\", \"status_code\", \"([0-9])[0-9][0-9]\"))",
+              "legendFormat": "{{class}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Gateway Type/s",
+          "type": "timeseries",
+          "description": "Gateway request rate collapsed into HTTP status classes (2xx/3xx/4xx/5xx), one line each. Individual status codes are in \"Gateway req/s\" below; this is the at-a-glance health shape."
+        },
+        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
@@ -106,7 +264,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 1
+            "y": 9
           },
           "id": 2,
           "options": {
@@ -199,7 +357,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 1
+            "y": 9
           },
           "id": 3,
           "options": {
@@ -292,7 +450,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 1
+            "y": 9
           },
           "id": 4,
           "options": {
@@ -390,7 +548,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 1
+            "y": 9
           },
           "id": 5,
           "options": {
@@ -483,7 +641,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 9
+            "y": 17
           },
           "id": 6,
           "options": {
@@ -581,7 +739,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 6,
-            "y": 9
+            "y": 17
           },
           "id": 82,
           "options": {
@@ -674,7 +832,7 @@ data:
             "h": 8,
             "w": 7,
             "x": 14,
-            "y": 9
+            "y": 17
           },
           "id": 81,
           "options": {
@@ -768,7 +926,7 @@ data:
             "h": 8,
             "w": 3,
             "x": 21,
-            "y": 9
+            "y": 17
           },
           "id": 83,
           "options": {
@@ -810,7 +968,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 17
+            "y": 25
           },
           "id": 80,
           "panels": [],
@@ -823,7 +981,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 18
+            "y": 26
           },
           "id": 10,
           "panels": [],
@@ -896,7 +1054,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 19
+            "y": 27
           },
           "id": 11,
           "options": {
@@ -932,7 +1090,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 27
+            "y": 35
           },
           "id": 20,
           "panels": [],
@@ -1005,7 +1163,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 28
+            "y": 36
           },
           "id": 21,
           "options": {
@@ -1098,7 +1256,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 28
+            "y": 36
           },
           "id": 22,
           "options": {
@@ -1191,7 +1349,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 28
+            "y": 36
           },
           "id": 23,
           "options": {
@@ -1284,7 +1442,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 28
+            "y": 36
           },
           "id": 24,
           "options": {
@@ -1317,7 +1475,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 36
+            "y": 44
           },
           "id": 30,
           "panels": [],
@@ -1390,7 +1548,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 37
+            "y": 45
           },
           "id": 31,
           "options": {
@@ -1483,7 +1641,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 37
+            "y": 45
           },
           "id": 32,
           "options": {
@@ -1576,7 +1734,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 37
+            "y": 45
           },
           "id": 33,
           "options": {
@@ -1609,7 +1767,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 45
+            "y": 53
           },
           "id": 40,
           "panels": [],
@@ -1682,7 +1840,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 54
           },
           "id": 41,
           "options": {
@@ -1775,7 +1933,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 54
           },
           "id": 42,
           "options": {
@@ -1808,7 +1966,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 54
+            "y": 62
           },
           "id": 50,
           "panels": [],
@@ -1881,7 +2039,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 55
+            "y": 63
           },
           "id": 51,
           "options": {
@@ -1978,13 +2136,37 @@ data:
               },
               "unit": "bytes"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "fill %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 55
+            "y": 63
           },
           "id": 52,
           "options": {
@@ -2009,12 +2191,18 @@ data:
             },
             {
               "expr": "max(redis_memory_max_bytes{service_namespace=\"$namespace\"})",
-              "legendFormat": "max",
+              "legendFormat": "maxmemory (cap)",
               "refId": "B"
+            },
+            {
+              "expr": "max(avg_over_time(redis_memory_used_bytes{service_namespace=\"$namespace\"}[2m])) / max(redis_memory_max_bytes{service_namespace=\"$namespace\"} > 0) * 100",
+              "legendFormat": "fill %",
+              "refId": "C"
             }
           ],
-          "title": "Redis memory",
-          "type": "timeseries"
+          "title": "Redis memory (redis-queues cluster)",
+          "type": "timeseries",
+          "description": "Memory of the redis-queues CLUSTER (noeviction) \u2014 the instance that carries the upload LPUSH, chunk pub/sub and cephor:* coordination keys; when it fills, every write fails. Emitted by the app collector, which sums used_memory/maxmemory across all cluster primaries (a RedisCluster INFO returns one dict per node). max() de-dupes the identical value each pod reports; pods that cannot reach the cluster report 0 and are ignored by max()."
         },
         {
           "datasource": {
@@ -2054,7 +2242,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 55
+            "y": 63
           },
           "id": 53,
           "options": {
@@ -2080,8 +2268,9 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Cache disk usage",
-          "type": "gauge"
+          "title": "Cache disk usage (PVC quota)",
+          "type": "gauge",
+          "description": "statvfs on the cache mount = the CephFS PVC QUOTA, not the backing pool. Compare with \"Ceph pool usage (data0)\" to the right \u2014 they diverge sharply when the pool fills ahead of the quota (the 2026-07-24 blind spot)."
         },
         {
           "datasource": {
@@ -2118,8 +2307,8 @@ data:
           "gridPos": {
             "h": 8,
             "w": 6,
-            "x": 18,
-            "y": 55
+            "x": 0,
+            "y": 71
           },
           "id": 54,
           "options": {
@@ -2148,7 +2337,8 @@ data:
             }
           ],
           "title": "Cache parts on disk",
-          "type": "stat"
+          "type": "stat",
+          "description": "Parts on disk across the whole cache tree. CENSUS METRIC \u2014 only published after a FULL, untruncated janitor sweep. On prod the FS walk hits its wall-clock budget every cycle (truncated=True), so the gauge never gets a complete sweep and holds its initial 0 (\"Census sweep truncated by walk budget - holding last complete census\" in the janitor log). Staging, whose tree fits in the budget, reports real values. Reads as \"empty cache\", not \"unknown\" \u2014 the janitor should publish a partial census instead (tracked separately)."
         },
         {
           "collapsed": false,
@@ -2156,7 +2346,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 63
+            "y": 71
           },
           "id": 60,
           "panels": [],
@@ -2235,7 +2425,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 64
+            "y": 72
           },
           "id": 61,
           "options": {
@@ -2422,7 +2612,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 64
+            "y": 72
           },
           "id": 62,
           "options": {
@@ -2447,7 +2637,8 @@ data:
             }
           ],
           "title": "Cache age distribution",
-          "type": "timeseries"
+          "type": "timeseries",
+          "description": "Parts bucketed by age. CENSUS METRIC \u2014 only published after a FULL, untruncated janitor sweep. On prod the FS walk hits its wall-clock budget every cycle (truncated=True), so the gauge never gets a complete sweep and holds its initial 0 (\"Census sweep truncated by walk budget - holding last complete census\" in the janitor log). Staging, whose tree fits in the budget, reports real values. Reads as \"empty cache\", not \"unknown\" \u2014 the janitor should publish a partial census instead (tracked separately)."
         },
         {
           "datasource": {
@@ -2515,7 +2706,7 @@ data:
             "h": 8,
             "w": 4,
             "x": 16,
-            "y": 64
+            "y": 72
           },
           "id": 63,
           "options": {
@@ -2608,13 +2799,16 @@ data:
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 64
+            "y": 72
           },
           "id": 64,
           "options": {
             "legend": {
-              "calcs": [],
-              "displayMode": "list",
+              "calcs": [
+                "last",
+                "max"
+              ],
+              "displayMode": "table",
               "placement": "bottom",
               "showLegend": true
             },
@@ -2627,13 +2821,14 @@ data:
           "pluginVersion": "12.3.1",
           "targets": [
             {
-              "expr": "sum(rate(fs_janitor_deleted_total{service_namespace=\"$namespace\"}[10m]))",
-              "legendFormat": "GC rate",
+              "expr": "sum by (reason) (rate(fs_janitor_deleted_total{service_namespace=\"$namespace\"}[10m]))",
+              "legendFormat": "{{reason}}",
               "refId": "A"
             }
           ],
-          "title": "GC rate",
-          "type": "timeseries"
+          "title": "Janitor GC rate (parts deleted/s)",
+          "type": "timeseries",
+          "description": "Rate at which the janitor DELETES cache parts from disk, split by reason:\n- gc_age: replication-gated age eviction (part is fully replicated to every required backend, cold i.e. atime outside the hot-retention window, and not DLQ-protected). This is normal cache reclaim.\n- stale_mtime: stale/orphan reap (mtime older than the MPU stale threshold with no live parts row).\n- abandoned: terminally-abandoned upload reclaimed (failed part on an unservable version).\nSustained 0 while the disk is filling means eviction is blocked - usually nothing is replicated yet (the replication gate is absolute) or everything is inside the hot-retention window."
         },
         {
           "collapsed": false,
@@ -2641,7 +2836,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 72
+            "y": 80
           },
           "id": 70,
           "panels": [],
@@ -2720,7 +2915,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 73
+            "y": 81
           },
           "id": 71,
           "options": {
@@ -2832,7 +3027,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 73
+            "y": 81
           },
           "id": 72,
           "options": {
@@ -2899,7 +3094,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 73
+            "y": 81
           },
           "id": 73,
           "options": {
@@ -2936,7 +3131,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 81
+            "y": 89
           },
           "id": 84,
           "panels": [],
@@ -2975,7 +3170,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 82
+            "y": 90
           },
           "id": 85,
           "options": {
@@ -3040,7 +3235,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 82
+            "y": 90
           },
           "id": 86,
           "options": {
@@ -3103,7 +3298,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 82
+            "y": 90
           },
           "id": 87,
           "options": {
@@ -3166,7 +3361,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 82
+            "y": 90
           },
           "id": 88,
           "options": {
@@ -3238,7 +3433,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 90
+            "y": 98
           },
           "id": 89,
           "options": {
@@ -3301,7 +3496,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 90
+            "y": 98
           },
           "id": 90,
           "options": {
@@ -3364,7 +3559,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 90
+            "y": 98
           },
           "id": 91,
           "options": {
@@ -3427,7 +3622,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 90
+            "y": 98
           },
           "id": 92,
           "options": {
@@ -3444,17 +3639,14 @@ data:
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
-              "expr": "sum(rate(fs_janitor_abandoned_reclaimed_total{service_namespace=\"$namespace\"}[10m]))",
+              "expr": "sum(rate(fs_janitor_deleted_total{service_namespace=\"$namespace\", reason=\"abandoned\"}[10m]))",
               "legendFormat": "reclaimed/s",
               "refId": "A"
             }
           ],
           "title": "Abandoned-part reclaim (janitor)",
-          "type": "timeseries"
+          "type": "timeseries",
+          "description": "Terminally-abandoned parts reclaimed by the janitor. Was querying fs_janitor_abandoned_reclaimed_total, which is not a metric this codebase emits (panel was permanently empty); the real signal is the abandoned reason on fs_janitor_deleted_total."
         },
         {
           "datasource": {
@@ -3490,7 +3682,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 98
+            "y": 106
           },
           "id": 93,
           "options": {
@@ -3553,7 +3745,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 98
+            "y": 106
           },
           "id": 94,
           "options": {
@@ -3616,7 +3808,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 98
+            "y": 106
           },
           "id": 95,
           "options": {
@@ -3644,6 +3836,74 @@ data:
           ],
           "title": "Account cacher \u2014 cycles",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 85
+                  },
+                  {
+                    "color": "red",
+                    "value": 95
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 63
+          },
+          "id": 97,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "expr": "max(ceph_pool_percent_used * on(pool_id) group_left(name) ceph_pool_metadata{name=\"ceph-filesystem-data0\"}) * 100",
+              "legendFormat": "pool %USED",
+              "refId": "A"
+            }
+          ],
+          "title": "Ceph pool usage (data0)",
+          "type": "gauge",
+          "description": "TRUE fullness of the backing CephFS pool ceph-filesystem-data0, straight from the ceph-mgr exporter. The panel to the left reads statvfs on the cache mount, which only sees the PVC QUOTA \u2014 during the 2026-07-24 incident that read ~69% while this pool was at ~94%. Ceph gates writes on the fullest OSD, so this is the number that matters: >=85% nearfull, >=95% read-only."
         }
       ],
       "preload": false,

--- a/monitoring/grafana/dashboards/system-load.json
+++ b/monitoring/grafana/dashboards/system-load.json
@@ -21,6 +21,164 @@
   "links": [],
   "panels": [
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "3xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 96,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "expr": "sum by (class) (label_replace(rate(http_requests_total{service_namespace=\"$namespace\", handler=~\"gateway.*\"}[5m]), \"class\", \"${1}xx\", \"status_code\", \"([0-9])[0-9][0-9]\"))",
+          "legendFormat": "{{class}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway Type/s",
+      "type": "timeseries",
+      "description": "Gateway request rate collapsed into HTTP status classes (2xx/3xx/4xx/5xx), one line each. Individual status codes are in \"Gateway req/s\" below; this is the at-a-glance health shape."
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -99,7 +257,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 1
+        "y": 9
       },
       "id": 2,
       "options": {
@@ -192,7 +350,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 1
+        "y": 9
       },
       "id": 3,
       "options": {
@@ -285,7 +443,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 1
+        "y": 9
       },
       "id": 4,
       "options": {
@@ -383,7 +541,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 1
+        "y": 9
       },
       "id": 5,
       "options": {
@@ -476,7 +634,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 9
+        "y": 17
       },
       "id": 6,
       "options": {
@@ -574,7 +732,7 @@
         "h": 8,
         "w": 8,
         "x": 6,
-        "y": 9
+        "y": 17
       },
       "id": 82,
       "options": {
@@ -667,7 +825,7 @@
         "h": 8,
         "w": 7,
         "x": 14,
-        "y": 9
+        "y": 17
       },
       "id": 81,
       "options": {
@@ -761,7 +919,7 @@
         "h": 8,
         "w": 3,
         "x": 21,
-        "y": 9
+        "y": 17
       },
       "id": 83,
       "options": {
@@ -803,7 +961,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 25
       },
       "id": 80,
       "panels": [],
@@ -816,7 +974,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 26
       },
       "id": 10,
       "panels": [],
@@ -889,7 +1047,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 27
       },
       "id": 11,
       "options": {
@@ -925,7 +1083,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 35
       },
       "id": 20,
       "panels": [],
@@ -998,7 +1156,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 28
+        "y": 36
       },
       "id": 21,
       "options": {
@@ -1091,7 +1249,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 28
+        "y": 36
       },
       "id": 22,
       "options": {
@@ -1184,7 +1342,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 28
+        "y": 36
       },
       "id": 23,
       "options": {
@@ -1277,7 +1435,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 28
+        "y": 36
       },
       "id": 24,
       "options": {
@@ -1310,7 +1468,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 44
       },
       "id": 30,
       "panels": [],
@@ -1383,7 +1541,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 37
+        "y": 45
       },
       "id": 31,
       "options": {
@@ -1476,7 +1634,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 37
+        "y": 45
       },
       "id": 32,
       "options": {
@@ -1569,7 +1727,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 37
+        "y": 45
       },
       "id": 33,
       "options": {
@@ -1602,7 +1760,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 53
       },
       "id": 40,
       "panels": [],
@@ -1675,7 +1833,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 46
+        "y": 54
       },
       "id": 41,
       "options": {
@@ -1768,7 +1926,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 46
+        "y": 54
       },
       "id": 42,
       "options": {
@@ -1801,7 +1959,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 62
       },
       "id": 50,
       "panels": [],
@@ -1874,7 +2032,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 55
+        "y": 63
       },
       "id": 51,
       "options": {
@@ -1971,13 +2129,37 @@
           },
           "unit": "bytes"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "fill %"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 55
+        "y": 63
       },
       "id": 52,
       "options": {
@@ -2002,12 +2184,18 @@
         },
         {
           "expr": "max(redis_memory_max_bytes{service_namespace=\"$namespace\"})",
-          "legendFormat": "max",
+          "legendFormat": "maxmemory (cap)",
           "refId": "B"
+        },
+        {
+          "expr": "max(avg_over_time(redis_memory_used_bytes{service_namespace=\"$namespace\"}[2m])) / max(redis_memory_max_bytes{service_namespace=\"$namespace\"} > 0) * 100",
+          "legendFormat": "fill %",
+          "refId": "C"
         }
       ],
-      "title": "Redis memory",
-      "type": "timeseries"
+      "title": "Redis memory (redis-queues cluster)",
+      "type": "timeseries",
+      "description": "Memory of the redis-queues CLUSTER (noeviction) \u2014 the instance that carries the upload LPUSH, chunk pub/sub and cephor:* coordination keys; when it fills, every write fails. Emitted by the app collector, which sums used_memory/maxmemory across all cluster primaries (a RedisCluster INFO returns one dict per node). max() de-dupes the identical value each pod reports; pods that cannot reach the cluster report 0 and are ignored by max()."
     },
     {
       "datasource": {
@@ -2047,7 +2235,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 55
+        "y": 63
       },
       "id": 53,
       "options": {
@@ -2073,8 +2261,9 @@
           "refId": "A"
         }
       ],
-      "title": "Cache disk usage",
-      "type": "gauge"
+      "title": "Cache disk usage (PVC quota)",
+      "type": "gauge",
+      "description": "statvfs on the cache mount = the CephFS PVC QUOTA, not the backing pool. Compare with \"Ceph pool usage (data0)\" to the right \u2014 they diverge sharply when the pool fills ahead of the quota (the 2026-07-24 blind spot)."
     },
     {
       "datasource": {
@@ -2111,8 +2300,8 @@
       "gridPos": {
         "h": 8,
         "w": 6,
-        "x": 18,
-        "y": 55
+        "x": 0,
+        "y": 71
       },
       "id": 54,
       "options": {
@@ -2141,7 +2330,8 @@
         }
       ],
       "title": "Cache parts on disk",
-      "type": "stat"
+      "type": "stat",
+      "description": "Parts on disk across the whole cache tree. CENSUS METRIC \u2014 only published after a FULL, untruncated janitor sweep. On prod the FS walk hits its wall-clock budget every cycle (truncated=True), so the gauge never gets a complete sweep and holds its initial 0 (\"Census sweep truncated by walk budget - holding last complete census\" in the janitor log). Staging, whose tree fits in the budget, reports real values. Reads as \"empty cache\", not \"unknown\" \u2014 the janitor should publish a partial census instead (tracked separately)."
     },
     {
       "collapsed": false,
@@ -2149,7 +2339,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 71
       },
       "id": 60,
       "panels": [],
@@ -2228,7 +2418,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 64
+        "y": 72
       },
       "id": 61,
       "options": {
@@ -2415,7 +2605,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 64
+        "y": 72
       },
       "id": 62,
       "options": {
@@ -2440,7 +2630,8 @@
         }
       ],
       "title": "Cache age distribution",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Parts bucketed by age. CENSUS METRIC \u2014 only published after a FULL, untruncated janitor sweep. On prod the FS walk hits its wall-clock budget every cycle (truncated=True), so the gauge never gets a complete sweep and holds its initial 0 (\"Census sweep truncated by walk budget - holding last complete census\" in the janitor log). Staging, whose tree fits in the budget, reports real values. Reads as \"empty cache\", not \"unknown\" \u2014 the janitor should publish a partial census instead (tracked separately)."
     },
     {
       "datasource": {
@@ -2508,7 +2699,7 @@
         "h": 8,
         "w": 4,
         "x": 16,
-        "y": 64
+        "y": 72
       },
       "id": 63,
       "options": {
@@ -2601,13 +2792,16 @@
         "h": 8,
         "w": 4,
         "x": 20,
-        "y": 64
+        "y": 72
       },
       "id": 64,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -2620,13 +2814,14 @@
       "pluginVersion": "12.3.1",
       "targets": [
         {
-          "expr": "sum(rate(fs_janitor_deleted_total{service_namespace=\"$namespace\"}[10m]))",
-          "legendFormat": "GC rate",
+          "expr": "sum by (reason) (rate(fs_janitor_deleted_total{service_namespace=\"$namespace\"}[10m]))",
+          "legendFormat": "{{reason}}",
           "refId": "A"
         }
       ],
-      "title": "GC rate",
-      "type": "timeseries"
+      "title": "Janitor GC rate (parts deleted/s)",
+      "type": "timeseries",
+      "description": "Rate at which the janitor DELETES cache parts from disk, split by reason:\n- gc_age: replication-gated age eviction (part is fully replicated to every required backend, cold i.e. atime outside the hot-retention window, and not DLQ-protected). This is normal cache reclaim.\n- stale_mtime: stale/orphan reap (mtime older than the MPU stale threshold with no live parts row).\n- abandoned: terminally-abandoned upload reclaimed (failed part on an unservable version).\nSustained 0 while the disk is filling means eviction is blocked - usually nothing is replicated yet (the replication gate is absolute) or everything is inside the hot-retention window."
     },
     {
       "collapsed": false,
@@ -2634,7 +2829,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 72
+        "y": 80
       },
       "id": 70,
       "panels": [],
@@ -2713,7 +2908,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 73
+        "y": 81
       },
       "id": 71,
       "options": {
@@ -2825,7 +3020,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 73
+        "y": 81
       },
       "id": 72,
       "options": {
@@ -2892,7 +3087,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 73
+        "y": 81
       },
       "id": 73,
       "options": {
@@ -2929,7 +3124,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 81
+        "y": 89
       },
       "id": 84,
       "panels": [],
@@ -2968,7 +3163,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 82
+        "y": 90
       },
       "id": 85,
       "options": {
@@ -3033,7 +3228,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 82
+        "y": 90
       },
       "id": 86,
       "options": {
@@ -3096,7 +3291,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 82
+        "y": 90
       },
       "id": 87,
       "options": {
@@ -3159,7 +3354,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 82
+        "y": 90
       },
       "id": 88,
       "options": {
@@ -3231,7 +3426,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 90
+        "y": 98
       },
       "id": 89,
       "options": {
@@ -3294,7 +3489,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 90
+        "y": 98
       },
       "id": 90,
       "options": {
@@ -3357,7 +3552,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 90
+        "y": 98
       },
       "id": 91,
       "options": {
@@ -3420,7 +3615,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 90
+        "y": 98
       },
       "id": 92,
       "options": {
@@ -3437,17 +3632,14 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(rate(fs_janitor_abandoned_reclaimed_total{service_namespace=\"$namespace\"}[10m]))",
+          "expr": "sum(rate(fs_janitor_deleted_total{service_namespace=\"$namespace\", reason=\"abandoned\"}[10m]))",
           "legendFormat": "reclaimed/s",
           "refId": "A"
         }
       ],
       "title": "Abandoned-part reclaim (janitor)",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Terminally-abandoned parts reclaimed by the janitor. Was querying fs_janitor_abandoned_reclaimed_total, which is not a metric this codebase emits (panel was permanently empty); the real signal is the abandoned reason on fs_janitor_deleted_total."
     },
     {
       "datasource": {
@@ -3483,7 +3675,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 98
+        "y": 106
       },
       "id": 93,
       "options": {
@@ -3546,7 +3738,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 98
+        "y": 106
       },
       "id": 94,
       "options": {
@@ -3609,7 +3801,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 98
+        "y": 106
       },
       "id": 95,
       "options": {
@@ -3637,6 +3829,74 @@
       ],
       "title": "Account cacher \u2014 cycles",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 85
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 63
+      },
+      "id": 97,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "expr": "max(ceph_pool_percent_used * on(pool_id) group_left(name) ceph_pool_metadata{name=\"ceph-filesystem-data0\"}) * 100",
+          "legendFormat": "pool %USED",
+          "refId": "A"
+        }
+      ],
+      "title": "Ceph pool usage (data0)",
+      "type": "gauge",
+      "description": "TRUE fullness of the backing CephFS pool ceph-filesystem-data0, straight from the ceph-mgr exporter. The panel to the left reads statvfs on the cache mount, which only sees the PVC QUOTA \u2014 during the 2026-07-24 incident that read ~69% while this pool was at ~94%. Ceph gates writes on the fullest OSD, so this is the number that matters: >=85% nearfull, >=95% read-only."
     }
   ],
   "preload": false,

--- a/tests/unit/test_monitoring_collector.py
+++ b/tests/unit/test_monitoring_collector.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import pytest
 
+from hippius_s3.metrics_collector_task import _redis_memory
 from hippius_s3.monitoring import MetricsCollector
 from hippius_s3.monitoring import NullMetricsCollector
 
@@ -38,3 +39,28 @@ def test_null_collector_no_ops_every_new_method() -> None:
 def test_dlq_requeue_ignores_nonpositive_counts(count: int) -> None:
     # A batch that requeued nothing must not emit a spurious increment.
     MetricsCollector().record_dlq_requeue(queue="q", count=count)
+
+
+# ------------------------------------------------------- redis memory gauge (cluster-aware)
+
+
+def test_redis_memory_reads_a_single_node_info() -> None:
+    used, cap = _redis_memory({"used_memory": 15354056, "maxmemory": 4294967296})
+    assert (used, cap) == (15354056, 4294967296)
+
+
+def test_redis_memory_sums_across_cluster_nodes() -> None:
+    """A RedisCluster fans INFO out to every primary and returns one mapping PER NODE, so the flat
+    `info["used_memory"]` lookup returned 0 and the gauge read empty for cluster-backed pods."""
+    info = {
+        "10.0.0.1:6379": {"used_memory": 100, "maxmemory": 1000},
+        "10.0.0.2:6379": {"used_memory": 250, "maxmemory": 1000},
+        "10.0.0.3:6379": {"used_memory": 50, "maxmemory": 1000},
+    }
+    assert _redis_memory(info) == (400, 3000)
+
+
+@pytest.mark.parametrize("info", [{}, {"n1": {}}, {"n1": {"used_memory": 5}, "n2": {}}])
+def test_redis_memory_tolerates_missing_fields(info: dict) -> None:
+    used, cap = _redis_memory(info)
+    assert used >= 0 and cap >= 0


### PR DESCRIPTION
Every query here was validated against the live Prometheus before being written into the dashboard.

## New panels
- **Gateway Type/s** — full-width line chart at the top of the Traffic row. Gateway request rate collapsed into HTTP status classes via `label_replace` on `status_code`, one line per class, coloured green (2xx) → `#EAB839` (3xx) → orange (4xx) → red (5xx). Verified live: `2xx=23.3 3xx=1.2 4xx=1.6 5xx=7.8 req/s`.
- **Ceph pool usage (data0)** — gauge beside the cache disk gauge, reading true pool fullness from the ceph-mgr exporter (`ceph_pool_percent_used * on(pool_id) group_left(name) ceph_pool_metadata`). Verified live: **90.5%**. Thresholds mirror Ceph's own semantics (85% nearfull / 95% read-only).

## Fixes
| Panel | Problem | Fix |
|---|---|---|
| Redis memory | Read **0** on every cluster-backed pod | `RedisCluster.info()` fans out to each primary and returns **one mapping per node**, so the flat `info["used_memory"]` lookup missed entirely. `_redis_memory()` now sums `used_memory`/`maxmemory` across nodes (single-node INFO unchanged). Panel retitled to name the redis-queues cluster and given a fill-% series. |
| Cache disk usage | Misleading | It reads `statvfs` = the **PVC quota**, not the pool. Retitled "Cache disk usage (PVC quota)" and cross-referenced with the new Ceph gauge — during the 2026-07-24 incident this read ~69% while the pool was ~94%. |
| Cache parts on disk | Shows **0** on prod | These are **census** gauges, published only after a *full untruncated* janitor sweep. Prod's FS walk hits its wall-clock budget every cycle (`truncated=True` → "Census sweep truncated by walk budget — holding last complete census"), so they never receive a complete sweep and hold their initial 0. Staging, whose tree fits the budget, reports real values (730 parts). Documented on the panel. |
| Cache age distribution | Shows **0** on prod | Same census root cause; documented. |
| GC rate | Unexplained single line | Split by `reason` (`gc_age` / `stale_mtime` / `abandoned`), retitled "Janitor GC rate (parts deleted/s)", and documented what each reason means and what a sustained 0 implies. Verified live: `gc_age=10.5/s, stale_mtime=12.8/s`. |
| Abandoned-part reclaim | Permanently empty | Queried `fs_janitor_abandoned_reclaimed_total`, a metric this codebase never emits. Repointed at `fs_janitor_deleted_total{reason="abandoned"}`. |

## Notes
- `k8s/base/grafana-dashboards.yaml` embeds the dashboard, so it is regenerated in lockstep and verified byte-identical to the JSON; `kubectl apply --dry-run` passes.
- The **janitor-side** fix for the census gauges (publish a partial census instead of holding 0, so the panel reads "partial" rather than "empty cache") is deliberately **not** in this PR: that code lives on `staging`/`k8s-production`, not `main`. Worth a follow-up there.
- Tests: `tests/unit/test_monitoring_collector.py` covers single-node, cluster-sum, and missing-field INFO shapes. 9 passed; ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)