### PR TITLE
Guard: never unpin the current version of a live object

### DIFF
--- a/hippius_s3/sql/queries/get_chunk_backend_identifiers.sql
+++ b/hippius_s3/sql/queries/get_chunk_backend_identifiers.sql
@@ -1,11 +1,33 @@
 -- $1 backend (TEXT), $2 object_id (UUID), $3 object_version (BIGINT, nullable)
+--
+-- DEFENSIVE GUARD (last line): never hand the unpinner the CURRENT version of a LIVE object.
+--
+-- The unpinner deletes whatever this returns from the backend; until now nothing here
+-- re-checked that the object was still deleted, so safety rested ENTIRELY on the caller
+-- passing the right object_version. That holds today only because a re-PUT of a deleted
+-- object revives the SAME row and BUMPS the version (upsert_object_basic:
+-- `deleted_at = NULL, current_object_version = GREATEST(...) + 1`), so a racing revive
+-- lands on version N+1 while an in-flight unpin still targets the dead version N. That is
+-- a single point of failure: any future change that reuses a version number, or any caller
+-- that passes a stale/NULL version, would delete live data from the backend.
+--
+-- The guard is deliberately NOT a blunt `o.deleted_at IS NOT NULL`: superseded versions of
+-- LIVE objects are legitimately unpinned (overwrite retention, cleanup_migration_versions.py,
+-- the unpin DLQ requeue path), and that check would silently block them. The precise
+-- invariant is "the version being unpinned must not be the live current one".
+--
+-- Fail direction is safe-by-construction: if the guard excludes rows the unpinner simply
+-- deletes nothing (the chunk_backend rows stay live and the object stays un-hard-deletable),
+-- which is a visible stall rather than data loss.
 SELECT cb.backend_identifier, cb.chunk_id
 FROM chunk_backend cb
 JOIN part_chunks pc ON pc.id = cb.chunk_id
 JOIN parts p ON pc.part_id = p.part_id
+JOIN objects o ON o.object_id = p.object_id
 WHERE cb.backend = $1
   AND p.object_id = $2
   AND ($3::bigint IS NULL OR p.object_version = $3)
   AND NOT cb.deleted
   AND cb.backend_identifier IS NOT NULL
+  AND (o.deleted_at IS NOT NULL OR p.object_version <> o.current_object_version)
 ORDER BY cb.chunk_id;

