### PR TITLE
fix(drain): stop head-of-line starvation in the drain pipeline

### DIFF
--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -308,6 +308,9 @@ impl Config {
             decay_half_life: duration_secs(&get, "CEPHOR_DECAY_HALF_LIFE_SECS", DEFAULT_DECAY_HALF_LIFE)?,
             allocation_poll: duration_secs(&get, "CEPHOR_ALLOCATION_POLL_SECS", DEFAULT_ALLOCATION_POLL)?,
             claim_lease: duration_secs(&get, "CEPHOR_CLAIM_LEASE_TTL_SECS", DEFAULT_CLAIM_LEASE)?,
+            // Burst termination leans on this being nonzero: a skipped part's backoff is
+            // what keeps it out of the claim set, so 0 lets a burst re-claim/re-defer the
+            // same part in a tight loop until cancellation.
             defer_backoff: duration_secs(&get, "CEPHOR_DEFER_BACKOFF_SECS", DEFAULT_DEFER_BACKOFF)?,
             defer_backoff_cap: duration_secs(&get, "CEPHOR_DEFER_BACKOFF_CAP_SECS", DEFAULT_DEFER_BACKOFF_CAP)?,
             heartbeat_ttl: duration_secs(&get, "CEPHOR_HEARTBEAT_TTL_SECS", DEFAULT_HEARTBEAT_TTL)?,

--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -54,6 +54,11 @@ const DEFAULT_CLAIM_LEASE: Duration = Duration::from_mins(5);
 /// parked before it is re-claimable, so the drain does not spin on not-ready parts every
 /// poll. Mirrors the store-side default.
 const DEFAULT_DEFER_BACKOFF: Duration = Duration::from_secs(5);
+/// Deferral-backoff ceiling when `CEPHOR_DEFER_BACKOFF_CAP_SECS` is unset: the per-row
+/// exponential backoff (base × 2^attempts) never parks a part longer than this, so a
+/// chronically not-ready part still re-checks within minutes of its address finally
+/// landing. Mirrors the store-side default.
+const DEFAULT_DEFER_BACKOFF_CAP: Duration = Duration::from_mins(10);
 /// Heartbeat key TTL when `CEPHOR_HEARTBEAT_TTL_SECS` is unset: how long this node's
 /// heartbeat stays live in the fleet before it must be refreshed. This IS the
 /// fleet-staleness window (the allocator drops a node whose key has expired), so it must
@@ -123,8 +128,12 @@ pub struct Config {
     /// (the H1 crash-recovery TTL; wired into the store via `with_claim_lease`).
     pub claim_lease: Duration,
     /// How long a deferred (enqueue-not-ready) part is backed off before re-claim,
-    /// wired into the store via `with_defer_backoff`.
+    /// wired into the store via `with_defer_backoff`. The base of the per-row
+    /// exponential backoff, doubled per deferral up to `defer_backoff_cap`.
     pub defer_backoff: Duration,
+    /// Ceiling on the exponential deferral backoff, wired into the store via
+    /// `with_defer_backoff_cap`.
+    pub defer_backoff_cap: Duration,
     /// TTL stamped on this node's heartbeat key — the fleet-staleness window the
     /// allocator sees (a node whose key expires drops out of the fleet).
     pub heartbeat_ttl: Duration,
@@ -300,6 +309,7 @@ impl Config {
             allocation_poll: duration_secs(&get, "CEPHOR_ALLOCATION_POLL_SECS", DEFAULT_ALLOCATION_POLL)?,
             claim_lease: duration_secs(&get, "CEPHOR_CLAIM_LEASE_TTL_SECS", DEFAULT_CLAIM_LEASE)?,
             defer_backoff: duration_secs(&get, "CEPHOR_DEFER_BACKOFF_SECS", DEFAULT_DEFER_BACKOFF)?,
+            defer_backoff_cap: duration_secs(&get, "CEPHOR_DEFER_BACKOFF_CAP_SECS", DEFAULT_DEFER_BACKOFF_CAP)?,
             heartbeat_ttl: duration_secs(&get, "CEPHOR_HEARTBEAT_TTL_SECS", DEFAULT_HEARTBEAT_TTL)?,
             redis_queues_url: required(&get, "REDIS_QUEUES_URL")?,
             upload_backends: parse_backends(&get, "HIPPIUS_UPLOAD_BACKENDS"),
@@ -414,9 +424,9 @@ fn duration_secs(get: &impl Fn(&str) -> Option<String>, var: &'static str, defau
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::{
-        Config, ConfigError, DEFAULT_ALLOCATION_POLL, DEFAULT_CLAIM_LEASE, DEFAULT_DECAY_HALF_LIFE, DEFAULT_DRAIN_CONCURRENCY, DEFAULT_DRAIN_POLL,
-        DEFAULT_FLOOR_RATE_BPS, DEFAULT_HEARTBEAT_POLL, DEFAULT_HEARTBEAT_TTL, DEFAULT_MAX_DRAIN_RATE_BPS, DEFAULT_ORPHAN_RECLAIM_GRACE,
-        DEFAULT_RECLAIM_GRACE, DEFAULT_RECLAIM_POLL, DEFAULT_REPLICATED_RECLAIM_GRACE,
+        Config, ConfigError, DEFAULT_ALLOCATION_POLL, DEFAULT_CLAIM_LEASE, DEFAULT_DECAY_HALF_LIFE, DEFAULT_DEFER_BACKOFF_CAP,
+        DEFAULT_DRAIN_CONCURRENCY, DEFAULT_DRAIN_POLL, DEFAULT_FLOOR_RATE_BPS, DEFAULT_HEARTBEAT_POLL, DEFAULT_HEARTBEAT_TTL,
+        DEFAULT_MAX_DRAIN_RATE_BPS, DEFAULT_ORPHAN_RECLAIM_GRACE, DEFAULT_RECLAIM_GRACE, DEFAULT_RECLAIM_POLL, DEFAULT_REPLICATED_RECLAIM_GRACE,
     };
     use core::str::FromStr;
     use hippius_drain_core::{ByteRate, NodeId};
@@ -528,6 +538,20 @@ mod tests {
         pairs.push(("CEPHOR_CLAIM_LEASE_TTL_SECS", "600"));
         let config = Config::from_lookup(lookup(&pairs)).unwrap();
         assert_eq!(config.claim_lease, Duration::from_mins(10));
+    }
+
+    #[test]
+    fn defaults_the_defer_backoff_cap() {
+        let config = Config::from_lookup(lookup(&required_only())).unwrap();
+        assert_eq!(config.defer_backoff_cap, DEFAULT_DEFER_BACKOFF_CAP);
+    }
+
+    #[test]
+    fn a_numeric_defer_backoff_cap_overrides_the_default() {
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_DEFER_BACKOFF_CAP_SECS", "1200"));
+        let config = Config::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(config.defer_backoff_cap, Duration::from_mins(20));
     }
 
     #[test]

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -159,6 +159,52 @@ impl LocalSsd {
         self.root.as_path()
     }
 
+    /// Whether an absent part under this root means "that part is gone" rather than
+    /// "the whole volume is gone".
+    ///
+    /// A per-part `ENOENT` is ambiguous on its own: an ext4 ingest volume that fails
+    /// to mount leaves an EMPTY directory on the PARENT filesystem, so every part
+    /// stats `NotFound` cleanly, with no error to distinguish it from a genuinely
+    /// vanished source. Escalating that to the terminal missing-source write-off would
+    /// retire a node's entire backlog as unrecoverable within hours of a mount failure.
+    ///
+    /// Two positive signals, either of which proves the volume is really there:
+    /// - the root has at least one entry (data is present, so absence is real), or
+    /// - the root is its own mount point (`st_dev` differs from its parent), which
+    ///   covers the legitimately-empty case of a fully-drained node — the orphan rows
+    ///   this write-off exists to clear.
+    ///
+    /// Unreadable, or empty AND not a mount point, returns `false`: the caller must
+    /// treat that as a node-global condition instead of blaming the part. Erring this
+    /// way only delays a write-off; the opposite error is silent replication loss.
+    pub async fn root_is_available(&self) -> bool {
+        use std::os::unix::fs::MetadataExt;
+
+        let Ok(meta) = fs::metadata(&self.root).await else {
+            return false;
+        };
+        if !meta.is_dir() {
+            return false;
+        }
+        match fs::read_dir(&self.root).await {
+            Ok(mut entries) => {
+                if matches!(entries.next_entry().await, Ok(Some(_))) {
+                    return true;
+                }
+            }
+            Err(_) => return false,
+        }
+        // Empty. Only a distinct st_dev separates "drained volume" from "never mounted".
+        match self.root.parent() {
+            Some(parent) => match fs::metadata(parent).await {
+                Ok(parent_meta) => parent_meta.dev() != meta.dev(),
+                Err(_) => false,
+            },
+            // No parent means the root IS the filesystem root; nothing to compare.
+            None => true,
+        }
+    }
+
     /// Removes orphaned write-temp files left on the SSD by a crashed mid-write PUT
     /// (the api's `<name>.tmp.<uuid>`) or a cancelled persist (the agent's
     /// `.tmp-<name>`), once older than `max_age`.
@@ -720,6 +766,55 @@ mod tests {
             "both carry the stable per-process nonce: {a} {b}"
         );
     }
+
+    // `root_is_available` gates the terminal missing-source write-off. Its whole job is
+    // to tell "this part vanished" apart from "the ingest volume vanished", because both
+    // surface as a bare ENOENT on the part path and only the first may retire a row.
+
+    #[tokio::test]
+    async fn a_populated_root_proves_the_volume_is_present() {
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("some-object")).unwrap();
+        assert!(
+            LocalSsd::new(dir.path()).root_is_available().await,
+            "any entry under the root is positive proof the volume is mounted"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_root_that_is_not_a_mount_point_is_not_available() {
+        // The mount-failure shape: an EMPTY directory sitting on its parent's
+        // filesystem. Indistinguishable from a drained volume by content alone, so the
+        // st_dev comparison is what has to catch it. Nested inside a TempDir, both
+        // share one st_dev — exactly an ingest SSD that never mounted.
+        let dir = TempDir::new().unwrap();
+        let never_mounted = dir.path().join("local_object_cache");
+        std::fs::create_dir_all(&never_mounted).unwrap();
+        assert!(
+            !LocalSsd::new(&never_mounted).root_is_available().await,
+            "an empty non-mount root must NOT authorize write-offs — this is the mass \
+             write-off hazard the guard exists for"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_missing_or_non_directory_root_is_not_available() {
+        let dir = TempDir::new().unwrap();
+        assert!(
+            !LocalSsd::new(dir.path().join("absent")).root_is_available().await,
+            "a root that isn't there proves nothing about the parts under it"
+        );
+        let file = dir.path().join("not-a-dir");
+        std::fs::write(&file, b"x").unwrap();
+        assert!(
+            !LocalSsd::new(&file).root_is_available().await,
+            "a non-directory root is a misconfiguration, not a drained volume"
+        );
+    }
+
+    // NB: the remaining arm — empty AND a real mount point, i.e. a fully-drained node
+    // whose orphan rows SHOULD still be written off — needs an actual mount and so is
+    // not unit-testable here. It is the `parent_meta.dev() != meta.dev()` branch.
 
     #[tokio::test]
     async fn remove_object_deletes_the_whole_file_folder_and_surfaces_absence() {

--- a/crates/hippius-drain-agent/src/main.rs
+++ b/crates/hippius-drain-agent/src/main.rs
@@ -58,6 +58,7 @@ async fn main() -> Result<ExitCode, StartupError> {
             .await?
             .with_claim_lease(config.claim_lease)
             .with_defer_backoff(config.defer_backoff)
+            .with_defer_backoff_cap(config.defer_backoff_cap)
             .with_node_id(config.node_id.as_str()),
     );
 

--- a/crates/hippius-drain-agent/src/metrics.rs
+++ b/crates/hippius-drain-agent/src/metrics.rs
@@ -150,6 +150,31 @@ pub fn init(service_name: &'static str, snapshot: &Arc<SnapshotCell>, enforcer: 
             .build(),
     ));
 
+    // Starvation: age of this node's oldest still-`pending` row (gauge, seconds), refreshed
+    // by the heartbeat from Store::node_oldest_pending_age_secs. The 2026-07-26 incident's
+    // earliest unambiguous signal — one node's age exploding while its peers sat near zero —
+    // was only reachable by hand-written SQL; this makes it a standing per-node gauge.
+    // Deferred (backed-off) rows count: an MPU wall aging past hours is exactly the tell.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_gauge("drain_pending_oldest_age_seconds")
+            .with_callback(move |observer| observer.observe(snap.oldest_pending_age_secs(), &[]))
+            .build(),
+    ));
+
+    // Write-off alarm: parts escalated to terminal `failed` by the missing-source path
+    // (monotonic counter). The only DURABLE signal of a write-off — the row is excluded from
+    // node_undrained_count and later deleted by the terminal GC, leaving just a WARN log.
+    // Deliberately not folded into error_bps/failed: a write-off is not a Ceph failure.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_counter("drain_parts_written_off_total")
+            .with_callback(move |observer| observer.observe(snap.load().written_off, &[]))
+            .build(),
+    ));
+
     // Silent-failure alarm: the Ceph breaker (trips at debug-level today) as a 0/1 gauge.
     if let Some(enforcer) = enforcer {
         let enforcer = Arc::clone(enforcer);

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -427,8 +427,11 @@ async fn enqueue_sweep_once<E: UploadEnqueuer>(store: &Store, enqueuer: &E) {
 /// Sets the enforcer's rate under its lock. The op is synchronous, so the guard
 /// never crosses an `.await` (axiom `rust_quality_74`); a poisoned lock recovers
 /// via `into_inner` — the `Enforcer` is a small `Copy` value left consistent.
-fn apply_rate(enforcer: &Arc<Mutex<Enforcer>>, rate: ByteRate) {
-    enforcer.lock().unwrap_or_else(PoisonError::into_inner).set_rate(rate);
+/// `now` settles the bucket's un-refilled window at the outgoing rate before the
+/// swap, so a budget change cannot re-price elapsed time (debt payment is not
+/// burst-capped, so re-pricing would mint or destroy real budget).
+fn apply_rate(enforcer: &Arc<Mutex<Enforcer>>, rate: ByteRate, now: Instant) {
+    enforcer.lock().unwrap_or_else(PoisonError::into_inner).set_rate(rate, now);
 }
 
 /// The enforcer action for one allocation-pull outcome, separated from the async
@@ -482,9 +485,12 @@ async fn run_alloc(token: CancellationToken, coord: Arc<Coordinator>, rate_contr
             PullAction::Adopt(budget) => {
                 base = budget;
                 allocated_at = clock.now();
-                apply_rate(&enforcer, base);
+                apply_rate(&enforcer, base, allocated_at);
             }
-            PullAction::Decay => apply_rate(&enforcer, decay_rate(base, floor, clock.now().duration_since(allocated_at), half_life)),
+            PullAction::Decay => {
+                let now = clock.now();
+                apply_rate(&enforcer, decay_rate(base, floor, now.duration_since(allocated_at), half_life), now);
+            }
         }
         tokio::select! {
             () = token.cancelled() => return,

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -199,7 +199,7 @@ async fn run_drain<E: UploadEnqueuer>(token: CancellationToken, period: Duration
         )
         .await
         {
-            Ok(drained) => tracing::debug!(drained, "drain cycle complete"),
+            Ok(tally) => tracing::debug!(drained = tally.drained, skipped = tally.skipped, "drain cycle complete"),
             // Debug-format the error so the `PartDrainError` variant + `DrainStep` + the
             // underlying io errno surface; `%err` (Display) only prints the opaque
             // "draining a part failed" and hides which step/errno actually failed.

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -216,8 +216,9 @@ async fn run_drain<E: UploadEnqueuer>(token: CancellationToken, period: Duration
 /// Probes SSD disk pressure off the async runtime (statvfs blocks) and upserts
 /// this node's heartbeat. Probe or upsert failures are logged and skipped — the
 /// next tick retries; a missed heartbeat only ages the node out of the fleet.
-/// Refreshes this node's two DB-sourced drain-demand gauges: the byte backlog
-/// (`drain_ssd_backlog_bytes`) and the undrained-row COUNT (the C8 readiness wedge signal).
+/// Refreshes this node's three DB-sourced drain-demand gauges: the byte backlog
+/// (`drain_ssd_backlog_bytes`), the undrained-row COUNT (the C8 readiness wedge signal),
+/// and the oldest-pending age (`drain_pending_oldest_age_seconds`, the starvation signal).
 ///
 /// The byte backlog is the TRUE undrained-bytes gauge — the DB sum of this node's
 /// pending/draining part bytes — NOT raw disk occupancy (`usage.used_bytes`), which the
@@ -234,6 +235,14 @@ async fn record_drain_signals(store: &Store, node: &NodeId, snapshot: &SnapshotC
     match store.node_undrained_count(node.as_str()).await {
         Ok(count) => snapshot.record_undrained_count(count),
         Err(err) => tracing::warn!(error = %err, "undrained-count query failed; keeping the last value"),
+    }
+    // The Task F starvation gauge: the age of this node's oldest still-pending row. The
+    // 2026-07-26 incident's earliest unambiguous signal — one node's oldest pending age
+    // exploding while peers sat near zero — existed only as hand-written SQL; this tick
+    // makes it a standing gauge at the same cadence as the other DB-sourced signals.
+    match store.node_oldest_pending_age_secs(node.as_str()).await {
+        Ok(secs) => snapshot.record_oldest_pending_age_secs(secs),
+        Err(err) => tracing::warn!(error = %err, "oldest-pending-age query failed; keeping the last value"),
     }
 }
 
@@ -889,6 +898,41 @@ mod tests {
         assert!(
             !tracker.observe(0, snapshot.undrained_count(), t0 + Duration::from_mins(2)),
             "undrained rows + no progress past the stall -> NotReady (keying on the 0-byte backlog would stay Ready)"
+        );
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn record_drain_signals_refreshes_the_oldest_pending_age(pool: PgPool) {
+        // Task F starvation gauge, wired at the same tick as the undrained count: a pending
+        // row backdated 300s must surface as this node's oldest-pending age, while an even
+        // older DRAINING row (being worked) must not — the signal is claimable-or-backed-off
+        // work nobody has finished, the 2026-07-26 tell.
+        let store = Store::from_pool(pool.clone());
+        // node_backlog_bytes joins `parts`, which the cephor-only migrations do not create.
+        sqlx::query(
+            "CREATE TABLE parts (object_id uuid NOT NULL, object_version bigint NOT NULL, part_number bigint NOT NULL, \
+             size_bytes bigint, upload_id uuid)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO cephor_replication_status (object_id, version, part_number, status, node_id, landed_at) VALUES \
+             ($1, 1, 1, 'pending', 'node-x', now() - interval '300 seconds'), \
+             ($1, 1, 2, 'draining', 'node-x', now() - interval '9000 seconds')",
+        )
+        .bind(UUID)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let node = NodeId::from_str("node-x").unwrap();
+        let snapshot = SnapshotCell::new();
+        record_drain_signals(&store, &node, &snapshot).await;
+        let age = snapshot.oldest_pending_age_secs();
+        assert!(
+            (300..330).contains(&age),
+            "the tick records the oldest PENDING row's age (the draining row is being worked), got {age}"
         );
     }
 

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -161,9 +161,13 @@ pub async fn drain_next<E: UploadEnqueuer>(
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                 // The SSD source is gone (MPU abort / DeleteObject / overwrite deleted
                 // the ingest copy) — specific to THIS part, so back it off and keep the
-                // burst claiming. Counted as a deferral, exactly like the mid-drain
-                // vanished-source case, so the metric does not depend on WHERE the
-                // ENOENT surfaced. The store counts the observation and — atomically,
+                // burst claiming. The DEFERRAL metric is counted exactly like the
+                // mid-drain vanished-source case, so that metric does not depend on
+                // WHERE the ENOENT surfaced — but the missing-source ESCALATION is
+                // location-dependent by design: only this size-gate arm observes it
+                // (a mid-drain ENOENT goes through plain defer_part and counts nothing
+                // toward the write-off; a truly gone source hits this gate on the next
+                // claim anyway). The store counts the observation and — atomically,
                 // inside the same draining-guarded UPDATE — writes the part off as
                 // terminal `failed` once it has been observed missing
                 // MISSING_SOURCE_FAIL_ATTEMPTS times: a source that is permanently

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -10,8 +10,8 @@ use crate::localfs::{LocalFs, LocalSsd};
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
 use hippius_drain_core::{
-    BreakerSignal, DrainDecision, DrainOutcome, Enforcer, PartDrainError, PartKey, PartSource, SnapshotCell, Store, StoreError, UploadEnqueuer,
-    breaker_signal_for, drain_part,
+    BreakerSignal, DenyReason, DrainDecision, DrainOutcome, Enforcer, PartDrainError, PartKey, PartSource, SnapshotCell, Store, StoreError,
+    UploadEnqueuer, breaker_signal_for, drain_part,
 };
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Instant;
@@ -82,31 +82,55 @@ impl Drop for PermitGuard<'_> {
 }
 
 /// The SSD byte size the bandwidth gate charges for this part: the sum of its chunk
-/// files. `None` if listing or stat-ing any chunk fails — the caller then denies
-/// admission and retries rather than charging 0 and draining unmetered (audit F7).
-/// Charging 0 on a stat race would defeat the rate gate exactly under SSD I/O
-/// pressure, when it matters most.
-async fn part_size(ssd: &LocalSsd, part: &PartKey) -> Option<u64> {
-    let indices = ssd.list_chunks(part).await.ok()?;
+/// files. An error means the size is unknown — the caller must not admit the part at
+/// zero cost and drain unmetered (audit F7): charging 0 on a stat race would defeat
+/// the rate gate exactly under SSD I/O pressure, when it matters most. The io kind
+/// is surfaced so the caller can split a vanished source (`NotFound` — part-specific)
+/// from genuine node I/O trouble (everything else — node-global).
+async fn part_size(ssd: &LocalSsd, part: &PartKey) -> std::io::Result<u64> {
+    let indices = ssd.list_chunks(part).await?;
+    if indices.is_empty() {
+        // `list_chunks` maps a missing part dir to an empty listing (a scan nicety);
+        // here that would admit a vanished source at zero cost, so re-stat the meta
+        // marker to surface the missing dir as the `NotFound` it is.
+        tokio::fs::metadata(ssd.meta_source(part)?).await?;
+        return Ok(0);
+    }
     let mut total = 0_u64;
     for index in indices {
-        let path = ssd.chunk_source(part, index).ok()?;
-        let meta = tokio::fs::metadata(&path).await.ok()?;
+        let path = ssd.chunk_source(part, index)?;
+        let meta = tokio::fs::metadata(&path).await?;
         total = total.saturating_add(meta.len());
     }
-    Some(total)
+    Ok(total)
+}
+
+/// One claim-slot outcome, distinguishing part-specific skips (keep claiming)
+/// from node-global stops (budget spent / breaker open / backlog empty).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DrainStep {
+    /// The claimed part drained to the pool.
+    Drained(DrainOutcome),
+    /// This part cannot proceed right now but others can: it was deferred
+    /// (backoff) and the burst must keep refilling.
+    Skipped,
+    /// Nothing claimable, or a node-global denial: stop refilling this burst.
+    Idle,
 }
 
 /// Claims one pending part and drains it SSD → pool, gated by `enforcer`.
 ///
-/// Returns `Ok(None)` when nothing is pending, or when the enforcer throttled the
-/// claimed part (which is returned to pending for a later wake); `Ok(Some(..))` for
-/// the part it drained. With `enforcer = None` the drain is ungated. A drain failure
-/// leaves the SSD copy intact, so the cycle is always safe to retry.
+/// Returns [`DrainStep::Drained`] for the part it drained; [`DrainStep::Skipped`]
+/// when the claimed part cannot proceed right now but others can (it was deferred
+/// with backoff, so the caller keeps the burst claiming); [`DrainStep::Idle`] when
+/// nothing is pending or a node-global gate denied — the claimed part, if any, is
+/// returned to pending for a later wake. With `enforcer = None` the drain is
+/// ungated. A drain failure leaves the SSD copy intact, so the cycle is always
+/// safe to retry.
 ///
 /// # Errors
 ///
-/// [`DrainCycleError::Claim`] if the claim/release query fails;
+/// [`DrainCycleError::Claim`] if the claim/release/defer query fails;
 /// [`DrainCycleError::Drain`] if the copy/verify/commit/unlink sequence fails.
 pub async fn drain_next<E: UploadEnqueuer>(
     ceph: &LocalFs,
@@ -115,20 +139,37 @@ pub async fn drain_next<E: UploadEnqueuer>(
     enqueuer: &E,
     enforcer: Option<&Arc<Mutex<Enforcer>>>,
     snapshot: Option<&SnapshotCell>,
-) -> Result<Option<DrainOutcome>, DrainCycleError> {
+) -> Result<DrainStep, DrainCycleError> {
     let Some(claim) = store.claim_part().await? else {
-        return Ok(None);
+        return Ok(DrainStep::Idle);
     };
 
     if let Some(enforcer) = enforcer {
-        let Some(bytes) = part_size(ssd, claim.part()).await else {
-            // A stat/list failure must not admit the part at zero cost (audit F7): hand
-            // the claim back and retry next wake. With node-scoped claims (migration
-            // 0006) a missing local part dir no longer happens, so this is a genuine
-            // transient I/O error worth backing off on.
-            store.release_part(claim.part()).await?;
-            tracing::debug!("part size unavailable; part returned to pending");
-            return Ok(None);
+        let bytes = match part_size(ssd, claim.part()).await {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                // The SSD source is gone (MPU abort / DeleteObject / overwrite deleted
+                // the ingest copy) — specific to THIS part, so back it off and keep the
+                // burst claiming. Counted as a deferral, exactly like the mid-drain
+                // vanished-source case, so the metric does not depend on WHERE the
+                // ENOENT surfaced. Terminal escalation of a persistently missing
+                // source lands next (Task E) on top of this defer.
+                store.defer_part(claim.part()).await?;
+                if let Some(snapshot) = snapshot {
+                    snapshot.record_deferred(1);
+                }
+                tracing::debug!("part source missing; part deferred, burst continues");
+                return Ok(DrainStep::Skipped);
+            }
+            Err(err) => {
+                // Any other stat/list failure must not admit the part at zero cost
+                // (audit F7) and — unlike a vanished source — smells like genuine
+                // transient node I/O trouble, so briefly backing the whole node off is
+                // right: hand the claim back (promptly re-claimable) and end the burst.
+                store.release_part(claim.part()).await?;
+                tracing::debug!(error = ?err, "part size unavailable; part returned to pending");
+                return Ok(DrainStep::Idle);
+            }
         };
         // The guard's scope ends before the drain await — a `MutexGuard` must never
         // cross an `.await` (axiom rust_quality_74). Poisoning recovers via
@@ -139,19 +180,36 @@ pub async fn drain_next<E: UploadEnqueuer>(
             guard.try_drain(bytes, Instant::now())
         };
         if let DrainDecision::Denied(reason) = decision {
-            // No concurrency permit was taken on denial; hand the claim back so it
-            // retries once the budget refills (the next wake re-claims it).
-            store.release_part(claim.part()).await?;
-            // A denial is liveness progress: the loop DID cycle a claim, it just backed off
-            // (breaker open on a Ceph outage, or the write budget is spent). Recording it
-            // keeps the readiness tracker's `processed` count advancing so a pool-wide outage
-            // does not flip every node NotReady and wedge a rolling update (a wedge, not a
-            // healthy back-off, is what readiness must catch). Kept out of drain outcomes.
+            // No concurrency permit was taken on any denial. A denial is liveness
+            // progress either way: the loop DID cycle a claim, it just backed off.
+            // Recording it keeps the readiness tracker's `processed` count advancing so
+            // a pool-wide outage does not flip every node NotReady and wedge a rolling
+            // update (a wedge, not a healthy back-off, is what readiness must catch).
+            // Kept out of drain outcomes.
             if let Some(snapshot) = snapshot {
                 snapshot.record_throttled(1);
             }
-            tracing::debug!(?reason, "drain throttled; part returned to pending");
-            return Ok(None);
+            return match reason {
+                // Part-specific: an EARLIER overdraft is still being paid off, so only
+                // this (oversized) part must wait. Releasing it un-backed-off put it
+                // straight back at the oldest-first claim head, where it was denied
+                // again every burst and starved the whole node (2026-07-26 incident) —
+                // defer it out of the claim set and keep the burst going.
+                DenyReason::OverdraftOutstanding => {
+                    store.defer_part(claim.part()).await?;
+                    tracing::debug!(?reason, "drain deferred; part backed off, burst continues");
+                    Ok(DrainStep::Skipped)
+                }
+                // Node-global: the budget is spent, the breaker is open, or every
+                // in-flight slot is taken — no part would fare better, so hand the
+                // claim back (promptly re-claimable once the gate reopens) and stop
+                // the burst until the next wake.
+                DenyReason::BreakerOpen | DenyReason::RateLimited | DenyReason::AtConcurrencyLimit => {
+                    store.release_part(claim.part()).await?;
+                    tracing::debug!(?reason, "drain throttled; part returned to pending");
+                    Ok(DrainStep::Idle)
+                }
+            };
         }
     }
 
@@ -235,11 +293,22 @@ pub async fn drain_next<E: UploadEnqueuer>(
             );
         }
     }
-    result.map(Some).map_err(DrainCycleError::from)
+    result.map(DrainStep::Drained).map_err(DrainCycleError::from)
+}
+
+/// What one burst accomplished: parts drained to the pool, and part-specific
+/// skips that deferred a part (backoff) while the burst kept claiming.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct BurstTally {
+    /// Parts drained (committed to the pool) in this burst.
+    pub drained: u64,
+    /// Parts skipped: deferred with backoff without stopping the refill.
+    pub skipped: u64,
 }
 
 /// Drains pending parts — up to `concurrency` at once — until the backlog is empty,
-/// the enforcer throttles, or `token` is cancelled, returning how many were drained.
+/// the enforcer stops the node, or `token` is cancelled, returning a [`BurstTally`]
+/// of parts drained and parts skipped.
 ///
 /// Runs up to `concurrency` [`drain_next`] calls concurrently rather than one at a
 /// time. `claim_part` uses `FOR UPDATE SKIP LOCKED`, so concurrent claims take distinct
@@ -250,12 +319,15 @@ pub async fn drain_next<E: UploadEnqueuer>(
 /// `Enforcer` still bounds the real rate/concurrency; this just stops the *driver*
 /// from being the bottleneck.
 ///
-/// A `drain_next` returning `None` (empty backlog or a throttle/denial) stops claiming
-/// new work, but in-flight drains are awaited to completion — never abandoned
-/// mid-flight, since dropping one at its await would strand its part in `draining`
-/// until the claim lease expires. A drain *failure* likewise stops new claims and is
-/// surfaced (the first one) only after the in-flight set drains; each failed
-/// `drain_next` has already released its own part.
+/// Each slot resolves three ways ([`DrainStep`]): `Drained` counts and refills;
+/// `Skipped` (a part-specific back-off — the part was deferred) refills WITHOUT
+/// counting, so one unprocessable part cannot stop the burst and starve the parts
+/// behind it (the 2026-07-26 head-of-line incident); `Idle` (empty backlog or a
+/// node-global denial) stops claiming new work, but in-flight drains are awaited to
+/// completion — never abandoned mid-flight, since dropping one at its await would
+/// strand its part in `draining` until the claim lease expires. A drain *failure*
+/// likewise stops new claims and is surfaced (the first one) only after the
+/// in-flight set drains; each failed `drain_next` has already released its own part.
 ///
 /// Cancellation is observed before claiming each new part: on shutdown the burst stops
 /// taking work immediately and only the already-started drains finish, so the worker
@@ -277,9 +349,9 @@ pub async fn drain_until_empty<E: UploadEnqueuer>(
     snapshot: Option<&SnapshotCell>,
     token: &CancellationToken,
     concurrency: usize,
-) -> Result<u64, DrainCycleError> {
+) -> Result<BurstTally, DrainCycleError> {
     let concurrency = concurrency.max(1);
-    let mut drained = 0u64;
+    let mut tally = BurstTally::default();
     let mut first_err: Option<DrainCycleError> = None;
     // Cleared by an empty backlog, a throttle, a failure, or cancellation — once we
     // stop refilling we only wind down the in-flight set.
@@ -299,15 +371,28 @@ pub async fn drain_until_empty<E: UploadEnqueuer>(
     // borrow ends before the body runs, so the refill push is safe.
     while let Some(outcome) = inflight.next().await {
         match outcome {
-            Ok(Some(_)) => {
-                drained += 1;
+            Ok(DrainStep::Drained(_)) => {
+                tally.drained += 1;
                 if refill && !token.is_cancelled() {
                     inflight.push(drain_next(ceph, ssd, store, enqueuer, enforcer, snapshot));
                 } else {
                     refill = false;
                 }
             }
-            Ok(None) => refill = false,
+            Ok(DrainStep::Skipped) => {
+                // The part was deferred (backed off out of the claim set), so the burst
+                // keeps claiming: the parts behind it are often ready, and stopping here
+                // is what starved a node down to 64 parts/hour (2026-07-26). The backoff
+                // makes the skipped part unclaimable within this burst, so the burst
+                // still terminates once only backed-off parts remain.
+                tally.skipped += 1;
+                if refill && !token.is_cancelled() {
+                    inflight.push(drain_next(ceph, ssd, store, enqueuer, enforcer, snapshot));
+                } else {
+                    refill = false;
+                }
+            }
+            Ok(DrainStep::Idle) => refill = false,
             Err(err) if err.is_deferral() => {
                 // A deferral is not a cycle failure: the part backed off, so keep
                 // draining the rest of the backlog instead of stopping the burst —
@@ -332,7 +417,7 @@ pub async fn drain_until_empty<E: UploadEnqueuer>(
 
     match first_err {
         Some(err) => Err(err),
-        None => Ok(drained),
+        None => Ok(tally),
     }
 }
 
@@ -340,7 +425,7 @@ pub async fn drain_until_empty<E: UploadEnqueuer>(
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::PermitGuard;
-    use super::{drain_next, drain_until_empty};
+    use super::{DrainStep, drain_next, drain_until_empty};
     use crate::localfs::{LocalFs, LocalSsd};
     use core::str::FromStr;
     use hippius_drain_core::{
@@ -361,6 +446,22 @@ mod tests {
 
     async fn status_of(store: &Store, part: &PartKey) -> Option<ReplicationState> {
         <Store as PartReplicationStore>::status(store, part).await.unwrap()
+    }
+
+    /// The row's `(deferred_until set, defer_attempts)` — the observable difference
+    /// between a defer (backed off out of the claim set: `(true, n>0)`) and a release
+    /// (promptly re-claimable: `(false, unchanged)`).
+    async fn defer_state(db: &PgPool, part: &PartKey) -> (bool, i64) {
+        sqlx::query_as(
+            "SELECT deferred_until IS NOT NULL, defer_attempts::bigint FROM cephor_replication_status \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(part.object().as_str())
+        .bind(i64::from(part.version().get()))
+        .bind(i64::from(part.part().get()))
+        .fetch_one(db)
+        .await
+        .unwrap()
     }
 
     /// Lays a complete SSD part (`chunk_<i>.bin` files + meta.json) under `ssd_root`
@@ -488,7 +589,7 @@ mod tests {
 
         // One ungated cycle claims it and drains it end-to-end.
         let outcome = drain_next(&ceph, &ssd, &store, &NoopEnqueuer, None, None).await.unwrap();
-        assert_eq!(outcome, Some(DrainOutcome::Replicated));
+        assert_eq!(outcome, DrainStep::Drained(DrainOutcome::Replicated));
 
         // The SSD part is freed only after the verified, committed pool copy exists.
         let ssd_part = ssd_dir.path().join(part.relative_dir());
@@ -502,7 +603,7 @@ mod tests {
         assert!(pool_part.join("meta.json").exists(), "the meta marker landed last");
 
         // Nothing else is pending: the next cycle is a no-op.
-        assert_eq!(drain_next(&ceph, &ssd, &store, &NoopEnqueuer, None, None).await.unwrap(), None);
+        assert_eq!(drain_next(&ceph, &ssd, &store, &NoopEnqueuer, None, None).await.unwrap(), DrainStep::Idle);
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
@@ -523,7 +624,7 @@ mod tests {
             drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&empty), Some(&snapshot))
                 .await
                 .unwrap(),
-            None
+            DrainStep::Idle
         );
         assert!(ssd_part.exists(), "a throttled drain leaves the SSD part untouched");
         assert_eq!(
@@ -541,7 +642,7 @@ mod tests {
         let ample = enforcer_with(1_000_000);
         assert_eq!(
             drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&ample), None).await.unwrap(),
-            Some(DrainOutcome::Replicated)
+            DrainStep::Drained(DrainOutcome::Replicated)
         );
         assert!(!ssd_part.exists(), "the admitted drain frees the SSD part");
     }
@@ -560,7 +661,7 @@ mod tests {
         // A successful drain feeds its latency into the window, so p99 leaves zero.
         assert_eq!(
             drain_next(&ceph, &ssd, &store, &NoopEnqueuer, None, Some(&snapshot)).await.unwrap(),
-            Some(DrainOutcome::Replicated)
+            DrainStep::Drained(DrainOutcome::Replicated)
         );
         assert!(snapshot.p99() > Duration::ZERO, "the drain's latency was recorded in the snapshot");
     }
@@ -614,15 +715,18 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
-    async fn a_vanished_source_counts_as_deferred_not_failed_and_spares_the_breaker(pool: PgPool) {
+    async fn a_vanished_source_skips_with_backoff_and_spares_the_breaker(pool: PgPool) {
         // A part recorded landed but with NO SSD files models the SSD source vanishing
         // out from under the drain: the MPU-abort / DeleteObject / overwrite paths (and,
-        // in e2e, the `clear_object_cache` helper) delete the ingest copy while the drain
-        // may be mid-copy, so `persist` hits ENOENT. That is NOT Ceph unhealth — there is
-        // simply nothing left to copy — so it must count as a DEFERRAL (not a failure),
-        // stay out of `error_bps`, be returned to `pending`, and — the load-bearing part —
-        // NOT trip the node-global Ceph breaker (which would halt draining of every other,
-        // healthy part on the node).
+        // in e2e, the `clear_object_cache` helper) delete the ingest copy. That is NOT
+        // Ceph unhealth — there is simply nothing left to copy — and it is specific to
+        // THIS part, so the gated path resolves it at the size gate: `Skipped` (deferred
+        // with backoff so the burst keeps claiming), counted as a DEFERRAL (not a
+        // failure), kept out of `error_bps`, and — the load-bearing part — NOT tripping
+        // the node-global Ceph breaker (which would halt draining of every other,
+        // healthy part on the node). Old behavior stopped the burst here; the 2026-07-26
+        // incident showed one such part starves the whole node.
+        let db = pool.clone();
         let ssd_dir = tempfile::tempdir().unwrap();
         let pool_dir = tempfile::tempdir().unwrap();
         let ssd = LocalSsd::new(ssd_dir.path());
@@ -643,9 +747,10 @@ mod tests {
         let part = part_at(5, 1);
         store.record_landed_part(&part).await.unwrap();
 
-        drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), Some(&snapshot))
+        let step = drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), Some(&snapshot))
             .await
-            .unwrap_err();
+            .unwrap();
+        assert_eq!(step, DrainStep::Skipped, "a vanished source skips this part; the burst keeps claiming");
 
         let counts = snapshot.load();
         assert_eq!(counts.deferred, 1, "a vanished source is counted as a deferral");
@@ -658,9 +763,168 @@ mod tests {
             "a deferred part is returned to pending for a later re-drain",
         );
         assert_eq!(
+            defer_state(&db, &part).await,
+            (true, 1),
+            "the part is backed off (deferred), not released into the next claim",
+        );
+        assert_eq!(
             enforcer.lock().unwrap().try_drain(1, Instant::now()),
             DrainDecision::Allowed,
             "a vanished source must not trip the Ceph breaker",
+        );
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn an_overdraft_denied_part_defers_and_the_burst_continues(pool: PgPool) {
+        // The 2026-07-26 head-of-line incident shape: a part denied at the claim head
+        // used to be released un-backed-off and the burst stopped — next wake it was
+        // oldest again, denied again, and every part behind it starved (64 parts/hour).
+        // OverdraftOutstanding is PART-specific (an earlier overdraft is still being
+        // paid off), so the part must be deferred with backoff and the burst continue.
+        let db = pool.clone();
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = Store::from_pool(pool);
+        let snapshot = SnapshotCell::new();
+        // Rate 1 B/s with a 64-byte burst: the ~10 KB debt booked below repays over
+        // hours, so it is deterministically outstanding for the whole test.
+        let enforcer = Arc::new(Mutex::new(Enforcer::new(
+            CircuitBreaker::new(BreakerConfig {
+                failure_threshold: 3,
+                cooldown: Duration::from_secs(5),
+            }),
+            TokenBucket::new(ByteRate::new(1), Bytes::new(64), Instant::now()),
+            ConcurrencyLimiter::new(4),
+        )));
+        // Book the outstanding overdraft (Task C semantics): an oversized admission
+        // drains the bucket and carries the remainder as debt; record_outcome returns
+        // the permit without touching the breaker.
+        {
+            let mut guard = enforcer.lock().unwrap();
+            assert_eq!(
+                guard.try_drain(10_000, Instant::now()),
+                DrainDecision::Allowed,
+                "the first overdraft is admitted"
+            );
+            guard.record_outcome(BreakerSignal::Deferred, Instant::now());
+        }
+
+        // Oldest first: an oversized part (100 B > 64 B burst → overdraft path, denied
+        // OverdraftOutstanding while the debt is unpaid), then a zero-byte part the
+        // empty bucket can still admit (a 0-byte charge needs no tokens).
+        let oversized = part_at(5, 1);
+        seed_part(ssd_dir.path(), &store, &oversized, &[&[7_u8; 100]]).await;
+        let tiny = part_at(5, 2);
+        seed_part(ssd_dir.path(), &store, &tiny, &[b""]).await;
+
+        let token = CancellationToken::new();
+        let tally = drain_until_empty(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), Some(&snapshot), &token, 1)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            (tally.drained, tally.skipped),
+            (1, 1),
+            "the burst skipped the denied part and kept claiming"
+        );
+        assert_eq!(
+            status_of(&store, &tiny).await,
+            Some(ReplicationState::Replicated),
+            "the part behind the denied one drained in the same cycle",
+        );
+        assert_eq!(
+            status_of(&store, &oversized).await,
+            Some(ReplicationState::Pending),
+            "the denied part stays pending"
+        );
+        assert_eq!(
+            defer_state(&db, &oversized).await,
+            (true, 1),
+            "the denied part is backed off out of the claim set, not released to the head",
+        );
+        assert_eq!(snapshot.load().throttled, 1, "the denial still records a throttled readiness tick");
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn a_missing_ssd_source_defers_and_the_burst_continues(pool: PgPool) {
+        // Burst-level counterpart of the vanished-source skip: with the missing-source
+        // part claimed FIRST (oldest), the ready part behind it must still drain in the
+        // SAME cycle instead of waiting for the next wake.
+        let db = pool.clone();
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = Store::from_pool(pool);
+
+        let missing = part_at(5, 1);
+        store.record_landed_part(&missing).await.unwrap();
+        let ready = part_at(5, 2);
+        seed_part(ssd_dir.path(), &store, &ready, &[b"ready part"]).await;
+
+        let enforcer = enforcer_with(1_000_000);
+        let token = CancellationToken::new();
+        let tally = drain_until_empty(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), None, &token, 1)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            (tally.drained, tally.skipped),
+            (1, 1),
+            "the missing source skipped; the ready part drained"
+        );
+        assert_eq!(
+            status_of(&store, &ready).await,
+            Some(ReplicationState::Replicated),
+            "the ready part is not starved"
+        );
+        assert_eq!(defer_state(&db, &missing).await, (true, 1), "the missing-source part is backed off");
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn a_non_notfound_stat_failure_releases_the_part_and_idles_the_burst(pool: PgPool) {
+        // A stat/list failure that is NOT ENOENT (here NotADirectory: a regular file
+        // where the part directory should be) smells like genuine node I/O trouble, so
+        // the whole node briefly backs off: the part is RELEASED (no backoff — retried
+        // promptly next wake) and the burst stops, leaving the parts behind untouched.
+        let db = pool.clone();
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = Store::from_pool(pool);
+
+        let broken = part_at(5, 1);
+        let dir = ssd_dir.path().join(broken.relative_dir());
+        std::fs::create_dir_all(dir.parent().unwrap()).unwrap();
+        std::fs::write(&dir, b"not a directory").unwrap();
+        store.record_landed_part(&broken).await.unwrap();
+        let behind = part_at(5, 2);
+        seed_part(ssd_dir.path(), &store, &behind, &[b"ready part"]).await;
+
+        let enforcer = enforcer_with(1_000_000);
+        let token = CancellationToken::new();
+        let tally = drain_until_empty(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), None, &token, 1)
+            .await
+            .unwrap();
+
+        assert_eq!((tally.drained, tally.skipped), (0, 0), "node I/O trouble idles the whole burst");
+        assert_eq!(
+            status_of(&store, &broken).await,
+            Some(ReplicationState::Pending),
+            "the part is handed back"
+        );
+        assert_eq!(
+            defer_state(&db, &broken).await,
+            (false, 0),
+            "released without backoff: a transient node blip retries on the next wake",
+        );
+        assert_eq!(
+            status_of(&store, &behind).await,
+            Some(ReplicationState::Pending),
+            "the burst stopped before reaching the part behind",
         );
     }
 
@@ -693,7 +957,11 @@ mod tests {
         let outcome = drain_next(&ceph, &ssd, &store, &DeferringEnqueuer, Some(&enforcer), Some(&snapshot))
             .await
             .unwrap();
-        assert_eq!(outcome, Some(DrainOutcome::Replicated), "a not-ready enqueue still commits Replicated");
+        assert_eq!(
+            outcome,
+            DrainStep::Drained(DrainOutcome::Replicated),
+            "a not-ready enqueue still commits Replicated"
+        );
 
         let counts = snapshot.load();
         assert_eq!(counts.drained, 1, "the part was committed (Ceph-durable)");
@@ -781,7 +1049,8 @@ mod tests {
         let token = CancellationToken::new();
         let drained = drain_until_empty(&ceph, &ssd, &store, &DeferPartOneEnqueuer, None, None, &token, 1)
             .await
-            .unwrap();
+            .unwrap()
+            .drained;
         assert_eq!(drained, 3, "all three parts committed (a not-ready enqueue no longer defers)");
 
         for number in 1..=3_u32 {
@@ -815,13 +1084,15 @@ mod tests {
         let token = CancellationToken::new();
         let drained = drain_until_empty(&ceph, &ssd, &store, &NoopEnqueuer, None, None, &token, 4)
             .await
-            .unwrap();
+            .unwrap()
+            .drained;
         assert_eq!(drained, 3, "every pending part was drained in one run");
         // The backlog is now empty.
         assert_eq!(
             drain_until_empty(&ceph, &ssd, &store, &NoopEnqueuer, None, None, &token, 4)
                 .await
-                .unwrap(),
+                .unwrap()
+                .drained,
             0
         );
     }
@@ -843,12 +1114,14 @@ mod tests {
         let token = CancellationToken::new();
         let drained = drain_until_empty(&ceph, &ssd, &store, &NoopEnqueuer, None, None, &token, 3)
             .await
-            .unwrap();
+            .unwrap()
+            .drained;
         assert_eq!(drained, 8, "all 8 parts drained with concurrency 3 (refill works)");
         assert_eq!(
             drain_until_empty(&ceph, &ssd, &store, &NoopEnqueuer, None, None, &token, 3)
                 .await
-                .unwrap(),
+                .unwrap()
+                .drained,
             0
         );
     }
@@ -873,7 +1146,8 @@ mod tests {
         token.cancel();
         let drained = drain_until_empty(&ceph, &ssd, &store, &NoopEnqueuer, None, None, &token, 4)
             .await
-            .unwrap();
+            .unwrap()
+            .drained;
         assert_eq!(drained, 0, "a cancelled drain stops before touching the backlog");
     }
 }

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -182,9 +182,9 @@ pub async fn drain_next<E: UploadEnqueuer>(
                         tracing::debug!(observations, "part source missing; part deferred, burst continues");
                     }
                     MissingSourceOutcome::Failed => {
-                        // The DURABLE write-off record: `node_undrained_count` excludes
-                        // `failed` and the terminal GC deletes the row, so without this
-                        // counter the disposition survives only as the WARN below. Still
+                        // The only standing metric of a write-off (per-process; the WARN
+                        // below is the only per-event trace): `node_undrained_count`
+                        // excludes `failed` and the terminal GC deletes the row. Still
                         // NOT counted in `failed`/error_bps — not a Ceph-write failure.
                         if let Some(snapshot) = snapshot {
                             snapshot.record_written_off(1);
@@ -873,7 +873,7 @@ mod tests {
         assert_eq!(counts.error_bps(), 0, "the write-off stays out of the Ceph failure rate");
         assert_eq!(
             counts.written_off, 1,
-            "the write-off is durably counted — the WARN log and the (GC'd) failed row are not a signal"
+            "the write-off is counted in the snapshot — the WARN log and the (GC'd) failed row are not a metric"
         );
         assert_eq!(
             enforcer.lock().unwrap().try_drain(1, Instant::now()),
@@ -1047,7 +1047,11 @@ mod tests {
         )));
         {
             let mut guard = enforcer.lock().unwrap();
-            assert_eq!(guard.try_drain(10_000, Instant::now()), DrainDecision::Allowed, "book the incident's debt");
+            assert_eq!(
+                guard.try_drain(10_000, Instant::now()),
+                DrainDecision::Allowed,
+                "book the incident's debt"
+            );
             guard.record_outcome(BreakerSignal::Deferred, Instant::now());
         }
 
@@ -1109,7 +1113,11 @@ mod tests {
         // The wall stays pending-with-backoff — deferred out of the claim head, not
         // written off and not churning as promptly-reclaimable releases.
         for part in &wall {
-            assert_eq!(status_of(&store, part).await, Some(ReplicationState::Pending), "the wall is not written off");
+            assert_eq!(
+                status_of(&store, part).await,
+                Some(ReplicationState::Pending),
+                "the wall is not written off"
+            );
             let (backed_off, attempts) = defer_state(&db, part).await;
             assert!(backed_off && attempts >= 1, "wall part {} is deferred with backoff", part.part().get());
         }

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -182,6 +182,13 @@ pub async fn drain_next<E: UploadEnqueuer>(
                         tracing::debug!(observations, "part source missing; part deferred, burst continues");
                     }
                     MissingSourceOutcome::Failed => {
+                        // The DURABLE write-off record: `node_undrained_count` excludes
+                        // `failed` and the terminal GC deletes the row, so without this
+                        // counter the disposition survives only as the WARN below. Still
+                        // NOT counted in `failed`/error_bps — not a Ceph-write failure.
+                        if let Some(snapshot) = snapshot {
+                            snapshot.record_written_off(1);
+                        }
                         tracing::warn!(
                             object_id = %claim.part().object().as_str(),
                             version = claim.part().version().get(),
@@ -864,6 +871,10 @@ mod tests {
         let counts = snapshot.load();
         assert_eq!(counts.failed, 0, "a write-off is not a Ceph-write failure");
         assert_eq!(counts.error_bps(), 0, "the write-off stays out of the Ceph failure rate");
+        assert_eq!(
+            counts.written_off, 1,
+            "the write-off is durably counted — the WARN log and the (GC'd) failed row are not a signal"
+        );
         assert_eq!(
             enforcer.lock().unwrap().try_drain(1, Instant::now()),
             DrainDecision::Allowed,

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -999,6 +999,127 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn the_incident_backlog_shape_cannot_starve_the_ready_parts(pool: PgPool) {
+        // The 2026-07-26 incident, end to end. One node's backlog, in landed order:
+        //   (a) a WALL of 20 not-ready parts — registered pending but with no SSD
+        //       source, the abandoned/in-progress-MPU rows that wedged node1 (the
+        //       enqueue-not-ready shape now commits Replicated under the Tier-2
+        //       decoupled commit, so the vanished/never-finalized source is the
+        //       not-ready deferral shape that still exists at the admission gate);
+        //   (b) ONE oversized part (100 B > the 64 B burst) while an EARLIER
+        //       overdraft's debt is still being paid off — prod had two 2 GiB parts
+        //       against a ~2 MB/s budget, i.e. hours of outstanding debt;
+        //   (c) 10 READY parts landed LAST. Zero-byte on purpose: while overdraft
+        //       debt is outstanding the bucket holds zero tokens, so a zero-byte
+        //       charge is the only admittable follower — which is exactly what makes
+        //       this discriminate ORDERING starvation from budget exhaustion.
+        // Pre-fix, the wall churned the oldest-first claim head (released un-backed-
+        // off, denied again every burst) and the ready parts starved for hours
+        // (64 parts/hour vs 10-17k healthy). The fix defers part-specific denials out
+        // of the claim set and keeps the burst going, so the ready parts must all
+        // replicate within a bounded number of poll cycles.
+        //
+        // Cycle bound: after its FIRST deferral a wall/oversized part is parked for
+        // >= the 5s base backoff (doubling per attempt), so on any sane machine the
+        // whole wall defers exactly once and the ready parts drain in cycle 1. 30
+        // cycles is ~30x margin for a stalled CI box where backoffs expire mid-test —
+        // each expiry only re-defers with a doubled park, and even a minutes-long
+        // stall yields a handful of observations per wall part, far under the
+        // 20-observation missing-source write-off threshold (the wall must stay
+        // pending-with-backoff, not get written off).
+        const CYCLE_BOUND: usize = 30;
+        let db = pool.clone();
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = Store::from_pool(pool);
+        let snapshot = SnapshotCell::new();
+        // Rate 1 B/s, burst 64 B, with ~10 KB of pre-booked overdraft debt: repayment
+        // takes hours, so the debt is deterministically outstanding for the whole test.
+        let enforcer = Arc::new(Mutex::new(Enforcer::new(
+            CircuitBreaker::new(BreakerConfig {
+                failure_threshold: 3,
+                cooldown: Duration::from_secs(5),
+            }),
+            TokenBucket::new(ByteRate::new(1), Bytes::new(64), Instant::now()),
+            ConcurrencyLimiter::new(4),
+        )));
+        {
+            let mut guard = enforcer.lock().unwrap();
+            assert_eq!(guard.try_drain(10_000, Instant::now()), DrainDecision::Allowed, "book the incident's debt");
+            guard.record_outcome(BreakerSignal::Deferred, Instant::now());
+        }
+
+        // (a) The wall lands first: pending rows whose SSD source does not exist.
+        let wall: Vec<PartKey> = (1..=20_u32).map(|number| part_at(1, number)).collect();
+        for part in &wall {
+            store.record_landed_part(part).await.unwrap();
+        }
+        // (b) Then the oversized part (a real, complete SSD part).
+        let oversized = part_at(2, 1);
+        seed_part(ssd_dir.path(), &store, &oversized, &[&[7_u8; 100]]).await;
+        // (c) The ready parts land last — youngest, so oldest-first claiming reaches
+        // them only after the wall and the oversized part have been dealt with.
+        let ready: Vec<PartKey> = (1..=10_u32).map(|number| part_at(3, number)).collect();
+        for part in &ready {
+            seed_part(ssd_dir.path(), &store, part, &[b""]).await;
+        }
+
+        let token = CancellationToken::new();
+        let mut total_drained = 0_u64;
+        let mut total_skipped = 0_u64;
+        let mut cycles = 0_usize;
+        while cycles < CYCLE_BOUND {
+            cycles += 1;
+            // concurrency 1 keeps the oldest-first claim order observable, which is
+            // the ordering the incident's starvation depended on.
+            let tally = drain_until_empty(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), Some(&snapshot), &token, 1)
+                .await
+                .unwrap();
+            total_drained += tally.drained;
+            total_skipped += tally.skipped;
+            let mut all_replicated = true;
+            for part in &ready {
+                if status_of(&store, part).await != Some(ReplicationState::Replicated) {
+                    all_replicated = false;
+                    break;
+                }
+            }
+            if all_replicated {
+                break;
+            }
+        }
+
+        for part in &ready {
+            assert_eq!(
+                status_of(&store, part).await,
+                Some(ReplicationState::Replicated),
+                "ready part {} must drain within {CYCLE_BOUND} cycles despite the wall (took {cycles} cycles; \
+                 drained {total_drained}, skipped {total_skipped})",
+                part.part().get(),
+            );
+        }
+        // The burst tally shows work continuing: the skips did not zero out the drains.
+        assert_eq!(total_drained, 10, "every ready part drained exactly once");
+        assert!(
+            total_skipped >= 21,
+            "the wall (20) and the oversized part (1) were each skipped at least once, got {total_skipped}"
+        );
+        // The wall stays pending-with-backoff — deferred out of the claim head, not
+        // written off and not churning as promptly-reclaimable releases.
+        for part in &wall {
+            assert_eq!(status_of(&store, part).await, Some(ReplicationState::Pending), "the wall is not written off");
+            let (backed_off, attempts) = defer_state(&db, part).await;
+            assert!(backed_off && attempts >= 1, "wall part {} is deferred with backoff", part.part().get());
+        }
+        // The oversized part is deferred too: its debt-denial is part-specific.
+        assert_eq!(status_of(&store, &oversized).await, Some(ReplicationState::Pending));
+        let (backed_off, attempts) = defer_state(&db, &oversized).await;
+        assert!(backed_off && attempts >= 1, "the oversized part is deferred out of the claim head");
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
     async fn a_missing_ssd_source_defers_and_the_burst_continues(pool: PgPool) {
         // Burst-level counterpart of the vanished-source skip: with the missing-source
         // part claimed FIRST (oldest), the ready part behind it must still drain in the

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -108,7 +108,7 @@ async fn part_size(ssd: &LocalSsd, part: &PartKey) -> std::io::Result<u64> {
 /// One claim-slot outcome, distinguishing part-specific skips (keep claiming)
 /// from node-global stops (budget spent / breaker open / backlog empty).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DrainStep {
+pub enum ClaimOutcome {
     /// The claimed part drained to the pool.
     Drained(DrainOutcome),
     /// This part cannot proceed right now but others can: it was deferred
@@ -120,9 +120,9 @@ pub enum DrainStep {
 
 /// Claims one pending part and drains it SSD → pool, gated by `enforcer`.
 ///
-/// Returns [`DrainStep::Drained`] for the part it drained; [`DrainStep::Skipped`]
+/// Returns [`ClaimOutcome::Drained`] for the part it drained; [`ClaimOutcome::Skipped`]
 /// when the claimed part cannot proceed right now but others can (it was deferred
-/// with backoff, so the caller keeps the burst claiming); [`DrainStep::Idle`] when
+/// with backoff, so the caller keeps the burst claiming); [`ClaimOutcome::Idle`] when
 /// nothing is pending or a node-global gate denied — the claimed part, if any, is
 /// returned to pending for a later wake. With `enforcer = None` the drain is
 /// ungated. A drain failure leaves the SSD copy intact, so the cycle is always
@@ -139,9 +139,9 @@ pub async fn drain_next<E: UploadEnqueuer>(
     enqueuer: &E,
     enforcer: Option<&Arc<Mutex<Enforcer>>>,
     snapshot: Option<&SnapshotCell>,
-) -> Result<DrainStep, DrainCycleError> {
+) -> Result<ClaimOutcome, DrainCycleError> {
     let Some(claim) = store.claim_part().await? else {
-        return Ok(DrainStep::Idle);
+        return Ok(ClaimOutcome::Idle);
     };
 
     if let Some(enforcer) = enforcer {
@@ -159,7 +159,7 @@ pub async fn drain_next<E: UploadEnqueuer>(
                     snapshot.record_deferred(1);
                 }
                 tracing::debug!("part source missing; part deferred, burst continues");
-                return Ok(DrainStep::Skipped);
+                return Ok(ClaimOutcome::Skipped);
             }
             Err(err) => {
                 // Any other stat/list failure must not admit the part at zero cost
@@ -168,7 +168,7 @@ pub async fn drain_next<E: UploadEnqueuer>(
                 // right: hand the claim back (promptly re-claimable) and end the burst.
                 store.release_part(claim.part()).await?;
                 tracing::debug!(error = ?err, "part size unavailable; part returned to pending");
-                return Ok(DrainStep::Idle);
+                return Ok(ClaimOutcome::Idle);
             }
         };
         // The guard's scope ends before the drain await — a `MutexGuard` must never
@@ -198,7 +198,7 @@ pub async fn drain_next<E: UploadEnqueuer>(
                 DenyReason::OverdraftOutstanding => {
                     store.defer_part(claim.part()).await?;
                     tracing::debug!(?reason, "drain deferred; part backed off, burst continues");
-                    Ok(DrainStep::Skipped)
+                    Ok(ClaimOutcome::Skipped)
                 }
                 // Node-global: the budget is spent, the breaker is open, or every
                 // in-flight slot is taken — no part would fare better, so hand the
@@ -207,7 +207,7 @@ pub async fn drain_next<E: UploadEnqueuer>(
                 DenyReason::BreakerOpen | DenyReason::RateLimited | DenyReason::AtConcurrencyLimit => {
                     store.release_part(claim.part()).await?;
                     tracing::debug!(?reason, "drain throttled; part returned to pending");
-                    Ok(DrainStep::Idle)
+                    Ok(ClaimOutcome::Idle)
                 }
             };
         }
@@ -293,7 +293,7 @@ pub async fn drain_next<E: UploadEnqueuer>(
             );
         }
     }
-    result.map(DrainStep::Drained).map_err(DrainCycleError::from)
+    result.map(ClaimOutcome::Drained).map_err(DrainCycleError::from)
 }
 
 /// What one burst accomplished: parts drained to the pool, and part-specific
@@ -302,7 +302,8 @@ pub async fn drain_next<E: UploadEnqueuer>(
 pub struct BurstTally {
     /// Parts drained (committed to the pool) in this burst.
     pub drained: u64,
-    /// Parts skipped: deferred with backoff without stopping the refill.
+    /// Parts skipped: deferred with backoff — at the admission gate or mid-drain —
+    /// without stopping the refill.
     pub skipped: u64,
 }
 
@@ -319,9 +320,10 @@ pub struct BurstTally {
 /// `Enforcer` still bounds the real rate/concurrency; this just stops the *driver*
 /// from being the bottleneck.
 ///
-/// Each slot resolves three ways ([`DrainStep`]): `Drained` counts and refills;
-/// `Skipped` (a part-specific back-off — the part was deferred) refills WITHOUT
-/// counting, so one unprocessable part cannot stop the burst and starve the parts
+/// Each slot resolves three ways ([`ClaimOutcome`]): `Drained` counts and refills;
+/// `Skipped` (a part-specific back-off — the part was deferred, whether at the
+/// admission gate or as a mid-drain benign-deferral `Err`) counts as `skipped` and
+/// refills, so one unprocessable part cannot stop the burst and starve the parts
 /// behind it (the 2026-07-26 head-of-line incident); `Idle` (empty backlog or a
 /// node-global denial) stops claiming new work, but in-flight drains are awaited to
 /// completion — never abandoned mid-flight, since dropping one at its await would
@@ -370,48 +372,39 @@ pub async fn drain_until_empty<E: UploadEnqueuer>(
     // Pushing into a FuturesUnordered while iterating it is supported; the `.next()`
     // borrow ends before the body runs, so the refill push is safe.
     while let Some(outcome) = inflight.next().await {
-        match outcome {
-            Ok(DrainStep::Drained(_)) => {
+        // Classify the slot once: does the burst keep claiming after it? A skip — the
+        // gated ClaimOutcome::Skipped or a mid-drain benign-deferral Err — deferred its
+        // part (backed off out of the claim set), so the burst keeps claiming: the
+        // parts behind it are often ready, and stopping here is what starved a node
+        // down to 64 parts/hour (2026-07-26). The backoff makes the skipped part
+        // unclaimable within this burst, so the burst still terminates once only
+        // backed-off parts remain (claim_part then returns None). Idle and real
+        // failures stop the refill; each failed drain has already returned its part.
+        let keep_claiming = match outcome {
+            Ok(ClaimOutcome::Drained(_)) => {
                 tally.drained += 1;
-                if refill && !token.is_cancelled() {
-                    inflight.push(drain_next(ceph, ssd, store, enqueuer, enforcer, snapshot));
-                } else {
-                    refill = false;
-                }
+                true
             }
-            Ok(DrainStep::Skipped) => {
-                // The part was deferred (backed off out of the claim set), so the burst
-                // keeps claiming: the parts behind it are often ready, and stopping here
-                // is what starved a node down to 64 parts/hour (2026-07-26). The backoff
-                // makes the skipped part unclaimable within this burst, so the burst
-                // still terminates once only backed-off parts remain.
+            Ok(ClaimOutcome::Skipped) => {
                 tally.skipped += 1;
-                if refill && !token.is_cancelled() {
-                    inflight.push(drain_next(ceph, ssd, store, enqueuer, enforcer, snapshot));
-                } else {
-                    refill = false;
-                }
+                true
             }
-            Ok(DrainStep::Idle) => refill = false,
+            Ok(ClaimOutcome::Idle) => false,
             Err(err) if err.is_deferral() => {
-                // A deferral is not a cycle failure: the part backed off, so keep
-                // draining the rest of the backlog instead of stopping the burst —
-                // otherwise a not-ready part (an in-progress/abandoned MPU) starves the
-                // ready parts behind it. The backoff keeps the deferred part out of the
-                // claim set, so the burst still terminates when only backed-off parts
-                // remain (claim_part then returns None).
-                if refill && !token.is_cancelled() {
-                    inflight.push(drain_next(ceph, ssd, store, enqueuer, enforcer, snapshot));
-                } else {
-                    refill = false;
-                }
+                tally.skipped += 1;
+                true
             }
             Err(err) => {
                 if first_err.is_none() {
                     first_err = Some(err);
                 }
-                refill = false;
+                false
             }
+        };
+        if keep_claiming && refill && !token.is_cancelled() {
+            inflight.push(drain_next(ceph, ssd, store, enqueuer, enforcer, snapshot));
+        } else {
+            refill = false;
         }
     }
 
@@ -425,7 +418,7 @@ pub async fn drain_until_empty<E: UploadEnqueuer>(
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::PermitGuard;
-    use super::{DrainStep, drain_next, drain_until_empty};
+    use super::{ClaimOutcome, drain_next, drain_until_empty};
     use crate::localfs::{LocalFs, LocalSsd};
     use core::str::FromStr;
     use hippius_drain_core::{
@@ -589,7 +582,7 @@ mod tests {
 
         // One ungated cycle claims it and drains it end-to-end.
         let outcome = drain_next(&ceph, &ssd, &store, &NoopEnqueuer, None, None).await.unwrap();
-        assert_eq!(outcome, DrainStep::Drained(DrainOutcome::Replicated));
+        assert_eq!(outcome, ClaimOutcome::Drained(DrainOutcome::Replicated));
 
         // The SSD part is freed only after the verified, committed pool copy exists.
         let ssd_part = ssd_dir.path().join(part.relative_dir());
@@ -603,7 +596,10 @@ mod tests {
         assert!(pool_part.join("meta.json").exists(), "the meta marker landed last");
 
         // Nothing else is pending: the next cycle is a no-op.
-        assert_eq!(drain_next(&ceph, &ssd, &store, &NoopEnqueuer, None, None).await.unwrap(), DrainStep::Idle);
+        assert_eq!(
+            drain_next(&ceph, &ssd, &store, &NoopEnqueuer, None, None).await.unwrap(),
+            ClaimOutcome::Idle
+        );
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
@@ -624,7 +620,7 @@ mod tests {
             drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&empty), Some(&snapshot))
                 .await
                 .unwrap(),
-            DrainStep::Idle
+            ClaimOutcome::Idle
         );
         assert!(ssd_part.exists(), "a throttled drain leaves the SSD part untouched");
         assert_eq!(
@@ -642,7 +638,7 @@ mod tests {
         let ample = enforcer_with(1_000_000);
         assert_eq!(
             drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&ample), None).await.unwrap(),
-            DrainStep::Drained(DrainOutcome::Replicated)
+            ClaimOutcome::Drained(DrainOutcome::Replicated)
         );
         assert!(!ssd_part.exists(), "the admitted drain frees the SSD part");
     }
@@ -661,7 +657,7 @@ mod tests {
         // A successful drain feeds its latency into the window, so p99 leaves zero.
         assert_eq!(
             drain_next(&ceph, &ssd, &store, &NoopEnqueuer, None, Some(&snapshot)).await.unwrap(),
-            DrainStep::Drained(DrainOutcome::Replicated)
+            ClaimOutcome::Drained(DrainOutcome::Replicated)
         );
         assert!(snapshot.p99() > Duration::ZERO, "the drain's latency was recorded in the snapshot");
     }
@@ -750,7 +746,7 @@ mod tests {
         let step = drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), Some(&snapshot))
             .await
             .unwrap();
-        assert_eq!(step, DrainStep::Skipped, "a vanished source skips this part; the burst keeps claiming");
+        assert_eq!(step, ClaimOutcome::Skipped, "a vanished source skips this part; the burst keeps claiming");
 
         let counts = snapshot.load();
         assert_eq!(counts.deferred, 1, "a vanished source is counted as a deferral");
@@ -781,6 +777,10 @@ mod tests {
         // oldest again, denied again, and every part behind it starved (64 parts/hour).
         // OverdraftOutstanding is PART-specific (an earlier overdraft is still being
         // paid off), so the part must be deferred with backoff and the burst continue.
+        // Intra-burst continuation under OverdraftOutstanding is mostly theoretical —
+        // while debt is outstanding the bucket holds zero tokens, so followers are
+        // RateLimited (hence the zero-byte follower below); the production win is the
+        // backoff removing the oversized part from the claim head across wakes.
         let db = pool.clone();
         let ssd_dir = tempfile::tempdir().unwrap();
         let pool_dir = tempfile::tempdir().unwrap();
@@ -884,6 +884,35 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn a_mid_drain_deferral_counts_as_a_skip_in_the_tally(pool: PgPool) {
+        // UNGATED (enforcer None), the size gate never runs, so a missing source only
+        // surfaces mid-drain as a benign-deferral Err. That arm defers with backoff and
+        // keeps the burst refilling — which IS the documented meaning of `skipped` — so
+        // the tally must count it, or the cycle log undercounts what the burst skipped.
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = Store::from_pool(pool);
+
+        let missing = part_at(5, 1);
+        store.record_landed_part(&missing).await.unwrap();
+        let ready = part_at(5, 2);
+        seed_part(ssd_dir.path(), &store, &ready, &[b"ready part"]).await;
+
+        let token = CancellationToken::new();
+        let tally = drain_until_empty(&ceph, &ssd, &store, &NoopEnqueuer, None, None, &token, 1)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            (tally.drained, tally.skipped),
+            (1, 1),
+            "the mid-drain deferral is a skip: burst continued, part backed off"
+        );
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
     async fn a_non_notfound_stat_failure_releases_the_part_and_idles_the_burst(pool: PgPool) {
         // A stat/list failure that is NOT ENOENT (here NotADirectory: a regular file
         // where the part directory should be) smells like genuine node I/O trouble, so
@@ -959,7 +988,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             outcome,
-            DrainStep::Drained(DrainOutcome::Replicated),
+            ClaimOutcome::Drained(DrainOutcome::Replicated),
             "a not-ready enqueue still commits Replicated"
         );
 

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -10,8 +10,8 @@ use crate::localfs::{LocalFs, LocalSsd};
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
 use hippius_drain_core::{
-    BreakerSignal, DenyReason, DrainDecision, DrainOutcome, Enforcer, MissingSourceOutcome, PartDrainError, PartKey, PartSource, SnapshotCell, Store,
-    StoreError, UploadEnqueuer, breaker_signal_for, drain_part,
+    BreakerSignal, ClaimedPart, DenyReason, DrainDecision, DrainOutcome, Enforcer, MissingSourceOutcome, PartDrainError, PartKey, PartSource,
+    SnapshotCell, Store, StoreError, UploadEnqueuer, breaker_signal_for, drain_part,
 };
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Instant;
@@ -129,6 +129,78 @@ pub enum ClaimOutcome {
     Idle,
 }
 
+/// Resolves a size-gate `ENOENT`: the SSD source for the claimed part is absent.
+///
+/// Split out of [`drain_next`] so the volume guard and the escalation ladder read as one
+/// decision (and to keep `drain_next` inside the function-length lint).
+///
+/// The SSD source being gone (MPU abort / `DeleteObject` / overwrite deleted the ingest
+/// copy) is specific to THIS part, so it is deferred and the burst keeps claiming. The
+/// DEFERRAL metric is counted exactly like the mid-drain vanished-source case, so that
+/// metric does not depend on WHERE the ENOENT surfaced — but the missing-source
+/// ESCALATION is location-dependent by design: only this arm observes it (a mid-drain
+/// ENOENT goes through plain `defer_part` and counts nothing toward the write-off; a
+/// truly gone source hits this gate on the next claim anyway). The store counts the
+/// observation and — atomically, inside the same draining-guarded UPDATE — writes the
+/// part off as terminal `failed` once observed missing `MISSING_SOURCE_FAIL_ATTEMPTS`
+/// times, so a permanently gone source (the 2026-07-22 rows) stops churning
+/// claim→defer forever. A write-off is NOT a Ceph failure: it stays off the breaker and
+/// out of `error_bps`.
+///
+/// # Errors
+///
+/// [`DrainCycleError::Claim`] if the release/defer query fails.
+async fn resolve_missing_source(
+    ssd: &LocalSsd,
+    store: &Store,
+    claim: &ClaimedPart,
+    snapshot: Option<&SnapshotCell>,
+) -> Result<ClaimOutcome, DrainCycleError> {
+    // The escalation may only run once the VOLUME is proven present. An ingest SSD that
+    // fails to mount leaves an empty dir on the parent filesystem, so every part on the
+    // node stats ENOENT identically to a genuinely vanished source — and the escalation
+    // would retire the node's whole backlog as terminal `failed` (never resurrected)
+    // within hours of a mount failure. That is volume-wide, not this part's fault: hand
+    // the claim back un-counted and end the burst, exactly like the breaker. Costs a
+    // delayed write-off; the inverse costs data.
+    if !ssd.root_is_available().await {
+        store.release_part(claim.part()).await?;
+        tracing::warn!(
+            ssd_root = %ssd.root().display(),
+            "SSD root unavailable (unmounted or unreadable); part returned to pending, \
+             missing-source escalation suppressed",
+        );
+        return Ok(ClaimOutcome::Idle);
+    }
+    match store.defer_part_missing_source(claim.part(), MISSING_SOURCE_FAIL_ATTEMPTS).await? {
+        MissingSourceOutcome::Deferred(observations) => {
+            if let Some(snapshot) = snapshot {
+                snapshot.record_deferred(1);
+            }
+            tracing::debug!(observations, "part source missing; part deferred, burst continues");
+        }
+        MissingSourceOutcome::Failed => {
+            // The only standing metric of a write-off (per-process; the WARN below is the
+            // only per-event trace): `node_undrained_count` excludes `failed` and the
+            // terminal GC deletes the row. Still NOT counted in `failed`/error_bps.
+            if let Some(snapshot) = snapshot {
+                snapshot.record_written_off(1);
+            }
+            tracing::warn!(
+                object_id = %claim.part().object().as_str(),
+                version = claim.part().version().get(),
+                part_number = claim.part().part().get(),
+                observations = MISSING_SOURCE_FAIL_ATTEMPTS,
+                "writing off part: SSD source gone after repeated observations",
+            );
+        }
+        MissingSourceOutcome::Superseded => {
+            tracing::debug!("part source missing but the claim was superseded; nothing recorded");
+        }
+    }
+    Ok(ClaimOutcome::Skipped)
+}
+
 /// Claims one pending part and drains it SSD → pool, gated by `enforcer`.
 ///
 /// Returns [`ClaimOutcome::Drained`] for the part it drained; [`ClaimOutcome::Skipped`]
@@ -159,49 +231,7 @@ pub async fn drain_next<E: UploadEnqueuer>(
         let bytes = match part_size(ssd, claim.part()).await {
             Ok(bytes) => bytes,
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                // The SSD source is gone (MPU abort / DeleteObject / overwrite deleted
-                // the ingest copy) — specific to THIS part, so back it off and keep the
-                // burst claiming. The DEFERRAL metric is counted exactly like the
-                // mid-drain vanished-source case, so that metric does not depend on
-                // WHERE the ENOENT surfaced — but the missing-source ESCALATION is
-                // location-dependent by design: only this size-gate arm observes it
-                // (a mid-drain ENOENT goes through plain defer_part and counts nothing
-                // toward the write-off; a truly gone source hits this gate on the next
-                // claim anyway). The store counts the observation and — atomically,
-                // inside the same draining-guarded UPDATE — writes the part off as
-                // terminal `failed` once it has been observed missing
-                // MISSING_SOURCE_FAIL_ATTEMPTS times: a source that is permanently
-                // gone (the 2026-07-22 rows) must stop churning claim→defer forever.
-                // A write-off is NOT a Ceph failure: it stays off the breaker and out
-                // of error_bps (the WARN + the terminal row are its record).
-                match store.defer_part_missing_source(claim.part(), MISSING_SOURCE_FAIL_ATTEMPTS).await? {
-                    MissingSourceOutcome::Deferred(observations) => {
-                        if let Some(snapshot) = snapshot {
-                            snapshot.record_deferred(1);
-                        }
-                        tracing::debug!(observations, "part source missing; part deferred, burst continues");
-                    }
-                    MissingSourceOutcome::Failed => {
-                        // The only standing metric of a write-off (per-process; the WARN
-                        // below is the only per-event trace): `node_undrained_count`
-                        // excludes `failed` and the terminal GC deletes the row. Still
-                        // NOT counted in `failed`/error_bps — not a Ceph-write failure.
-                        if let Some(snapshot) = snapshot {
-                            snapshot.record_written_off(1);
-                        }
-                        tracing::warn!(
-                            object_id = %claim.part().object().as_str(),
-                            version = claim.part().version().get(),
-                            part_number = claim.part().part().get(),
-                            observations = MISSING_SOURCE_FAIL_ATTEMPTS,
-                            "writing off part: SSD source gone after repeated observations",
-                        );
-                    }
-                    MissingSourceOutcome::Superseded => {
-                        tracing::debug!("part source missing but the claim was superseded; nothing recorded");
-                    }
-                }
-                return Ok(ClaimOutcome::Skipped);
+                return resolve_missing_source(ssd, store, &claim, snapshot).await;
             }
             Err(err) => {
                 // Any other stat/list failure must not admit the part at zero cost
@@ -765,7 +795,7 @@ mod tests {
         // healthy part on the node). Old behavior stopped the burst here; the 2026-07-26
         // incident showed one such part starves the whole node.
         let db = pool.clone();
-        let ssd_dir = tempfile::tempdir().unwrap();
+        let ssd_dir = mounted_ssd_dir();
         let pool_dir = tempfile::tempdir().unwrap();
         let ssd = LocalSsd::new(ssd_dir.path());
         let ceph = LocalFs::new(pool_dir.path());
@@ -817,6 +847,85 @@ mod tests {
         );
     }
 
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn an_unavailable_ssd_root_suppresses_the_missing_source_escalation(pool: PgPool) {
+        // The mass write-off hazard. An ingest SSD that fails to mount leaves an EMPTY
+        // directory on the parent filesystem, so EVERY part on the node stats ENOENT
+        // exactly like a genuinely vanished source. Without a volume-level check the
+        // escalation would count an observation per part per cycle and retire the whole
+        // node's backlog as terminal `failed` (never resurrected) within hours — silent
+        // replication loss at node scale, from a cable, not a delete.
+        //
+        // The root here is empty AND not a mount point: the unmounted shape. The part
+        // must come back as node-global `Idle` (claim handed back, burst ended, exactly
+        // like the breaker) with the escalation counter UNTOUCHED.
+        let db = pool.clone();
+        let parent = tempfile::tempdir().unwrap();
+        let never_mounted = parent.path().join("local_object_cache");
+        std::fs::create_dir_all(&never_mounted).unwrap();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let ssd = LocalSsd::new(&never_mounted);
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = Store::from_pool(pool);
+        let snapshot = SnapshotCell::new();
+        let enforcer = Arc::new(Mutex::new(Enforcer::new(
+            CircuitBreaker::new(BreakerConfig {
+                failure_threshold: 1,
+                cooldown: Duration::from_secs(5),
+            }),
+            TokenBucket::new(ByteRate::new(1_000_000), Bytes::new(1_000_000), Instant::now()),
+            ConcurrencyLimiter::new(4),
+        )));
+
+        let part = part_at(11, 1);
+        store.record_landed_part(&part).await.unwrap();
+
+        let step = drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), Some(&snapshot))
+            .await
+            .unwrap();
+        assert_eq!(
+            step,
+            ClaimOutcome::Idle,
+            "an unavailable volume is node-global: end the burst, do not blame the part"
+        );
+        assert_eq!(
+            missing_source_count(&db, &part).await,
+            0,
+            "the write-off counter must NOT advance while the volume is unproven — this is \
+             the assertion that stops a mount failure from retiring the node's backlog",
+        );
+        assert_eq!(
+            status_of(&store, &part).await,
+            Some(ReplicationState::Pending),
+            "the part is released back to pending, promptly re-claimable once the mount returns",
+        );
+        assert_eq!(
+            defer_state(&db, &part).await,
+            (false, 0),
+            "released, not backed off: nothing about this part is wrong",
+        );
+        assert_eq!(snapshot.load().written_off, 0, "no write-off was recorded");
+        assert_eq!(
+            enforcer.lock().unwrap().try_drain(1, Instant::now()),
+            DrainDecision::Allowed,
+            "an unavailable SSD volume is not a Ceph failure and must not trip the breaker",
+        );
+    }
+
+    /// An SSD root that looks like a MOUNTED volume to `LocalSsd::root_is_available`.
+    ///
+    /// A bare `tempdir()` is empty AND shares its parent's `st_dev` — precisely the
+    /// never-mounted shape the volume guard rejects. A fixture that records a part as
+    /// landed without writing any files therefore reads as "the whole disk is gone"
+    /// rather than "this part is gone", which suppresses the missing-source escalation
+    /// under test. Real nodes holding pending parts always have something under the
+    /// root; this marker restores that property without weakening the guard.
+    fn mounted_ssd_dir() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".mounted")).unwrap();
+        dir
+    }
+
     /// The row's `missing_source_attempts` — the write-off escalation counter.
     async fn missing_source_count(db: &PgPool, part: &PartKey) -> i64 {
         sqlx::query_scalar(
@@ -840,7 +949,7 @@ mod tests {
         // write-off is NOT a Ceph failure: it must stay out of error_bps and off the
         // breaker, and the burst keeps claiming (Skipped).
         let db = pool.clone();
-        let ssd_dir = tempfile::tempdir().unwrap();
+        let ssd_dir = mounted_ssd_dir();
         let pool_dir = tempfile::tempdir().unwrap();
         let ssd = LocalSsd::new(ssd_dir.path());
         let ceph = LocalFs::new(pool_dir.path());
@@ -890,7 +999,7 @@ mod tests {
         // resurrected, so that would be silent replication loss. Only missing-source
         // observations count.
         let db = pool.clone();
-        let ssd_dir = tempfile::tempdir().unwrap();
+        let ssd_dir = mounted_ssd_dir();
         let pool_dir = tempfile::tempdir().unwrap();
         let ssd = LocalSsd::new(ssd_dir.path());
         let ceph = LocalFs::new(pool_dir.path());

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -10,13 +10,24 @@ use crate::localfs::{LocalFs, LocalSsd};
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
 use hippius_drain_core::{
-    BreakerSignal, DenyReason, DrainDecision, DrainOutcome, Enforcer, PartDrainError, PartKey, PartSource, SnapshotCell, Store, StoreError,
-    UploadEnqueuer, breaker_signal_for, drain_part,
+    BreakerSignal, DenyReason, DrainDecision, DrainOutcome, Enforcer, MissingSourceOutcome, PartDrainError, PartKey, PartSource, SnapshotCell, Store,
+    StoreError, UploadEnqueuer, breaker_signal_for, drain_part,
 };
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Instant;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
+
+/// Missing-source observations before a part is written off as terminal `failed`.
+///
+/// Conservative on purpose: `failed` is never resurrected (the reconciler only
+/// registers parts that exist on SSD, and `record_landed_part` never revives a
+/// `failed` row), so a wrong write-off is silent replication loss. At 20 exponential
+/// deferrals (5s base, capped at 10min) the row is HOURS old before the 20th distinct
+/// `NotFound` lands — a slow or blipping mount does not plausibly produce 20 separate
+/// missing-source observations, only a source that is permanently gone does (the
+/// 2026-07-22 rows whose SSD dirs no longer exist).
+const MISSING_SOURCE_FAIL_ATTEMPTS: u32 = 20;
 
 /// A failure during one drain cycle: either claiming the part or draining it.
 ///
@@ -152,13 +163,33 @@ pub async fn drain_next<E: UploadEnqueuer>(
                 // the ingest copy) — specific to THIS part, so back it off and keep the
                 // burst claiming. Counted as a deferral, exactly like the mid-drain
                 // vanished-source case, so the metric does not depend on WHERE the
-                // ENOENT surfaced. Terminal escalation of a persistently missing
-                // source lands next (Task E) on top of this defer.
-                store.defer_part(claim.part()).await?;
-                if let Some(snapshot) = snapshot {
-                    snapshot.record_deferred(1);
+                // ENOENT surfaced. The store counts the observation and — atomically,
+                // inside the same draining-guarded UPDATE — writes the part off as
+                // terminal `failed` once it has been observed missing
+                // MISSING_SOURCE_FAIL_ATTEMPTS times: a source that is permanently
+                // gone (the 2026-07-22 rows) must stop churning claim→defer forever.
+                // A write-off is NOT a Ceph failure: it stays off the breaker and out
+                // of error_bps (the WARN + the terminal row are its record).
+                match store.defer_part_missing_source(claim.part(), MISSING_SOURCE_FAIL_ATTEMPTS).await? {
+                    MissingSourceOutcome::Deferred(observations) => {
+                        if let Some(snapshot) = snapshot {
+                            snapshot.record_deferred(1);
+                        }
+                        tracing::debug!(observations, "part source missing; part deferred, burst continues");
+                    }
+                    MissingSourceOutcome::Failed => {
+                        tracing::warn!(
+                            object_id = %claim.part().object().as_str(),
+                            version = claim.part().version().get(),
+                            part_number = claim.part().part().get(),
+                            observations = MISSING_SOURCE_FAIL_ATTEMPTS,
+                            "writing off part: SSD source gone after repeated observations",
+                        );
+                    }
+                    MissingSourceOutcome::Superseded => {
+                        tracing::debug!("part source missing but the claim was superseded; nothing recorded");
+                    }
                 }
-                tracing::debug!("part source missing; part deferred, burst continues");
                 return Ok(ClaimOutcome::Skipped);
             }
             Err(err) => {
@@ -764,9 +795,114 @@ mod tests {
             "the part is backed off (deferred), not released into the next claim",
         );
         assert_eq!(
+            missing_source_count(&db, &part).await,
+            1,
+            "the vanished source is counted as one missing-source observation",
+        );
+        assert_eq!(
             enforcer.lock().unwrap().try_drain(1, Instant::now()),
             DrainDecision::Allowed,
             "a vanished source must not trip the Ceph breaker",
+        );
+    }
+
+    /// The row's `missing_source_attempts` — the write-off escalation counter.
+    async fn missing_source_count(db: &PgPool, part: &PartKey) -> i64 {
+        sqlx::query_scalar(
+            "SELECT missing_source_attempts::bigint FROM cephor_replication_status \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(part.object().as_str())
+        .bind(i64::from(part.version().get()))
+        .bind(i64::from(part.part().get()))
+        .fetch_one(db)
+        .await
+        .unwrap()
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn a_source_missing_at_the_threshold_is_written_off_terminally(pool: PgPool) {
+        // The prod motivation (2026-07-22 rows): a part whose SSD dir is permanently
+        // gone deferred forever — claim → ENOENT → defer, on every node, for days. At
+        // the threshold-th missing-source observation the row must go terminal
+        // `failed` (never re-claimed, never resurrected) so it stops churning. The
+        // write-off is NOT a Ceph failure: it must stay out of error_bps and off the
+        // breaker, and the burst keeps claiming (Skipped).
+        let db = pool.clone();
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = Store::from_pool(pool);
+        let snapshot = SnapshotCell::new();
+        let enforcer = enforcer_with(1_000_000);
+
+        let part = part_at(5, 1);
+        store.record_landed_part(&part).await.unwrap();
+        // Threshold-1 prior observations: this claim's ENOENT is the deciding one.
+        sqlx::query("UPDATE cephor_replication_status SET missing_source_attempts = $1 WHERE object_id = $2")
+            .bind(i64::from(super::MISSING_SOURCE_FAIL_ATTEMPTS - 1))
+            .bind(part.object().as_str())
+            .execute(&db)
+            .await
+            .unwrap();
+
+        let step = drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), Some(&snapshot))
+            .await
+            .unwrap();
+        assert_eq!(step, ClaimOutcome::Skipped, "a write-off is part-specific; the burst keeps claiming");
+
+        assert_eq!(
+            status_of(&store, &part).await,
+            Some(ReplicationState::Failed),
+            "the row is written off terminally — no more claim churn",
+        );
+        let counts = snapshot.load();
+        assert_eq!(counts.failed, 0, "a write-off is not a Ceph-write failure");
+        assert_eq!(counts.error_bps(), 0, "the write-off stays out of the Ceph failure rate");
+        assert_eq!(
+            enforcer.lock().unwrap().try_drain(1, Instant::now()),
+            DrainDecision::Allowed,
+            "the write-off must not trip the Ceph breaker",
+        );
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn an_unrelated_defer_history_cannot_fast_track_the_write_off(pool: PgPool) {
+        // The amendment's whole point: defer_attempts is shared with overdraft and
+        // not-ready deferrals, so a part with a LONG unrelated backoff history must
+        // NOT be written off on its first transient NotFound — `failed` is never
+        // resurrected, so that would be silent replication loss. Only missing-source
+        // observations count.
+        let db = pool.clone();
+        let ssd_dir = tempfile::tempdir().unwrap();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = Store::from_pool(pool);
+        let enforcer = enforcer_with(1_000_000);
+
+        let part = part_at(5, 1);
+        store.record_landed_part(&part).await.unwrap();
+        // A long overdraft/not-ready history, but zero missing-source observations.
+        sqlx::query("UPDATE cephor_replication_status SET defer_attempts = 25 WHERE object_id = $1")
+            .bind(part.object().as_str())
+            .execute(&db)
+            .await
+            .unwrap();
+
+        let step = drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), None).await.unwrap();
+        assert_eq!(step, ClaimOutcome::Skipped);
+
+        assert_eq!(
+            status_of(&store, &part).await,
+            Some(ReplicationState::Pending),
+            "the first missing-source observation only defers — the unrelated history must not escalate it",
+        );
+        assert_eq!(
+            missing_source_count(&db, &part).await,
+            1,
+            "the NotFound is counted as the FIRST missing-source observation",
         );
     }
 

--- a/crates/hippius-drain-core/migrations/0014_replication_defer_attempts.sql
+++ b/crates/hippius-drain-core/migrations/0014_replication_defer_attempts.sql
@@ -1,0 +1,6 @@
+-- Exponential defer backoff needs a per-row attempt counter: a part that keeps
+-- deferring (in-progress MPU, missing address, vanished source) must back off
+-- geometrically instead of re-entering the claim head every fixed interval
+-- (the 2026-07-26 head-of-line starvation incident).
+ALTER TABLE cephor_replication_status
+    ADD COLUMN defer_attempts INTEGER NOT NULL DEFAULT 0;

--- a/crates/hippius-drain-core/migrations/0015_replication_missing_source.sql
+++ b/crates/hippius-drain-core/migrations/0015_replication_missing_source.sql
@@ -1,0 +1,6 @@
+-- Terminal escalation for vanished SSD sources must count ONLY missing-source
+-- observations: defer_attempts is shared with overdraft/not-ready deferrals, so
+-- keying on it would let an unrelated backoff history fast-track a healthy part
+-- to 'failed' (which is never resurrected) on its first transient NotFound.
+ALTER TABLE cephor_replication_status
+    ADD COLUMN missing_source_attempts INTEGER NOT NULL DEFAULT 0;

--- a/crates/hippius-drain-core/src/enforce.rs
+++ b/crates/hippius-drain-core/src/enforce.rs
@@ -169,7 +169,13 @@ impl TokenBucket {
     }
 
     /// Replaces the refill rate (the adapter from an [`crate::Allocation`] budget).
-    pub fn set_rate(&mut self, rate: ByteRate) {
+    /// Settles the un-refilled window since `last` at the OLD rate before swapping:
+    /// `refill` prices the whole elapsed window at the current rate, and while debt
+    /// is outstanding that minting is NOT burst-capped — re-pricing a quiet stretch
+    /// at a higher new rate would erase real debt for free (and a drop would
+    /// underpay it), breaking the "long-run throughput <= rate" guarantee.
+    pub fn set_rate(&mut self, rate: ByteRate, now: Instant) {
+        self.refill(now);
         self.rate = rate;
     }
 
@@ -229,10 +235,13 @@ impl TokenBucket {
     /// Total for any `bytes`: with `bytes <= tokens` it degenerates to a plain
     /// [`try_take`](Self::try_take) (takes `bytes`, zero debt), so a misrouted
     /// small part is charged correctly rather than panicking or over-charging.
+    /// Denied outright at rate 0: an overdraft is a loan against future refill,
+    /// and a zero rate (the allocator's Ceph-critical freeze) can never repay it —
+    /// admitting would hand a multi-GiB write to a pool that asked for silence.
     #[must_use]
     pub fn try_take_overdraft(&mut self, bytes: u64, now: Instant) -> bool {
         self.refill(now);
-        if self.debt > 0 {
+        if self.debt > 0 || self.rate.get() == 0 {
             return false;
         }
         let taken = self.tokens.min(bytes);
@@ -323,8 +332,8 @@ pub enum DenyReason {
     RateLimited,
     /// An earlier overdraft admission is still being paid off, so another oversized
     /// part cannot be admitted yet. This is a part-specific wait, NOT node-global
-    /// budget exhaustion like [`DenyReason::RateLimited`]: the worker should defer
-    /// just this part and keep the claim burst moving (Task D wires that handling).
+    /// budget exhaustion like [`DenyReason::RateLimited`]: the worker defers just
+    /// this part with backoff instead of stopping the burst.
     OverdraftOutstanding,
     /// The concurrency limit is reached.
     AtConcurrencyLimit,
@@ -389,9 +398,11 @@ impl Enforcer {
         }
     }
 
-    /// Applies a fresh allocation by setting the bandwidth refill rate.
-    pub fn set_rate(&mut self, rate: ByteRate) {
-        self.bucket.set_rate(rate);
+    /// Applies a fresh allocation by setting the bandwidth refill rate. `now` lets
+    /// the bucket settle the elapsed window at the outgoing rate before the swap
+    /// (see [`TokenBucket::set_rate`]).
+    pub fn set_rate(&mut self, rate: ByteRate, now: Instant) {
+        self.bucket.set_rate(rate, now);
     }
 
     /// The bandwidth budget currently enforced (the token-bucket refill rate).
@@ -423,14 +434,16 @@ impl Enforcer {
         // forever (audit F1); admit it via the debt-carrying overdraft, which takes
         // whatever is available now and charges the remainder against future refills —
         // the full `bytes` is the charge either way, so a concurrency denial's
-        // `refund(charged)` fully unwinds it. The `burst > 0` guard keeps a
-        // fully-throttled (zero-budget) bucket denying everything via the normal
-        // RateLimited path: with no budget the overdraft must never fire, or a
-        // zero-rate node would still admit parts on pure debt.
+        // `refund(charged)` fully unwinds it. The `burst > 0 && rate > 0` guards keep
+        // a throttled bucket denying everything via the normal RateLimited path:
+        // `burst` is fixed at construction while `rate` tracks the live allocation,
+        // so a zero-RATE bucket (the allocator's Ceph-critical freeze) still holds
+        // tokens/burst — without the rate guard the overdraft would admit a
+        // multi-GiB part on never-repayable debt exactly when the pool is critical.
         let burst = self.bucket.burst();
         let charged = if self.bucket.try_take(bytes, now) {
             bytes
-        } else if bytes > burst && burst > 0 {
+        } else if bytes > burst && burst > 0 && self.bucket.rate().get() > 0 {
             if !self.bucket.try_take_overdraft(bytes, now) {
                 return DrainDecision::Denied(DenyReason::OverdraftOutstanding);
             }
@@ -590,6 +603,40 @@ mod tests {
             bucket.try_take_overdraft(150, now),
             "debt was zeroed by the refund, so a fresh overdraft is admitted"
         );
+    }
+
+    #[test]
+    fn set_rate_settles_the_elapsed_window_at_the_old_rate() {
+        // The refill prices the whole window since `last` at the CURRENT rate, so a
+        // rate swap must settle the un-refilled window at the OLD rate first. Debt
+        // payment is not burst-capped: re-pricing a quiet second at the new
+        // 10_000 B/s would mint 10_000 against a 250 debt and erase it (plus a full
+        // burst) for free, letting the next oversized part admit far ahead of budget.
+        let now = t0();
+        let mut bucket = TokenBucket::new(ByteRate::new(100), Bytes::new(100), now);
+        assert!(bucket.try_take_overdraft(350, now)); // tokens 100 -> 0, debt 250
+        // 1s at the old 100 B/s pays 100 of the debt (250 -> 150), nothing more.
+        let t1 = now + Duration::from_secs(1);
+        bucket.set_rate(ByteRate::new(10_000), t1);
+        assert!(!bucket.try_take(1, t1), "150 debt remains; the swap itself minted nothing extra");
+        // 15ms at the NEW rate mints exactly the remaining 150 debt: still no tokens.
+        let t2 = t1 + Duration::from_millis(15);
+        assert!(!bucket.try_take(1, t2), "post-swap minting services the settled debt first");
+        // 10ms more mints 100 tokens (burst-capped): the bucket is healthy again.
+        let t3 = t2 + Duration::from_millis(10);
+        assert!(bucket.try_take(100, t3), "tokens mint at the new rate once the debt clears");
+        assert!(!bucket.try_take(1, t3), "and not a token more");
+    }
+
+    #[test]
+    fn zero_rate_denies_the_overdraft_even_with_tokens_banked() {
+        // At rate 0 the refill can never repay debt, so the overdraft loan must be
+        // refused no matter how many tokens are banked from before the throttle —
+        // otherwise a multi-GiB part would be admitted on never-repayable debt.
+        let now = t0();
+        let mut bucket = TokenBucket::new(ByteRate::new(0), Bytes::new(100), now);
+        assert!(!bucket.try_take_overdraft(250, now), "no loan without repayment capacity");
+        assert!(bucket.try_take(100, now), "the refused overdraft left the banked tokens intact");
     }
 
     #[test]
@@ -882,12 +929,29 @@ mod tests {
     }
 
     #[test]
+    fn enforcer_denies_oversized_part_after_rate_drops_to_zero() {
+        // The reachable prod state: the allocator hands out budget 0 under
+        // CephCeiling::Critical and the runtime adopts it via set_rate(0), but
+        // `burst` stays fixed from construction. Without a rate guard the debt
+        // overdraft would admit a multi-GiB Ceph write exactly when the pool is
+        // critical — on debt a zero rate can never repay.
+        let now = t0();
+        let mut e = enforcer(now); // rate 1_000, burst 1_000
+        e.set_rate(ByteRate::new(0), now);
+        assert_eq!(
+            e.try_drain(5_000, now),
+            DrainDecision::Denied(DenyReason::RateLimited),
+            "a zero-rate node must not admit an oversized part on never-repayable debt",
+        );
+    }
+
+    #[test]
     fn enforcer_set_rate_applies_allocation() {
         let now = t0();
         let mut e = enforcer(now);
         assert_eq!(e.try_drain(1_000, now), DrainDecision::Allowed);
         e.record_outcome(BreakerSignal::CephSuccess, now);
-        e.set_rate(ByteRate::new(2_000)); // a larger allocation refills faster
+        e.set_rate(ByteRate::new(2_000), now); // a larger allocation refills faster
         let later = now + Duration::from_secs(1);
         assert_eq!(
             e.try_drain(1_000, later),

--- a/crates/hippius-drain-core/src/enforce.rs
+++ b/crates/hippius-drain-core/src/enforce.rs
@@ -144,6 +144,14 @@ pub struct TokenBucket {
     /// tick. Carrying it makes a low-rate / high-frequency refill exact instead of
     /// systematically under-crediting (each tick would otherwise truncate to zero).
     remainder_nanos: u64,
+    /// Bytes admitted ahead of budget by [`Self::try_take_overdraft`] and not yet
+    /// paid back. `refill` services this before minting any token and an overdraft
+    /// only fires at `debt == 0` after draining `tokens` to zero, so on every path
+    /// `tokens > 0` implies `debt == 0` — which is what makes a plain `try_take`
+    /// implicitly denied for the whole payoff window: an oversized admission
+    /// suppresses exactly its own byte-cost of future budget, keeping long-run
+    /// throughput <= rate.
+    debt: u64,
 }
 
 impl TokenBucket {
@@ -156,6 +164,7 @@ impl TokenBucket {
             tokens: burst.get(),
             last: now,
             remainder_nanos: 0,
+            debt: 0,
         }
     }
 
@@ -171,7 +180,8 @@ impl TokenBucket {
     }
 
     /// The burst ceiling (the max tokens the bucket holds — one second of rate). The
-    /// drain admission clamps an oversize part's charge to this so it can always make
+    /// drain admission routes parts larger than this through
+    /// [`try_take_overdraft`](Self::try_take_overdraft) so they can always make
     /// progress (audit F1).
     #[must_use]
     pub fn burst(&self) -> u64 {
@@ -187,7 +197,12 @@ impl TokenBucket {
         let numerator = u128::from(self.rate.get()) * elapsed.as_nanos() + u128::from(self.remainder_nanos);
         let added = u64::try_from(numerator / 1_000_000_000).unwrap_or(u64::MAX);
         self.remainder_nanos = u64::try_from(numerator % 1_000_000_000).unwrap_or(0);
-        self.tokens = self.tokens.saturating_add(added).min(self.burst.get());
+        // Newly minted tokens pay outstanding overdraft debt before crediting the
+        // bucket, so an oversized admission consumes exactly its byte-cost of
+        // future budget rather than getting the over-burst remainder for free.
+        let repaid = added.min(self.debt);
+        self.debt -= repaid;
+        self.tokens = self.tokens.saturating_add(added - repaid).min(self.burst.get());
         self.last = now;
     }
 
@@ -203,9 +218,38 @@ impl TokenBucket {
         }
     }
 
-    /// Returns `bytes` tokens to the bucket (used when a later gate denies).
+    /// Admits a part larger than the burst by taking everything available now and
+    /// carrying the remainder as debt the refill pays off before any new tokens mint.
+    /// One overdraft at a time: denied while debt is outstanding. This guarantees an
+    /// oversized part drains at the budgeted rate; the prior full-bucket-only overdraft
+    /// never fired under continuous load (2026-07-26: two 2 GiB parts churned the claim
+    /// head for 4h), while long-run throughput stays <= rate because the debt suppresses
+    /// exactly `bytes` of future admissions.
+    ///
+    /// Total for any `bytes`: with `bytes <= tokens` it degenerates to a plain
+    /// [`try_take`](Self::try_take) (takes `bytes`, zero debt), so a misrouted
+    /// small part is charged correctly rather than panicking or over-charging.
+    #[must_use]
+    pub fn try_take_overdraft(&mut self, bytes: u64, now: Instant) -> bool {
+        self.refill(now);
+        if self.debt > 0 {
+            return false;
+        }
+        let taken = self.tokens.min(bytes);
+        self.tokens -= taken;
+        self.debt = bytes - taken;
+        true
+    }
+
+    /// Returns `bytes` tokens to the bucket (used when a later gate denies). Pays
+    /// outstanding debt first, then credits tokens capped at burst — the exact
+    /// mirror of an overdraft charge (tokens drained, remainder as debt), so an
+    /// admission unwound by a concurrency denial restores the bucket as if it
+    /// never happened, and the `tokens > 0 ⟹ debt == 0` invariant is preserved.
     pub fn refund(&mut self, bytes: u64) {
-        self.tokens = self.tokens.saturating_add(bytes).min(self.burst.get());
+        let repaid = bytes.min(self.debt);
+        self.debt -= repaid;
+        self.tokens = self.tokens.saturating_add(bytes - repaid).min(self.burst.get());
     }
 }
 
@@ -277,6 +321,11 @@ pub enum DenyReason {
     BreakerOpen,
     /// The bandwidth budget for this tick is exhausted.
     RateLimited,
+    /// An earlier overdraft admission is still being paid off, so another oversized
+    /// part cannot be admitted yet. This is a part-specific wait, NOT node-global
+    /// budget exhaustion like [`DenyReason::RateLimited`]: the worker should defer
+    /// just this part and keep the claim burst moving (Task D wires that handling).
+    OverdraftOutstanding,
     /// The concurrency limit is reached.
     AtConcurrencyLimit,
 }
@@ -371,16 +420,21 @@ impl Enforcer {
         }
         // Bandwidth gate. Normal path spends `bytes`. A part larger than the burst can
         // never fit (tokens cap at `burst`), so it would loop `Denied(RateLimited)`
-        // forever (audit F1); admit it as a one-shot overdraft when the bucket is full,
-        // spending one burst. The `burst > 0` guard keeps a fully-throttled (zero-budget)
-        // bucket denying everything — without it `bytes.min(0) == 0` would admit any
-        // part free. The amount actually charged is refunded if concurrency then denies,
-        // so a rejected drain costs no budget.
+        // forever (audit F1); admit it via the debt-carrying overdraft, which takes
+        // whatever is available now and charges the remainder against future refills —
+        // the full `bytes` is the charge either way, so a concurrency denial's
+        // `refund(charged)` fully unwinds it. The `burst > 0` guard keeps a
+        // fully-throttled (zero-budget) bucket denying everything via the normal
+        // RateLimited path: with no budget the overdraft must never fire, or a
+        // zero-rate node would still admit parts on pure debt.
         let burst = self.bucket.burst();
         let charged = if self.bucket.try_take(bytes, now) {
             bytes
-        } else if bytes > burst && burst > 0 && self.bucket.try_take(burst, now) {
-            burst
+        } else if bytes > burst && burst > 0 {
+            if !self.bucket.try_take_overdraft(bytes, now) {
+                return DrainDecision::Denied(DenyReason::OverdraftOutstanding);
+            }
+            bytes
         } else {
             return DrainDecision::Denied(DenyReason::RateLimited);
         };
@@ -499,6 +553,54 @@ mod tests {
         let later = now + Duration::from_secs(10);
         assert!(bucket.try_take(1_000, later));
         assert!(!bucket.try_take(1, later), "tokens cannot exceed burst");
+    }
+
+    #[test]
+    fn oversized_part_admits_via_debt_and_blocks_next_overdraft() {
+        let now = t0();
+        let mut bucket = TokenBucket::new(ByteRate::new(100), Bytes::new(100), now);
+        assert!(
+            bucket.try_take_overdraft(250, now),
+            "at debt == 0 an oversized take is admitted immediately, draining all tokens"
+        );
+        assert!(
+            !bucket.try_take_overdraft(250, now),
+            "a second oversized take is denied while the first's debt is outstanding"
+        );
+        // 1.5s at 100 B/s mints exactly the 150 debt: it clears, but no token has
+        // minted yet, so even a 1-byte take is still denied at this instant.
+        let paid = now + Duration::from_millis(1_500);
+        assert!(!bucket.try_take(1, paid), "the refill paid debt only; no tokens yet");
+        // Past the payoff, refill credits tokens again.
+        let later = now + Duration::from_secs(2);
+        assert!(bucket.try_take(50, later), "0.5s past payoff minted 50 fresh tokens");
+    }
+
+    #[test]
+    fn refund_pays_debt_before_crediting_tokens() {
+        let now = t0();
+        let mut bucket = TokenBucket::new(ByteRate::new(100), Bytes::new(100), now);
+        assert!(bucket.try_take_overdraft(250, now)); // tokens 100 -> 0, debt 150
+        // The exact mirror of the charge: 150 pays the debt, the remaining 100
+        // restores the tokens — as if the admission never happened.
+        bucket.refund(250);
+        assert!(bucket.try_take(100, now), "tokens restored to the pre-admission full burst");
+        assert!(!bucket.try_take(1, now), "but not a token more");
+        assert!(
+            bucket.try_take_overdraft(150, now),
+            "debt was zeroed by the refund, so a fresh overdraft is admitted"
+        );
+    }
+
+    #[test]
+    fn normal_take_is_denied_while_debt_outstanding() {
+        let now = t0();
+        let mut bucket = TokenBucket::new(ByteRate::new(100), Bytes::new(100), now);
+        assert!(bucket.try_take_overdraft(250, now)); // debt 150
+        // 1s mints 100 tokens; ALL of it services the debt (150 -> 50), so tokens
+        // stay 0 and even a 1-byte take is denied: tokens > 0 implies debt == 0.
+        let later = now + Duration::from_secs(1);
+        assert!(!bucket.try_take(1, later), "refill pays debt before minting any token");
     }
 
     // --- CircuitBreaker ---
@@ -713,10 +815,11 @@ mod tests {
     }
 
     #[test]
-    fn enforcer_admits_a_part_larger_than_the_burst_ceiling() {
-        // Regression for F1: a part bigger than one second of rate (burst) must still
-        // drain. Before the charge-clamp it looped Denied(RateLimited) forever because
-        // `tokens` caps at `burst`, so `tokens >= bytes` was unsatisfiable.
+    fn enforcer_admits_a_part_larger_than_the_burst_and_charges_it_in_full() {
+        // Regression for F1, upgraded to debt semantics: a part bigger than one second
+        // of rate (burst) must still drain — and now pays for ALL its bytes. The burst
+        // is taken up front and the remaining 4_000 is carried as debt the refill
+        // services before minting any token, so long-run throughput stays <= rate.
         let now = t0();
         let mut e = enforcer(now); // burst = 1_000
         assert_eq!(
@@ -724,10 +827,41 @@ mod tests {
             DrainDecision::Allowed,
             "a 5_000-byte part must be admitted from a full 1_000 burst, not stalled",
         );
-        // It paid at most one burst: the bucket is now empty, so the next drain is rate
-        // limited (and the oversize part did NOT overdraw into a negative balance).
         e.record_outcome(BreakerSignal::CephSuccess, now);
         assert_eq!(e.try_drain(1, now), DrainDecision::Denied(DenyReason::RateLimited));
+        // 4s of refill (4_000 tokens at 1_000 B/s) all services the debt: not a
+        // single token mints, so a 1-byte drain is still rate limited.
+        let paying = now + Duration::from_secs(4);
+        assert_eq!(e.try_drain(1, paying), DrainDecision::Denied(DenyReason::RateLimited));
+        // One second past the payoff, a full burst is available again.
+        let paid = now + Duration::from_secs(5);
+        assert_eq!(e.try_drain(1_000, paid), DrainDecision::Allowed);
+    }
+
+    #[test]
+    fn enforcer_admits_an_oversized_part_from_a_non_full_bucket() {
+        // The exact prod failure (2026-07-26): under continuous load the bucket is
+        // never exactly full, so the old full-bucket-only overdraft never fired and
+        // two 2 GiB parts churned Denied(RateLimited) at the claim head for 4+ hours.
+        // The debt overdraft must admit at ANY debt-free level, then deny further
+        // overdrafts with the part-specific OverdraftOutstanding until the debt clears.
+        let now = t0();
+        let mut e = enforcer(now); // rate 1_000, burst 1_000, concurrency 1
+        assert_eq!(e.try_drain(400, now), DrainDecision::Allowed); // bucket at 600: NOT full
+        e.record_outcome(BreakerSignal::CephSuccess, now);
+        assert_eq!(
+            e.try_drain(5_000, now),
+            DrainDecision::Allowed,
+            "an oversized part is admitted from a non-full bucket while debt == 0",
+        );
+        e.record_outcome(BreakerSignal::CephSuccess, now);
+        // debt = 5_000 - 600 = 4_400: the next oversized part gets the part-specific
+        // reason (defer just this part), while a normal part reads as rate limited.
+        assert_eq!(e.try_drain(5_000, now), DrainDecision::Denied(DenyReason::OverdraftOutstanding));
+        assert_eq!(e.try_drain(1, now), DrainDecision::Denied(DenyReason::RateLimited));
+        // 4.4s pays the debt off at the budgeted rate; 1s more refills a full burst.
+        let later = now + Duration::from_millis(5_400);
+        assert_eq!(e.try_drain(1_000, later), DrainDecision::Allowed, "debt paid at the budgeted rate");
     }
 
     #[test]

--- a/crates/hippius-drain-core/src/enforce.rs
+++ b/crates/hippius-drain-core/src/enforce.rs
@@ -209,7 +209,12 @@ impl TokenBucket {
         let repaid = added.min(self.debt);
         self.debt -= repaid;
         self.tokens = self.tokens.saturating_add(added - repaid).min(self.burst.get());
-        self.last = now;
+        // Only ever ADVANCE the clock: a stale `now` (an Instant captured before the
+        // caller won the enforcer lock, arriving after a fresher refill) prices a
+        // zero-length window above, but assigning it would rewind `last` and let the
+        // NEXT refill re-price the already-minted [now, last] window — free tokens
+        // (and free debt payoff) exactly under lock contention.
+        self.last = self.last.max(now);
     }
 
     /// Tries to spend `bytes` tokens, refilling first. Returns whether granted.
@@ -555,6 +560,21 @@ mod tests {
             prop_assert!(bucket.try_take(expected, t), "credited at least the exact total {expected}");
             prop_assert!(!bucket.try_take(1, t), "credited no more than the exact total {expected}");
         }
+    }
+
+    #[test]
+    fn a_stale_refill_cannot_regress_the_clock_and_remint_a_window() {
+        // Two callers race for the enforcer lock, each with an Instant captured
+        // pre-lock. The loser's older `now` must not rewind the bucket's clock:
+        // rewinding re-prices the already-minted [stale_now, last] window on the
+        // NEXT refill — free tokens (and free debt payoff) under lock contention.
+        let now = t0();
+        let mut bucket = TokenBucket::new(ByteRate::new(1_000), Bytes::new(1_000), now);
+        assert!(bucket.try_take(1_000, now), "drain the initial burst");
+        let later = now + Duration::from_secs(1);
+        assert!(bucket.try_take(1_000, later), "the now->later window minted its full burst once");
+        let _ = bucket.try_take(0, now); // the stale, pre-lock refill arrives late
+        assert!(!bucket.try_take(1, later), "a stale refill after a fresh one mints nothing extra");
     }
 
     #[test]

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -52,6 +52,6 @@ pub use clock::TestClock;
 #[cfg(feature = "coord")]
 pub use coordination::{CoordError, Coordinator, DEFAULT_REDIS_TIMEOUT, Lease, StoredAllocation};
 #[cfg(feature = "pg")]
-pub use store::{PendingPart, Store, StoreError, UploadContext};
+pub use store::{MissingSourceOutcome, PendingPart, Store, StoreError, UploadContext};
 #[cfg(feature = "coord")]
 pub use tick::{CephCeilingSource, StaticCeiling, TickConfig, TickOutcome, run_tick};

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -110,8 +110,9 @@ pub struct AgentSnapshot {
     pub throttled: u64,
     /// Parts written off as terminal `failed` by the missing-source escalation: the SSD
     /// source was observed gone enough consecutive claims that the row will never drain.
-    /// This is the DURABLE record of a write-off — `node_undrained_count` excludes `failed`
-    /// and the terminal GC deletes the row, so without this counter only a WARN log remains.
+    /// This is the only standing metric of a write-off — the counter is per-process (reset
+    /// on restart), `node_undrained_count` excludes `failed`, and the terminal GC deletes
+    /// the row, so the WARN log in Loki is the only per-event trace.
     /// Kept OUT of [`error_bps`](Self::error_bps) like `deferred`: a write-off is a data
     /// disposition, not a Ceph-write failure.
     pub written_off: u64,

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -108,6 +108,13 @@ pub struct AgentSnapshot {
     /// (a wedge, not an outage, is what readiness must catch). Kept out of `error_bps` (a
     /// throttle is not a Ceph-write failure), exactly like `deferred`.
     pub throttled: u64,
+    /// Parts written off as terminal `failed` by the missing-source escalation: the SSD
+    /// source was observed gone enough consecutive claims that the row will never drain.
+    /// This is the DURABLE record of a write-off — `node_undrained_count` excludes `failed`
+    /// and the terminal GC deletes the row, so without this counter only a WARN log remains.
+    /// Kept OUT of [`error_bps`](Self::error_bps) like `deferred`: a write-off is a data
+    /// disposition, not a Ceph-write failure.
+    pub written_off: u64,
 }
 
 impl AgentSnapshot {
@@ -148,6 +155,7 @@ pub struct SnapshotCell {
     /// [`AgentSnapshot::reclaim_backing_errors`] for why it stays out of `error_bps`.
     reclaim_backing_errors: AtomicU64,
     throttled: AtomicU64,
+    written_off: AtomicU64,
     /// Current SSD backlog (undrained bytes) — a LEVEL, not a monotonic counter, so it
     /// has its own atomic (set, not accumulated) rather than living in [`AgentSnapshot`].
     /// The heartbeat worker writes it (`usage.used_bytes`) each tick; the metrics layer
@@ -160,6 +168,11 @@ pub struct SnapshotCell {
     /// while undrained rows remain — which readiness would misread as idle. The COUNT cannot be
     /// zeroed that way, so readiness keys on it while the gauge keeps reporting bytes.
     undrained_count: AtomicU64,
+    /// Age in whole seconds of this node's oldest `pending` replication row — a LEVEL like
+    /// `undrained_count`, set each heartbeat from `Store::node_oldest_pending_age_secs`. The
+    /// starvation signal the 2026-07-26 incident lacked: one node's oldest pending age
+    /// exploding while peers sit near zero means claimable work nobody is finishing.
+    oldest_pending_age_secs: AtomicU64,
     /// Current SSD disk saturation in basis points (`0..=10000` = `0.0..=1.0` full) — a
     /// LEVEL like `backlog_bytes`, set each heartbeat from the same `statvfs` probe. This
     /// is the fill fraction that 503s every PUT once it crosses the api's cutoff, so it is
@@ -249,6 +262,26 @@ impl SnapshotCell {
         self.undrained_count.load(Ordering::Relaxed)
     }
 
+    /// Records the current age (whole seconds) of this node's oldest `pending` replication
+    /// row. A gauge: `store`, not add. The heartbeat writes it from
+    /// `Store::node_oldest_pending_age_secs` each tick.
+    pub fn record_oldest_pending_age_secs(&self, secs: u64) {
+        self.oldest_pending_age_secs.store(secs, Ordering::Relaxed);
+    }
+
+    /// The last-recorded oldest-pending age in seconds (the `drain_pending_oldest_age_seconds`
+    /// gauge source) — the per-node starvation signal (see the field doc).
+    #[must_use]
+    pub fn oldest_pending_age_secs(&self) -> u64 {
+        self.oldest_pending_age_secs.load(Ordering::Relaxed)
+    }
+
+    /// Records `n` parts written off as terminal `failed` by the missing-source escalation
+    /// (not a Ceph-write failure — see [`AgentSnapshot::written_off`]).
+    pub fn record_written_off(&self, n: u64) {
+        self.written_off.fetch_add(n, Ordering::Relaxed);
+    }
+
     /// Records the current SSD disk saturation in basis points (`0..=10000`). A gauge:
     /// `store`, not add. The heartbeat writes it from the `statvfs` pressure each tick.
     pub fn record_disk_pressure(&self, bps: u16) {
@@ -305,6 +338,7 @@ impl SnapshotCell {
             reclaimed: self.reclaimed.load(Ordering::Relaxed),
             reclaim_backing_errors: self.reclaim_backing_errors.load(Ordering::Relaxed),
             throttled: self.throttled.load(Ordering::Relaxed),
+            written_off: self.written_off.load(Ordering::Relaxed),
         }
     }
 }
@@ -394,6 +428,35 @@ mod tests {
     }
 
     #[test]
+    fn oldest_pending_age_is_a_settable_gauge_not_a_counter() {
+        // Task F starvation signal: the age of this node's oldest `pending` row, a LEVEL
+        // set each heartbeat from Store::node_oldest_pending_age_secs — so a later record
+        // replaces rather than accumulates, exactly like undrained_count.
+        let cell = SnapshotCell::new();
+        assert_eq!(cell.oldest_pending_age_secs(), 0, "a fresh cell reports no pending age");
+        cell.record_oldest_pending_age_secs(12_600); // the 2026-07-26 3.5h wall
+        assert_eq!(cell.oldest_pending_age_secs(), 12_600);
+        cell.record_oldest_pending_age_secs(10);
+        assert_eq!(cell.oldest_pending_age_secs(), 10, "age is a level: a later record replaces");
+    }
+
+    #[test]
+    fn written_off_records_accumulate_without_polluting_error_bps() {
+        // Task F durable write-off signal: a terminal missing-source escalation
+        // (status='failed', GC'd later) previously left only a WARN log. The counter is
+        // monotonic like `deferred` and — like every non-Ceph outcome — must stay out
+        // of error_bps: a write-off is not a Ceph-write failure.
+        let cell = SnapshotCell::new();
+        cell.record_drained(7);
+        cell.record_failed(3);
+        cell.record_written_off(1);
+        cell.record_written_off(1);
+        let snap = cell.load();
+        assert_eq!(snap.written_off, 2, "each write-off is counted durably");
+        assert_eq!(snap.error_bps(), 3000, "write-offs stay out of the Ceph failure rate");
+    }
+
+    #[test]
     fn records_accumulate_per_counter() {
         let cell = SnapshotCell::new();
         cell.record_drained(3);
@@ -412,6 +475,7 @@ mod tests {
                 reclaimed: 6,
                 reclaim_backing_errors: 0,
                 throttled: 9,
+                written_off: 0,
             },
         );
     }
@@ -476,6 +540,7 @@ mod tests {
             reclaimed: 0,
             reclaim_backing_errors: 0,
             throttled: 0,
+            written_off: 0,
         };
         assert_eq!(snapshot.error_bps(), 10_000);
     }
@@ -490,6 +555,7 @@ mod tests {
             reclaimed: 0,
             reclaim_backing_errors: 0,
             throttled: 0,
+            written_off: 0,
         };
         // 3 failed attempts of 10 total attempts = 30%, i.e. 3000 basis points.
         assert_eq!(snapshot.error_bps(), 3000);

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -182,6 +182,12 @@ const DEFAULT_CLAIM_LEASE: Duration = Duration::from_mins(5);
 /// [`Store::with_defer_backoff`].
 const DEFAULT_DEFER_BACKOFF: Duration = Duration::from_secs(5);
 
+/// The ceiling on the exponential deferral backoff: a part that keeps deferring
+/// (an abandoned MPU that never finalizes) doubles its backoff per attempt but is
+/// never parked longer than this, so it still re-checks within minutes of the
+/// address finally landing. Override via [`Store::with_defer_backoff_cap`].
+const DEFAULT_DEFER_BACKOFF_CAP: Duration = Duration::from_mins(10);
+
 /// Handle to the Postgres central state. Cheap to clone (shares the pool).
 #[derive(Debug, Clone)]
 pub struct Store {
@@ -192,7 +198,12 @@ pub struct Store {
     /// How long a deferred part is backed off before it is re-claimable, so the
     /// drain does not re-claim a not-ready part on every poll (which would starve
     /// the ready ones). Applied by [`Store::defer_part`], honored by `claim_part`.
+    /// This is the BASE of the per-row exponential backoff; the row's
+    /// `defer_attempts` doubles it per deferral up to [`defer_backoff_cap`](Self::with_defer_backoff_cap).
     defer_backoff: Duration,
+    /// Ceiling on the exponential deferral backoff, so a chronically not-ready part
+    /// still re-checks within minutes of its address finally landing.
+    defer_backoff_cap: Duration,
     /// The agent's node id. Parts live on node-local SSD, so a part may only be
     /// drained by the node that holds it: `record_landed_part` stamps this and
     /// `claim_part` scopes to it. `None` for the allocator, which records/claims
@@ -212,6 +223,7 @@ impl Store {
             pool,
             claim_lease: DEFAULT_CLAIM_LEASE,
             defer_backoff: DEFAULT_DEFER_BACKOFF,
+            defer_backoff_cap: DEFAULT_DEFER_BACKOFF_CAP,
             node_id: None,
         })
     }
@@ -226,6 +238,7 @@ impl Store {
             pool,
             claim_lease: DEFAULT_CLAIM_LEASE,
             defer_backoff: DEFAULT_DEFER_BACKOFF,
+            defer_backoff_cap: DEFAULT_DEFER_BACKOFF_CAP,
             node_id: Some("test-node".to_owned()),
         }
     }
@@ -243,6 +256,14 @@ impl Store {
     #[must_use]
     pub fn with_defer_backoff(mut self, backoff: Duration) -> Self {
         self.defer_backoff = backoff;
+        self
+    }
+
+    /// Sets the exponential-deferral ceiling (the daemon wires this from
+    /// `CEPHOR_DEFER_BACKOFF_CAP_SECS`). No deferral parks a part longer than `cap`.
+    #[must_use]
+    pub fn with_defer_backoff_cap(mut self, cap: Duration) -> Self {
+        self.defer_backoff_cap = cap;
         self
     }
 
@@ -527,7 +548,9 @@ impl Store {
     pub async fn release_part(&self, part: &PartKey) -> Result<()> {
         // Clear deferred_until too: a release is the Ceph-failure retry path, which
         // should be re-claimable immediately — it must not inherit a stale backoff a
-        // prior deferral parked on the row.
+        // prior deferral parked on the row. defer_attempts is deliberately left alone:
+        // the escalation tracks the not-ready condition, which a Ceph blip says
+        // nothing about, so resetting it here would re-arm the starvation spiral.
         sqlx::query(
             "UPDATE cephor_replication_status SET status = 'pending', updated_at = now(), claimed_at = NULL, deferred_until = NULL \
              WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'draining'",
@@ -549,19 +572,33 @@ impl Store {
     /// on `draining` like [`release_part`](Store::release_part), so a late defer cannot
     /// resurrect a finished part.
     ///
+    /// The backoff is EXPONENTIAL per row (base × 2^`defer_attempts`, capped): a fixed
+    /// backoff let a wall of not-ready in-progress-MPU parts — oldest by `landed_at`,
+    /// so at the claim head — re-enter the claimable set every interval and consume
+    /// every claim slot, starving all younger parts (the 2026-07-26 head-of-line
+    /// starvation incident). Doubling per deferral moves a not-ready wall out of the
+    /// claim hot path geometrically. The inner `LEAST(defer_attempts, 16)` clamps the
+    /// exponent so `power` cannot overflow; the outer `LEAST` enforces
+    /// [`defer_backoff_cap`](Store::with_defer_backoff_cap). `release_part` deliberately
+    /// preserves `defer_attempts` — a transient Ceph-failure retry must not erase the
+    /// not-ready escalation.
+    ///
     /// # Errors
     ///
     /// [`StoreError::Database`] on failure.
     pub async fn defer_part(&self, part: &PartKey) -> Result<()> {
         sqlx::query(
             "UPDATE cephor_replication_status \
-             SET status = 'pending', updated_at = now(), claimed_at = NULL, deferred_until = now() + $4 * interval '1 second' \
+             SET status = 'pending', updated_at = now(), claimed_at = NULL, \
+                 defer_attempts = defer_attempts + 1, \
+                 deferred_until = now() + LEAST($4 * power(2::float8, LEAST(defer_attempts, 16)), $5) * interval '1 second' \
              WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'draining'",
         )
         .bind(part.object().as_str())
         .bind(i64::from(part.version().get()))
         .bind(i64::from(part.part().get()))
         .bind(self.defer_backoff.as_secs_f64())
+        .bind(self.defer_backoff_cap.as_secs_f64())
         .execute(&self.pool)
         .await?;
         Ok(())
@@ -2199,6 +2236,107 @@ mod part_tests {
             store.claim_part().await.unwrap().is_some(),
             "release clears the backoff, so a Ceph-failed part retries immediately",
         );
+    }
+
+    /// Seconds until the row's `deferred_until`, measured against the same DB clock
+    /// that stamped it — so the assertion is immune to test-host/DB clock skew.
+    async fn defer_remaining_secs(pool: &PgPool, part: &PartKey) -> f64 {
+        sqlx::query_scalar(
+            "SELECT EXTRACT(EPOCH FROM (deferred_until - now()))::float8 FROM cephor_replication_status \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(part.object().as_str())
+        .bind(i64::from(part.version().get()))
+        .bind(i64::from(part.part().get()))
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[sqlx::test]
+    async fn defer_part_backs_off_exponentially(pool: PgPool) {
+        // The 2026-07-26 head-of-line starvation incident: with a FIXED backoff, a wall
+        // of not-ready MPU parts re-entered the claimable head every interval and — being
+        // oldest by landed_at — consumed every claim slot, starving every younger part.
+        // Repeated deferrals must therefore back off geometrically: 5s, 10s, 20s, ...
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+
+        let mut observed = Vec::new();
+        for _ in 0..3 {
+            store.claim_part().await.unwrap().expect("the part is claimable");
+            store.defer_part(&p).await.unwrap();
+            observed.push(defer_remaining_secs(&pool, &p).await);
+            // Clear the parked backoff so the next round can re-claim immediately.
+            sqlx::query("UPDATE cephor_replication_status SET deferred_until = NULL WHERE object_id = $1")
+                .bind(p.object().as_str())
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+        for (n, (remaining, expected)) in observed.iter().zip([5.0_f64, 10.0, 20.0]).enumerate() {
+            assert!(
+                (expected - 1.0..=expected + 1.0).contains(remaining),
+                "deferral #{n} should park the part ~{expected}s, got {remaining}s (all: {observed:?})",
+            );
+        }
+    }
+
+    #[sqlx::test]
+    async fn defer_backoff_is_capped(pool: PgPool) {
+        // A part that has deferred many times (an abandoned MPU that never finalizes)
+        // must park at the cap, not for days: uncapped, 30 attempts would be
+        // 5 * 2^16 s (~3.8 days) even after the exponent clamp.
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+        store.claim_part().await.unwrap().expect("the part is claimable");
+        sqlx::query("UPDATE cephor_replication_status SET defer_attempts = 30 WHERE object_id = $1")
+            .bind(p.object().as_str())
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        store.defer_part(&p).await.unwrap();
+        let remaining = defer_remaining_secs(&pool, &p).await;
+        assert!(remaining <= 601.0, "the deferral must not exceed the 600s cap, got {remaining}s");
+        assert!(
+            remaining >= 599.0,
+            "a 30-attempt row is parked at the FULL cap, not the base backoff, got {remaining}s",
+        );
+    }
+
+    #[sqlx::test]
+    async fn release_part_preserves_defer_attempts(pool: PgPool) {
+        // A transient Ceph-failure release retries promptly (deferred_until cleared)
+        // but must NOT erase the not-ready escalation: if the part defers again, the
+        // backoff continues geometrically instead of restarting at the base interval.
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+        store.claim_part().await.unwrap().expect("the part is claimable");
+        store.defer_part(&p).await.unwrap();
+        sqlx::query("UPDATE cephor_replication_status SET deferred_until = now() - interval '1 second' WHERE object_id = $1")
+            .bind(p.object().as_str())
+            .execute(&pool)
+            .await
+            .unwrap();
+        store.claim_part().await.unwrap().expect("re-claimable once the backoff elapsed");
+
+        store.release_part(&p).await.unwrap();
+        let (attempts, deferred_is_null): (i32, bool) = sqlx::query_as(
+            "SELECT defer_attempts, deferred_until IS NULL FROM cephor_replication_status \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(p.object().as_str())
+        .bind(i64::from(p.version().get()))
+        .bind(i64::from(p.part().get()))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(attempts, 1, "release must not reset the defer escalation");
+        assert!(deferred_is_null, "release clears the parked backoff for a prompt retry");
     }
 
     /// Drives one part `pending → draining → replicated` (the drain's commit path) and returns it.

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -188,6 +188,23 @@ const DEFAULT_DEFER_BACKOFF: Duration = Duration::from_secs(5);
 /// address finally landing. Override via [`Store::with_defer_backoff_cap`].
 const DEFAULT_DEFER_BACKOFF_CAP: Duration = Duration::from_mins(10);
 
+/// What [`Store::defer_part_missing_source`] did to the row — decided atomically
+/// inside the guarded UPDATE, so no concurrent claim can interleave between the
+/// deferral and the terminal escalation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MissingSourceOutcome {
+    /// Below the threshold: deferred back to `pending` with the shared exponential
+    /// backoff, carrying the row's new missing-source observation count.
+    Deferred(u64),
+    /// The observation count reached the threshold: the row is now terminal `failed`
+    /// (never resurrected — the write-off is deliberate and conservative).
+    Failed,
+    /// The `status='draining'` guard missed — the row advanced under a concurrent
+    /// transition (e.g. a lease-expiry re-claim) — so nothing changed. A no-op
+    /// defer cannot escalate.
+    Superseded,
+}
+
 /// Handle to the Postgres central state. Cheap to clone (shares the pool).
 #[derive(Debug, Clone)]
 pub struct Store {
@@ -602,6 +619,69 @@ impl Store {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// Defers a claimed part whose SSD source directory is GONE (ENOENT at the size
+    /// gate), counting the observation toward the terminal write-off — and, when the
+    /// count reaches `fail_threshold`, flips the row terminal `failed` instead.
+    ///
+    /// Why a separate counter (`missing_source_attempts`, migration 0015) instead of
+    /// keying the escalation on `defer_attempts`: that counter is SHARED with the
+    /// overdraft (`OverdraftOutstanding`) and not-ready (in-progress MPU) deferral
+    /// paths, so a healthy oversized part paying off a long debt — or an MPU part
+    /// waiting on its address — could accumulate attempts and then be written off on
+    /// its FIRST transient `NotFound`. `failed` is never resurrected (the reconciler
+    /// only registers parts that exist on SSD, and `record_landed_part`'s ON CONFLICT
+    /// never touches status), so a wrong write-off is silent replication loss; only
+    /// genuine missing-source observations may count toward it.
+    ///
+    /// The defer and the escalation are ONE guarded UPDATE (`status='draining'`, the
+    /// pending↔failed choice a CASE on the incremented count): a defer-then-fail pair
+    /// would flip the row `pending` first, opening a window where a concurrent claim
+    /// re-takes it and the follow-up fail either misses its guard or clobbers a live
+    /// claim. Below the threshold the row defers exactly like [`defer_part`]
+    /// (`defer_attempts` still increments — the backoff geometry stays shared); the
+    /// new observation count is RETURNED so the caller needs no second round trip.
+    /// A guard miss (the row advanced concurrently) is [`MissingSourceOutcome::Superseded`]:
+    /// a no-op defer cannot escalate.
+    ///
+    /// [`defer_part`]: Store::defer_part
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Database`] on failure; [`StoreError::Invalid`] if the stored
+    /// counter reads back negative (unreachable by construction).
+    pub async fn defer_part_missing_source(&self, part: &PartKey, fail_threshold: u32) -> Result<MissingSourceOutcome> {
+        let row: Option<(i32, String)> = sqlx::query_as(
+            "UPDATE cephor_replication_status \
+             SET missing_source_attempts = missing_source_attempts + 1, \
+                 defer_attempts = defer_attempts + 1, \
+                 status = CASE WHEN missing_source_attempts + 1 >= $6 THEN 'failed' ELSE 'pending' END, \
+                 updated_at = now(), claimed_at = NULL, \
+                 deferred_until = CASE WHEN missing_source_attempts + 1 >= $6 THEN NULL \
+                     ELSE now() + LEAST($4 * power(2::float8, LEAST(defer_attempts, 16)), $5) * interval '1 second' END \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'draining' \
+             RETURNING missing_source_attempts, status",
+        )
+        .bind(part.object().as_str())
+        .bind(i64::from(part.version().get()))
+        .bind(i64::from(part.part().get()))
+        .bind(self.defer_backoff.as_secs_f64())
+        .bind(self.defer_backoff_cap.as_secs_f64())
+        .bind(i64::from(fail_threshold))
+        .fetch_optional(&self.pool)
+        .await?;
+        let Some((observations, status)) = row else {
+            return Ok(MissingSourceOutcome::Superseded);
+        };
+        if status == "failed" {
+            return Ok(MissingSourceOutcome::Failed);
+        }
+        let observations = u64::try_from(observations).map_err(|_| StoreError::Invalid {
+            field: "missing_source_attempts",
+            value: i64::from(observations),
+        })?;
+        Ok(MissingSourceOutcome::Deferred(observations))
     }
 
     /// Lists up to `limit` pending parts, oldest first — the reconciler's advisory
@@ -1238,7 +1318,7 @@ mod tests {
 #[cfg(feature = "pg")]
 #[expect(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
 mod part_tests {
-    use super::{Store, StoreError};
+    use super::{MissingSourceOutcome, Store, StoreError};
     use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
     use crate::partdrain::{ClaimedPart, PartReplicationStore, PartVerified};
     use crate::ssd_reclaim::ReclaimLog;
@@ -2337,6 +2417,132 @@ mod part_tests {
         .unwrap();
         assert_eq!(attempts, 1, "release must not reset the defer escalation");
         assert!(deferred_is_null, "release clears the parked backoff for a prompt retry");
+    }
+
+    /// The row's `(defer_attempts, missing_source_attempts)` — the pair the
+    /// missing-source escalation must keep separable (the shared-counter hazard).
+    async fn attempt_counters(pool: &PgPool, part: &PartKey) -> (i64, i64) {
+        sqlx::query_as(
+            "SELECT defer_attempts::bigint, missing_source_attempts::bigint FROM cephor_replication_status \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(part.object().as_str())
+        .bind(i64::from(part.version().get()))
+        .bind(i64::from(part.part().get()))
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[sqlx::test]
+    async fn defer_part_missing_source_counts_the_observation_and_keeps_the_shared_backoff(pool: PgPool) {
+        // A missing-source deferral is a normal exponential defer PLUS one
+        // missing-source observation: both counters advance, the backoff stays the
+        // shared defer_attempts geometry (5s, 10s, ...), and the returned count lets
+        // the worker escalate without a second round trip.
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+
+        store.claim_part().await.unwrap().expect("the part is claimable");
+        let first = store.defer_part_missing_source(&p, 20).await.unwrap();
+        assert_eq!(first, MissingSourceOutcome::Deferred(1), "the first observation is counted and returned");
+        assert_eq!(
+            attempt_counters(&pool, &p).await,
+            (1, 1),
+            "both counters advance on a missing-source defer"
+        );
+        let remaining = defer_remaining_secs(&pool, &p).await;
+        assert!(
+            (4.0..=6.0).contains(&remaining),
+            "the first backoff is the shared 5s base, got {remaining}s"
+        );
+        assert_eq!(
+            <Store as PartReplicationStore>::status(&store, &p).await.unwrap(),
+            Some(ReplicationState::Pending),
+            "below the threshold the part is deferred back to pending",
+        );
+
+        sqlx::query("UPDATE cephor_replication_status SET deferred_until = NULL WHERE object_id = $1")
+            .bind(p.object().as_str())
+            .execute(&pool)
+            .await
+            .unwrap();
+        store.claim_part().await.unwrap().expect("re-claimable once the backoff is cleared");
+        let second = store.defer_part_missing_source(&p, 20).await.unwrap();
+        assert_eq!(second, MissingSourceOutcome::Deferred(2));
+        let remaining = defer_remaining_secs(&pool, &p).await;
+        assert!(
+            (9.0..=11.0).contains(&remaining),
+            "the backoff doubles like a plain defer, got {remaining}s"
+        );
+    }
+
+    #[sqlx::test]
+    async fn defer_part_missing_source_fails_the_row_atomically_at_the_threshold(pool: PgPool) {
+        // Reaching the threshold must flip the row terminal `failed` IN the same
+        // guarded UPDATE that would otherwise defer it: a defer-then-fail pair would
+        // open a window where the deferred (pending) row is re-claimed between the
+        // two statements and the fail either misses or clobbers a live claim.
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+        store.claim_part().await.unwrap().expect("the part is claimable");
+        sqlx::query("UPDATE cephor_replication_status SET missing_source_attempts = 19 WHERE object_id = $1")
+            .bind(p.object().as_str())
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let outcome = store.defer_part_missing_source(&p, 20).await.unwrap();
+        assert_eq!(outcome, MissingSourceOutcome::Failed, "the 20th observation writes the part off");
+        assert_eq!(
+            <Store as PartReplicationStore>::status(&store, &p).await.unwrap(),
+            Some(ReplicationState::Failed),
+            "the row is terminal failed",
+        );
+        assert!(
+            store.claim_part().await.unwrap().is_none(),
+            "a failed row is out of the claim set for good — no more churn",
+        );
+    }
+
+    #[sqlx::test]
+    async fn defer_part_missing_source_is_a_no_op_off_the_draining_guard(pool: PgPool) {
+        // Like defer_part/release_part, the `status='draining'` guard makes a late
+        // call a no-op when the row has since advanced — and a no-op defer must not
+        // escalate, so the outcome is Superseded, never Failed.
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+
+        // Never claimed: the row is 'pending', so the guard misses.
+        let outcome = store.defer_part_missing_source(&p, 20).await.unwrap();
+        assert_eq!(outcome, MissingSourceOutcome::Superseded, "a guard miss reports Superseded, not a count");
+        assert_eq!(attempt_counters(&pool, &p).await, (0, 0), "a guard miss touches neither counter");
+        assert_eq!(
+            <Store as PartReplicationStore>::status(&store, &p).await.unwrap(),
+            Some(ReplicationState::Pending),
+            "the row is left exactly as it was",
+        );
+    }
+
+    #[sqlx::test]
+    async fn plain_defer_part_never_touches_missing_source_attempts(pool: PgPool) {
+        // The amendment's core invariant: overdraft/not-ready deferrals go through
+        // defer_part and must NOT count toward the missing-source write-off — only
+        // defer_part_missing_source observes a vanished source.
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+        store.claim_part().await.unwrap().expect("the part is claimable");
+
+        store.defer_part(&p).await.unwrap();
+        assert_eq!(
+            attempt_counters(&pool, &p).await,
+            (1, 0),
+            "a plain defer advances only the shared backoff counter",
+        );
     }
 
     /// Drives one part `pending → draining → replicated` (the drain's commit path) and returns it.

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -205,6 +205,24 @@ pub enum MissingSourceOutcome {
     Superseded,
 }
 
+/// Splices the shared exponential-backoff expression between two SQL literal halves,
+/// yielding one `&'static str` (sqlx 0.9's `SqlSafeStr` rejects runtime-built strings,
+/// so this is `concat!`, not `format!`). The expression — base × 2^`defer_attempts`,
+/// exponent clamped at 16 so `power` cannot overflow, product capped by the outer
+/// `LEAST` — is defined ONCE here so the cap/clamp geometry cannot drift between
+/// [`Store::defer_part`] and [`Store::defer_part_missing_source`]. It reads the row's
+/// OLD `defer_attempts` (UPDATE right-hand sides see pre-update values) and requires
+/// the splicing query to bind `$4` = base backoff seconds and `$5` = cap seconds.
+macro_rules! with_defer_backoff_sql {
+    ($prefix:expr, $suffix:expr) => {
+        concat!(
+            $prefix,
+            "now() + LEAST($4 * power(2::float8, LEAST(defer_attempts, 16)), $5) * interval '1 second'",
+            $suffix
+        )
+    };
+}
+
 /// Handle to the Postgres central state. Cheap to clone (shares the pool).
 #[derive(Debug, Clone)]
 pub struct Store {
@@ -604,13 +622,13 @@ impl Store {
     ///
     /// [`StoreError::Database`] on failure.
     pub async fn defer_part(&self, part: &PartKey) -> Result<()> {
-        sqlx::query(
+        sqlx::query(with_defer_backoff_sql!(
             "UPDATE cephor_replication_status \
              SET status = 'pending', updated_at = now(), claimed_at = NULL, \
                  defer_attempts = defer_attempts + 1, \
-                 deferred_until = now() + LEAST($4 * power(2::float8, LEAST(defer_attempts, 16)), $5) * interval '1 second' \
-             WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'draining'",
-        )
+                 deferred_until = ",
+            " WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'draining'"
+        ))
         .bind(part.object().as_str())
         .bind(i64::from(part.version().get()))
         .bind(i64::from(part.part().get()))
@@ -645,6 +663,11 @@ impl Store {
     /// A guard miss (the row advanced concurrently) is [`MissingSourceOutcome::Superseded`]:
     /// a no-op defer cannot escalate.
     ///
+    /// `fail_threshold` must be greater than 1: a threshold of 0 or 1 writes the part
+    /// off on its FIRST observation — the exact transient-`NotFound` hazard this
+    /// design exists to prevent — so debug builds assert it (release builds execute
+    /// the first-observation write-off as written).
+    ///
     /// [`defer_part`]: Store::defer_part
     ///
     /// # Errors
@@ -652,17 +675,21 @@ impl Store {
     /// [`StoreError::Database`] on failure; [`StoreError::Invalid`] if the stored
     /// counter reads back negative (unreachable by construction).
     pub async fn defer_part_missing_source(&self, part: &PartKey, fail_threshold: u32) -> Result<MissingSourceOutcome> {
-        let row: Option<(i32, String)> = sqlx::query_as(
+        debug_assert!(
+            fail_threshold > 1,
+            "fail_threshold {fail_threshold} writes a part off on its first missing-source observation"
+        );
+        let row: Option<(i32, String)> = sqlx::query_as(with_defer_backoff_sql!(
             "UPDATE cephor_replication_status \
              SET missing_source_attempts = missing_source_attempts + 1, \
                  defer_attempts = defer_attempts + 1, \
                  status = CASE WHEN missing_source_attempts + 1 >= $6 THEN 'failed' ELSE 'pending' END, \
                  updated_at = now(), claimed_at = NULL, \
-                 deferred_until = CASE WHEN missing_source_attempts + 1 >= $6 THEN NULL \
-                     ELSE now() + LEAST($4 * power(2::float8, LEAST(defer_attempts, 16)), $5) * interval '1 second' END \
+                 deferred_until = CASE WHEN missing_source_attempts + 1 >= $6 THEN NULL ELSE ",
+            " END \
              WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'draining' \
-             RETURNING missing_source_attempts, status",
-        )
+             RETURNING missing_source_attempts, status"
+        ))
         .bind(part.object().as_str())
         .bind(i64::from(part.version().get()))
         .bind(i64::from(part.part().get()))
@@ -2505,6 +2532,33 @@ mod part_tests {
             store.claim_part().await.unwrap().is_none(),
             "a failed row is out of the claim set for good — no more churn",
         );
+        let unparked: bool = sqlx::query_scalar(
+            "SELECT deferred_until IS NULL FROM cephor_replication_status \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(p.object().as_str())
+        .bind(i64::from(p.version().get()))
+        .bind(i64::from(p.part().get()))
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(unparked, "the fail arm parks no backoff — deferred_until is cleared, not set");
+    }
+
+    // debug_assert compiles out in release, so this pin only exists where the guard does.
+    #[cfg(debug_assertions)]
+    #[sqlx::test]
+    #[should_panic(expected = "first missing-source observation")]
+    async fn defer_part_missing_source_rejects_a_degenerate_threshold_in_debug(pool: PgPool) {
+        // The domain edge, pinned: a threshold of 0 or 1 means the FIRST observation
+        // writes the part off — the exact transient-NotFound hazard the separate
+        // counter exists to prevent — so debug builds refuse it outright (in release
+        // the documented first-observation write-off would execute as written).
+        let store = Store::from_pool(pool.clone());
+        let p = part(UUID_A, 5, 1);
+        store.record_landed_part(&p).await.unwrap();
+        store.claim_part().await.unwrap().expect("the part is claimable");
+        let _ = store.defer_part_missing_source(&p, 1).await;
     }
 
     #[sqlx::test]

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -410,6 +410,36 @@ impl Store {
         Ok(u64::try_from(count).unwrap_or(0))
     }
 
+    /// The age in whole seconds of `node`'s oldest `pending` replication row, or 0 when none
+    /// — the per-node starvation signal that would have caught 2026-07-26 at ~03:40: one
+    /// node's oldest pending age past 30min while its peers sat near zero (a part landed
+    /// 03:48 sat unclaimed 3.5h, diagnosable only by hand-written SQL at the time).
+    ///
+    /// `pending` ONLY — a `draining` row is being worked, so the signal is specifically
+    /// "claimable-or-backed-off work nobody has finished". Deferred rows are deliberately
+    /// INCLUDED (a backed-off row is still `pending`): an in-progress/abandoned-MPU wall
+    /// aging past hours is exactly what the operator must see.
+    ///
+    /// Served index-only by `cephor_replication_status_pending` (0006: `(node_id, landed_at)
+    /// WHERE status = 'pending'`) — the min is the first entry under the node prefix.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Database`] if the query fails.
+    pub async fn node_oldest_pending_age_secs(&self, node: &str) -> Result<u64> {
+        let (secs,): (i64,) = sqlx::query_as(
+            "SELECT COALESCE(EXTRACT(EPOCH FROM (now() - min(landed_at)))::bigint, 0) \
+             FROM cephor_replication_status \
+             WHERE node_id = $1 AND status = 'pending'",
+        )
+        .bind(node)
+        .fetch_one(&self.pool)
+        .await?;
+        // Clock skew could put min(landed_at) marginally in the future; clamp to 0 rather
+        // than wrap into an absurd u64 age.
+        Ok(u64::try_from(secs).unwrap_or(0))
+    }
+
     /// R4 re-drive: reset this node's `corrupt` parts back to `pending` for a fresh SSD->pool
     /// copy (overwriting the corrupt pool copy from the intact SSD source), bounded by
     /// `max_attempts`. Only rows still under the cap are reset; each reset bumps
@@ -1760,6 +1790,62 @@ mod part_tests {
         assert_eq!(store.node_undrained_count("node-b").await?, 1, "counts only this node's rows");
         assert_eq!(store.node_undrained_count("node-c").await?, 0, "a node with no rows is idle");
         Ok(())
+    }
+
+    /// Backdates a status row's `landed_at` by `secs`, to age it for the starvation gauge.
+    async fn backdate_landed(pool: &PgPool, object: &str, version: i64, number: i64, secs: i64) {
+        sqlx::query(
+            "UPDATE cephor_replication_status SET landed_at = now() - (interval '1 second' * $4) \
+             WHERE object_id = $1 AND version = $2 AND part_number = $3",
+        )
+        .bind(object)
+        .bind(version)
+        .bind(number)
+        .bind(secs)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[sqlx::test]
+    async fn node_oldest_pending_age_secs_is_the_age_of_the_oldest_pending_row_only(pool: PgPool) {
+        let store = Store::from_pool(pool.clone());
+        assert_eq!(
+            store.node_oldest_pending_age_secs("node-a").await.unwrap(),
+            0,
+            "a node with no pending rows reports zero age, not an error"
+        );
+
+        // node-a: two pending rows, 90s and 300s old — the oldest wins. The 300s row is
+        // ALSO backed off (deferred_until in the future): a deferred row is still
+        // `pending`, and an MPU wall aging past hours is exactly what the gauge must show.
+        seed_status_node(&pool, UUID_A, 1, 1, "pending", "node-a").await;
+        backdate_landed(&pool, UUID_A, 1, 1, 90).await;
+        seed_status_node(&pool, UUID_A, 1, 2, "pending", "node-a").await;
+        backdate_landed(&pool, UUID_A, 1, 2, 300).await;
+        sqlx::query("UPDATE cephor_replication_status SET deferred_until = now() + interval '10 minutes' WHERE part_number = 2")
+            .execute(&pool)
+            .await
+            .unwrap();
+        // Far older draining/replicated/failed rows: a draining row is being worked and
+        // terminal rows are done — none is starving claimable work, so none counts.
+        seed_status_node(&pool, UUID_A, 1, 3, "draining", "node-a").await;
+        backdate_landed(&pool, UUID_A, 1, 3, 9_000).await;
+        seed_status_node(&pool, UUID_A, 1, 4, "replicated", "node-a").await;
+        backdate_landed(&pool, UUID_A, 1, 4, 9_000).await;
+        seed_status_node(&pool, UUID_A, 1, 5, "failed", "node-a").await;
+        backdate_landed(&pool, UUID_A, 1, 5, 9_000).await;
+        // A peer node's even older pending row is that node's starvation, not this one's.
+        seed_status_node(&pool, UUID_B, 2, 1, "pending", "node-b").await;
+        backdate_landed(&pool, UUID_B, 2, 1, 9_000).await;
+
+        let age = store.node_oldest_pending_age_secs("node-a").await.unwrap();
+        assert!(
+            (300..330).contains(&age),
+            "the oldest pending row (deferred, 300s) wins over the younger one and the non-pending rows, got {age}"
+        );
+        let peer = store.node_oldest_pending_age_secs("node-b").await.unwrap();
+        assert!(peer >= 9_000, "the peer's pending age is scoped to the peer, got {peer}");
     }
 
     #[sqlx::test]

--- a/crates/hippius-drain-core/tests/it/enforcer.rs
+++ b/crates/hippius-drain-core/tests/it/enforcer.rs
@@ -18,6 +18,7 @@ fn label(decision: DrainDecision) -> String {
         DrainDecision::Allowed => "ALLOW".to_owned(),
         DrainDecision::Denied(DenyReason::BreakerOpen) => "DENY (breaker open)".to_owned(),
         DrainDecision::Denied(DenyReason::RateLimited) => "DENY (rate limited)".to_owned(),
+        DrainDecision::Denied(DenyReason::OverdraftOutstanding) => "DENY (overdraft outstanding)".to_owned(),
         DrainDecision::Denied(DenyReason::AtConcurrencyLimit) => "DENY (at concurrency limit)".to_owned(),
     }
 }

--- a/docs/plans/2026-07-26-drain-head-of-line-starvation-fix.md
+++ b/docs/plans/2026-07-26-drain-head-of-line-starvation-fix.md
@@ -433,6 +433,19 @@ incident** — it must fail on `main` and pass on the branch (verify both).
 soak (watch `drain_pending_oldest_age_seconds`, per-node replicated/hour via the diagnosis query in
 the hippius-mem note) → `k8s-production`. Do not push or open the PR without the user's go-ahead.
 
+**Rollout notes:**
+
+- **Deploy the allocator before the agent DaemonSet.** The allocator is the sole `migrate()` caller
+  (`crates/hippius-drain-allocator/src/main.rs:54`), so migrations 0014/0015 apply only when it rolls.
+  An agent from this branch against the pre-0014 schema errors on every `defer_part` /
+  `defer_part_missing_source` (missing `defer_attempts` / `missing_source_attempts` columns); it
+  degrades safely via claim-lease recovery rather than losing data, but is noisy and cannot back
+  off a not-ready part until the columns exist.
+- **The `drain_pending_oldest_age_seconds` alert must pair its threshold with an absence/staleness
+  check** (e.g. `absent(...)` or `... unless timestamp(...) < time() - <staleness>`): an agent
+  restarting during a DB blip briefly serves 0 for the gauge, so a threshold-only rule reads a
+  live starvation as recovered exactly when the node is least healthy.
+
 **Step 4:** After prod soak, `mcp__hippius-mem__remember` the deploy outcome and link it to
 `mem_01KYEMV313BBPJ7GDKQ3WAEVP9`; mark the fix-directions paragraph there as implemented via
 `mcp__hippius-mem__edit`.

--- a/docs/plans/2026-07-26-drain-head-of-line-starvation-fix.md
+++ b/docs/plans/2026-07-26-drain-head-of-line-starvation-fix.md
@@ -313,12 +313,12 @@ if an end-to-end drain-cycle harness exists there — check `tests/it/main.rs` f
 
 **Step 3: Implement**
 
-- Change `drain_next` to return `Result<DrainStep, DrainCycleError>` with
+- Change `drain_next` to return `Result<ClaimOutcome, DrainCycleError>` with
 
 ```rust
 /// One claim-slot outcome, distinguishing part-specific skips (keep claiming)
 /// from node-global stops (budget spent / breaker open / backlog empty).
-pub enum DrainStep {
+pub enum ClaimOutcome {
     Drained(DrainOutcome),
     /// This part cannot proceed right now but others can: it was deferred
     /// (backoff) and the burst must keep refilling.

--- a/docs/plans/2026-07-26-drain-head-of-line-starvation-fix.md
+++ b/docs/plans/2026-07-26-drain-head-of-line-starvation-fix.md
@@ -1,0 +1,438 @@
+# Drain Head-of-Line Starvation Fix — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> Before the first Rust edit, load the `rust-style` skill (mandatory per global standards).
+> Call `mcp__hippius-mem__recall` with "drain head-of-line starvation" before starting — the incident
+> anatomy is in note `mem_01KYEMV313BBPJ7GDKQ3WAEVP9`.
+
+**Goal:** Make the drain agent immune to the head-of-line starvation class that collapsed node1/node5
+drain throughput on 2026-07-26 (incomplete-MPU part walls + oversized-part denial churn), so no single
+workload can starve replication of everything behind it.
+
+**Architecture:** Four independent mechanism fixes in the drain crates plus one wake hook in the Python
+API: (1) exponential per-row defer backoff (new `defer_attempts` column) so not-ready parts leave the
+claim hot path geometrically; (2) debt-carrying token-bucket overdraft so parts larger than the burst
+are guaranteed to drain at the budgeted rate instead of waiting for a bucket that is never full;
+(3) burst semantics split into part-specific vs node-global outcomes so one unprocessable part no longer
+stops the whole claim burst; (4) terminal `failed` state for parts whose SSD source is permanently gone.
+The API clears backoffs on CompleteMultipartUpload so finished MPUs drain immediately.
+
+**Tech Stack:** Rust (sqlx/tokio) in `crates/hippius-drain-core` + `crates/hippius-drain-agent`;
+one sqlx migration; one small Python change in `hippius_s3`; Prometheus gauge + follow-up alert rule
+in `thenervelab/hippius-otel`.
+
+---
+
+## Incident summary (why each fix exists)
+
+Verified on prod 2026-07-26 (full anatomy in hippius-mem `mem_01KYEMV313BBPJ7GDKQ3WAEVP9`):
+
+- Five in-progress ~100 GB MPUs (`beam-dev/destination/backup/100gbdestination1-5`, initiated 03:18,
+  `is_completed=false`) registered hundreds of ~41 MiB parts as `pending`. `claim_part` orders strictly
+  `ORDER BY landed_at`; each part hit the "upload enqueue not ready" benign deferral with a fixed
+  **5-second** backoff (`DEFAULT_DEFER_BACKOFF`, [store.rs:183](../../crates/hippius-drain-core/src/store.rs)),
+  so the whole wall re-entered the claimable head every 5s and consumed the 16 claim slots.
+- Two 2 GiB single-part uploads hit the oversized-part path in `try_drain`
+  ([enforce.rs:368-392](../../crates/hippius-drain-core/src/enforce.rs)): the F1 overdraft admits only
+  when the bucket is exactly full, which never happens under load → `Denied(RateLimited)` → released
+  with **no backoff** AND the denial returns `Ok(None)` from `drain_next`, which **stops the burst**
+  ([worker.rs](../../crates/hippius-drain-agent/src/worker.rs) `drain_until_empty`, `refill = false`).
+- ~32 rows from 2026-07-22 whose SSD source dirs no longer exist churn claim→defer forever on every node.
+- Net effect: node1 replicated 64 parts/hour vs 13,396/hour landing; parts landed after 03:36 were never
+  claimed; backup worker never saw them on the pool; hydrator logged "Missing backup chunk"; uploader
+  DLQ'd `missing_cipher_chunk`.
+
+**Rejected alternative:** not registering in-progress-MPU parts in `cephor_replication_status` until
+CompleteMultipartUpload. Rejected because the reconciler registers from SSD directory scans and has no
+cheap MPU-state source, and because exponential backoff fixes the whole *class* of not-ready parts
+(abandoned MPUs, missing addresses, future cases), not just this instance.
+
+## Conventions and guardrails
+
+- Rust: load `rust-style` skill first; `cargo clippy --all-targets --all-features -- -D warnings` and
+  `cargo fmt` must stay clean. Tests are in-file `#[test]`/`#[sqlx::test]` modules following the
+  existing patterns in each file (store.rs has ~47, enforce.rs ~24).
+- Test command (matches CI, [test-and-lint.yml:262](../../.github/workflows/test-and-lint.yml)):
+  ```bash
+  DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres \
+  CEPHOR_TEST_REDIS_URL=redis://localhost:6379/0 \
+  cargo test --workspace --all-features --locked -- --include-ignored
+  ```
+  Local Postgres/Redis: `docker compose up -d postgres redis` from the repo root. For fast iteration,
+  scope to one crate: `cargo test -p hippius-drain-core`.
+- Python: ruff + mypy strict, line length 120, no defensive try/except except narrowly justified.
+- Commits: one logical change each, imperative mood, never push without being asked.
+- Rollout: `staging` branch → staging soak → `k8s-production` (repo rule; the migration is additive so
+  old agents keep working mid-rollout).
+
+---
+
+### Task 0: Worktree + baseline
+
+**Step 1:** Create an isolated worktree (use superpowers:using-git-worktrees), branch
+`fix/drain-head-of-line-starvation` off `main`.
+
+**Step 2:** Run the baseline crate tests and record the result (must be green before any edit):
+
+```bash
+docker compose up -d postgres redis
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres \
+CEPHOR_TEST_REDIS_URL=redis://localhost:6379/0 \
+cargo test -p hippius-drain-core -p hippius-drain-agent --all-features -- --include-ignored
+```
+
+Expected: all pass (some Redis-dependent tests may be `ignored` if Redis is absent — that's fine, note it).
+
+---
+
+### Task 1: Migration — `defer_attempts` column
+
+**Files:**
+- Create: `crates/hippius-drain-core/migrations/0014_replication_defer_attempts.sql`
+
+**Step 1: Write the migration**
+
+```sql
+-- Exponential defer backoff needs a per-row attempt counter: a part that keeps
+-- deferring (in-progress MPU, missing address, vanished source) must back off
+-- geometrically instead of re-entering the claim head every fixed interval
+-- (the 2026-07-26 head-of-line starvation incident).
+ALTER TABLE cephor_replication_status
+    ADD COLUMN defer_attempts INTEGER NOT NULL DEFAULT 0;
+```
+
+**Step 2: Verify sqlx picks it up**
+
+Run: `cargo test -p hippius-drain-core` (the `#[sqlx::test]` harness applies migrations).
+Expected: PASS (no behavior change yet).
+
+**Step 3: Commit** — `feat(drain): add defer_attempts column for exponential backoff`
+
+---
+
+### Task 2: Exponential defer backoff in `defer_part`
+
+**Files:**
+- Modify: `crates/hippius-drain-core/src/store.rs` (`defer_part`, `DEFAULT_DEFER_BACKOFF` area,
+  `Store` builder)
+- Modify: `crates/hippius-drain-agent/src/config.rs` (new `CEPHOR_DEFER_BACKOFF_CAP_SECS`)
+- Modify: `crates/hippius-drain-agent/src/main.rs` (wire the cap via a new `with_defer_backoff_cap`)
+
+**Step 1: Write the failing tests** (in `store.rs` tests module, following the existing
+`#[sqlx::test]` style there):
+
+```rust
+#[sqlx::test(migrator = "MIGRATOR")]
+async fn defer_part_backs_off_exponentially(pool: PgPool) {
+    // base 5s: attempt 0 defers ~5s, attempt 1 ~10s, attempt 2 ~20s.
+    let store = test_store(pool, "node-a").with_defer_backoff(Duration::from_secs(5));
+    let part = landed_part(&store).await; // helper: record_landed_part + claim_part
+    for expected_min in [5i64, 10, 20] {
+        store.defer_part(part.part()).await.unwrap();
+        let (deferred_until, attempts) = defer_state(&store, part.part()).await;
+        let delta = (deferred_until - now(&store).await).num_seconds();
+        assert!(delta >= expected_min - 1 && delta <= expected_min + 1, "attempt backoff {delta} != ~{expected_min}");
+        reclaim_after_clearing_backoff(&store, part.part()).await; // set deferred_until = now(), claim again
+    }
+}
+
+#[sqlx::test(migrator = "MIGRATOR")]
+async fn defer_backoff_is_capped(pool: PgPool) {
+    // With attempts pre-set to 30, the deferral must not exceed the cap.
+    let store = test_store(pool, "node-a")
+        .with_defer_backoff(Duration::from_secs(5))
+        .with_defer_backoff_cap(Duration::from_secs(600));
+    // ... seed defer_attempts = 30 directly, defer, assert delta <= 600 + 1
+}
+
+#[sqlx::test(migrator = "MIGRATOR")]
+async fn release_part_preserves_defer_attempts(pool: PgPool) {
+    // A transient Ceph-failure release must not reset the not-ready escalation.
+}
+```
+
+(Write the small helpers — `defer_state`, `reclaim_after_clearing_backoff` — inside the test module;
+mirror the existing test helpers in that file rather than inventing new patterns.)
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p hippius-drain-core defer_part_backs_off` — expected FAIL
+(`with_defer_backoff_cap` not defined / backoff constant).
+
+**Step 3: Implement**
+
+In `store.rs`:
+- Add `defer_backoff_cap: Duration` to `Store` (default `DEFAULT_DEFER_BACKOFF_CAP: Duration =
+  Duration::from_secs(600)`) + `with_defer_backoff_cap` builder next to `with_defer_backoff`
+  (store.rs:241-245).
+- Change the `defer_part` UPDATE to compute the backoff in SQL and bump the counter:
+
+```sql
+UPDATE cephor_replication_status
+SET status = 'pending', updated_at = now(), claimed_at = NULL,
+    defer_attempts = defer_attempts + 1,
+    deferred_until = now() + LEAST($4 * power(2, LEAST(defer_attempts, 16)), $5) * interval '1 second'
+WHERE object_id = $1 AND version = $2 AND part_number = $3 AND status = 'draining'
+```
+
+with `$4 = defer_backoff.as_secs_f64()`, `$5 = defer_backoff_cap.as_secs_f64()`. The `LEAST(…, 16)`
+exponent clamp prevents `power` overflow; the outer `LEAST` enforces the cap.
+
+In `config.rs` / `main.rs`: read `CEPHOR_DEFER_BACKOFF_CAP_SECS` (default 600) with the existing
+`duration_secs` helper (config.rs:302 pattern) and wire `with_defer_backoff_cap`.
+
+Doc-comment the *why* on `defer_part`: fixed backoff let an MPU part wall re-enter the claim head
+every interval and starve younger parts (2026-07-26).
+
+**Step 4: Run tests** — `cargo test -p hippius-drain-core` — expected PASS, zero clippy warnings.
+
+**Step 5: Commit** — `fix(drain): exponential defer backoff — not-ready parts leave the claim head`
+
+---
+
+### Task 3: Reset backoff on CompleteMultipartUpload (Python wake)
+
+Without this, a legitimately completed 100 GB MPU could wait up to the backoff cap (10 min) before its
+parts start draining — unacceptable for the cross-node read path.
+
+**Files:**
+- Modify: `hippius_s3/api/s3/multipart.py` (the CompleteMultipartUpload handler — **verify the exact
+  function first**: `rg -n "complete" hippius_s3/api/s3/multipart.py`)
+- Create: `hippius_s3/sql/queries/` entry if the repo pattern demands file-based SQL (check
+  neighboring queries; otherwise inline via the repository layer used by the handler)
+- Test: `tests/unit/test_mpu_complete_drain_wake.py`
+
+**Step 1: Write the failing test** — behavior: after the complete handler succeeds, an UPDATE ran:
+
+```python
+async def test_complete_mpu_clears_drain_backoff(mock_db):
+    # Arrange a completed MPU flow with mocked db; assert the executed SQL set
+    # includes the cephor_replication_status wake for (object_id, version).
+```
+
+Mock only the DB boundary (repo testing rule). Assert on the query + params, not internals.
+
+**Step 2: Run** — `pytest tests/unit/test_mpu_complete_drain_wake.py -xvs` — expected FAIL.
+
+**Step 3: Implement** — after the MPU-complete transaction commits, run:
+
+```sql
+UPDATE cephor_replication_status
+SET deferred_until = NULL, defer_attempts = 0, updated_at = now()
+WHERE object_id = $1 AND version = $2 AND status = 'pending'
+```
+
+Best-effort: a failure here must not fail an already-committed complete (narrow, justified exception
+to the no-try/except rule — log at WARNING). Comment the why: parts of an in-progress MPU sit in
+exponential defer backoff; completion is the wake signal.
+
+**Step 4: Run** — test passes; `ruff check . && mypy hippius_s3` clean.
+
+**Step 5: Commit** — `fix(mpu): wake drain backoff on CompleteMultipartUpload`
+
+---
+
+### Task 4: Debt-carrying overdraft in `TokenBucket`
+
+**Files:**
+- Modify: `crates/hippius-drain-core/src/enforce.rs` (`TokenBucket` at :137, `try_drain` at :368,
+  `DenyReason` at :275)
+
+**Step 1: Write the failing tests** (in enforce.rs tests module, same style as
+`bucket_credits_fractional_tokens_across_small_refills`):
+
+```rust
+#[test]
+fn oversized_part_admits_via_debt_and_blocks_next_overdraft() {
+    // burst 100, rate 100/s. A 250-byte part admits immediately when debt == 0:
+    // tokens drop to 0 and debt = 150. A second oversized part is denied while
+    // debt > 0. After 1.5s of refill the debt is paid and tokens grow again.
+}
+
+#[test]
+fn refund_pays_debt_before_crediting_tokens() {
+    // After an overdraft admission charged 250, refund(250) must zero the debt
+    // and restore tokens — the state as if the admission never happened.
+}
+
+#[test]
+fn normal_take_is_denied_while_debt_outstanding() {}
+```
+
+**Step 2: Run** — `cargo test -p hippius-drain-core enforce` — expected FAIL.
+
+**Step 3: Implement**
+
+- `TokenBucket`: add `debt: u64`. In `refill()` (enforce.rs:183-190): newly minted tokens pay `debt`
+  first, remainder credits `tokens` (still capped at burst). New method:
+
+```rust
+/// Admits a part larger than the burst by taking everything available now and
+/// carrying the remainder as debt the refill pays off before any new tokens mint.
+/// One overdraft at a time: denied while debt is outstanding. This guarantees an
+/// oversized part drains at the budgeted rate; the prior full-bucket-only overdraft
+/// never fired under continuous load (2026-07-26: two 2 GiB parts churned the claim
+/// head for 4h), while long-run throughput stays <= rate because the debt suppresses
+/// exactly `bytes` of future admissions.
+pub fn try_take_overdraft(&mut self, bytes: u64, now: Instant) -> bool
+```
+
+- `refund(bytes)`: pay down `debt` first, then credit tokens (mirror of the charge).
+- `try_drain`: replace the full-bucket overdraft branch (:382) with `try_take_overdraft`; when it
+  fails because debt is outstanding return `Denied(DenyReason::OverdraftOutstanding)` — **new
+  variant** on `DenyReason` (doc: part-specific wait, not node-global exhaustion; the worker defers
+  the part instead of stopping the burst).
+- `charged` bookkeeping for the concurrency-deny refund path stays `bytes` for the overdraft case.
+
+**Step 4: Run** — enforce tests + full crate: PASS, clippy clean. Check the existing overdraft test
+(`a part larger than the burst…` around the F1 fix) — update its expectations to the debt semantics
+and rename it to describe the new behavior.
+
+**Step 5: Commit** — `fix(drain): debt-carrying overdraft guarantees oversized parts drain at budget rate`
+
+---
+
+### Task 5: Burst semantics — part-specific outcomes don't stop the burst
+
+**Files:**
+- Modify: `crates/hippius-drain-agent/src/worker.rs` (`drain_next`, `drain_until_empty`)
+
+**Step 1: Write the failing tests** (worker.rs test module + `crates/hippius-drain-core/tests/it/`
+if an end-to-end drain-cycle harness exists there — check `tests/it/main.rs` for the pattern):
+
+```rust
+// 1. A part denied OverdraftOutstanding is deferred (deferred_until set, backoff)
+//    and the burst continues draining the parts behind it.
+// 2. A part whose SSD source stat fails with NotFound is deferred and the burst
+//    continues (was: released with no backoff + burst stop).
+// 3. BreakerOpen / RateLimited / AtConcurrencyLimit still stop the burst (idle),
+//    and the claimed part is released promptly (unchanged global semantics).
+```
+
+**Step 2: Run** — expected FAIL (no way to express "skip and continue" today).
+
+**Step 3: Implement**
+
+- Change `drain_next` to return `Result<DrainStep, DrainCycleError>` with
+
+```rust
+/// One claim-slot outcome, distinguishing part-specific skips (keep claiming)
+/// from node-global stops (budget spent / breaker open / backlog empty).
+pub enum DrainStep {
+    Drained(DrainOutcome),
+    /// This part cannot proceed right now but others can: it was deferred
+    /// (backoff) and the burst must keep refilling.
+    Skipped,
+    /// Nothing claimable, or a node-global denial: stop refilling this burst.
+    Idle,
+}
+```
+
+- Mapping inside `drain_next`:
+  - claim returns `None` → `Idle`.
+  - `part_size` stat failure: if the underlying io error is `NotFound` → `store.defer_part` +
+    `Skipped` (Task 6 adds the terminal escalation); any other io error → release + `Idle`
+    (genuine transient node I/O trouble — backing the whole node off briefly is right).
+  - `Denied(OverdraftOutstanding)` → `store.defer_part` + `Skipped` + `snapshot.record_throttled(1)`.
+  - `Denied(BreakerOpen | RateLimited | AtConcurrencyLimit)` → release + `Idle` (unchanged).
+  - benign-deferral drain errors keep their current Err path (already continues).
+- `drain_until_empty`: `Drained` → count + refill; `Skipped` → refill (do NOT count as drained);
+  `Idle` → `refill = false`. Preserve the existing in-flight wind-down and cancellation semantics
+  exactly (the doc comment block on that function is the contract — update it).
+
+**Step 4: Run** — worker + core tests PASS; clippy clean.
+
+**Step 5: Commit** — `fix(drain): part-specific denials defer and skip instead of stopping the burst`
+
+---
+
+### Task 6: Terminal state for permanently missing SSD sources
+
+**Files:**
+- Modify: `crates/hippius-drain-core/src/store.rs` (expose `defer_attempts` on `ClaimedPart`;
+  new `mark_failed_missing_source`)
+- Modify: `crates/hippius-drain-agent/src/worker.rs` (escalation in the stat-`NotFound` path)
+
+**Step 1: Write the failing tests**
+
+```rust
+// store.rs: mark_failed_missing_source moves a draining row to 'failed' and is a
+// no-op if the row already advanced (same guard pattern as release_part).
+// worker.rs: with defer_attempts >= MISSING_SOURCE_FAIL_ATTEMPTS (const 20) and a
+// NotFound stat, the part transitions to failed (WARN logged) and the burst continues;
+// below the threshold it defers as in Task 5.
+```
+
+**Step 2: Run** — expected FAIL.
+
+**Step 3: Implement**
+
+- `claim_part` RETURNING gains `defer_attempts`; thread it through `ClaimedPart`.
+- `mark_failed_missing_source(part)`: `UPDATE … SET status='failed', updated_at=now() WHERE … AND
+  status='draining'`. Doc: the reconciler only re-registers parts that exist on SSD, so a row whose
+  source is gone can never drain — after N observed-missing claims it must leave the claim set
+  instead of deferring forever (the 2026-07-22 legacy rows). Guard on `NotFound` only — any other
+  stat error must not burn toward the threshold.
+- Worker: `const MISSING_SOURCE_FAIL_ATTEMPTS: u32 = 20;` — at ~20 exponential defers the row is
+  hours old; a genuinely slow mount does not hit this.
+- WARN log includes object_id/version/part so operators can audit what was written off.
+
+**Step 4: Run** — PASS. Note: the ~32 prod legacy rows will self-heal through this path after deploy
+(no manual cleanup script — verify in staging that a seeded missing-source row converges to `failed`).
+
+**Step 5: Commit** — `fix(drain): fail parts whose SSD source is permanently gone instead of deferring forever`
+
+---
+
+### Task 7: Starvation observability — oldest-pending-age gauge
+
+The incident's earliest unambiguous signal was "oldest pending row age exploding on one node" — make
+it a first-class metric so the alert (follow-up) can page before reads fail.
+
+**Files:**
+- Modify: `crates/hippius-drain-core/src/store.rs` (query), `crates/hippius-drain-core/src/snapshot.rs`
+  (`record_…`), `crates/hippius-drain-agent/src/runtime.rs` (the existing undrained-count tick at
+  :220-236 — same cadence), `crates/hippius-drain-agent/src/metrics.rs` (export)
+
+**Step 1: Failing test** — store query returns the age in seconds of the oldest `pending` row for the
+node (0 when none), exercised via `#[sqlx::test]`; snapshot gauge follows the `record_undrained_count`
+pattern.
+
+**Step 2: Run** — FAIL. **Step 3:** Implement (`drain_pending_oldest_age_seconds` gauge, labelled by
+node like the existing backlog gauges). **Step 4:** Run — PASS, clippy clean.
+
+**Step 5: Commit** — `feat(drain): export oldest-pending-age gauge (starvation signal)`
+
+**Follow-up (cross-repo, separate PR, do NOT do here):** alert rule in `thenervelab/hippius-otel`
+(single source of truth for alerting — plan constraint from
+[2026-07-24-outage-prevention-implementation-plan.md](2026-07-24-outage-prevention-implementation-plan.md)):
+`max(drain_pending_oldest_age_seconds) > 1800`, `for: 15m`. This rule would have fired ~03:40 on
+2026-07-26.
+
+---
+
+### Task 8: Full verification + rollout prep
+
+**Step 1:** Full workspace gate:
+
+```bash
+cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings
+DATABASE_URL=… CEPHOR_TEST_REDIS_URL=… cargo test --workspace --all-features --locked -- --include-ignored
+ruff check . && mypy hippius_s3 && pytest tests/unit -q
+```
+
+All green, zero warnings.
+
+**Step 2:** Scenario test (integration, `crates/hippius-drain-core/tests/it/` or the agent runtime
+test harness — reuse whichever already spins a fake backlog): seed one node with (a) 50 not-ready
+MPU parts landed first, (b) one oversized part, (c) 20 ready parts landed last. Assert all 20 ready
+parts replicate within a bounded number of poll cycles. **This is the regression test for the whole
+incident** — it must fail on `main` and pass on the branch (verify both).
+
+**Step 3:** Use superpowers:requesting-code-review, then merge path per repo rules: PR → `staging` →
+soak (watch `drain_pending_oldest_age_seconds`, per-node replicated/hour via the diagnosis query in
+the hippius-mem note) → `k8s-production`. Do not push or open the PR without the user's go-ahead.
+
+**Step 4:** After prod soak, `mcp__hippius-mem__remember` the deploy outcome and link it to
+`mem_01KYEMV313BBPJ7GDKQ3WAEVP9`; mark the fix-directions paragraph there as implemented via
+`mcp__hippius-mem__edit`.

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -1201,19 +1201,19 @@ async def complete_multipart_upload(
             address=request.state.account.main_account,
         )
 
-        # Drain wake: this version's parts sat in exponential defer backoff (upload enqueue
-        # not ready) while the MPU was in progress; the address write above removes that
-        # cause, so clear the backoff — defer_attempts included, deliberately unlike the
-        # Rust release_part which preserves escalation: the history is about the
-        # unfinalized address and is obsolete once complete. Best-effort (narrow exception
-        # to the no-try/except rule): the complete is already committed, the wake is only
-        # an optimization — the backoff self-heals within the cap — and this handler's
+        # Drain wake: the address write above removes the cause of this version's defer
+        # backoff (rationale, incl. the deliberate defer_attempts reset, lives in
+        # wake_replication_status_for_version.sql). Best-effort (narrow exception to the
+        # no-try/except rule): the complete is already committed, the wake is only an
+        # optimization — the backoff self-heals within the cap — and this handler's
         # outer catch-all would otherwise turn a wake failure into a 500 for a success.
         try:
             await wake_version_replication(db, object_id=object_id, object_version=object_version)
         except Exception:
             logger.warning(
-                "drain wake failed after CompleteMultipartUpload object_id=%s version=%s",
+                "drain wake failed after CompleteMultipartUpload bucket=%s upload_id=%s object_id=%s version=%s",
+                bucket_name,
+                upload_id,
                 object_id,
                 object_version,
                 exc_info=True,

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -34,6 +34,7 @@ from hippius_s3.services.envelope_service import generate_dek
 from hippius_s3.services.envelope_service import wrap_dek
 from hippius_s3.services.kek_service import get_or_create_active_bucket_kek
 from hippius_s3.services.mpu_cleanup import fail_version_replication
+from hippius_s3.services.mpu_cleanup import wake_version_replication
 from hippius_s3.storage_version import require_supported_storage_version
 from hippius_s3.utils import get_query
 from hippius_s3.writer.db import set_object_version_address
@@ -1199,6 +1200,24 @@ async def complete_multipart_upload(
             object_version=int(object_version),
             address=request.state.account.main_account,
         )
+
+        # Drain wake: this version's parts sat in exponential defer backoff (upload enqueue
+        # not ready) while the MPU was in progress; the address write above removes that
+        # cause, so clear the backoff — defer_attempts included, deliberately unlike the
+        # Rust release_part which preserves escalation: the history is about the
+        # unfinalized address and is obsolete once complete. Best-effort (narrow exception
+        # to the no-try/except rule): the complete is already committed, the wake is only
+        # an optimization — the backoff self-heals within the cap — and this handler's
+        # outer catch-all would otherwise turn a wake failure into a 500 for a success.
+        try:
+            await wake_version_replication(db, object_id=object_id, object_version=object_version)
+        except Exception:
+            logger.warning(
+                "drain wake failed after CompleteMultipartUpload object_id=%s version=%s",
+                object_id,
+                object_version,
+                exc_info=True,
+            )
 
         # Create XML response
         xml_bytes = f"""<?xml version="1.0" encoding="UTF-8"?>

--- a/hippius_s3/services/mpu_cleanup.py
+++ b/hippius_s3/services/mpu_cleanup.py
@@ -68,6 +68,21 @@ async def fail_version_replication(db: Any, *, object_id: Any, object_version: i
     )
 
 
+async def wake_version_replication(db: Any, *, object_id: Any, object_version: int) -> None:
+    """Clear drain defer backoff for one completed version's still-'pending' rows.
+
+    The counterpart of ``fail_version_replication``: completion (not abort) is the
+    signal. In-progress-MPU parts defer with exponential backoff because their upload
+    enqueue is not ready until the address lands at complete; clearing the backoff lets
+    the drain claim them on its next poll instead of waiting out up to the cap.
+    """
+    await db.execute(
+        get_query("wake_replication_status_for_version"),
+        str(object_id),
+        int(object_version),
+    )
+
+
 async def reap_abandoned_uploads(db: Any, *, stale_seconds: int, dlq_object_ids: set[str]) -> ReapResult:
     """Auto-abort never-finalized multipart uploads older than ``stale_seconds``.
 

--- a/hippius_s3/services/mpu_cleanup.py
+++ b/hippius_s3/services/mpu_cleanup.py
@@ -1,4 +1,6 @@
-# Terminal cleanup for aborted or abandoned multipart uploads.
+# Terminal cleanup for aborted or abandoned multipart uploads — plus the completion-side
+# counterpart (wake_version_replication), so every Python-side mutation of the drain's
+# cephor_replication_status rows lives in one module.
 #
 # An MPU writes each part to a node-local SSD object cache (the drain's CEPHOR_SSD_ROOT)
 # and the drain records a cephor_replication_status row per part, but

--- a/hippius_s3/sql/queries/wake_replication_status_for_version.sql
+++ b/hippius_s3/sql/queries/wake_replication_status_for_version.sql
@@ -11,7 +11,9 @@
 --
 -- Only 'pending' rows: 'failed' is terminal by design and 'replicated'/'draining' rows are
 -- past the defer gate — resurrecting or touching them here would fight the drain's own
--- state machine.
+-- state machine. Accepted residual race: a part mid-claim that read the address as NULL
+-- just before the write defers once more with its preserved near-cap attempts — bounded
+-- to one extra backoff interval for at most claim-slot-count parts.
 -- Parameters: $1: object_id (text), $2: object_version (bigint)
 UPDATE cephor_replication_status
 SET deferred_until = NULL, defer_attempts = 0, updated_at = now()

--- a/hippius_s3/sql/queries/wake_replication_status_for_version.sql
+++ b/hippius_s3/sql/queries/wake_replication_status_for_version.sql
@@ -1,0 +1,18 @@
+-- Wake one completed version's still-pending replication rows out of drain defer backoff.
+-- Parts of an in-progress MPU cannot finish draining (upload enqueue not ready — the object
+-- address is written only at complete) and accumulate exponential defer backoff, up to the
+-- cap. CompleteMultipartUpload is the wake signal: clearing deferred_until lets the drain
+-- claim the parts on its next poll instead of waiting out up to the full cap.
+--
+-- defer_attempts is reset too — deliberately unlike the drain's release_part (Rust), which
+-- preserves escalation across deferrals. Completion removes the CAUSE of these deferrals
+-- (the unfinalized address), so the escalation history is obsolete; preserving it would
+-- re-escalate a now-healthy part's first transient hiccup straight back toward the cap.
+--
+-- Only 'pending' rows: 'failed' is terminal by design and 'replicated'/'draining' rows are
+-- past the defer gate — resurrecting or touching them here would fight the drain's own
+-- state machine.
+-- Parameters: $1: object_id (text), $2: object_version (bigint)
+UPDATE cephor_replication_status
+SET deferred_until = NULL, defer_attempts = 0, updated_at = now()
+WHERE object_id = $1 AND version = $2 AND status = 'pending'

--- a/k8s/production/drain-agent-daemonset.yaml
+++ b/k8s/production/drain-agent-daemonset.yaml
@@ -164,12 +164,14 @@ spec:
             #   the claim query is a partial-index (node_id, landed_at) WHERE status='pending'
             #   lookup, so 1s polling scans only the small active-pending set, not the ~94M-row
             #   parts table — unconditionally cheap even at prod scale.
-            # CEPHOR_DEFER_BACKOFF_SECS is deliberately left at its 5s code default: a
+            # CEPHOR_DEFER_BACKOFF_SECS is deliberately left at its 5s code default. Since the
+            # 2026-07-26 head-of-line fix it is the BASE of a per-part EXPONENTIAL backoff: a
             # not-yet-drainable part (MPU whose Complete hasn't written object_versions.address,
-            # or a stuck A21 orphan) re-parks for that long, so lowering it to 1s would make those
-            # parts retry the claim 5x more often — pure churn at prod cardinality with the A21
-            # orphan leak unfixed. It only affects the tail (MPU parts already wait for Complete),
-            # not the common simple-PUT case the poll cut covers.
+            # or a stuck A21 orphan) re-parks for base × 2^defer_attempts — 5s, 10s, 20s, … —
+            # capped by CEPHOR_DEFER_BACKOFF_CAP_SECS (code default 600). A chronic wall thus
+            # escalates out of the oldest-first claim head instead of churning it, while still
+            # re-checking within minutes; CompleteMultipartUpload clears the backoff (deferred_until
+            # AND defer_attempts), so a just-completed MPU's parts drain promptly regardless.
             - name: CEPHOR_DRAIN_POLL_SECS
               value: "1"
             # Reconciler scan period (was the 60s code default). The reconciler is the SOLE

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -152,12 +152,14 @@ spec:
             #   the claim query is a partial-index (node_id, landed_at) WHERE status='pending'
             #   lookup, so 1s polling scans only the small active-pending set, not the ~94M-row
             #   parts table — unconditionally cheap even at prod scale.
-            # CEPHOR_DEFER_BACKOFF_SECS is deliberately left at its 5s code default: a
+            # CEPHOR_DEFER_BACKOFF_SECS is deliberately left at its 5s code default. Since the
+            # 2026-07-26 head-of-line fix it is the BASE of a per-part EXPONENTIAL backoff: a
             # not-yet-drainable part (MPU whose Complete hasn't written object_versions.address,
-            # or a stuck A21 orphan) re-parks for that long, so lowering it to 1s would make those
-            # parts retry the claim 5x more often — pure churn at prod cardinality with the A21
-            # orphan leak unfixed. It only affects the tail (MPU parts already wait for Complete),
-            # not the common simple-PUT case the poll cut covers.
+            # or a stuck A21 orphan) re-parks for base × 2^defer_attempts — 5s, 10s, 20s, … —
+            # capped by CEPHOR_DEFER_BACKOFF_CAP_SECS (code default 600). A chronic wall thus
+            # escalates out of the oldest-first claim head instead of churning it, while still
+            # re-checking within minutes; CompleteMultipartUpload clears the backoff (deferred_until
+            # AND defer_attempts), so a just-completed MPU's parts drain promptly regardless.
             - name: CEPHOR_DRAIN_POLL_SECS
               value: "1"
             # Reconciler scan period (was the 60s code default). The reconciler is the SOLE

--- a/tests/unit/test_mpu_complete_drain_wake.py
+++ b/tests/unit/test_mpu_complete_drain_wake.py
@@ -68,7 +68,9 @@ class _FakeDb:
         raise AssertionError(f"unexpected fetch in complete flow: {query!r}")
 
     async def execute(self, query: str, *args: Any) -> None:
-        if self._execute_error is not None:
+        # Fault injection is scoped to the wake UPDATE so a future earlier handler
+        # execute doesn't trip it and fail the flow before the code under test runs.
+        if self._execute_error is not None and "cephor_replication_status" in query:
             raise self._execute_error
         self.executed.append((query, args))
 
@@ -162,9 +164,11 @@ async def test_complete_mpu_clears_drain_backoff(monkeypatch: Any, tmp_path: Any
     wakes = _wake_updates(db)
     assert len(wakes) == 1, f"expected exactly one drain wake, got {db.executed!r}"
     query, params = wakes[0]
-    assert "deferred_until = NULL" in query
-    assert "defer_attempts = 0" in query
-    assert "status = 'pending'" in query, "wake must never resurrect failed/replicated rows"
+    # SQL is loaded from disk; normalize whitespace so a reflow of the file doesn't break us.
+    normalized = " ".join(query.split())
+    assert "deferred_until = NULL" in normalized
+    assert "defer_attempts = 0" in normalized
+    assert "status = 'pending'" in normalized, "wake must never resurrect failed/replicated rows"
     assert params == ("obj-1", _PARTS_VERSION), "wake must target the upload's own parts version, not the pointer"
 
 

--- a/tests/unit/test_mpu_complete_drain_wake.py
+++ b/tests/unit/test_mpu_complete_drain_wake.py
@@ -1,0 +1,184 @@
+"""CompleteMultipartUpload must wake the drain's defer backoff for the completed version.
+
+Parts of an in-progress MPU sit in cephor_replication_status under exponential defer backoff
+(up to the cap) because their upload enqueue is not ready until the object address is written
+at complete. Completion is the wake signal: the handler clears deferred_until/defer_attempts
+for the version's still-'pending' rows so the drain claims them on its next poll instead of
+waiting out the cap. The wake is best-effort — the complete is already committed, so a wake
+failure must not turn a successful completion into a 500.
+
+These drive the real complete_multipart_upload handler with fakes at the DB boundary only
+(handler connection + writer pool), mirroring tests/unit/api/test_multipart_abort_version.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hippius_s3.api.s3 import multipart
+from hippius_s3.cache import FileSystemPartsStore
+
+
+# One uploaded part; the ETag hex prefix must be valid even-length hex for mpu_complete's
+# combined-ETag computation (bytes.fromhex).
+_PART_ROWS = [{"etag": "aabbccdd-1", "part_number": 1, "size_bytes": 100}]
+
+_COMPLETE_XML = (
+    "<CompleteMultipartUpload>"
+    "<Part><PartNumber>1</PartNumber><ETag>&quot;aabbccdd-1&quot;</ETag></Part>"
+    "</CompleteMultipartUpload>"
+).replace("&quot;", '"')
+
+# current_object_version (7) deliberately diverges from the upload's own parts version (3):
+# the wake MUST key on the version the replication rows carry (parts.object_version), not the
+# pointer a later same-key upload may have advanced.
+_POINTER_VERSION = 7
+_PARTS_VERSION = 3
+
+
+class _FakeDb:
+    """The handler's DB connection. Routes fetches by query NAME (multipart.get_query is
+    monkeypatched to identity) and records/faults `execute` — the wake's only surface."""
+
+    def __init__(self, *, execute_error: Exception | None = None) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+        self._execute_error = execute_error
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        if query == "get_multipart_upload":
+            return {
+                "object_id": "obj-1",
+                "object_key": "k",
+                "is_completed": False,
+                "current_object_version": _POINTER_VERSION,
+            }
+        if query == "get_bucket_by_name":
+            return {"bucket_id": "bkt-1"}
+        if query == "get_multipart_version_by_upload":
+            return {"object_version": _PARTS_VERSION}
+        raise AssertionError(f"unexpected fetchrow in complete flow: {query!r}")
+
+    async def fetch(self, query: str, *args: Any) -> list[Any]:
+        if query == "list_parts_for_version":
+            return list(_PART_ROWS)
+        raise AssertionError(f"unexpected fetch in complete flow: {query!r}")
+
+    async def execute(self, query: str, *args: Any) -> None:
+        if self._execute_error is not None:
+            raise self._execute_error
+        self.executed.append((query, args))
+
+
+class _FakeTxn:
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(self, *_exc: Any) -> bool:
+        return False
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    def transaction(self) -> _FakeTxn:
+        return _FakeTxn()
+
+    async def execute(self, query: str, *args: Any) -> None:
+        self.executed.append((query, args))
+
+
+class _FakeAcquire:
+    def __init__(self, conn: _FakeConn) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> _FakeConn:
+        return self._conn
+
+    async def __aexit__(self, *_exc: Any) -> bool:
+        return False
+
+
+class _FakePool:
+    """Writer-side pool surface: mpu_complete gets db_parts passed through (MPU-3), so it
+    never fetches; set_object_version_address runs one pool-level execute."""
+
+    def __init__(self) -> None:
+        self.conn = _FakeConn()
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetch(self, query: str, *_args: Any) -> list[Any]:
+        raise AssertionError(f"db_parts supplied — mpu_complete must not re-read parts: {query!r}")
+
+    async def execute(self, query: str, *args: Any) -> None:
+        self.executed.append((query, args))
+
+    def acquire(self) -> _FakeAcquire:
+        return _FakeAcquire(self.conn)
+
+
+def _fake_request(tmp_path: Any) -> Any:
+    return SimpleNamespace(
+        headers={"Host": "test"},
+        state=SimpleNamespace(account=SimpleNamespace(main_account="5MainAcct")),
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                postgres_pool=_FakePool(),
+                redis_client=object(),
+                fs_store=FileSystemPartsStore(str(tmp_path)),
+            )
+        ),
+    )
+
+
+async def _run_complete(monkeypatch: Any, tmp_path: Any, db: _FakeDb) -> Any:
+    monkeypatch.setattr(multipart, "get_query", lambda name: name)
+
+    async def _body(_request: Any) -> bytes:
+        return _COMPLETE_XML.encode()
+
+    monkeypatch.setattr(multipart, "get_request_body", _body)
+    return await multipart.complete_multipart_upload("b", "k", "up-1", _fake_request(tmp_path), db)
+
+
+def _wake_updates(db: _FakeDb) -> list[tuple[str, tuple[Any, ...]]]:
+    return [(q, a) for q, a in db.executed if "cephor_replication_status" in q]
+
+
+@pytest.mark.asyncio
+async def test_complete_mpu_clears_drain_backoff(monkeypatch: Any, tmp_path: Any) -> None:
+    """After a successful complete, exactly one wake UPDATE ran against the handler's
+    connection, keyed on the upload's OWN parts version — resetting both deferred_until
+    and defer_attempts, and touching only still-'pending' rows."""
+    db = _FakeDb()
+
+    resp = await _run_complete(monkeypatch, tmp_path, db)
+
+    assert resp.status_code == 200
+    wakes = _wake_updates(db)
+    assert len(wakes) == 1, f"expected exactly one drain wake, got {db.executed!r}"
+    query, params = wakes[0]
+    assert "deferred_until = NULL" in query
+    assert "defer_attempts = 0" in query
+    assert "status = 'pending'" in query, "wake must never resurrect failed/replicated rows"
+    assert params == ("obj-1", _PARTS_VERSION), "wake must target the upload's own parts version, not the pointer"
+
+
+@pytest.mark.asyncio
+async def test_wake_failure_does_not_fail_committed_complete(monkeypatch: Any, tmp_path: Any, caplog: Any) -> None:
+    """The complete is already committed when the wake runs: a wake failure must be
+    swallowed (WARNING with object/version context), never surfaced as a 500."""
+    db = _FakeDb(execute_error=RuntimeError("db went away"))
+
+    with caplog.at_level(logging.WARNING, logger="hippius_s3.api.s3.multipart"):
+        resp = await _run_complete(monkeypatch, tmp_path, db)
+
+    assert resp.status_code == 200, "wake failure must not fail the already-committed complete"
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "wake" in r.getMessage()]
+    assert warnings, "wake failure must be logged at WARNING"
+    assert "obj-1" in warnings[0].getMessage()
+    assert str(_PARTS_VERSION) in warnings[0].getMessage()


### PR DESCRIPTION
## Summary

Fixes the 2026-07-26 prod incident where drain throughput on node1/node5 collapsed (64 parts/hour vs 13k/hour landing) because not-ready and oversized parts monopolized the oldest-first claim queue. Five mechanisms, each incident-derived:

- **Exponential defer backoff** (migration 0014, `defer_attempts`): not-ready parts back off base 5s doubling to a 10-min cap (`CEPHOR_DEFER_BACKOFF_CAP_SECS`) instead of re-entering the claim head every 5s.
- **Burst semantics split** (`ClaimOutcome`): part-specific denials (overdraft outstanding, missing SSD source) defer the part and keep the burst claiming; only node-global conditions (breaker, budget, concurrency) stop it.
- **Debt-carrying token-bucket overdraft**: parts larger than the burst are admitted by carrying debt the refill pays first, so they drain at the budgeted rate (the old full-bucket-only overdraft never fired under load). Includes a zero-rate guard, settle-before-`set_rate`, and a monotonic refill clock.
- **Conservative missing-source write-off** (migration 0015, `missing_source_attempts`): a part whose SSD source is gone transitions to terminal `failed` after 20 distinct missing-source observations (~2.3h minimum), counted separately from other deferrals so unrelated backoff history can never fast-track a write-off.
- **MPU-complete drain wake** (Python): CompleteMultipartUpload clears the backoff for the completed version so finished MPUs drain on the next poll instead of waiting out the cap.

Observability: `drain_pending_oldest_age_seconds` gauge (the signal that would have caught the incident at ~03:40) and `drain_parts_written_off_total` counter. An incident-shape regression test (`the_incident_backlog_shape_cannot_starve_the_ready_parts`) fails against the old behavior and passes with the fixes.

## Rollout

- **Deploy the allocator before the agent DaemonSet**: the allocator is the sole `migrate()` caller; an updated agent against a pre-0014 schema errors on every `defer_part` until migrations apply (degrades via claim-lease recovery, but noisily).
- Migrations 0014/0015 are additive; old agents run unchanged against the new schema.
- Follow-up (separate PRs): `hippius-otel` alert rule on `drain_pending_oldest_age_seconds` (pair the threshold with a staleness check), and optional config validation rejecting zero backoff values.

## Test plan

- [x] `cargo test --workspace --all-features --locked -- --include-ignored` — 436 passed
- [x] `pytest tests/unit` — 2152 passed
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `ruff check` — clean
- [ ] Staging soak: watch per-node replicated/hour and `drain_pending_oldest_age_seconds`