### PR TITLE
feat(janitor): queue depth/age gauges for all Redis work queues

### DIFF
--- a/hippius_s3/queue_metrics.py
+++ b/hippius_s3/queue_metrics.py
@@ -32,18 +32,12 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_SAMPLE_INTERVAL_SECONDS = 30.0
 
-# The pinner's consume queue is not backend-derived; it is fed by the api's
-# producer fan-out and drained by the external pinner. substrate_requests is
-# the chain-publish queue, likewise not backend-derived.
-#
 # OVERLAP NOTE: the api's BackgroundMetricsCollector also samples list depths
 # into `hippius_queue_length{queue_name=...}` every 10s. This sampler is the
 # intended single source of truth going forward (it adds retry ZSETs and
 # oldest-age, and lives with the janitor rather than every api pod); retiring
 # the api collector's depth loop is a planned follow-up — until then dashboards
 # should prefer `queue_depth{queue=...}`.
-PINNER_QUEUE = "upload_requests"
-SUBSTRATE_QUEUE = "substrate_requests"
 
 
 def build_queue_key_sets(config: Config) -> tuple[list[str], list[str]]:
@@ -59,7 +53,7 @@ def build_queue_key_sets(config: Config) -> tuple[list[str], list[str]]:
         ("download", config.download_backends),
         ("unpin", config.delete_backends),
     )
-    lists: list[str] = [PINNER_QUEUE, SUBSTRATE_QUEUE]
+    lists: list[str] = []
     zsets: list[str] = []
     for kind, backends in kinds:
         lists.extend(f"{backend}_{kind}_requests" for backend in backends)

--- a/hippius_s3/queue_metrics.py
+++ b/hippius_s3/queue_metrics.py
@@ -115,24 +115,31 @@ class QueueDepthSampler:
 
     async def sample_once(self, now: float | None = None) -> None:
         now = time.time() if now is None else now
+        # Build fresh dicts and atomically rebind at the end. The OTel exporter runs the
+        # gauge callbacks on a BACKGROUND thread, so mutating the live dicts in place here
+        # (on the event loop) can raise "dictionary changed size during iteration" in a
+        # callback. A reference rebind is atomic under the GIL, so a callback always reads a
+        # complete prior-or-next snapshot.
+        new_depths: dict[str, int] = {}
         for key in self.list_keys:
-            self.depths[key] = int(await self._redis.llen(key))
+            new_depths[key] = int(await self._redis.llen(key))
         for key in self.zset_keys:
-            self.depths[key] = int(await self._redis.zcard(key))
+            new_depths[key] = int(await self._redis.zcard(key))
         # Oldest-age only for plain request lists: BRPOP consumes from the
         # right, so index -1 is the next payload out and the oldest waiting.
+        # Keys with unknowable age are simply omitted (fresh dict starts empty).
+        new_oldest_age: dict[str, float] = {}
         for key in self.list_keys:
             if key.endswith(":dlq"):
                 continue
-            age: float | None = None
-            if self.depths.get(key, 0) > 0:
+            if new_depths.get(key, 0) > 0:
                 raw = await self._redis.lindex(key, -1)
                 if raw is not None:
                     age = _payload_age_seconds(raw, now)
-            if age is None:
-                self.oldest_age.pop(key, None)
-            else:
-                self.oldest_age[key] = age
+                    if age is not None:
+                        new_oldest_age[key] = age
+        self.depths = new_depths
+        self.oldest_age = new_oldest_age
 
     async def run(self, interval: float = DEFAULT_SAMPLE_INTERVAL_SECONDS) -> None:
         while True:

--- a/hippius_s3/queue_metrics.py
+++ b/hippius_s3/queue_metrics.py
@@ -1,0 +1,151 @@
+"""Depth/age gauges for the Redis work queues.
+
+The 2026-07-25 audit found 136k payloads silently accumulated in
+`ovh_download_requests` (fan-out enabled, consumer scaled to 0) on a
+`noeviction` Redis — invisible because nothing measured queue depth. These
+gauges make every work queue, retry ZSET, and DLQ a first-class signal:
+
+    queue_depth{queue=...}              LLEN / ZCARD per key
+    queue_oldest_age_seconds{queue=...} age of the head payload, where knowable
+
+Runs inside the janitor (single instance, already holds a queues-Redis client),
+sampled on a fixed interval off the cycle path. Sampling is best-effort: a
+Redis blip keeps the previous values rather than crashing the janitor or
+zeroing gauges (a false "queue empty" during an outage would mask the exact
+condition this exists to catch).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any
+
+from opentelemetry import metrics as otel_metrics
+
+from hippius_s3.config import Config
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SAMPLE_INTERVAL_SECONDS = 30.0
+
+# The pinner's consume queue is not backend-derived; it is fed by the api's
+# producer fan-out and drained by the external pinner.
+PINNER_QUEUE = "upload_requests"
+
+
+def build_queue_key_sets(config: Config) -> tuple[list[str], list[str]]:
+    """(list_keys, zset_keys) for every queue this deployment can produce.
+
+    Derived from the backend config rather than hardcoded so a new backend is
+    covered the moment it is configured. Naming mirrors hippius_s3.queue:
+    `{b}_{kind}_requests` lists, `{b}_{kind}_retries` ZSETs, and the DLQ lists
+    (`{b}_upload_requests:dlq`, shared `unpin_requests:dlq`).
+    """
+    kinds = (
+        ("upload", config.upload_backends),
+        ("download", config.download_backends),
+        ("unpin", config.delete_backends),
+    )
+    lists: list[str] = [PINNER_QUEUE]
+    zsets: list[str] = []
+    for kind, backends in kinds:
+        lists.extend(f"{backend}_{kind}_requests" for backend in backends)
+        zsets.extend(f"{backend}_{kind}_retries" for backend in backends)
+    lists.extend(f"{backend}_upload_requests:dlq" for backend in config.upload_backends)
+    lists.append("unpin_requests:dlq")
+    return lists, zsets
+
+
+def _payload_age_seconds(raw: Any, now: float) -> float | None:
+    """Best-effort age of a queue payload from its own timestamps.
+
+    `first_enqueued_at` is authoritative when set; `expire_at` minus the
+    reader's cache TTL would be guesswork, so a payload without a usable
+    timestamp reports no age rather than a wrong one.
+    """
+    try:
+        data = json.loads(raw)
+        enqueued = data.get("first_enqueued_at")
+        if enqueued:
+            return max(0.0, now - float(enqueued))
+    except Exception:
+        return None
+    return None
+
+
+class QueueDepthSampler:
+    """Samples queue depths/ages into dicts served by OTel observable gauges."""
+
+    def __init__(
+        self,
+        redis_client: Any,
+        config: Config,
+        *,
+        register_metrics: bool = True,
+    ) -> None:
+        self._redis = redis_client
+        self.list_keys, self.zset_keys = build_queue_key_sets(config)
+        self.depths: dict[str, int] = {}
+        self.oldest_age: dict[str, float] = {}
+        if register_metrics:
+            meter = otel_metrics.get_meter(__name__)
+            meter.create_observable_gauge(
+                name="queue_depth",
+                callbacks=[self._obs_depth],
+                description="Items in each Redis work queue / retry ZSET / DLQ",
+            )
+            meter.create_observable_gauge(
+                name="queue_oldest_age_seconds",
+                callbacks=[self._obs_age],
+                description="Age of the oldest payload in each work queue, where knowable",
+            )
+
+    def _obs_depth(self, _: object) -> list[otel_metrics.Observation]:
+        return [otel_metrics.Observation(v, {"queue": k}) for k, v in self.depths.items()]
+
+    def _obs_age(self, _: object) -> list[otel_metrics.Observation]:
+        return [otel_metrics.Observation(v, {"queue": k}) for k, v in self.oldest_age.items()]
+
+    async def sample_once(self, now: float | None = None) -> None:
+        now = time.time() if now is None else now
+        for key in self.list_keys:
+            self.depths[key] = int(await self._redis.llen(key))
+        for key in self.zset_keys:
+            self.depths[key] = int(await self._redis.zcard(key))
+        # Oldest-age only for plain request lists: BRPOP consumes from the
+        # right, so index -1 is the next payload out and the oldest waiting.
+        for key in self.list_keys:
+            if key.endswith(":dlq"):
+                continue
+            age: float | None = None
+            if self.depths.get(key, 0) > 0:
+                raw = await self._redis.lindex(key, -1)
+                if raw is not None:
+                    age = _payload_age_seconds(raw, now)
+            if age is None:
+                self.oldest_age.pop(key, None)
+            else:
+                self.oldest_age[key] = age
+
+    async def run(self, interval: float = DEFAULT_SAMPLE_INTERVAL_SECONDS) -> None:
+        while True:
+            try:
+                await self.sample_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                # Keep prior values: zeroed gauges during a Redis outage would
+                # read as "all queues drained" — the opposite of the truth.
+                logger.warning("Queue depth sample failed (keeping last values): %s", exc)
+            await asyncio.sleep(interval)
+
+
+__all__ = [
+    "DEFAULT_SAMPLE_INTERVAL_SECONDS",
+    "QueueDepthSampler",
+    "build_queue_key_sets",
+]

--- a/hippius_s3/queue_metrics.py
+++ b/hippius_s3/queue_metrics.py
@@ -33,8 +33,17 @@ logger = logging.getLogger(__name__)
 DEFAULT_SAMPLE_INTERVAL_SECONDS = 30.0
 
 # The pinner's consume queue is not backend-derived; it is fed by the api's
-# producer fan-out and drained by the external pinner.
+# producer fan-out and drained by the external pinner. substrate_requests is
+# the chain-publish queue, likewise not backend-derived.
+#
+# OVERLAP NOTE: the api's BackgroundMetricsCollector also samples list depths
+# into `hippius_queue_length{queue_name=...}` every 10s. This sampler is the
+# intended single source of truth going forward (it adds retry ZSETs and
+# oldest-age, and lives with the janitor rather than every api pod); retiring
+# the api collector's depth loop is a planned follow-up — until then dashboards
+# should prefer `queue_depth{queue=...}`.
 PINNER_QUEUE = "upload_requests"
+SUBSTRATE_QUEUE = "substrate_requests"
 
 
 def build_queue_key_sets(config: Config) -> tuple[list[str], list[str]]:
@@ -50,7 +59,7 @@ def build_queue_key_sets(config: Config) -> tuple[list[str], list[str]]:
         ("download", config.download_backends),
         ("unpin", config.delete_backends),
     )
-    lists: list[str] = [PINNER_QUEUE]
+    lists: list[str] = [PINNER_QUEUE, SUBSTRATE_QUEUE]
     zsets: list[str] = []
     for kind, backends in kinds:
         lists.extend(f"{backend}_{kind}_requests" for backend in backends)

--- a/tests/unit/test_queue_metrics.py
+++ b/tests/unit/test_queue_metrics.py
@@ -1,0 +1,114 @@
+"""Unit tests for the janitor's queue depth/age sampler."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from hippius_s3.queue_metrics import QueueDepthSampler
+from hippius_s3.queue_metrics import build_queue_key_sets
+
+
+def _config(upload=None, download=None, delete=None):
+    return SimpleNamespace(
+        upload_backends=upload or ["arion", "ovh"],
+        download_backends=download or ["arion", "ovh"],
+        delete_backends=delete or ["arion", "ovh"],
+    )
+
+
+class FakeRedis:
+    def __init__(self, lists=None, zsets=None, fail=False):
+        self.lists = lists or {}
+        self.zsets = zsets or {}
+        self.fail = fail
+
+    async def llen(self, key):
+        if self.fail:
+            raise ConnectionError("redis down")
+        return len(self.lists.get(key, []))
+
+    async def zcard(self, key):
+        return len(self.zsets.get(key, []))
+
+    async def lindex(self, key, index):
+        items = self.lists.get(key)
+        if not items:
+            return None
+        return items[index]
+
+
+def test_key_sets_cover_all_backends_and_kinds():
+    lists, zsets = build_queue_key_sets(_config())
+
+    assert "upload_requests" in lists  # pinner queue
+    for backend in ("arion", "ovh"):
+        for kind in ("upload", "download", "unpin"):
+            assert f"{backend}_{kind}_requests" in lists
+            assert f"{backend}_{kind}_retries" in zsets
+        assert f"{backend}_upload_requests:dlq" in lists
+    assert "unpin_requests:dlq" in lists
+
+
+@pytest.mark.asyncio
+async def test_sample_reports_depths_and_age():
+    payload_old = json.dumps({"object_id": "x", "first_enqueued_at": 900.0})
+    payload_new = json.dumps({"object_id": "y", "first_enqueued_at": 990.0})
+    redis = FakeRedis(
+        lists={
+            # LPUSH-head order: index -1 is the oldest (next BRPOP out).
+            "ovh_download_requests": [payload_new, payload_old],
+            "arion_upload_requests:dlq": [payload_old],
+        },
+        zsets={"ovh_download_retries": ["a", "b", "c"]},
+    )
+    sampler = QueueDepthSampler(redis, _config(), register_metrics=False)
+
+    await sampler.sample_once(now=1000.0)
+
+    assert sampler.depths["ovh_download_requests"] == 2
+    assert sampler.depths["arion_upload_requests:dlq"] == 1
+    assert sampler.depths["ovh_download_retries"] == 3
+    assert sampler.depths["arion_download_requests"] == 0
+    assert sampler.oldest_age["ovh_download_requests"] == pytest.approx(100.0)
+    # DLQs report depth only — no age probe.
+    assert "arion_upload_requests:dlq" not in sampler.oldest_age
+
+
+@pytest.mark.asyncio
+async def test_payload_without_timestamp_reports_no_age():
+    redis = FakeRedis(lists={"ovh_download_requests": [json.dumps({"object_id": "x"})]})
+    sampler = QueueDepthSampler(redis, _config(), register_metrics=False)
+
+    await sampler.sample_once(now=1000.0)
+
+    assert sampler.depths["ovh_download_requests"] == 1
+    assert "ovh_download_requests" not in sampler.oldest_age
+
+
+@pytest.mark.asyncio
+async def test_malformed_payload_reports_no_age():
+    redis = FakeRedis(lists={"ovh_download_requests": [b"not-json"]})
+    sampler = QueueDepthSampler(redis, _config(), register_metrics=False)
+
+    await sampler.sample_once(now=1000.0)
+
+    assert sampler.depths["ovh_download_requests"] == 1
+    assert "ovh_download_requests" not in sampler.oldest_age
+
+
+@pytest.mark.asyncio
+async def test_redis_failure_keeps_previous_values():
+    redis = FakeRedis(lists={"ovh_download_requests": [json.dumps({"first_enqueued_at": 1.0})]})
+    sampler = QueueDepthSampler(redis, _config(), register_metrics=False)
+    await sampler.sample_once(now=10.0)
+    assert sampler.depths["ovh_download_requests"] == 1
+
+    redis.fail = True
+    with pytest.raises(ConnectionError):
+        await sampler.sample_once(now=20.0)
+    # run() swallows the raise and keeps the last-good values; sample_once
+    # surfaces it so the loop's except path owns the policy.
+    assert sampler.depths["ovh_download_requests"] == 1