--- a/tests/integration/test_unpin_identifiers_live_guard.py
+++ b/tests/integration/test_unpin_identifiers_live_guard.py
@@ -1,0 +1,156 @@
+"""The unpinner's chunk-selection guard: never hand back the CURRENT version of a LIVE object.
+
+`get_chunk_backend_identifiers` feeds the unpinner, which DELETES whatever it returns from the
+backend. Nothing in the query used to re-check that the object was still deleted, so safety rested
+entirely on the caller passing the right `object_version` — held up only by the fact that reviving a
+soft-deleted object bumps the version (`upsert_object_basic`: `deleted_at = NULL,
+current_object_version = GREATEST(...) + 1`). Any caller passing a stale/NULL version, or a future
+change that reuses version numbers, would have deleted live data off the backend.
+
+The guard is `(o.deleted_at IS NOT NULL OR p.object_version <> o.current_object_version)` — NOT a
+blunt `deleted_at IS NOT NULL`, because superseded versions of LIVE objects are legitimately
+unpinned (overwrite retention, cleanup_migration_versions.py, the unpin DLQ requeue path). These
+tests pin both halves: the live-current row is withheld, and every legitimate case still flows.
+
+Seed data goes through the auto-rolled-back `pg_tx` fixture; skips without Postgres on DATABASE_URL.
+"""
+
+import uuid
+
+import asyncpg
+import pytest
+
+from hippius_s3.utils import get_query
+
+
+async def _seed_bucket(conn: asyncpg.Connection) -> uuid.UUID:
+    acct = f"5HDTEST{uuid.uuid4().hex[:12]}"
+    await conn.execute("INSERT INTO users(main_account_id) VALUES($1) ON CONFLICT DO NOTHING", acct)
+    bucket_id = uuid.uuid4()
+    await conn.execute(
+        "INSERT INTO buckets(bucket_id, bucket_name, created_at, main_account_id) VALUES($1, $2, now(), $3)",
+        bucket_id,
+        f"unpin-guard-{bucket_id}",
+        acct,
+    )
+    return bucket_id
+
+
+async def _seed_object(
+    conn: asyncpg.Connection,
+    bucket_id: uuid.UUID,
+    *,
+    deleted: bool,
+    versions: list[int],
+    current_version: int,
+) -> uuid.UUID:
+    """Seed an object with a part+chunk per entry in `versions`, each carrying a live
+    `chunk_backend` row for backend 'arion' with a non-null identifier."""
+    oid = uuid.uuid4()
+    key = f"unpin-guard-{oid}"
+    await conn.execute(
+        "INSERT INTO objects(object_id, bucket_id, object_key, created_at, current_object_version, deleted_at)"
+        " VALUES($1, $2, $3, now(), $4, CASE WHEN $5::bool THEN now() ELSE NULL END)",
+        oid,
+        bucket_id,
+        key,
+        current_version,
+        deleted,
+    )
+    upload_id = uuid.uuid4()
+    await conn.execute(
+        "INSERT INTO multipart_uploads(upload_id, bucket_id, object_key, initiated_at) VALUES($1, $2, $3, now())",
+        upload_id,
+        bucket_id,
+        key,
+    )
+    for v in versions:
+        await conn.execute(
+            "INSERT INTO object_versions(object_id, object_version, storage_version, size_bytes, content_type)"
+            " VALUES($1, $2, 5, 100, 'application/octet-stream')",
+            oid,
+            v,
+        )
+        part_id = uuid.uuid4()
+        await conn.execute(
+            "INSERT INTO parts(part_id, upload_id, part_number, size_bytes, etag, uploaded_at, object_id, object_version)"
+            " VALUES($1, $2, 1, 100, 'etag', now(), $3, $4)",
+            part_id,
+            upload_id,
+            oid,
+            v,
+        )
+        chunk_pk = await conn.fetchval(
+            "INSERT INTO part_chunks(part_id, chunk_index, cipher_size_bytes) VALUES($1, 0, 100) RETURNING id",
+            part_id,
+        )
+        await conn.execute(
+            "INSERT INTO chunk_backend(chunk_id, backend, backend_identifier, deleted) VALUES($1, 'arion', $2, false)",
+            chunk_pk,
+            f"path-hash-{chunk_pk}",
+        )
+    return oid
+
+
+@pytest.mark.asyncio
+async def test_deleted_object_is_unpinnable(pg_tx: asyncpg.Connection) -> None:
+    """The normal path: the object is soft-deleted, so its chunks are handed to the unpinner."""
+    bucket_id = await _seed_bucket(pg_tx)
+    oid = await _seed_object(pg_tx, bucket_id, deleted=True, versions=[1], current_version=1)
+
+    rows = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, 1)
+    assert len(rows) == 1, "a soft-deleted object's chunks must still be unpinnable"
+
+
+@pytest.mark.asyncio
+async def test_live_object_current_version_is_withheld(pg_tx: asyncpg.Connection) -> None:
+    """THE data-loss case: object is LIVE and this is its current version — withhold the rows so
+    the unpinner cannot delete live data off the backend."""
+    bucket_id = await _seed_bucket(pg_tx)
+    oid = await _seed_object(pg_tx, bucket_id, deleted=False, versions=[1], current_version=1)
+
+    rows = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, 1)
+    assert rows == [], "the current version of a LIVE object must never be handed to the unpinner"
+
+
+@pytest.mark.asyncio
+async def test_live_object_superseded_version_is_still_unpinnable(pg_tx: asyncpg.Connection) -> None:
+    """The guard must NOT be a blunt deleted_at check: superseded versions of a live object are
+    legitimately unpinned (overwrite retention, cleanup_migration_versions, unpin DLQ requeue)."""
+    bucket_id = await _seed_bucket(pg_tx)
+    oid = await _seed_object(pg_tx, bucket_id, deleted=False, versions=[1, 2], current_version=2)
+
+    old = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, 1)
+    assert len(old) == 1, "a superseded version of a live object must remain unpinnable"
+
+    cur = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, 2)
+    assert cur == [], "...while its current version stays protected"
+
+
+@pytest.mark.asyncio
+async def test_null_version_on_live_object_returns_only_superseded(pg_tx: asyncpg.Connection) -> None:
+    """A NULL object_version means 'every version of this object'. On a LIVE object that must
+    still exclude the current version — this is the stale-caller case the guard exists for."""
+    bucket_id = await _seed_bucket(pg_tx)
+    oid = await _seed_object(pg_tx, bucket_id, deleted=False, versions=[1, 2, 3], current_version=3)
+
+    rows = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, None)
+    versions = {
+        await pg_tx.fetchval(
+            "SELECT p.object_version FROM part_chunks pc JOIN parts p ON p.part_id = pc.part_id WHERE pc.id = $1",
+            r["chunk_id"],
+        )
+        for r in rows
+    }
+    assert versions == {1, 2}, f"NULL version must yield only superseded versions, got {versions}"
+
+
+@pytest.mark.asyncio
+async def test_null_version_on_deleted_object_returns_every_version(pg_tx: asyncpg.Connection) -> None:
+    """Once the object is deleted, every version — including the last current one — is unpinnable,
+    otherwise the object could never become fully unpinned and hard-deletable."""
+    bucket_id = await _seed_bucket(pg_tx)
+    oid = await _seed_object(pg_tx, bucket_id, deleted=True, versions=[1, 2], current_version=2)
+
+    rows = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, None)
+    assert len(rows) == 2, "a deleted object must expose all versions so it can be fully unpinned"


