### PR TITLE
feat(pressure): publish shared fs_cache:pressure signal, consume in api gate

### DIFF
--- a/hippius_s3/api/middlewares/fs_cache_pressure.py
+++ b/hippius_s3/api/middlewares/fs_cache_pressure.py
@@ -9,6 +9,7 @@ from fastapi import Response
 
 from hippius_s3.api.s3 import errors as s3_errors
 from hippius_s3.fs_pressure import should_reject_fs_cache_write
+from hippius_s3.pressure_signal import get_published_pressure_mode
 
 
 logger = logging.getLogger(__name__)
@@ -56,7 +57,12 @@ async def fs_cache_pressure_middleware(
     if config is None:
         return await call_next(request)
 
-    reject, retry_after, pressure, reason = should_reject_fs_cache_write(config=config)
+    # Janitor-published pool signal (memoized ~5s; None = unavailable → the
+    # local statvfs check alone governs, which is the pre-signal behavior).
+    published_mode = await get_published_pressure_mode(getattr(request.app.state, "redis_client", None))
+    reject, retry_after, pressure, reason = should_reject_fs_cache_write(
+        config=config, published_mode=published_mode
+    )
     if not reject:
         return await call_next(request)
 

--- a/hippius_s3/api/middlewares/fs_cache_pressure.py
+++ b/hippius_s3/api/middlewares/fs_cache_pressure.py
@@ -60,9 +60,7 @@ async def fs_cache_pressure_middleware(
     # Janitor-published pool signal (memoized ~5s; None = unavailable → the
     # local statvfs check alone governs, which is the pre-signal behavior).
     published_mode = await get_published_pressure_mode(getattr(request.app.state, "redis_client", None))
-    reject, retry_after, pressure, reason = should_reject_fs_cache_write(
-        config=config, published_mode=published_mode
-    )
+    reject, retry_after, pressure, reason = should_reject_fs_cache_write(config=config, published_mode=published_mode)
     if not reject:
         return await call_next(request)
 

--- a/hippius_s3/fs_pressure.py
+++ b/hippius_s3/fs_pressure.py
@@ -27,19 +27,31 @@ def get_fs_cache_pressure(config: Config) -> FsCachePressure:
 def should_reject_fs_cache_write(
     *,
     config: Config,
+    published_mode: int | None = None,
 ) -> tuple[bool, float, FsCachePressure, str]:
-    """Reject when current free-space is below configured thresholds."""
+    """Reject when local free-space OR the published pool signal says stop.
+
+    The local statvfs check sees only the mount under `object_cache_dir` — on
+    prod api-local that is the node NVMe, which stayed green on 2026-07-24
+    while the backing Ceph pool filled to the read-only cliff. The janitor's
+    published `fs_cache:pressure` mode (pressure_signal.py) closes that blind
+    spot; `None` (signal unavailable) preserves the local-only behavior.
+    """
     pressure = get_fs_cache_pressure(config)
 
     threshold_hit = pressure.free_bytes <= int(config.fs_cache_min_free_bytes) or pressure.free_ratio <= float(
         config.fs_cache_min_free_ratio
     )
+    reason = "threshold"
+    if not threshold_hit and published_mode == 2:
+        threshold_hit = True
+        reason = "pool"
     if threshold_hit:
         # C2: jitter Retry-After ±25% so a fleet of throttled clients doesn't retry in a
         # synchronized wave (thundering herd) the instant a shared window elapses — which would
         # re-spike disk pressure and re-trigger the gate. Floor at 1s.
         base = float(config.fs_cache_retry_after_seconds)
         jittered = max(1.0, base * random.uniform(0.75, 1.25))
-        return True, jittered, pressure, "threshold"
+        return True, jittered, pressure, reason
 
     return False, 0.0, pressure, "ok"

--- a/hippius_s3/pressure_signal.py
+++ b/hippius_s3/pressure_signal.py
@@ -1,0 +1,219 @@
+"""Shared FS-cache pressure signal: one authority, many consumers.
+
+The janitor computes pressure as max(local statvfs, fullest Ceph pool %USED
+from the mgr exporter) and publishes it here; every writer that must back off
+(api PUT throttle, the s3-backup hydrator, future writers) reads the published
+key instead of probing the mgr or guessing from its own mount. Independent
+per-writer probes are how the api middleware ended up gating on the local NVMe
+while the backing pool filled to the read-only cliff (2026-07-24 incident).
+
+Contract (mirrored in s3-backup docs/plans/2026-07-25-hydrator-audit-remediation.md §C1):
+    key   fs_cache:pressure                       (cache Redis)
+    value {"mode": 0|1|2, "ratio": float, "source": "janitor", "ts": unix}
+    SET every PUBLISH_INTERVAL_SECONDS with EX=PRESSURE_TTL_SECONDS
+Consumers treat a missing/expired key as "signal unavailable" and fall back to
+their own local check — never fail-open silently, never hard-stop on absence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+logger = logging.getLogger(__name__)
+
+PRESSURE_KEY = "fs_cache:pressure"
+PUBLISH_INTERVAL_SECONDS = 30.0
+# TTL covers several missed publishes before consumers fall back to local
+# checks; a janitor outage degrades the gate rather than freezing a stale mode.
+PRESSURE_TTL_SECONDS = 120
+
+# Enter/exit watermark pairs (hysteresis): a disk hovering at a boundary must
+# not flap the mode — and everything keyed off it — every sample.
+PRESSURE_ELEVATED = 0.85
+PRESSURE_ELEVATED_EXIT = 0.83
+PRESSURE_CRITICAL = 0.95
+PRESSURE_CRITICAL_EXIT = 0.93
+
+
+def label_value(line: str, needle: str) -> str | None:
+    """The prometheus label value following `needle` (e.g. `pool_id="`), up to its closing quote."""
+    start = line.find(needle)
+    if start < 0:
+        return None
+    start += len(needle)
+    end = line.find('"', start)
+    return line[start:end] if end >= 0 else None
+
+
+def parse_pool_percent_used(body: str, pools: list[str]) -> float | None:
+    """The fullest of `pools` from a mgr prometheus scrape, resolving each name to its id via
+    `ceph_pool_metadata` then reading `ceph_pool_percent_used`. Returns None if ANY pool is absent
+    — a missing pool must fail safe (fall back to statvfs), never silently shrink the gate. Pure so
+    the parse is unit-testable without a live exporter."""
+    name_to_id: dict[str, str] = {}
+    id_to_pct: dict[str, float] = {}
+    for line in body.splitlines():
+        if line.startswith("ceph_pool_metadata{"):
+            name = label_value(line, 'name="')
+            pool_id = label_value(line, 'pool_id="')
+            if name is not None and pool_id is not None and name in pools:
+                name_to_id[name] = pool_id
+        elif line.startswith("ceph_pool_percent_used{"):
+            pool_id = label_value(line, 'pool_id="')
+            if pool_id is None:
+                continue
+            try:
+                value = float(line.rsplit(" ", 1)[1])
+            except (ValueError, IndexError):
+                continue
+            if math.isfinite(value):  # a NaN/inf is not a ratio — drop it so the pool reads missing
+                id_to_pct[pool_id] = value
+
+    fullest: float | None = None
+    for pool in pools:
+        pool_id = name_to_id.get(pool)
+        pct = id_to_pct.get(pool_id) if pool_id is not None else None
+        if pct is None:
+            logger.warning("pool-fullness probe: pool %r absent from mgr output; falling back to statvfs", pool)
+            return None
+        pct = min(max(pct, 0.0), 1.0)  # exporter rounding can nudge just past 1.0
+        fullest = pct if fullest is None else max(fullest, pct)
+    return fullest
+
+
+def compute_mode(ratio: float, prev_mode: int) -> int:
+    """Hysteresis step: enter at the higher threshold, exit below the lower one."""
+    if ratio >= PRESSURE_CRITICAL or (prev_mode == 2 and ratio >= PRESSURE_CRITICAL_EXIT):
+        return 2
+    if ratio >= PRESSURE_ELEVATED or (prev_mode >= 1 and ratio >= PRESSURE_ELEVATED_EXIT):
+        return 1
+    return 0
+
+
+class PressurePublisher:
+    """Publishes the pressure mode to the cache Redis on a fixed interval.
+
+    Owns its own hysteresis state — sampled every 30s rather than once per
+    janitor cycle (~20min), because a mass writer (hydrator restore, drain
+    burst) can move the pool percent materially inside one cycle.
+    """
+
+    def __init__(
+        self,
+        redis_client: Any,
+        root: Path,
+        *,
+        mgr_metrics_url: str,
+        pools: list[str],
+        probe_timeout_seconds: float,
+    ) -> None:
+        self._redis = redis_client
+        self._root = root
+        self._mgr_metrics_url = mgr_metrics_url
+        self._pools = [p.strip() for p in pools if p.strip()]
+        self._probe_timeout = probe_timeout_seconds
+        self._prev_mode = 0
+
+    async def _pool_ratio(self) -> float | None:
+        if not self._mgr_metrics_url or not self._pools:
+            return None
+        try:
+            async with httpx.AsyncClient(timeout=self._probe_timeout) as client:
+                resp = await client.get(self._mgr_metrics_url)
+                resp.raise_for_status()
+                body = resp.text
+        except httpx.HTTPError as exc:
+            logger.warning("pool-fullness probe failed (%s); publishing statvfs-only pressure", exc)
+            return None
+        return parse_pool_percent_used(body, self._pools)
+
+    async def compute_payload(self) -> dict[str, Any] | None:
+        """Current pressure payload, or None when even statvfs is unreadable
+        (publishing a made-up mode would be worse than letting the TTL lapse)."""
+
+        def _local_ratio() -> float:
+            usage = shutil.disk_usage(self._root)
+            return usage.used / usage.total if usage.total else 0.0
+
+        try:
+            local_ratio = await asyncio.to_thread(_local_ratio)
+        except OSError as exc:
+            logger.warning("statvfs failed (%s); skipping pressure publish", exc)
+            return None
+        pool_ratio = await self._pool_ratio()
+        ratio = max(local_ratio, pool_ratio or 0.0)
+        self._prev_mode = compute_mode(ratio, self._prev_mode)
+        return {"mode": self._prev_mode, "ratio": round(ratio, 4), "source": "janitor", "ts": time.time()}
+
+    async def publish_once(self) -> None:
+        payload = await self.compute_payload()
+        if payload is None:
+            return
+        await self._redis.set(PRESSURE_KEY, json.dumps(payload), ex=PRESSURE_TTL_SECONDS)
+
+    async def run(self, interval: float = PUBLISH_INTERVAL_SECONDS) -> None:
+        while True:
+            try:
+                await self.publish_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                # The TTL is the fail-safe: consumers fall back to local checks
+                # once the key lapses, so a publish failure must not kill the janitor.
+                logger.warning("pressure publish failed (consumers fall back on TTL lapse): %s", exc)
+            await asyncio.sleep(interval)
+
+
+# Consumer-side memo: one Redis read per _PUBLISHED_MEMO_SECONDS per process,
+# not one per request. (mode, ts) — ts=0 forces the first read.
+_published_cache: tuple[int | None, float] = (None, 0.0)
+_PUBLISHED_MEMO_SECONDS = 5.0
+
+
+async def get_published_pressure_mode(redis_client: Any) -> int | None:
+    """The published mode, or None when the signal is unavailable (consumer
+    then falls back to its own local check per the contract)."""
+    global _published_cache
+    cached_mode, cached_at = _published_cache
+    now = time.monotonic()
+    if now - cached_at < _PUBLISHED_MEMO_SECONDS:
+        return cached_mode
+
+    mode: int | None = None
+    if redis_client is not None:
+        try:
+            raw = await redis_client.get(PRESSURE_KEY)
+            if raw:
+                parsed = int(json.loads(raw)["mode"])
+                if parsed in (0, 1, 2):
+                    mode = parsed
+        except Exception as exc:
+            logger.debug("published pressure read failed (falling back to local): %s", exc)
+    _published_cache = (mode, now)
+    return mode
+
+
+__all__ = [
+    "PRESSURE_CRITICAL",
+    "PRESSURE_CRITICAL_EXIT",
+    "PRESSURE_ELEVATED",
+    "PRESSURE_ELEVATED_EXIT",
+    "PRESSURE_KEY",
+    "PRESSURE_TTL_SECONDS",
+    "PUBLISH_INTERVAL_SECONDS",
+    "PressurePublisher",
+    "compute_mode",
+    "get_published_pressure_mode",
+    "label_value",
+    "parse_pool_percent_used",
+]

--- a/hippius_s3/pressure_signal.py
+++ b/hippius_s3/pressure_signal.py
@@ -175,15 +175,19 @@ class PressurePublisher:
 
 
 # Consumer-side memo: one Redis read per _PUBLISHED_MEMO_SECONDS per process,
-# not one per request. (mode, ts) — ts=0 forces the first read.
+# not one per request. (mode, ts) — ts=0 forces the first read. _last_good
+# survives READ ERRORS (a Redis blip during genuine mode-2 must not open the
+# gate) but never key ABSENCE (absence is the publisher's honest "signal off"),
+# and only within the publish TTL so a dead Redis can't pin a stale mode.
 _published_cache: tuple[int | None, float] = (None, 0.0)
+_last_good: tuple[int | None, float] = (None, 0.0)
 _PUBLISHED_MEMO_SECONDS = 5.0
 
 
 async def get_published_pressure_mode(redis_client: Any) -> int | None:
     """The published mode, or None when the signal is unavailable (consumer
     then falls back to its own local check per the contract)."""
-    global _published_cache
+    global _published_cache, _last_good
     cached_mode, cached_at = _published_cache
     now = time.monotonic()
     if now - cached_at < _PUBLISHED_MEMO_SECONDS:
@@ -197,8 +201,12 @@ async def get_published_pressure_mode(redis_client: Any) -> int | None:
                 parsed = int(json.loads(raw)["mode"])
                 if parsed in (0, 1, 2):
                     mode = parsed
+                    _last_good = (mode, now)
         except Exception as exc:
-            logger.debug("published pressure read failed (falling back to local): %s", exc)
+            logger.debug("published pressure read failed: %s", exc)
+            good_mode, good_at = _last_good
+            if good_mode is not None and now - good_at < PRESSURE_TTL_SECONDS:
+                mode = good_mode
     _published_cache = (mode, now)
     return mode
 

--- a/tests/unit/test_janitor_pool_gate.py
+++ b/tests/unit/test_janitor_pool_gate.py
@@ -15,6 +15,8 @@ import httpx
 import pytest
 import respx
 
+from hippius_s3.pressure_signal import label_value
+from hippius_s3.pressure_signal import parse_pool_percent_used
 from workers import run_janitor_in_loop as janitor
 
 
@@ -35,25 +37,25 @@ POOL_SERIES = (
 
 def test_label_value_extracts_up_to_the_closing_quote() -> None:
     line = 'ceph_pool_metadata{pool_id="5",name="ceph-filesystem-data0",type="replicated"} 1.0'
-    assert janitor._label_value(line, 'pool_id="') == "5"
-    assert janitor._label_value(line, 'name="') == "ceph-filesystem-data0"
+    assert label_value(line, 'pool_id="') == "5"
+    assert label_value(line, 'name="') == "ceph-filesystem-data0"
 
 
 def test_label_value_absent_needle_is_none() -> None:
-    assert janitor._label_value("ceph_pool_percent_used 0.5", 'pool_id="') is None
+    assert label_value("ceph_pool_percent_used 0.5", 'pool_id="') is None
 
 
 # --------------------------------------------------------- _parse_pool_percent_used
 
 
 def test_parse_resolves_the_pool_fraction_via_its_metadata_id() -> None:
-    got = janitor._parse_pool_percent_used(HEALTHY + POOL_SERIES, ["ceph-filesystem-data0"])
+    got = parse_pool_percent_used(HEALTHY + POOL_SERIES, ["ceph-filesystem-data0"])
     assert got == pytest.approx(0.9507322907447815), "pool 5's fraction, not pool 2's"
 
 
 def test_parse_fullest_of_several_pools_wins_regardless_of_order() -> None:
     # data0 (95%) is fuller than blockpool (70%) and metadata (0.7%); order must not matter.
-    got = janitor._parse_pool_percent_used(
+    got = parse_pool_percent_used(
         HEALTHY + POOL_SERIES, ["ceph-blockpool", "ceph-filesystem-data0", "ceph-filesystem-metadata"]
     )
     assert got == pytest.approx(0.9507322907447815)
@@ -62,28 +64,28 @@ def test_parse_fullest_of_several_pools_wins_regardless_of_order() -> None:
 def test_parse_series_order_does_not_matter() -> None:
     # percent-used emitted BEFORE the metadata that names the pool must still resolve.
     body = HEALTHY + 'ceph_pool_percent_used{pool_id="5"} 0.5\nceph_pool_metadata{pool_id="5",name="data"} 1.0\n'
-    assert janitor._parse_pool_percent_used(body, ["data"]) == pytest.approx(0.5)
+    assert parse_pool_percent_used(body, ["data"]) == pytest.approx(0.5)
 
 
 def test_parse_missing_pool_is_none_fail_safe() -> None:
     # A typo'd/renamed pool anywhere in the list must fail safe (fall back to statvfs), never
     # silently shrink the gate to the pools that did resolve.
-    assert janitor._parse_pool_percent_used(HEALTHY + POOL_SERIES, ["ceph-filesystem-data0", "nope"]) is None
+    assert parse_pool_percent_used(HEALTHY + POOL_SERIES, ["ceph-filesystem-data0", "nope"]) is None
 
 
 def test_parse_pool_absent_entirely_is_none() -> None:
-    assert janitor._parse_pool_percent_used(HEALTHY, ["ceph-filesystem-data0"]) is None
+    assert parse_pool_percent_used(HEALTHY, ["ceph-filesystem-data0"]) is None
 
 
 def test_parse_prefix_name_is_not_matched() -> None:
     # name="data0" must not resolve for target "data": the label match is exact.
     body = HEALTHY + 'ceph_pool_metadata{pool_id="7",name="data0"} 1.0\nceph_pool_percent_used{pool_id="7"} 0.99\n'
-    assert janitor._parse_pool_percent_used(body, ["data"]) is None
+    assert parse_pool_percent_used(body, ["data"]) is None
 
 
 def test_parse_fraction_above_one_clamps() -> None:
     body = HEALTHY + 'ceph_pool_metadata{pool_id="5",name="data"} 1.0\nceph_pool_percent_used{pool_id="5"} 1.0000001\n'
-    assert janitor._parse_pool_percent_used(body, ["data"]) == pytest.approx(1.0)
+    assert parse_pool_percent_used(body, ["data"]) == pytest.approx(1.0)
 
 
 @pytest.mark.parametrize("bad", ["NaN", "inf", "garbage"])
@@ -91,7 +93,7 @@ def test_parse_non_finite_or_garbage_percent_reads_missing(bad: str) -> None:
     # A NaN/inf/garbage value is not a ratio — it is dropped, so the pool has no valid percent and
     # the whole probe reads "missing" → None (fail safe to statvfs), never a silent healthy read.
     body = HEALTHY + f'ceph_pool_metadata{{pool_id="5",name="data"}} 1.0\nceph_pool_percent_used{{pool_id="5"}} {bad}\n'
-    assert janitor._parse_pool_percent_used(body, ["data"]) is None
+    assert parse_pool_percent_used(body, ["data"]) is None
 
 
 # --------------------------------------------------------- _fetch_pool_percent_used

--- a/tests/unit/test_pressure_signal.py
+++ b/tests/unit/test_pressure_signal.py
@@ -1,0 +1,178 @@
+"""Unit tests for the shared fs_cache:pressure signal (publisher + consumer)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import hippius_s3.pressure_signal as ps
+from hippius_s3.fs_pressure import should_reject_fs_cache_write
+from hippius_s3.pressure_signal import PRESSURE_KEY
+from hippius_s3.pressure_signal import PRESSURE_TTL_SECONDS
+from hippius_s3.pressure_signal import PressurePublisher
+from hippius_s3.pressure_signal import compute_mode
+from hippius_s3.pressure_signal import get_published_pressure_mode
+
+
+class FakeRedis:
+    def __init__(self, value=None, fail=False):
+        self.value = value
+        self.fail = fail
+        self.set_calls = []
+
+    async def set(self, key, value, ex=None):
+        if self.fail:
+            raise ConnectionError("redis down")
+        self.set_calls.append((key, value, ex))
+
+    async def get(self, key):
+        if self.fail:
+            raise ConnectionError("redis down")
+        return self.value
+
+
+def _usage(used, total):
+    class U:
+        pass
+
+    u = U()
+    u.used = used
+    u.total = total
+    u.free = total - used
+    return u
+
+
+@pytest.fixture(autouse=True)
+def _reset_consumer_memo():
+    ps._published_cache = (None, 0.0)
+    yield
+    ps._published_cache = (None, 0.0)
+
+
+# ------------------------------------------------------------------ compute_mode
+
+def test_compute_mode_enter_and_exit_hysteresis():
+    assert compute_mode(0.5, 0) == 0
+    assert compute_mode(0.86, 0) == 1
+    assert compute_mode(0.96, 0) == 2
+    # Exit thresholds: mode is held until the ratio drops below the exit bound.
+    assert compute_mode(0.94, 2) == 2
+    assert compute_mode(0.92, 2) == 1
+    assert compute_mode(0.84, 1) == 1
+    assert compute_mode(0.82, 1) == 0
+
+
+# ------------------------------------------------------------------ publisher
+
+@pytest.mark.asyncio
+async def test_publish_once_sets_key_with_ttl(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr("hippius_s3.pressure_signal.shutil.disk_usage", lambda p: _usage(96, 100))
+    redis = FakeRedis()
+    pub = PressurePublisher(
+        redis, tmp_path, mgr_metrics_url="", pools=[], probe_timeout_seconds=1.0
+    )
+
+    await pub.publish_once()
+
+    assert len(redis.set_calls) == 1
+    key, raw, ex = redis.set_calls[0]
+    assert key == PRESSURE_KEY
+    assert ex == PRESSURE_TTL_SECONDS
+    payload = json.loads(raw)
+    assert payload["mode"] == 2
+    assert payload["source"] == "janitor"
+    assert payload["ratio"] == pytest.approx(0.96)
+
+
+@pytest.mark.asyncio
+async def test_publish_skipped_when_statvfs_fails(monkeypatch, tmp_path: Path):
+    def _boom(p):
+        raise OSError("mount gone")
+
+    monkeypatch.setattr("hippius_s3.pressure_signal.shutil.disk_usage", _boom)
+    redis = FakeRedis()
+    pub = PressurePublisher(
+        redis, tmp_path, mgr_metrics_url="", pools=[], probe_timeout_seconds=1.0
+    )
+
+    await pub.publish_once()
+
+    # Letting the TTL lapse (consumers fall back) beats publishing a guess.
+    assert redis.set_calls == []
+
+
+@pytest.mark.asyncio
+async def test_publisher_hysteresis_across_ticks(monkeypatch, tmp_path: Path):
+    ratios = iter([0.96, 0.94, 0.92])
+    monkeypatch.setattr(
+        "hippius_s3.pressure_signal.shutil.disk_usage", lambda p: _usage(int(next(ratios) * 100), 100)
+    )
+    redis = FakeRedis()
+    pub = PressurePublisher(
+        redis, tmp_path, mgr_metrics_url="", pools=[], probe_timeout_seconds=1.0
+    )
+
+    await pub.publish_once()  # 0.96 -> 2
+    await pub.publish_once()  # 0.94 holds 2 (exit is 0.93)
+    await pub.publish_once()  # 0.92 -> 1
+
+    modes = [json.loads(raw)["mode"] for _, raw, _ in redis.set_calls]
+    assert modes == [2, 2, 1]
+
+
+# ------------------------------------------------------------------ consumer
+
+@pytest.mark.asyncio
+async def test_consumer_reads_published_mode():
+    redis = FakeRedis(value=json.dumps({"mode": 2, "ratio": 0.96, "source": "janitor", "ts": 1.0}))
+    assert await get_published_pressure_mode(redis) == 2
+
+
+@pytest.mark.asyncio
+async def test_consumer_memoizes_reads():
+    redis = FakeRedis(value=json.dumps({"mode": 1, "ratio": 0.9, "source": "janitor", "ts": 1.0}))
+    assert await get_published_pressure_mode(redis) == 1
+    redis.fail = True  # a second read within the memo window must not hit Redis
+    assert await get_published_pressure_mode(redis) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [None, b"not-json", json.dumps({"mode": 7})])
+async def test_consumer_unavailable_signal_is_none(value):
+    assert await get_published_pressure_mode(FakeRedis(value=value)) is None
+
+
+@pytest.mark.asyncio
+async def test_consumer_none_redis_is_none():
+    assert await get_published_pressure_mode(None) is None
+
+
+# ------------------------------------------------------------------ fs_pressure integration
+
+def _config(tmp_path: Path):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        object_cache_dir=str(tmp_path),
+        fs_cache_min_free_bytes=0,
+        fs_cache_min_free_ratio=0.0,
+        fs_cache_retry_after_seconds=30,
+    )
+
+
+def test_reject_on_published_critical_even_with_local_headroom(tmp_path: Path):
+    reject, retry_after, _pressure, reason = should_reject_fs_cache_write(
+        config=_config(tmp_path), published_mode=2
+    )
+    assert reject is True
+    assert reason == "pool"
+    assert retry_after >= 1.0
+
+
+@pytest.mark.parametrize("mode", [None, 0, 1])
+def test_no_reject_below_critical_signal(tmp_path: Path, mode):
+    reject, _r, _p, reason = should_reject_fs_cache_write(config=_config(tmp_path), published_mode=mode)
+    assert reject is False
+    assert reason == "ok"

--- a/tests/unit/test_pressure_signal.py
+++ b/tests/unit/test_pressure_signal.py
@@ -47,8 +47,10 @@ def _usage(used, total):
 @pytest.fixture(autouse=True)
 def _reset_consumer_memo():
     ps._published_cache = (None, 0.0)
+    ps._last_good = (None, 0.0)
     yield
     ps._published_cache = (None, 0.0)
+    ps._last_good = (None, 0.0)
 
 
 # ------------------------------------------------------------------ compute_mode
@@ -147,6 +149,30 @@ async def test_consumer_unavailable_signal_is_none(value):
 @pytest.mark.asyncio
 async def test_consumer_none_redis_is_none():
     assert await get_published_pressure_mode(None) is None
+
+
+@pytest.mark.asyncio
+async def test_consumer_holds_last_good_mode_on_read_error():
+    """A Redis blip during genuine mode-2 must not open the PUT gate: read
+    ERRORS hold the last-good mode (bounded by the publish TTL)."""
+    redis = FakeRedis(value=json.dumps({"mode": 2, "ratio": 0.96, "source": "janitor", "ts": 1.0}))
+    assert await get_published_pressure_mode(redis) == 2
+
+    ps._published_cache = (2, -100.0)  # expire the memo, keep _last_good
+    redis.fail = True
+    assert await get_published_pressure_mode(redis) == 2
+
+
+@pytest.mark.asyncio
+async def test_consumer_key_absence_is_not_masked_by_last_good():
+    """Key ABSENCE is the publisher's honest 'signal unavailable' — last-good
+    must not override it (that's how a retired publisher would haunt the gate)."""
+    redis = FakeRedis(value=json.dumps({"mode": 2, "ratio": 0.96, "source": "janitor", "ts": 1.0}))
+    assert await get_published_pressure_mode(redis) == 2
+
+    ps._published_cache = (2, -100.0)
+    redis.value = None  # key expired/absent, read succeeds
+    assert await get_published_pressure_mode(redis) is None
 
 
 # ------------------------------------------------------------------ fs_pressure integration

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -65,6 +65,7 @@ from hippius_s3.pressure_signal import PRESSURE_ELEVATED_EXIT
 from hippius_s3.pressure_signal import PressurePublisher
 from hippius_s3.pressure_signal import parse_pool_percent_used
 from hippius_s3.queue_metrics import QueueDepthSampler
+from hippius_s3.redis_utils import create_redis_client
 from hippius_s3.repositories import fs_cache_inventory
 from hippius_s3.repositories.fs_cache_inventory import clear_cached
 from hippius_s3.repositories.fs_cache_inventory import get_janitor_state
@@ -2161,35 +2162,68 @@ async def gc_soft_deleted_objects(pool: asyncpg.Pool) -> int:
 async def run_janitor_loop():
     """Main janitor loop: periodically clean stale and old parts."""
     concurrency = max(1, config.janitor_concurrency)
-    db_pool = await asyncpg.create_pool(config.database_url, min_size=2, max_size=concurrency + 4)
-    fs_store = create_fs_store(config)
-    redis_client = Redis.from_url(config.redis_queues_url)
+    # Pre-declared so _shutdown can tear down exactly what was created — a
+    # mid-setup exception must not skip cleanup (review finding: setup used to
+    # sit outside the try, so a failed constructor leaked the earlier task and
+    # left clients unclosed).
+    db_pool = None
+    redis_client = None
+    cache_redis_client = None
+    queue_sampler_task = None
+    pressure_publish_task = None
 
-    # Initialize janitor-owned OTel metrics
-    _setup_janitor_metrics()
+    async def _shutdown() -> None:
+        # Idempotent teardown shared by the setup-failure path and the main
+        # finally; closures read the current values of the names above.
+        for task in (queue_sampler_task, pressure_publish_task):
+            if task is not None:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        if cache_redis_client is not None:
+            await cache_redis_client.close()
+        if redis_client is not None:
+            await redis_client.close()
+        if db_pool is not None:
+            await db_pool.close()
 
-    # Queue depth/age gauges (2026-07-25 audit: 136k payloads accumulated
-    # unseen in ovh_download_requests). Janitor hosts the sampler because it is
-    # single-instance and already holds the queues-Redis client; the task runs
-    # off the cycle path so a slow walk never blinds the queue gauges.
-    queue_sampler = QueueDepthSampler(redis_client, config)
-    queue_sampler_task = asyncio.create_task(queue_sampler.run())
+    try:
+        db_pool = await asyncpg.create_pool(config.database_url, min_size=2, max_size=concurrency + 4)
+        fs_store = create_fs_store(config)
+        redis_client = Redis.from_url(config.redis_queues_url)
 
-    # Publish the shared pressure signal (fs_cache:pressure on the CACHE Redis
-    # — where the api middleware and the s3-backup hydrator read it). Sampled
-    # every 30s rather than once per cycle: a mass writer can move the pool
-    # percent materially inside one ~20min cycle. The janitor's own per-cycle
-    # _pressure_mode stays authoritative for eviction pacing; both key off the
-    # same watermarks in hippius_s3.pressure_signal.
-    cache_redis_client = Redis.from_url(config.redis_url)
-    pressure_publisher = PressurePublisher(
-        cache_redis_client,
-        Path(config.object_cache_dir),
-        mgr_metrics_url=config.janitor_ceph_mgr_metrics_url,
-        pools=config.janitor_ceph_pools.split(","),
-        probe_timeout_seconds=config.janitor_ceph_probe_timeout_seconds,
-    )
-    pressure_publish_task = asyncio.create_task(pressure_publisher.run())
+        # Initialize janitor-owned OTel metrics
+        _setup_janitor_metrics()
+
+        # Queue depth/age gauges (2026-07-25 audit: 136k payloads accumulated
+        # unseen in ovh_download_requests). Janitor hosts the sampler because it
+        # is single-instance and already holds the queues-Redis client; the task
+        # runs off the cycle path so a slow walk never blinds the queue gauges.
+        queue_sampler = QueueDepthSampler(redis_client, config)
+        queue_sampler_task = asyncio.create_task(queue_sampler.run())
+
+        # Publish the shared pressure signal (fs_cache:pressure on the CACHE
+        # Redis — where the api middleware and the s3-backup hydrator read it).
+        # Sampled every 30s rather than once per cycle: a mass writer can move
+        # the pool percent materially inside one ~20min cycle. The janitor's own
+        # per-cycle _pressure_mode stays authoritative for eviction pacing; both
+        # key off the same watermarks in hippius_s3.pressure_signal.
+        # create_redis_client (not Redis.from_url): the cache Redis may be a
+        # cluster (cluster=true / redis-cluster URLs) — a standalone client
+        # there gets MOVED errors, every publish fails, and consumers silently
+        # stay on local-only pressure forever. Same factory the api uses.
+        cache_redis_client = create_redis_client(config.redis_url)
+        pressure_publisher = PressurePublisher(
+            cache_redis_client,
+            Path(config.object_cache_dir),
+            mgr_metrics_url=config.janitor_ceph_mgr_metrics_url,
+            pools=config.janitor_ceph_pools.split(","),
+            probe_timeout_seconds=config.janitor_ceph_probe_timeout_seconds,
+        )
+        pressure_publish_task = asyncio.create_task(pressure_publisher.run())
+    except BaseException:
+        await _shutdown()
+        raise
 
     logger.info("Starting janitor service...")
     logger.info(f"FS store root: {config.object_cache_dir}")
@@ -2331,15 +2365,7 @@ async def run_janitor_loop():
             _janitor_phase = 0
             await asyncio.sleep(sleep_interval)
     finally:
-        for task in (queue_sampler_task, pressure_publish_task):
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-        await cache_redis_client.close()
-        if redis_client:
-            await redis_client.close()
-        if db_pool:
-            await db_pool.close()
+        await _shutdown()
 
 
 if __name__ == "__main__":

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -25,7 +25,6 @@ import asyncio
 import contextlib
 import json
 import logging
-import math
 import os
 import shutil
 import sys
@@ -59,6 +58,12 @@ from hippius_s3.cache import create_fs_store
 from hippius_s3.config import get_config
 from hippius_s3.logging_config import setup_loki_logging
 from hippius_s3.otel_setup import build_resource
+from hippius_s3.pressure_signal import PRESSURE_CRITICAL
+from hippius_s3.pressure_signal import PRESSURE_CRITICAL_EXIT
+from hippius_s3.pressure_signal import PRESSURE_ELEVATED
+from hippius_s3.pressure_signal import PRESSURE_ELEVATED_EXIT
+from hippius_s3.pressure_signal import PressurePublisher
+from hippius_s3.pressure_signal import parse_pool_percent_used
 from hippius_s3.queue_metrics import QueueDepthSampler
 from hippius_s3.repositories import fs_cache_inventory
 from hippius_s3.repositories.fs_cache_inventory import clear_cached
@@ -85,13 +90,9 @@ AGE_BUCKET_BOUNDARIES = [
 ]
 AGE_BUCKET_NAMES = [b[0] for b in AGE_BUCKET_BOUNDARIES] + ["7d+"]
 
-# Disk pressure thresholds (fraction of total disk used). Enter thresholds are higher than exit
-# thresholds (hysteresis) so a disk hovering at a boundary doesn't flap the mode — and with it the
-# hot-retention window and loop-sleep — every cycle. C2.
-PRESSURE_ELEVATED = 0.85
-PRESSURE_ELEVATED_EXIT = 0.83
-PRESSURE_CRITICAL = 0.95
-PRESSURE_CRITICAL_EXIT = 0.93
+# Disk pressure thresholds live in hippius_s3.pressure_signal (imported below):
+# the janitor's cycle gating and the published fs_cache:pressure signal must
+# key off the SAME watermarks or consumers would disagree with the evictor.
 
 # Maximum age of an orphan `.tmp.*` file before we delete it. Atomic writes
 # finish in milliseconds; anything older than this is a crashed-write orphan.
@@ -235,52 +236,6 @@ def _classify_age_bucket(age_seconds: float) -> str:
     return "7d+"
 
 
-def _label_value(line: str, needle: str) -> str | None:
-    """The prometheus label value following `needle` (e.g. `pool_id="`), up to its closing quote."""
-    start = line.find(needle)
-    if start < 0:
-        return None
-    start += len(needle)
-    end = line.find('"', start)
-    return line[start:end] if end >= 0 else None
-
-
-def _parse_pool_percent_used(body: str, pools: list[str]) -> float | None:
-    """The fullest of `pools` from a mgr prometheus scrape, resolving each name to its id via
-    `ceph_pool_metadata` then reading `ceph_pool_percent_used`. Returns None if ANY pool is absent
-    — a missing pool must fail safe (fall back to statvfs), never silently shrink the gate. Pure so
-    the parse is unit-testable without a live exporter."""
-    name_to_id: dict[str, str] = {}
-    id_to_pct: dict[str, float] = {}
-    for line in body.splitlines():
-        if line.startswith("ceph_pool_metadata{"):
-            name = _label_value(line, 'name="')
-            pool_id = _label_value(line, 'pool_id="')
-            if name is not None and pool_id is not None and name in pools:
-                name_to_id[name] = pool_id
-        elif line.startswith("ceph_pool_percent_used{"):
-            pool_id = _label_value(line, 'pool_id="')
-            if pool_id is None:
-                continue
-            try:
-                value = float(line.rsplit(" ", 1)[1])
-            except (ValueError, IndexError):
-                continue
-            if math.isfinite(value):  # a NaN/inf is not a ratio — drop it so the pool reads missing
-                id_to_pct[pool_id] = value
-
-    fullest: float | None = None
-    for pool in pools:
-        pool_id = name_to_id.get(pool)
-        pct = id_to_pct.get(pool_id) if pool_id is not None else None
-        if pct is None:
-            logger.warning("janitor pool-fullness probe: pool %r absent from mgr output; falling back to statvfs", pool)
-            return None
-        pct = min(max(pct, 0.0), 1.0)  # exporter rounding can nudge just past 1.0
-        fullest = pct if fullest is None else max(fullest, pct)
-    return fullest
-
-
 async def _fetch_pool_percent_used() -> float | None:
     """The fullest configured Ceph pool's %USED (0.0-1.0) from the mgr exporter, or None.
 
@@ -306,7 +261,7 @@ async def _fetch_pool_percent_used() -> float | None:
     except httpx.HTTPError as exc:
         logger.warning("janitor pool-fullness probe failed (%s); falling back to statvfs", exc)
         return None
-    return _parse_pool_percent_used(body, pools)
+    return parse_pool_percent_used(body, pools)
 
 
 def _pressure_mode(root: Path) -> int:
@@ -2220,6 +2175,22 @@ async def run_janitor_loop():
     queue_sampler = QueueDepthSampler(redis_client, config)
     queue_sampler_task = asyncio.create_task(queue_sampler.run())
 
+    # Publish the shared pressure signal (fs_cache:pressure on the CACHE Redis
+    # — where the api middleware and the s3-backup hydrator read it). Sampled
+    # every 30s rather than once per cycle: a mass writer can move the pool
+    # percent materially inside one ~20min cycle. The janitor's own per-cycle
+    # _pressure_mode stays authoritative for eviction pacing; both key off the
+    # same watermarks in hippius_s3.pressure_signal.
+    cache_redis_client = Redis.from_url(config.redis_url)
+    pressure_publisher = PressurePublisher(
+        cache_redis_client,
+        Path(config.object_cache_dir),
+        mgr_metrics_url=config.janitor_ceph_mgr_metrics_url,
+        pools=config.janitor_ceph_pools.split(","),
+        probe_timeout_seconds=config.janitor_ceph_probe_timeout_seconds,
+    )
+    pressure_publish_task = asyncio.create_task(pressure_publisher.run())
+
     logger.info("Starting janitor service...")
     logger.info(f"FS store root: {config.object_cache_dir}")
     logger.info(f"MPU stale threshold: {config.mpu_stale_seconds}s")
@@ -2360,9 +2331,11 @@ async def run_janitor_loop():
             _janitor_phase = 0
             await asyncio.sleep(sleep_interval)
     finally:
-        queue_sampler_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await queue_sampler_task
+        for task in (queue_sampler_task, pressure_publish_task):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        await cache_redis_client.close()
         if redis_client:
             await redis_client.close()
         if db_pool:


### PR DESCRIPTION
## What

Second hippius-s3 slice of the 2026-07-25 audit (plan §PR H2). Stacked on #352.

**One pressure authority, many consumers.** Today three components probe fullness independently with three different blind spots; the api PUT throttle still measures `disk_usage(object_cache_dir)` which on prod api-local is the **node NVMe** — structurally blind to the CephFS pool (the 2026-07-24 incident's shape).

- New `hippius_s3/pressure_signal.py`: watermark constants + the mgr-scrape parser (moved verbatim from the janitor — it now imports them), a hysteresis `compute_mode`, and `PressurePublisher`, which the janitor runs as a 30 s task publishing `fs_cache:pressure` = `{"mode": 0|1|2, "ratio": ..., "source": "janitor", "ts": ...}` on the **cache Redis** with `EX 120`. 30 s cadence because a mass writer can move the pool materially inside one ~20 min janitor cycle; statvfs failure skips the publish so the TTL lapse (not a stale mode) is the failure signal.
- `should_reject_fs_cache_write` gains `published_mode`: mode 2 rejects with `reason="pool"` even when local NVMe has headroom. The middleware reads the key via a ~5 s per-process memo (`get_published_pressure_mode`); absent/unreadable signal → `None` → exact pre-signal behavior.
- The janitor's own per-cycle `_pressure_mode` is untouched — eviction pacing and the published signal now share one set of watermarks instead of drifting.

## Cross-repo

s3-backup PR #23 consumes the same key in the hydrator (contract C1: consumers fall back to their own statvfs when the key is missing — deploy order is safe in either direction).

## Testing

`tests/unit/test_pressure_signal.py` (14 tests): hysteresis enter/exit, publish payload+TTL, statvfs-failure skips publish, hysteresis across ticks, consumer memo (second read within window never hits Redis), unavailable-signal→None variants, and `fs_pressure` integration (published mode 2 rejects with local headroom; None/0/1 don't). Pool-gate tests repointed to the moved parser — all 21 still pass. Full unit suite: 2169 passed, 37 skipped. Ruff clean.