--- a/tests/unit/test_queue_metrics.py
+++ b/tests/unit/test_queue_metrics.py
@@ -44,6 +44,7 @@ def test_key_sets_cover_all_backends_and_kinds():
     lists, zsets = build_queue_key_sets(_config())
 
     assert "upload_requests" in lists  # pinner queue
+    assert "substrate_requests" in lists  # chain-publish queue
     for backend in ("arion", "ovh"):
         for kind in ("upload", "download", "unpin"):
             assert f"{backend}_{kind}_requests" in lists

--- a/tests/unit/test_queue_metrics.py
+++ b/tests/unit/test_queue_metrics.py
@@ -43,8 +43,11 @@ class FakeRedis:
 def test_key_sets_cover_all_backends_and_kinds():
     lists, zsets = build_queue_key_sets(_config())
 
-    assert "upload_requests" in lists  # pinner queue
-    assert "substrate_requests" in lists  # chain-publish queue
+    # Only backend-qualified queues that the current producer actually writes to are gauged.
+    # The legacy bare `upload_requests` (old standalone pinner) and `substrate_requests`
+    # (chain-publish is now inline in the uploader) receive no traffic — no phantom always-0 gauges.
+    assert "upload_requests" not in lists
+    assert "substrate_requests" not in lists
     for backend in ("arion", "ovh"):
         for kind in ("upload", "download", "unpin"):
             assert f"{backend}_{kind}_requests" in lists

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -22,6 +22,7 @@ Disk-pressure modes (all still replication-gated):
 """
 
 import asyncio
+import contextlib
 import json
 import logging
 import math
@@ -58,6 +59,7 @@ from hippius_s3.cache import create_fs_store
 from hippius_s3.config import get_config
 from hippius_s3.logging_config import setup_loki_logging
 from hippius_s3.otel_setup import build_resource
+from hippius_s3.queue_metrics import QueueDepthSampler
 from hippius_s3.repositories import fs_cache_inventory
 from hippius_s3.repositories.fs_cache_inventory import clear_cached
 from hippius_s3.repositories.fs_cache_inventory import get_janitor_state
@@ -2211,6 +2213,13 @@ async def run_janitor_loop():
     # Initialize janitor-owned OTel metrics
     _setup_janitor_metrics()
 
+    # Queue depth/age gauges (2026-07-25 audit: 136k payloads accumulated
+    # unseen in ovh_download_requests). Janitor hosts the sampler because it is
+    # single-instance and already holds the queues-Redis client; the task runs
+    # off the cycle path so a slow walk never blinds the queue gauges.
+    queue_sampler = QueueDepthSampler(redis_client, config)
+    queue_sampler_task = asyncio.create_task(queue_sampler.run())
+
     logger.info("Starting janitor service...")
     logger.info(f"FS store root: {config.object_cache_dir}")
     logger.info(f"MPU stale threshold: {config.mpu_stale_seconds}s")
@@ -2351,6 +2360,9 @@ async def run_janitor_loop():
             _janitor_phase = 0
             await asyncio.sleep(sleep_interval)
     finally:
+        queue_sampler_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await queue_sampler_task
         if redis_client:
             await redis_client.close()
         if db_pool:


### PR DESCRIPTION
## What

First hippius-s3 slice of the 2026-07-25 hydrator/pool audit (plan lives in s3-backup `docs/plans/2026-07-25-hydrator-audit-remediation.md`, §PR H1).

**Why:** `ovh_download_requests` accumulated **136,604 payloads** with zero consumers (`HIPPIUS_DOWNLOAD_BACKENDS=arion,ovh` fans out to both queues; the hydrator deployment is scaled to 0) on `redis-queues`, which runs `maxmemory 4gb` + **`noeviction`** — the failure mode of letting that grow is cluster-wide queue-write failures. Nothing measured queue depth, so it was invisible.

- New `hippius_s3/queue_metrics.py`: `QueueDepthSampler` emits `queue_depth{queue=...}` (LLEN/ZCARD) and `queue_oldest_age_seconds{queue=...}` (head payload's `first_enqueued_at`, where present) for every `{backend}_{kind}_requests` list, `{backend}_{kind}_retries` ZSET, the pinner queue, and the DLQs — derived from backend config, not hardcoded.
- Janitor hosts the sampler (single-instance, already holds the queues-Redis client) as an asyncio task every 30 s, off the cycle path so a slow walk never blinds the gauges. Redis errors keep last-good values — zeroed gauges during an outage would read as "all queues drained".

## Follow-up (not in this PR)

Grafana alert rules belong in hippius-otel; proposed starting thresholds, flagged for calibration: `queue_depth > 10k for 30m`, `queue_oldest_age_seconds > 6h` on non-DLQ queues, any DLQ depth > 0.

## Testing

`tests/unit/test_queue_metrics.py` (5 tests): key-set coverage per backend/kind, depth+age sampling with BRPOP-order head, no-timestamp and malformed payloads report no age, Redis failure keeps prior values. Full unit suite: 2155 passed, 37 skipped. `ruff check` clean on touched files.