### PR DESCRIPTION
## Why
`get_chunk_backend_identifiers` feeds the unpinner, which **deletes whatever it returns from the backend**. Nothing in the query re-checked that the object was still deleted — safety rested *entirely* on the caller passing the right `object_version`.

That holds today only because reviving a soft-deleted object **bumps** the version (`upsert_object_basic`: `deleted_at = NULL, current_object_version = GREATEST(...) + 1`), so a racing revive lands on N+1 while an in-flight unpin still targets the dead N. It's a single point of failure: any caller passing a stale/NULL version, or a future change that reuses version numbers, would delete **live** data off the backend.

Found while auditing the soft-delete/unpin backlog (33M objects pending hard-delete, blocked because their unpins were lost in the redis-queues unpin-overrun incident).

## The guard
```sql
AND (o.deleted_at IS NOT NULL OR p.object_version <> o.current_object_version)
```
Deliberately **not** a blunt `o.deleted_at IS NOT NULL` — superseded versions of LIVE objects are legitimately unpinned (overwrite retention, `cleanup_migration_versions.py`, the unpin DLQ requeue path), and that check would silently block them. The precise invariant is *"the version being unpinned must not be the live current one."*

**Fail direction is safe by construction:** excluded rows mean the unpinner deletes nothing (chunk_backend rows stay live, object stays un-hard-deletable) — a visible stall, never data loss.

## Tests
New `tests/integration/test_unpin_identifiers_live_guard.py` — 5 cases, all passing against real Postgres:
- deleted object → unpinnable ✅
- **live object, current version → withheld** ✅ (the data-loss case)
- live object, superseded version → still unpinnable ✅
- NULL version on a live object → only superseded versions ✅
- NULL version on a deleted object → every version ✅

`test_find_objects_hard_delete_sql.py` still passes (no regression from the added JOIN). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)