### PR TITLE
feat(cache): track read recency in fs_cache_inventory, retire atime refresh

### DIFF
--- a/hippius_s3/cache/access_tracker.py
+++ b/hippius_s3/cache/access_tracker.py
@@ -31,6 +31,9 @@ FLUSH_INTERVAL_SECONDS = 30.0
 # Bound on the sampling map so a pathological key scan can't grow it forever;
 # pruning drops the oldest entries, which only means earlier re-sampling.
 MAX_TRACKED_KEYS = 100_000
+# One UPDATE's unnest arrays are capped so a storm-sized flush can't become a
+# single giant statement.
+FLUSH_CHUNK_SIZE = 10_000
 
 
 class AccessTracker:
@@ -61,38 +64,48 @@ class AccessTracker:
             return
         self._last_noted[key] = now
         self._pending.add(key)
+        if len(self._last_noted) > MAX_TRACKED_KEYS:
+            self._enforce_bound(now)
 
     async def flush_once(self) -> int:
-        """Write pending keys in one batched UPDATE. Returns rows attempted."""
+        """Write pending keys in chunked batched UPDATEs. Returns rows attempted."""
         if not self._pending:
-            self._prune(time.monotonic())
             return 0
         batch = list(self._pending)
         self._pending.clear()
-        try:
-            await self._pool.execute(
-                """
-                UPDATE fs_cache_inventory AS f SET last_access_at = now()
-                FROM unnest($1::text[], $2::bigint[], $3::bigint[]) AS u(oid, ver, pnum)
-                WHERE f.object_id = u.oid AND f.object_version = u.ver AND f.part_number = u.pnum
-                """,
-                [k[0] for k in batch],
-                [k[1] for k in batch],
-                [k[2] for k in batch],
-            )
-        except Exception as exc:
-            # Advisory data: dropping the batch (not re-queueing) keeps a DB
-            # outage from growing an unbounded buffer; the parts re-sample on
-            # their next read after the sample window.
-            logger.warning("last_access_at flush failed (%s keys dropped): %s", len(batch), exc)
-        self._prune(time.monotonic())
+        for start in range(0, len(batch), FLUSH_CHUNK_SIZE):
+            chunk = batch[start : start + FLUSH_CHUNK_SIZE]
+            try:
+                await self._pool.execute(
+                    """
+                    UPDATE fs_cache_inventory AS f SET last_access_at = now()
+                    FROM unnest($1::text[], $2::bigint[], $3::bigint[]) AS u(oid, ver, pnum)
+                    WHERE f.object_id = u.oid AND f.object_version = u.ver AND f.part_number = u.pnum
+                    """,
+                    [k[0] for k in chunk],
+                    [k[1] for k in chunk],
+                    [k[2] for k in chunk],
+                )
+            except Exception as exc:
+                # Advisory data: dropping the chunk (not re-queueing) keeps a DB
+                # outage from growing an unbounded buffer; the parts re-sample
+                # on their next read after the sample window.
+                logger.warning("last_access_at flush failed (%s keys dropped): %s", len(chunk), exc)
         return len(batch)
 
-    def _prune(self, now: float) -> None:
-        if len(self._last_noted) <= MAX_TRACKED_KEYS:
-            return
+    def _enforce_bound(self, now: float) -> None:
+        """Shrink the sampling map: window-prune first, then hard-evict oldest.
+
+        The window prune alone cannot shrink a map whose keys were ALL read
+        within the sample window (key-diverse storm) — that case drops the
+        oldest quarter; the only cost is earlier re-sampling of those parts.
+        """
         cutoff = now - self._sample_window
         self._last_noted = {k: ts for k, ts in self._last_noted.items() if ts >= cutoff}
