### PR TITLE
SAFETY: declare HIPPIUS_BACKUP_BACKENDS so the janitor gate keeps requiring arion AND ovh

### DIFF
--- a/k8s/production/environment-patch.yaml
+++ b/k8s/production/environment-patch.yaml
@@ -13,3 +13,21 @@ data:
   # in the same change as a 396-commit cutover — it is rollback-without-redeploy, so enable it
   # as a separate change AFTER the cutover has soaked.
   HIPPIUS_STREAM_SINGLE_SUBSCRIPTION: "false"
+  # SAFETY-CRITICAL — the janitor's absolute replication gate. Do not remove.
+  #
+  # is_replicated_on_all_backends() unions this into the required-backend set before ANY
+  # eviction, so this is what makes "replicated to BOTH arion and ovh" the condition for
+  # deleting a cached part. Legacy object_versions rows whose `upload_backends` column says
+  # only ['arion'] are covered by ovh ONLY because of this value.
+  #
+  # It has to be declared here because config.py defaults it to EMPTY
+  # (`env("HIPPIUS_BACKUP_BACKENDS:")`). Until 2026-07-25 it existed solely as a live
+  # `kubectl set env` override on the prod janitor and appeared nowhere in git — one
+  # server-side apply, `kubectl replace`, deployment recreate, or "reconcile to the manifest"
+  # would have silently dropped ovh from the gate and made every arion-only chunk instantly
+  # evictable (>=500 live chunks were in exactly that state when this was found).
+  #
+  # PRODUCTION-ONLY on purpose: staging does not replicate to ovh, so requiring ovh coverage
+  # there would make nothing ever evictable and wedge its janitor. Read only by the janitor
+  # (gate + replication sentinel + SQL eviction) — no other component consumes it.
+  HIPPIUS_BACKUP_BACKENDS: "ovh"


### PR DESCRIPTION
**Merge this first.** One line of config; removes a live single-point-of-failure in the janitor's data-safety gate.

## The problem
The janitor's absolute replication gate only evicts a cached part once every chunk is live on every **required** backend. `is_replicated_on_all_backends()` builds that set as:

```
(per-version upload_backends OR config.upload_backends)  UNION  config.backup_backends
```

So `backup_backends=ovh` is *precisely* what makes **"replicated to BOTH arion and ovh"** the condition for deleting cached data. Legacy `object_versions` rows whose `upload_backends` column says only `['arion']` are covered by ovh **solely** because of it.

`config.py` defaults it to **empty** (`env("HIPPIUS_BACKUP_BACKENDS:")`), and until now the value existed **only as a live `kubectl set env` override** on the prod janitor — present nowhere in git:

```
live prod janitor:  HIPPIUS_BACKUP_BACKENDS=ovh
grep -rn HIPPIUS_BACKUP_BACKENDS k8s/ .github/   →  (nothing)
```

Any server-side apply, `kubectl replace`, deployment recreate, or "reconcile to the manifest" would have silently dropped ovh from the required set — and every arion-only chunk becomes **immediately evictable**. **≥500 live chunks are in exactly that state right now** (the replication sentinel is capped at 500 and pinned there).

It has survived only because CI happens to use **client-side** apply, whose 3-way merge preserves live-only env entries. That's an accident of tooling, not a design — and it is exactly the kind of thing a manifest-reconciliation PR would undo.

## The fix
Declare it in the **production overlay** (`environment-patch.yaml` → the `hippius-s3-environment` ConfigMap the janitor already consumes via `envFrom`).

**Production-only on purpose:** staging does not replicate to ovh, so requiring ovh coverage there would leave nothing evictable and wedge its janitor.

## Verification
```
kustomize k8s/production  → HIPPIUS_BACKUP_BACKENDS: ovh   (1 occurrence)
kustomize k8s/staging     → 0 occurrences
both overlays build clean
live prod value           → ovh   (identical → applying is a behavioural no-op)
```
Read exclusively by the janitor (gate + replication sentinel + SQL eviction); no other component consumes `backup_backends`.

Found by adversarial review of #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)