### PR TITLE
Janitor: break the hard-delete head-of-line block + guard live-object unpins

### DIFF
--- a/hippius_s3/scripts/backfill_soft_delete_unpins.py
+++ b/hippius_s3/scripts/backfill_soft_delete_unpins.py
@@ -28,9 +28,17 @@ Resumable: keyset-paginates by (deleted_at, object_id); pass the last printed cu
 --start-after-ts/--start-after-id to resume. --loop re-scans from the start after each full
 pass (continuous sweeper mode) to catch newly soft-deleted objects.
 
+ROUTING (--backends): unpins go to `<backend>_unpin_requests` for each backend in
+`config.delete_backends` unless --backends overrides it. This matters: on prod
+delete_backends is ['arion'], but the objects that block the hard-delete scan have their
+LIVE rows on **ovh** (arion is already fully unpinned). Default routing would enqueue work
+that is already done and leave them stuck forever. `ovh_unpin_requests` is consumed by the
+s3-backup `cleanup` worker, which deletes from OVH *and* marks `chunk_backend.deleted`.
+
   python -m hippius_s3.scripts.backfill_soft_delete_unpins --dry-run
   python -m hippius_s3.scripts.backfill_soft_delete_unpins --batch 1000 --queue-cap 50000 \
-      --throttle-queues arion_unpin_requests
+      --backends ovh --deprecated-backends ipfs \
+      --throttle-queues arion_unpin_requests,ovh_unpin_requests
 """
 
 from __future__ import annotations
@@ -111,6 +119,12 @@ async def main_async(args: argparse.Namespace) -> int:
     config = get_config()
     deprecated = [b.strip() for b in args.deprecated_backends.split(",") if b.strip()]
     throttle_queues = [q.strip() for q in args.throttle_queues.split(",") if q.strip()]
+    backends = [b.strip() for b in args.backends.split(",") if b.strip()]
+    logger.info(
+        "unpin routing: %s (deprecated, reconciled in-DB: %s)",
+        f"--backends {backends}" if backends else f"config.delete_backends {config.delete_backends}",
+        deprecated or "none",
+    )
     db = await asyncpg.connect(config.database_url)
     redis_q = async_redis.from_url(config.redis_queues_url)
     initialize_queue_client(redis_q)
@@ -149,6 +163,8 @@ async def main_async(args: argparse.Namespace) -> int:
                                 address=r["main_account_id"],
                                 object_id=str(oid),
                                 object_version=int(r["object_version"]),
+                                # None => fall back to config.delete_backends (the live delete path).
+                                delete_backends=backends or None,
                             )
                         )
                         enqueued += 1
@@ -196,6 +212,18 @@ def main() -> None:
         "--deprecated-backends",
         default="ipfs",
         help="Comma-separated backends with no unpin worker; their rows are reconciled in-DB (no backend call)",
+    )
+    ap.add_argument(
+        "--backends",
+        default="",
+        help=(
+            "Comma-separated backends to route the unpins to, overriding config.delete_backends "
+            "(each becomes a `<backend>_unpin_requests` queue). REQUIRED when the blocking rows are "
+            "on a backend that delete_backends omits: on prod delete_backends is ['arion'] but the "
+            "stuck objects' live rows are on ovh, so the default routing enqueues work that is "
+            "already done and the objects stay un-hard-deletable. `ovh_unpin_requests` is consumed "
+            "by the s3-backup `cleanup` worker, which deletes from OVH AND marks chunk_backend."
+        ),
     )
     ap.add_argument("--max-objects", type=int, default=0, help="Stop after scanning this many objects (0 = all)")
     ap.add_argument("--sleep", type=float, default=0.0, help="Seconds to sleep between batches")

--- a/hippius_s3/sql/queries/find_objects_ready_for_hard_delete.sql
+++ b/hippius_s3/sql/queries/find_objects_ready_for_hard_delete.sql
@@ -13,7 +13,8 @@
 -- exists per expected chunk — i.e. the object was actually replicated at
 -- some point, so the "all deleted" signal is meaningful.
 --
--- Parameter: $1 = batch size (max objects returned per call).
+-- Parameters: $1 = batch size (max objects SCANNED per call).
+--             $2 = cursor deleted_at, $3 = cursor object_id (keyset position).
 --
 -- We materialise a small batch of soft-deleted candidates FIRST, then apply
 -- the EXISTS/NOT EXISTS checks to just that batch. Without this, the planner
@@ -22,28 +23,54 @@
 -- parts on every call — a ~135 GiB read storm that saturated the data disk and
 -- stalled the primary (see oom-psql-postmortem.md). AS MATERIALIZED + LIMIT
 -- forces per-object index probes; the janitor drains the backlog over cycles.
+--
+-- HEAD-OF-LINE FIX (2026-07-24): the batch used to be a bare `ORDER BY deleted_at
+-- LIMIT $1` — always the SAME oldest N objects. Those oldest objects are permanently
+-- un-ready: their unpins were lost when the unpin queue was cleared during the
+-- redis-queues unpin-overrun incident, so they still hold LIVE chunk_backend rows and
+-- can never satisfy the NOT EXISTS. Measured on prod: of the 2000 oldest candidates
+-- 0 were ready, while 1577/2000 RECENT ones were. The janitor therefore re-scanned the
+-- same doomed batch every cycle and hard-deleted NOTHING (`hard_deleted=0` in every
+-- cycle) while ~33M ready objects queued behind them — leaving their `parts` rows in
+-- place, which in turn kept their FS cache dirs pinned (the replication gate reads an
+-- all-unpinned part as "unreplicated" and protects it). That is what filled the pool.
+--
+-- The keyset cursor ($2,$3) makes the scan ADVANCE past un-ready objects instead of
+-- restarting at the stuck head. The caller persists the cursor in `janitor_state` and
+-- wraps back to the epoch on a short page, so stuck objects are revisited once per full
+-- sweep (cheap) instead of blocking every cycle (fatal).
+--
+-- Returns EVERY scanned candidate with a `ready` flag — not just the ready ones — so the
+-- caller can advance the cursor over un-ready objects too. Returning only ready rows
+-- would leave the cursor pinned at the stuck head exactly as before.
 WITH candidates AS MATERIALIZED (
-    SELECT object_id
+    SELECT object_id, deleted_at
     FROM objects
     WHERE deleted_at IS NOT NULL
       AND deleted_at < now() - INTERVAL '1 hour'  -- grace period
-    ORDER BY deleted_at  -- oldest first; uses idx_objects_deleted
+      AND (deleted_at, object_id) > ($2::timestamptz, $3::uuid)
+    ORDER BY deleted_at, object_id  -- uses idx_objects_deleted
     LIMIT $1
 )
-SELECT c.object_id
+SELECT
+    c.object_id,
+    c.deleted_at,
+    (
+        EXISTS (
+            SELECT 1
+            FROM parts p
+            JOIN part_chunks pc ON pc.part_id = p.part_id
+            JOIN chunk_backend cb ON cb.chunk_id = pc.id
+            WHERE p.object_id = c.object_id
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM parts p
+            JOIN part_chunks pc ON pc.part_id = p.part_id
+            JOIN chunk_backend cb ON cb.chunk_id = pc.id
+            WHERE p.object_id = c.object_id
+              AND NOT cb.deleted
+        )
+    ) AS ready
 FROM candidates c
-WHERE EXISTS (
-      SELECT 1
-      FROM parts p
-      JOIN part_chunks pc ON pc.part_id = p.part_id
-      JOIN chunk_backend cb ON cb.chunk_id = pc.id
-      WHERE p.object_id = c.object_id
-  )
-  AND NOT EXISTS (
-      SELECT 1
-      FROM parts p
-      JOIN part_chunks pc ON pc.part_id = p.part_id
-      JOIN chunk_backend cb ON cb.chunk_id = pc.id
-      WHERE p.object_id = c.object_id
-        AND NOT cb.deleted
-  );
+ORDER BY c.deleted_at, c.object_id;

--- a/hippius_s3/sql/queries/get_chunk_backend_identifiers.sql
+++ b/hippius_s3/sql/queries/get_chunk_backend_identifiers.sql
@@ -1,11 +1,33 @@
 -- $1 backend (TEXT), $2 object_id (UUID), $3 object_version (BIGINT, nullable)
+--
+-- DEFENSIVE GUARD (last line): never hand the unpinner the CURRENT version of a LIVE object.
+--
+-- The unpinner deletes whatever this returns from the backend; until now nothing here
+-- re-checked that the object was still deleted, so safety rested ENTIRELY on the caller
+-- passing the right object_version. That holds today only because a re-PUT of a deleted
+-- object revives the SAME row and BUMPS the version (upsert_object_basic:
+-- `deleted_at = NULL, current_object_version = GREATEST(...) + 1`), so a racing revive
+-- lands on version N+1 while an in-flight unpin still targets the dead version N. That is
+-- a single point of failure: any future change that reuses a version number, or any caller
+-- that passes a stale/NULL version, would delete live data from the backend.
+--
+-- The guard is deliberately NOT a blunt `o.deleted_at IS NOT NULL`: superseded versions of
+-- LIVE objects are legitimately unpinned (overwrite retention, cleanup_migration_versions.py,
+-- the unpin DLQ requeue path), and that check would silently block them. The precise
+-- invariant is "the version being unpinned must not be the live current one".
+--
+-- Fail direction is safe-by-construction: if the guard excludes rows the unpinner simply
+-- deletes nothing (the chunk_backend rows stay live and the object stays un-hard-deletable),
+-- which is a visible stall rather than data loss.
 SELECT cb.backend_identifier, cb.chunk_id
 FROM chunk_backend cb
 JOIN part_chunks pc ON pc.id = cb.chunk_id
 JOIN parts p ON pc.part_id = p.part_id
+JOIN objects o ON o.object_id = p.object_id
 WHERE cb.backend = $1
   AND p.object_id = $2
   AND ($3::bigint IS NULL OR p.object_version = $3)
   AND NOT cb.deleted
   AND cb.backend_identifier IS NOT NULL
+  AND (o.deleted_at IS NOT NULL OR p.object_version <> o.current_object_version)
 ORDER BY cb.chunk_id;

--- a/tests/integration/test_find_objects_hard_delete_sql.py
+++ b/tests/integration/test_find_objects_hard_delete_sql.py
@@ -29,6 +29,10 @@ _T_D = datetime.datetime(2000, 1, 2, tzinfo=_EPOCH)  # ready
 _T_B = datetime.datetime(2000, 1, 3, tzinfo=_EPOCH)  # not-ready (a live backend)
 _T_C = datetime.datetime(2000, 1, 4, tzinfo=_EPOCH)  # no chunk_backend rows
 
+# Start-of-sweep keyset cursor: the query pages on (deleted_at, object_id) > ($2, $3).
+_EPOCH_CURSOR = datetime.datetime(1970, 1, 1, tzinfo=_EPOCH)
+_ZERO_UUID = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
 
 async def _seed_bucket(conn: asyncpg.Connection) -> uuid.UUID:
     acct = f"5HDTEST{uuid.uuid4().hex[:12]}"
@@ -112,23 +116,65 @@ async def test_find_objects_ready_for_hard_delete_semantics(pg_tx: asyncpg.Conne
 
     sql = get_query("find_objects_ready_for_hard_delete")
 
-    # Large batch: ready objects returned, not-ready / no-chunks excluded (membership —
-    # robust to any other soft-deleted rows already in the DB).
-    returned = {r["object_id"] for r in await pg_tx.fetch(sql, 1000)}
-    assert a in returned
-    assert d in returned
-    assert b not in returned
-    assert c not in returned
+    # Large batch from the epoch cursor. The query now returns EVERY scanned candidate with a
+    # `ready` flag (so the caller can advance its cursor past un-ready ones), so assert on the
+    # flag rather than on mere membership.
+    rows = await pg_tx.fetch(sql, 1000, _EPOCH_CURSOR, _ZERO_UUID)
+    ready = {r["object_id"] for r in rows if r["ready"]}
+    scanned = {r["object_id"] for r in rows}
+    assert a in ready
+    assert d in ready
+    assert b in scanned and b not in ready, "a live backend row means not-ready, but still scanned"
+    assert c in scanned and c not in ready, "no chunk_backend row at all means not-ready, but still scanned"
 
     # Batch=2: only the two OLDEST candidates (a, d) are even considered, so the
     # newer not-ready/no-chunks rows can't appear — proves LIMIT bounds the scan.
-    assert {r["object_id"] for r in await pg_tx.fetch(sql, 2)} == {a, d}
+    assert {r["object_id"] for r in await pg_tx.fetch(sql, 2, _EPOCH_CURSOR, _ZERO_UUID)} == {a, d}
 
 
 @pytest.mark.asyncio
 async def test_find_objects_ready_for_hard_delete_respects_batch_limit(pg_conn: asyncpg.Connection) -> None:
-    rows = await pg_conn.fetch(get_query("find_objects_ready_for_hard_delete"), 1)
+    rows = await pg_conn.fetch(get_query("find_objects_ready_for_hard_delete"), 1, _EPOCH_CURSOR, _ZERO_UUID)
     assert len(rows) <= 1
+
+
+@pytest.mark.asyncio
+async def test_cursor_advances_past_a_permanently_unready_head(pg_tx: asyncpg.Connection) -> None:
+    """THE head-of-line fix. `b` is un-ready forever (a live chunk_backend row) and sorts FIRST.
+    Un-cursored, the janitor re-scanned it every cycle and hard-deleted nothing — exactly the prod
+    state (`hard_deleted=0` for months while ~33M ready objects queued behind it). Paging past it
+    with the keyset cursor must surface the ready object that sits behind it."""
+    bucket_id = await _seed_bucket(pg_tx)
+    b = await _seed_object(pg_tx, bucket_id, _T_A, [True, False])  # oldest AND permanently un-ready
+    a = await _seed_object(pg_tx, bucket_id, _T_D, [True, True])  # ready, but stuck behind b
+
+    sql = get_query("find_objects_ready_for_hard_delete")
+
+    # Page 1 (batch=1 from epoch) sees only the stuck head and finds nothing ready — the old bug.
+    page1 = await pg_tx.fetch(sql, 1, _EPOCH_CURSOR, _ZERO_UUID)
+    assert [r["object_id"] for r in page1] == [b]
+    assert not any(r["ready"] for r in page1), "the stuck head is never ready"
+
+    # Advancing the cursor past it (what the caller now persists) reaches the ready object.
+    last = page1[-1]
+    page2 = await pg_tx.fetch(sql, 1, last["deleted_at"], last["object_id"])
+    assert [r["object_id"] for r in page2] == [a]
+    assert page2[0]["ready"], "the ready object behind the stuck head must now be reachable"
+
+
+@pytest.mark.asyncio
+async def test_cursor_is_exclusive_so_a_page_never_repeats_itself(pg_tx: asyncpg.Connection) -> None:
+    """Keyset must be strictly greater, otherwise the sweep would re-serve its last row forever."""
+    bucket_id = await _seed_bucket(pg_tx)
+    first = await _seed_object(pg_tx, bucket_id, _T_A, [True, True])
+
+    sql = get_query("find_objects_ready_for_hard_delete")
+    page1 = await pg_tx.fetch(sql, 1, _EPOCH_CURSOR, _ZERO_UUID)
+    assert [r["object_id"] for r in page1] == [first]
+
+    last = page1[-1]
+    page2 = await pg_tx.fetch(sql, 1, last["deleted_at"], last["object_id"])
+    assert first not in {r["object_id"] for r in page2}, "cursor must be exclusive (strictly >)"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_unpin_identifiers_live_guard.py
+++ b/tests/integration/test_unpin_identifiers_live_guard.py
@@ -1,0 +1,156 @@
+"""The unpinner's chunk-selection guard: never hand back the CURRENT version of a LIVE object.
+
+`get_chunk_backend_identifiers` feeds the unpinner, which DELETES whatever it returns from the
+backend. Nothing in the query used to re-check that the object was still deleted, so safety rested
+entirely on the caller passing the right `object_version` — held up only by the fact that reviving a
+soft-deleted object bumps the version (`upsert_object_basic`: `deleted_at = NULL,
+current_object_version = GREATEST(...) + 1`). Any caller passing a stale/NULL version, or a future
+change that reuses version numbers, would have deleted live data off the backend.
+
+The guard is `(o.deleted_at IS NOT NULL OR p.object_version <> o.current_object_version)` — NOT a
+blunt `deleted_at IS NOT NULL`, because superseded versions of LIVE objects are legitimately
+unpinned (overwrite retention, cleanup_migration_versions.py, the unpin DLQ requeue path). These
+tests pin both halves: the live-current row is withheld, and every legitimate case still flows.
+
+Seed data goes through the auto-rolled-back `pg_tx` fixture; skips without Postgres on DATABASE_URL.
+"""
+
+import uuid
+
+import asyncpg
+import pytest
+
+from hippius_s3.utils import get_query
+
+
+async def _seed_bucket(conn: asyncpg.Connection) -> uuid.UUID:
+    acct = f"5HDTEST{uuid.uuid4().hex[:12]}"
+    await conn.execute("INSERT INTO users(main_account_id) VALUES($1) ON CONFLICT DO NOTHING", acct)
+    bucket_id = uuid.uuid4()
+    await conn.execute(
+        "INSERT INTO buckets(bucket_id, bucket_name, created_at, main_account_id) VALUES($1, $2, now(), $3)",
+        bucket_id,
+        f"unpin-guard-{bucket_id}",
+        acct,
+    )
+    return bucket_id
+
+
+async def _seed_object(
+    conn: asyncpg.Connection,
+    bucket_id: uuid.UUID,
+    *,
+    deleted: bool,
+    versions: list[int],
+    current_version: int,
+) -> uuid.UUID:
+    """Seed an object with a part+chunk per entry in `versions`, each carrying a live
+    `chunk_backend` row for backend 'arion' with a non-null identifier."""
+    oid = uuid.uuid4()
+    key = f"unpin-guard-{oid}"
+    await conn.execute(
+        "INSERT INTO objects(object_id, bucket_id, object_key, created_at, current_object_version, deleted_at)"
+        " VALUES($1, $2, $3, now(), $4, CASE WHEN $5::bool THEN now() ELSE NULL END)",
+        oid,
+        bucket_id,
+        key,
+        current_version,
+        deleted,
+    )
+    upload_id = uuid.uuid4()
+    await conn.execute(
+        "INSERT INTO multipart_uploads(upload_id, bucket_id, object_key, initiated_at) VALUES($1, $2, $3, now())",
+        upload_id,
+        bucket_id,
+        key,
+    )
+    for v in versions:
+        await conn.execute(
+            "INSERT INTO object_versions(object_id, object_version, storage_version, size_bytes, content_type)"
+            " VALUES($1, $2, 5, 100, 'application/octet-stream')",
+            oid,
+            v,
+        )
+        part_id = uuid.uuid4()
+        await conn.execute(
+            "INSERT INTO parts(part_id, upload_id, part_number, size_bytes, etag, uploaded_at, object_id, object_version)"
+            " VALUES($1, $2, 1, 100, 'etag', now(), $3, $4)",
+            part_id,
+            upload_id,
+            oid,
+            v,
+        )
+        chunk_pk = await conn.fetchval(
+            "INSERT INTO part_chunks(part_id, chunk_index, cipher_size_bytes) VALUES($1, 0, 100) RETURNING id",
+            part_id,
+        )
+        await conn.execute(
+            "INSERT INTO chunk_backend(chunk_id, backend, backend_identifier, deleted) VALUES($1, 'arion', $2, false)",
+            chunk_pk,
+            f"path-hash-{chunk_pk}",
+        )
+    return oid
+
+
+@pytest.mark.asyncio
+async def test_deleted_object_is_unpinnable(pg_tx: asyncpg.Connection) -> None:
+    """The normal path: the object is soft-deleted, so its chunks are handed to the unpinner."""
+    bucket_id = await _seed_bucket(pg_tx)
+    oid = await _seed_object(pg_tx, bucket_id, deleted=True, versions=[1], current_version=1)
+
+    rows = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, 1)
+    assert len(rows) == 1, "a soft-deleted object's chunks must still be unpinnable"
+
+
+@pytest.mark.asyncio
+async def test_live_object_current_version_is_withheld(pg_tx: asyncpg.Connection) -> None:
+    """THE data-loss case: object is LIVE and this is its current version — withhold the rows so
+    the unpinner cannot delete live data off the backend."""
+    bucket_id = await _seed_bucket(pg_tx)
+    oid = await _seed_object(pg_tx, bucket_id, deleted=False, versions=[1], current_version=1)
+
+    rows = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, 1)
+    assert rows == [], "the current version of a LIVE object must never be handed to the unpinner"
+
+
+@pytest.mark.asyncio
+async def test_live_object_superseded_version_is_still_unpinnable(pg_tx: asyncpg.Connection) -> None:
+    """The guard must NOT be a blunt deleted_at check: superseded versions of a live object are
+    legitimately unpinned (overwrite retention, cleanup_migration_versions, unpin DLQ requeue)."""
+    bucket_id = await _seed_bucket(pg_tx)
+    oid = await _seed_object(pg_tx, bucket_id, deleted=False, versions=[1, 2], current_version=2)
+
+    old = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, 1)
+    assert len(old) == 1, "a superseded version of a live object must remain unpinnable"
+
+    cur = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, 2)
+    assert cur == [], "...while its current version stays protected"
+
+
+@pytest.mark.asyncio
+async def test_null_version_on_live_object_returns_only_superseded(pg_tx: asyncpg.Connection) -> None:
+    """A NULL object_version means 'every version of this object'. On a LIVE object that must
+    still exclude the current version — this is the stale-caller case the guard exists for."""
+    bucket_id = await _seed_bucket(pg_tx)
+    oid = await _seed_object(pg_tx, bucket_id, deleted=False, versions=[1, 2, 3], current_version=3)
+
+    rows = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, None)
+    versions = {
+        await pg_tx.fetchval(
+            "SELECT p.object_version FROM part_chunks pc JOIN parts p ON p.part_id = pc.part_id WHERE pc.id = $1",
+            r["chunk_id"],
+        )
+        for r in rows
+    }
+    assert versions == {1, 2}, f"NULL version must yield only superseded versions, got {versions}"
+
+
+@pytest.mark.asyncio
+async def test_null_version_on_deleted_object_returns_every_version(pg_tx: asyncpg.Connection) -> None:
+    """Once the object is deleted, every version — including the last current one — is unpinnable,
+    otherwise the object could never become fully unpinned and hard-deletable."""
+    bucket_id = await _seed_bucket(pg_tx)
+    oid = await _seed_object(pg_tx, bucket_id, deleted=True, versions=[1, 2], current_version=2)
+
+    rows = await pg_tx.fetch(get_query("get_chunk_backend_identifiers"), "arion", oid, None)
+    assert len(rows) == 2, "a deleted object must expose all versions so it can be fully unpinned"

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -2087,13 +2087,48 @@ async def evict_from_inventory(
     return deleted_total
 
 
+HARD_DELETE_CURSOR_KEY = "hard_delete_cursor"
+_HARD_DELETE_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+_HARD_DELETE_ZERO_UUID = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+
 async def gc_soft_deleted_objects(pool: asyncpg.Pool) -> int:
-    """Hard-delete objects where all backends have confirmed unpin."""
+    """Hard-delete objects where all backends have confirmed unpin.
+
+    Keyset-paged over a DURABLE cursor (`janitor_state.hard_delete_cursor`) rather than always
+    re-reading the oldest batch. The oldest soft-deleted objects on prod are permanently un-ready
+    — their unpins were lost in the redis-queues unpin-overrun incident, so they still hold live
+    chunk_backend rows — and the un-cursored query re-scanned exactly those every cycle, returning
+    0 forever while ~33M ready objects queued behind them. See the SQL for the full write-up.
+
+    The cursor advances over EVERY scanned candidate (ready or not), so a stuck object costs one
+    page-slot per full sweep instead of blocking the phase permanently. A short page means the end
+    of the table was reached, so the cursor wraps to the epoch and the next cycle re-sweeps from
+    the start (picking up newly soft-deleted objects, and retrying stuck ones once per lap).
+
+    The cursor is advisory: it is persisted best-effort AFTER the deletes, so a crash mid-page
+    re-scans that page next cycle (harmless — hard_delete_object is idempotent and re-verifies
+    readiness atomically).
+    """
     async with pool.acquire() as db:
-        rows = await db.fetch(get_query("find_objects_ready_for_hard_delete"), config.janitor_hard_delete_batch)
+        state = await get_janitor_state(db, HARD_DELETE_CURSOR_KEY) or {}
+        raw_ts, raw_id = state.get("deleted_at"), state.get("object_id")
+        try:
+            cursor_ts = datetime.fromisoformat(raw_ts) if raw_ts else _HARD_DELETE_EPOCH
+            cursor_id = uuid.UUID(raw_id) if raw_id else _HARD_DELETE_ZERO_UUID
+        except (TypeError, ValueError):
+            # A corrupt/hand-edited cursor must not wedge the phase: restart the sweep.
+            logger.warning("Hard-delete cursor unparseable (%r, %r); restarting sweep", raw_ts, raw_id)
+            cursor_ts, cursor_id = _HARD_DELETE_EPOCH, _HARD_DELETE_ZERO_UUID
+
+        batch = config.janitor_hard_delete_batch
+        rows = await db.fetch(get_query("find_objects_ready_for_hard_delete"), batch, cursor_ts, cursor_id)
         deleted = 0
         skipped = 0
+        scanned = len(rows)
         for row in rows:
+            if not row["ready"]:
+                continue  # scanned-but-not-ready: the cursor still advances past it
             try:
                 # Guarded delete: re-verifies readiness atomically so a row revived
                 # (re-PUT clears deleted_at + adds live chunks) between the find and
@@ -2103,11 +2138,36 @@ async def gc_soft_deleted_objects(pool: asyncpg.Pool) -> int:
                     skipped += 1
                     continue
                 deleted += 1
-                logger.info(f"Hard-deleted soft-deleted object: object_id={row['object_id']}")
+                logger.debug(f"Hard-deleted soft-deleted object: object_id={row['object_id']}")
             except Exception as e:
                 logger.warning(f"Failed to hard-delete object {row['object_id']}: {e}")
         if skipped:
             logger.info(f"Hard-delete skipped {skipped} object(s) no longer ready (revived/in-flight)")
+
+        # Advance (or wrap) the cursor. A short page == end of table.
+        if scanned < batch:
+            next_ts, next_id, wrapped = _HARD_DELETE_EPOCH, _HARD_DELETE_ZERO_UUID, True
+        else:
+            last = rows[-1]
+            next_ts, next_id, wrapped = last["deleted_at"], last["object_id"], False
+        try:
+            await set_janitor_state(
+                db,
+                HARD_DELETE_CURSOR_KEY,
+                {"deleted_at": next_ts.isoformat(), "object_id": str(next_id)},
+            )
+        except Exception as e:
+            # Losing the cursor write only costs a re-scan of this page next cycle.
+            logger.warning(f"Failed to persist hard-delete cursor: {e}")
+        logger.info(
+            "Hard-delete phase: scanned=%d ready_deleted=%d skipped=%d wrapped=%s cursor=(%s, %s)",
+            scanned,
+            deleted,
+            skipped,
+            wrapped,
+            next_ts.isoformat(),
+            next_id,
+        )
     return deleted
 
 


### PR DESCRIPTION
Two janitor safety/correctness fixes, targeted at **prod** because the first one is the reason the CephFS pool won't drain.

## 1. Head-of-line block in the hard-delete scan (the pool-filler)

`find_objects_ready_for_hard_delete` took the **oldest N** soft-deleted objects every cycle (`ORDER BY deleted_at LIMIT $1`) and only *then* filtered for readiness. On prod those oldest objects are **permanently un-ready** — their unpins were lost when the unpin queue was cleared during the redis-queues unpin-overrun incident, so they still hold live `chunk_backend` rows and can never satisfy the `NOT EXISTS`.

**Measured on prod:**
- of the **2000 oldest** candidates → **0 ready**
- of 2000 **recent** candidates → **1577 ready (79%)**
- every janitor cycle for months: **`hard_deleted=0`**, with **~33M** soft-deleted objects pending

Nothing hard-deleted → `parts` rows stay → their FS cache dirs stay pinned (the replication gate reads an all-unpinned part as "unreplicated" and *protects* it) → **~97% of the cold cache is deleted-object garbage the janitor is guarding.** That's what filled the pool.

**Fix:** page the scan on a keyset cursor (`$2 deleted_at`, `$3 object_id`) persisted in `janitor_state` (table already added by the SQL-eviction release), and return **every scanned candidate with a `ready` flag** so the caller advances past un-ready objects instead of restarting at them. A short page = end of table → cursor wraps to the epoch, so stuck objects cost one page-slot per sweep instead of blocking every cycle.

**Dry-run against prod (read-only) confirms it:**

| cursor | scanned | ready |
|---|---|---|
| epoch (what the old query always saw) | 2000 | **0** |
| 2026-03-01 | 500 | 0 |
| 2026-05-01 | 500 | 0 |
| **2026-07-01** | 500 | **500** |
| **3 days ago** | 500 | **498** |

## 2. Never unpin the current version of a live object

`get_chunk_backend_identifiers` feeds the unpinner, which **deletes whatever it returns from the backend**, and nothing re-checked that the object was still deleted — safety rested entirely on the caller passing the right `object_version`. Added `AND (o.deleted_at IS NOT NULL OR p.object_version <> o.current_object_version)`. Deliberately not a blunt `deleted_at` check, which would silently break legitimate unpins of superseded versions (overwrite retention, `cleanup_migration_versions.py`, unpin DLQ requeue). Fail direction is safe: excluded rows mean the unpinner deletes nothing (a visible stall), never data loss.

## Tests
- New: cursor advances past a permanently-unready head; cursor is exclusive (no page repeats).
- New: 5 cases for the unpin guard (live-current withheld; deleted / superseded / NULL-version fan-out all still flow).
- Updated the existing hard-delete semantics tests for the `ready`-flag signature.
- **143 janitor unit tests + 12 integration tests pass**; ruff clean; `ty` clean apart from a pre-existing `wait_for` diagnostic.

## Note
This does **not** by itself clear the ~33M backlog's stuck head — those objects still need their lost unpins re-driven (they're blocked on live **ovh** + **ipfs** rows; arion is already fully unpinned). That's the follow-up with `backfill_soft_delete_unpins.py`. This PR stops the *scan* from being wedged so everything behind them drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)