+        if len(self._last_noted) <= MAX_TRACKED_KEYS:
+            return
+        items = sorted(self._last_noted.items(), key=lambda kv: kv[1])
+        self._last_noted = dict(items[len(items) // 4 :])
 
     async def run(self) -> None:
         while True:

--- a/hippius_s3/cache/access_tracker.py
+++ b/hippius_s3/cache/access_tracker.py
@@ -1,0 +1,125 @@
+"""Sampled read-recency tracking into fs_cache_inventory.last_access_at.
+
+Replaces filesystem atime as the janitor's "recently read" hot-retention
+signal. The old channel — os.utime() on every chunk read — was dead on
+read-only mounts (prod api-local swallows EROFS, so read traffic protected
+nothing) and turned every read into a CephFS MDS metadata write elsewhere.
+
+Hot-path cost is one dict probe per chunk read (`note_read` is sync and
+never awaits); DB writes are sampled (a part is re-recorded at most once per
+quarter hot-window) and flushed as one batched UPDATE every 30s. Losing a
+flush costs at most premature evictability of a part that is then re-hydrated
+on next read — advisory, like the rest of the inventory.
+
+Wiring follows the repo's module-singleton pattern (initialize_cache_client):
+`initialize_access_tracker` in the api lifespan; worker processes that never
+initialize it get a None tracker and note_read is a no-op.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+from typing import Optional
+
+
+logger = logging.getLogger(__name__)
+
+FLUSH_INTERVAL_SECONDS = 30.0
+# Bound on the sampling map so a pathological key scan can't grow it forever;
+# pruning drops the oldest entries, which only means earlier re-sampling.
+MAX_TRACKED_KEYS = 100_000
+
+
+class AccessTracker:
+    """Buffers sampled (object_id, version, part) reads; flushes batched UPDATEs."""
+
+    def __init__(
+        self,
+        db_pool: Any,
+        *,
+        hot_window_seconds: float,
+        flush_interval: float = FLUSH_INTERVAL_SECONDS,
+    ) -> None:
+        self._pool = db_pool
+        # A part needs at most one refresh per quarter hot-window to stay hot;
+        # finer sampling is pure write amplification. Floored so a tiny window
+        # can't turn every read into a DB write.
+        self._sample_window = max(60.0, hot_window_seconds / 4)
+        self._flush_interval = flush_interval
+        self._last_noted: dict[tuple[str, int, int], float] = {}
+        self._pending: set[tuple[str, int, int]] = set()
+
+    def note_read(self, object_id: str, object_version: int, part_number: int) -> None:
+        """Record a chunk read. Sync and allocation-light — called per chunk on the stream path."""
+        key = (str(object_id), int(object_version), int(part_number))
+        now = time.monotonic()
+        last = self._last_noted.get(key)
+        if last is not None and now - last < self._sample_window:
+            return
+        self._last_noted[key] = now
+        self._pending.add(key)
+
+    async def flush_once(self) -> int:
+        """Write pending keys in one batched UPDATE. Returns rows attempted."""
+        if not self._pending:
+            self._prune(time.monotonic())
+            return 0
+        batch = list(self._pending)
+        self._pending.clear()
+        try:
+            await self._pool.execute(
+                """
+                UPDATE fs_cache_inventory AS f SET last_access_at = now()
+                FROM unnest($1::text[], $2::bigint[], $3::bigint[]) AS u(oid, ver, pnum)
+                WHERE f.object_id = u.oid AND f.object_version = u.ver AND f.part_number = u.pnum
+                """,
+                [k[0] for k in batch],
+                [k[1] for k in batch],
+                [k[2] for k in batch],
+            )
+        except Exception as exc:
+            # Advisory data: dropping the batch (not re-queueing) keeps a DB
+            # outage from growing an unbounded buffer; the parts re-sample on
+            # their next read after the sample window.
+            logger.warning("last_access_at flush failed (%s keys dropped): %s", len(batch), exc)
+        self._prune(time.monotonic())
+        return len(batch)
+
+    def _prune(self, now: float) -> None:
+        if len(self._last_noted) <= MAX_TRACKED_KEYS:
+            return
+        cutoff = now - self._sample_window
+        self._last_noted = {k: ts for k, ts in self._last_noted.items() if ts >= cutoff}
+
+    async def run(self) -> None:
+        while True:
+            await asyncio.sleep(self._flush_interval)
+            try:
+                await self.flush_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("access-tracker flush loop error: %s", exc)
+
+
+_tracker: Optional[AccessTracker] = None
+
+
+def initialize_access_tracker(db_pool: Any, *, hot_window_seconds: float) -> AccessTracker:
+    global _tracker
+    _tracker = AccessTracker(db_pool, hot_window_seconds=hot_window_seconds)
+    return _tracker
+
+
+def get_access_tracker() -> Optional[AccessTracker]:
+    return _tracker
+
+
+__all__ = [
+    "AccessTracker",
+    "get_access_tracker",
+    "initialize_access_tracker",
+]

--- a/hippius_s3/cache/fs_store.py
+++ b/hippius_s3/cache/fs_store.py
@@ -173,20 +173,17 @@ class FileSystemPartsStore:
             return None
 
         try:
+            # Read-recency for hot retention is recorded in
+            # fs_cache_inventory.last_access_at (cache/access_tracker.py), not
+            # via atime: the old per-read os.utime was silently dead on
+            # read-only mounts (prod api-local) and an MDS metadata WRITE on
+            # every read elsewhere. stat atime now reflects write recency only.
 
-            def _read_and_touch() -> bytes:
+            def _read() -> bytes:
                 with chunk_path.open("rb") as f:
-                    data = f.read()
-                # Update atime/mtime so janitor treats this as recently-read.
-                # Janitor's hot-retention check uses stat() on the part dir /
-                # meta, so touch both the chunk file AND the part dir's mtime.
-                with contextlib.suppress(OSError):
-                    os.utime(chunk_path, None)
-                with contextlib.suppress(OSError):
-                    os.utime(meta_path, None)
-                return data
+                    return f.read()
 
-            data = await asyncio.to_thread(_read_and_touch)
+            data = await asyncio.to_thread(_read)
             logger.debug(
                 f"FS: read chunk object_id={object_id} v={object_version} part={part_number} chunk={chunk_index} size={len(data)}"
             )

--- a/hippius_s3/cache/fs_store.py
+++ b/hippius_s3/cache/fs_store.py
@@ -20,6 +20,8 @@ from typing import Any
 from typing import Optional
 from uuid import UUID
 
+from hippius_s3.cache.access_tracker import get_access_tracker
+
 
 logger = logging.getLogger(__name__)
 
@@ -149,8 +151,10 @@ class FileSystemPartsStore:
         """Read a chunk from filesystem.
 
         Gated on meta.json existence — readers only see chunks once the part
-        is marked ready. Also touches the chunk file to update atime/mtime,
-        which the janitor uses for hot-file retention.
+        is marked ready. Read recency is recorded via the AccessTracker (into
+        fs_cache_inventory.last_access_at) rather than atime; the hook lives
+        HERE, at the store level, because the streamer passes fetch_fn =
+        fs.get_chunk directly and bypasses every higher-level wrapper.
 
         Args:
             object_id: Object UUID
@@ -184,6 +188,11 @@ class FileSystemPartsStore:
                     return f.read()
 
             data = await asyncio.to_thread(_read)
+            # Sync, sampled, no-op in processes that never initialize the
+            # tracker (workers/janitor).
+            tracker = get_access_tracker()
+            if tracker is not None:
+                tracker.note_read(object_id, int(object_version), int(part_number))
             logger.debug(
                 f"FS: read chunk object_id={object_id} v={object_version} part={part_number} chunk={chunk_index} size={len(data)}"
             )

--- a/hippius_s3/cache/object_parts.py
+++ b/hippius_s3/cache/object_parts.py
@@ -15,6 +15,7 @@ from typing import Any
 from typing import Optional
 from typing import Protocol
 
+from .access_tracker import get_access_tracker
 from .fs_store import FileSystemPartsStore
 from .notifier import ChunkNotifier
 from .notifier import build_chunk_key
@@ -119,6 +120,14 @@ class RedisObjectPartsCache:
     ) -> Optional[bytes]:
         data = await self.fs.get_chunk(object_id, int(object_version), int(part_number), int(chunk_index))
         _get_metrics_collector().record_cache_operation(hit=data is not None, operation="get_chunk")
+        if data is not None:
+            # Read-recency for the janitor's hot retention. Replaces the old
+            # per-read os.utime (dead on read-only mounts, an MDS write
+            # elsewhere). Sync + sampled; no-op in processes that never
+            # initialize the tracker (workers).
+            tracker = get_access_tracker()
+            if tracker is not None:
+                tracker.note_read(object_id, int(object_version), int(part_number))
         return data
 
     async def set_chunk(

--- a/hippius_s3/cache/object_parts.py
+++ b/hippius_s3/cache/object_parts.py
@@ -15,7 +15,6 @@ from typing import Any
 from typing import Optional
 from typing import Protocol
 
-from .access_tracker import get_access_tracker
 from .fs_store import FileSystemPartsStore
 from .notifier import ChunkNotifier
 from .notifier import build_chunk_key
@@ -118,16 +117,11 @@ class RedisObjectPartsCache:
     async def get_chunk(
         self, object_id: str, object_version: int, part_number: int, chunk_index: int
     ) -> Optional[bytes]:
+        # Read-recency tracking happens inside fs.get_chunk (store level): the
+        # streamer bypasses this wrapper with fetch_fn = fs.get_chunk, so a
+        # hook here would miss all streamed GET traffic.
         data = await self.fs.get_chunk(object_id, int(object_version), int(part_number), int(chunk_index))
         _get_metrics_collector().record_cache_operation(hit=data is not None, operation="get_chunk")
-        if data is not None:
-            # Read-recency for the janitor's hot retention. Replaces the old
-            # per-read os.utime (dead on read-only mounts, an MDS write
-            # elsewhere). Sync + sampled; no-op in processes that never
-            # initialize the tracker (workers).
-            tracker = get_access_tracker()
-            if tracker is not None:
-                tracker.note_read(object_id, int(object_version), int(part_number))
         return data
 
     async def set_chunk(

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -350,7 +350,9 @@ class Config:
     # Object parts filesystem cache configuration
     object_cache_dir: str = env("HIPPIUS_OBJECT_CACHE_DIR:/var/lib/hippius/object_cache")
     object_cache_fallback_dir: str = env("HIPPIUS_OBJECT_CACHE_FALLBACK_DIR:", convert=str)
-    # 24h since last access — reads bump mtime (os.utime sets both atime+mtime), so this gates on idle time.
+    # 24h since last WRITE — the read path no longer bumps timestamps (read
+    # recency lives in fs_cache_inventory.last_access_at), so this gates on
+    # time since the part landed, not since it was last streamed.
     fs_cache_gc_max_age_seconds: int = env("HIPPIUS_FS_CACHE_GC_MAX_AGE_SECONDS:86400", convert=int)
     # An MPU is "abandoned" only after this long with NO part activity (not just since
     # initiation) — a user can pause a multipart upload and resume it, so the window must

--- a/hippius_s3/main.py
+++ b/hippius_s3/main.py
@@ -180,7 +180,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
         tracker = initialize_access_tracker(
             app.state.postgres_pool,
-            hot_window_seconds=float(getattr(config, "fs_cache_hot_retention_seconds", 10800)),
+            hot_window_seconds=float(config.fs_cache_hot_retention_seconds),
         )
         app.state.access_tracker_task = asyncio.create_task(tracker.run())
         logger.info("Access tracker flush task started")
@@ -191,6 +191,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         try:
             if hasattr(app.state, "access_tracker_task"):
                 app.state.access_tracker_task.cancel()
+                import contextlib
+
+                with contextlib.suppress(asyncio.CancelledError):
+                    await app.state.access_tracker_task
         except Exception:
             logger.exception("Error stopping access tracker task")
 

--- a/hippius_s3/main.py
+++ b/hippius_s3/main.py
@@ -174,9 +174,26 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         asyncio.create_task(collect_pool_metrics())
         logger.info("Pool metrics collection task started")
 
+        # Read-recency tracker: feeds fs_cache_inventory.last_access_at so the
+        # janitor's hot retention sees reads (atime can't — see access_tracker).
+        from hippius_s3.cache.access_tracker import initialize_access_tracker
+
+        tracker = initialize_access_tracker(
+            app.state.postgres_pool,
+            hot_window_seconds=float(getattr(config, "fs_cache_hot_retention_seconds", 10800)),
+        )
+        app.state.access_tracker_task = asyncio.create_task(tracker.run())
+        logger.info("Access tracker flush task started")
+
         yield
 
     finally:
+        try:
+            if hasattr(app.state, "access_tracker_task"):
+                app.state.access_tracker_task.cancel()
+        except Exception:
+            logger.exception("Error stopping access tracker task")
+
         try:
             # Stop background metrics collection
             if hasattr(app.state, "background_metrics_collector"):

--- a/hippius_s3/sql/migrations/20260725120000_fs_cache_inventory_last_access.sql
+++ b/hippius_s3/sql/migrations/20260725120000_fs_cache_inventory_last_access.sql
@@ -1,0 +1,14 @@
+-- migrate:up
+
+-- Read-recency signal for hot-retention, replacing filesystem atime as the
+-- "recently read" channel. atime refresh was an os.utime() on every chunk read:
+-- dead on read-only mounts (prod api-local mounts the pool RO, so EROFS was
+-- silently swallowed and NO read traffic could protect a pool-resident part
+-- from eviction) and an MDS metadata WRITE from the read path everywhere else.
+-- NULL = never read since this column shipped; consumers treat NULL as
+-- cached_at, so the rollout degrades to the old write-recency behavior.
+ALTER TABLE fs_cache_inventory ADD COLUMN IF NOT EXISTS last_access_at TIMESTAMPTZ;
+
+-- migrate:down
+
+ALTER TABLE fs_cache_inventory DROP COLUMN IF EXISTS last_access_at;

--- a/tests/unit/test_access_tracker.py
+++ b/tests/unit/test_access_tracker.py
@@ -1,0 +1,108 @@
+"""Unit tests for the sampled read-recency tracker (fs_cache_inventory.last_access_at)."""
+
+from __future__ import annotations
+
+import pytest
+
+import hippius_s3.cache.access_tracker as at
+from hippius_s3.cache.access_tracker import AccessTracker
+from hippius_s3.cache.access_tracker import get_access_tracker
+from hippius_s3.cache.access_tracker import initialize_access_tracker
+
+
+class FakePool:
+    def __init__(self, fail: bool = False) -> None:
+        self.execute_calls: list[tuple[str, tuple]] = []
+        self.fail = fail
+
+    async def execute(self, sql: str, *args):
+        if self.fail:
+            raise ConnectionError("db down")
+        self.execute_calls.append((sql, args))
+        return "UPDATE 1"
+
+
+OID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    at._tracker = None
+    yield
+    at._tracker = None
+
+
+@pytest.mark.asyncio
+async def test_note_read_batches_and_flushes():
+    pool = FakePool()
+    tracker = AccessTracker(pool, hot_window_seconds=14400)
+    tracker.note_read(OID, 1, 1)
+    tracker.note_read(OID, 1, 2)
+
+    flushed = await tracker.flush_once()
+
+    assert flushed == 2
+    assert len(pool.execute_calls) == 1
+    sql, args = pool.execute_calls[0]
+    assert "last_access_at = now()" in sql
+    assert sorted(zip(args[0], args[1], args[2], strict=False)) == [(OID, 1, 1), (OID, 1, 2)]
+
+
+@pytest.mark.asyncio
+async def test_sampling_suppresses_repeat_notes_within_window():
+    pool = FakePool()
+    tracker = AccessTracker(pool, hot_window_seconds=14400)
+    for _ in range(100):
+        tracker.note_read(OID, 1, 1)
+
+    assert await tracker.flush_once() == 1
+    # Still inside the sample window: nothing new to record.
+    tracker.note_read(OID, 1, 1)
+    assert await tracker.flush_once() == 0
+    assert len(pool.execute_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_flush_failure_drops_batch_without_raising():
+    pool = FakePool(fail=True)
+    tracker = AccessTracker(pool, hot_window_seconds=14400)
+    tracker.note_read(OID, 1, 1)
+
+    assert await tracker.flush_once() == 1  # attempted
+    pool.fail = False
+    # Batch was dropped, not requeued: nothing to flush now.
+    assert await tracker.flush_once() == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_flush_is_noop():
+    pool = FakePool()
+    tracker = AccessTracker(pool, hot_window_seconds=14400)
+    assert await tracker.flush_once() == 0
+    assert pool.execute_calls == []
+
+
+def test_singleton_wiring():
+    assert get_access_tracker() is None
+    tracker = initialize_access_tracker(FakePool(), hot_window_seconds=3600)
+    assert get_access_tracker() is tracker
+
+
+@pytest.mark.asyncio
+async def test_object_parts_get_chunk_notes_read_on_hit():
+    from hippius_s3.cache.object_parts import RedisObjectPartsCache
+
+    tracker = initialize_access_tracker(FakePool(), hot_window_seconds=3600)
+
+    class FakeFs:
+        async def get_chunk(self, object_id, object_version, part_number, chunk_index):
+            return b"data" if chunk_index == 0 else None
+
+    cache = RedisObjectPartsCache.__new__(RedisObjectPartsCache)
+    cache._fs = FakeFs()
+
+    assert await cache.get_chunk(OID, 1, 3, 0) == b"data"
+    assert await cache.get_chunk(OID, 1, 4, 1) is None  # miss: no note
+
+    assert (OID, 1, 3) in tracker._pending
+    assert (OID, 1, 4) not in tracker._pending

--- a/tests/unit/test_access_tracker.py
+++ b/tests/unit/test_access_tracker.py
@@ -89,20 +89,32 @@ def test_singleton_wiring():
 
 
 @pytest.mark.asyncio
-async def test_object_parts_get_chunk_notes_read_on_hit():
-    from hippius_s3.cache.object_parts import RedisObjectPartsCache
+async def test_fs_store_get_chunk_notes_read_on_hit(tmp_path):
+    """The hook must live in FileSystemPartsStore.get_chunk itself: the
+    streamer passes fetch_fn = fs.get_chunk and bypasses every wrapper, so a
+    wrapper-level hook would be inert for all streamed GET traffic (the
+    original review blocker)."""
+    from hippius_s3.cache.fs_store import FileSystemPartsStore
 
     tracker = initialize_access_tracker(FakePool(), hot_window_seconds=3600)
+    store = FileSystemPartsStore(str(tmp_path))
+    await store.set_chunk(OID, 1, 3, 0, b"data")
+    await store.set_meta(OID, 1, 3, chunk_size=4, num_chunks=1, size_bytes=4)
 
-    class FakeFs:
-        async def get_chunk(self, object_id, object_version, part_number, chunk_index):
-            return b"data" if chunk_index == 0 else None
-
-    cache = RedisObjectPartsCache.__new__(RedisObjectPartsCache)
-    cache._fs = FakeFs()
-
-    assert await cache.get_chunk(OID, 1, 3, 0) == b"data"
-    assert await cache.get_chunk(OID, 1, 4, 1) is None  # miss: no note
+    assert await store.get_chunk(OID, 1, 3, 0) == b"data"
+    assert await store.get_chunk(OID, 1, 4, 0) is None  # miss: no note
 
     assert (OID, 1, 3) in tracker._pending
     assert (OID, 1, 4) not in tracker._pending
+
+
+def test_note_read_enforces_hard_key_bound():
+    """A key-diverse read storm inside the sample window must not grow the
+    sampling map unboundedly — the window prune alone can't shrink it."""
+    import hippius_s3.cache.access_tracker as mod
+
+    tracker = AccessTracker(FakePool(), hot_window_seconds=3600)
+    for i in range(mod.MAX_TRACKED_KEYS + 1000):
+        tracker.note_read(OID, 1, i)
+
+    assert len(tracker._last_noted) <= mod.MAX_TRACKED_KEYS

--- a/tests/unit/test_fs_store.py
+++ b/tests/unit/test_fs_store.py
@@ -272,14 +272,15 @@ async def test_touch_chunk_missing_is_noop(fs: FileSystemPartsStore) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_chunk_touches_file(fs: FileSystemPartsStore) -> None:
-    """Every successful read updates atime/mtime — the janitor's hot-retention
-    signal — without needing filesystem-level `strictatime`."""
+async def test_get_chunk_does_not_touch_file(fs: FileSystemPartsStore) -> None:
+    """Reads must NOT write filesystem timestamps: the per-read utime was dead
+    on read-only mounts and an MDS metadata write elsewhere. Read recency lives
+    in fs_cache_inventory.last_access_at (cache/access_tracker.py); stat times
+    now reflect write recency only."""
     await fs.set_chunk(OBJ, 1, 1, 0, b"payload")
     await fs.set_meta(OBJ, 1, 1, chunk_size=7, num_chunks=1, size_bytes=7)
 
     chunk_path = Path(fs.part_path(OBJ, 1, 1)) / "chunk_0.bin"
-    # Rewind both times to clearly distant past
     past = time.time() - 3600
     os.utime(chunk_path, (past, past))
     old_mtime = chunk_path.stat().st_mtime
@@ -287,8 +288,7 @@ async def test_get_chunk_touches_file(fs: FileSystemPartsStore) -> None:
     data = await fs.get_chunk(OBJ, 1, 1, 0)
     assert data == b"payload"
 
-    new_mtime = chunk_path.stat().st_mtime
-    assert new_mtime > old_mtime
+    assert chunk_path.stat().st_mtime == old_mtime
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_janitor_sql_evict.py
+++ b/tests/unit/test_janitor_sql_evict.py
@@ -90,12 +90,15 @@ class _RouterConn:
     serves that page's candidate rows, advancing to the next page after the filter fetch. A page's
     slice or cand entry may be an Exception instance to inject a timeout on that specific fetch."""
 
-    def __init__(self, pages: list[tuple[Any, Any]]) -> None:
+    def __init__(self, pages: list[tuple[Any, Any]], last_access: Any = None) -> None:
         self._pages = pages
         self._i = 0
         self.slice_args: list[tuple] = []
         self.filter_args: list[tuple] = []
         self.fetch = AsyncMock(side_effect=self._fetch)
+        # handle()'s read-recency probe (fs_cache_inventory.last_access_at).
+        # None = never read, which preserves the legacy write-recency-only path.
+        self.fetchval = AsyncMock(return_value=last_access)
 
     async def _fetch(self, query: str, *args: Any, **_kwargs: Any) -> Any:
         if query == "janitor_inventory_slice":
@@ -131,10 +134,11 @@ def _config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(janitor, "_janitor_deleted_counter", MagicMock())
 
 
-def _conn(*pages: tuple[Any, Any]) -> _RouterConn:
+def _conn(*pages: tuple[Any, Any], last_access: Any = None) -> _RouterConn:
     """Build a router conn from (slice_rows, cand_rows) pages. For the common case where every slice
-    row is also a candidate, pass the same list for both."""
-    return _RouterConn(list(pages))
+    row is also a candidate, pass the same list for both. `last_access` seeds the read-recency
+    probe (fs_cache_inventory.last_access_at); None = never read."""
+    return _RouterConn(list(pages), last_access=last_access)
 
 
 def _same(rows: list[dict]) -> tuple[list[dict], list[dict]]:
@@ -214,6 +218,20 @@ async def test_replicated_cold_candidate_is_deleted_cleared_and_counted(monkeypa
     assert fs.deleted == [(OID_A, 1, 1)]
     janitor.clear_cached.assert_awaited_once()
     janitor._janitor_deleted_counter.add.assert_called_once_with(1, attributes={"reason": "sql_evict"})
+
+
+@pytest.mark.asyncio
+async def test_recently_read_candidate_is_protected_via_last_access(monkeypatch: pytest.MonkeyPatch) -> None:
+    # atime is COLD (the read path no longer touches it), but the inventory's
+    # last_access_at is fresh — hot retention must protect the part.
+    monkeypatch.setattr(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=True))
+    fs = _FakeFs(stat_map={(OID_A, 1, 1): _stat(COLD)})
+    conn = _conn(_same([_row(OID_A)]), ([], []), last_access=datetime.now(timezone.utc))
+
+    deleted = await _evict(conn, fs)
+
+    assert deleted == 0
+    assert fs.deleted == []
 
 
 @pytest.mark.asyncio

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -1460,29 +1460,17 @@ async def cleanup_old_parts_by_mtime(
 
             # Check mtime (for age) and atime (for hot retention).
             #
-            # ZFS + noatime note: in prod the local-cache volume is a ZFS
-            # dataset mounted `noatime` (see `mount | grep local_object_cache`
-            # → `rw,noatime,xattr,noacl,casesensitive`). `noatime` only
-            # blocks VFS-triggered atime updates on reads (the
-            # `file_accessed() → atime_needs_update() → dirty_inode()`
-            # path). It does NOT block explicit `utimensat(2)` metadata
-            # writes, which go through `setattr()`. Our reader refreshes
-            # atime on every chunk read via `os.utime(path, None)` in
-            # `fs_store.get_chunk`, so hot-retention works correctly here.
-            # OpenZFS PR #4482 ("Fix atime handling and relatime") made
-            # this behaviour consistent — atime is handled purely by VFS
-            # and explicit setattr writes are always honoured regardless
-            # of the mount's noatime flag.
-            #
-            # Side effect: `os.utime(path, None)` sets BOTH atime and
-            # mtime to "now" (UTIME_NOW on both). Recently-read chunks
-            # therefore show `atime == mtime` to the nanosecond — that's
-            # expected, not a bug. It also means reads push mtime
-            # forward, so the mtime-based age check below is more
-            # conservative on actively-read content (treats hot chunks
-            # as younger than their original landing time). Replication
-            # is still the absolute gate, so this only relaxes, never
-            # tightens, what we delete.
+            # WRITE recency only: the read path no longer refreshes atime
+            # (fs_store.get_chunk's per-read os.utime was removed — it was
+            # silently dead on read-only mounts and an MDS metadata write
+            # elsewhere; read recency now lives in
+            # fs_cache_inventory.last_access_at via the AccessTracker).
+            # So on this walk path atime/mtime reflect the last WRITE, and
+            # the hot check protects fresh materializations, not active
+            # readers. Read-hot protection is enforced by the SQL-eviction
+            # path, which consults last_access_at; replication remains the
+            # absolute gate for both paths, so this difference only affects
+            # WHEN a part becomes evictable, never whether it is safe.
             try:
                 mtime = part.mtime
                 atime = part.atime

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -1961,8 +1961,23 @@ async def evict_from_inventory(
         if st is None:
             await clear_cached(conn, object_id, object_version, part_number)  # stale row: self-heal
             return False
-        if hot_window > 0 and st.st_atime > (now - hot_window):
-            return False  # recently read — hot retention protects it (skipped when window==0)
+        if hot_window > 0:
+            # Write recency: atime reflects the last write now that the read
+            # path no longer touches it (fs_store.get_chunk dropped os.utime).
+            if st.st_atime > (now - hot_window):
+                return False
+            # Read recency: recorded by the api's AccessTracker into
+            # last_access_at. NULL = not read since the column shipped, which
+            # degrades to the old write-recency-only behavior. PK lookup.
+            last_access = await conn.fetchval(
+                "SELECT last_access_at FROM fs_cache_inventory "
+                "WHERE object_id = $1 AND object_version = $2 AND part_number = $3",
+                object_id,
+                object_version,
+                part_number,
+            )
+            if last_access is not None and last_access.timestamp() > (now - hot_window):
+                return False  # recently read — hot retention protects it
         # ABSOLUTE safety gate — identical call to the walk's, never bypassed by the prefilter.
         try:
             fully_replicated = await is_replicated_on_all_backends(conn, object_id, object_version, part_number)


### PR DESCRIPTION
## What

Final slice of the 2026-07-25 audit (plan §PR H3). Stacked on #353.

**Problem:** hot retention's "recently read" signal was filesystem atime, refreshed by `os.utime()` on every chunk read. On prod api-local the pool is mounted `readOnly: true`, so the refresh raised EROFS into a `contextlib.suppress` — **no amount of read traffic could protect a pool-resident part from eviction**, enabling restore→evict→re-restore thrash under pressure. Where the mount is RW, the refresh made every read an MDS metadata write.

- **Migration:** `fs_cache_inventory.last_access_at TIMESTAMPTZ NULL`. NULL degrades to the old write-recency behavior, so api/janitor/migration can deploy in any order.
- **`AccessTracker`** (`cache/access_tracker.py`): `note_read` is sync + sampled (a part re-records at most once per quarter hot-window; dict probe on the stream hot path), flushed as one batched `UPDATE ... FROM unnest(...)` every 30 s. DB failure drops the batch (advisory data; re-samples on next read) instead of growing an unbounded buffer. Module singleton initialized in the api lifespan; worker processes that never initialize it get a no-op.
- **`fs_store.get_chunk`** no longer touches atime/mtime — stat times now mean write recency only, which the janitor's atime checks still correctly protect (fresh drain/downloader writes).
- **Janitor SQL eviction:** a candidate is hot iff `st_atime` recent (write) **or** `last_access_at` recent (read; PK lookup per candidate). The unified-walk path is unchanged.

## Testing

- `test_access_tracker.py` (6): batch+flush SQL args, sampling suppression, flush-failure drop, singleton wiring, and `RedisObjectPartsCache.get_chunk` noting hits but not misses.
- `test_janitor_sql_evict.py`: fake conn gained the `fetchval` probe (None = legacy path — all 23 prior tests pass unchanged); new test proves a cold-atime candidate with fresh `last_access_at` is protected.
- `test_fs_store.py`: the old "read touches mtime" test now asserts the inverse, documenting the new contract.

Full unit suite: 2176 passed, 37 skipped. Ruff clean.