### PR TITLE
fix(gateway): raise memory limit 4Gi→8Gi (surge headroom; routine deploys were at 95% of the old ceiling)

### DIFF
--- a/k8s/production/resource-limits.yaml
+++ b/k8s/production/resource-limits.yaml
@@ -8,13 +8,42 @@ spec:
     spec:
       containers:
         - name: gateway
+          # Memory is surge-driven, not a leak. The gateway is a streaming proxy: each
+          # in-flight request is individually bounded, but memory scales with CONCURRENT
+          # streams x buffered bytes, so a request surge costs GB while steady state sits
+          # at 0.4-1.5 GB. Measured 2026-07-26 (container_memory_working_set_bytes, 30s
+          # resolution — a 15min step undersamples these spikes badly and reads ~2.4 GB):
+          #   steady state, 8h+ flat, zero drift ...... 0.56-1.53 GB
+          #   rolling-deploy spike (11:53) ............ 4.10 GB  <- 95.5% of the old 4Gi
+          #   recovery-wave spike (12:19) ............. 4.20 GB  <- OOMKilled, exit 137
+          # Two OOMKills at 12:19 during the #356 recovery wave, then flat again for hours.
+          #
+          # Note the 11:53 number: that spike was the ROLLING DEPLOY itself, not the
+          # incident. Draining one pod shifts its in-flight streams onto the survivors, so
+          # every routine gateway deploy was already running within 4% of the limit. This
+          # is not headroom for one unusual day; the old ceiling was breached by normal ops.
+          #
+          # 8Gi ~= 2x the worst observed spike (the usual rule is p99 + 30-50%, which would
+          # give ~6Gi). Capacity is a non-issue: nodes are 251-377 GB allocatable and the
+          # whole namespace uses ~90 Gi, so 5 x 8Gi is a rounding error.
+          #
+          # Deliberate deviation: the common pattern is memory request == limit (Guaranteed
+          # QoS). Not used here — request==limit would reserve 40 Gi for a fleet that uses
+          # ~5 Gi at rest, and Guaranteed QoS only prevents EVICTION, not container OOMKill,
+          # so it would not have saved these pods. request is set to 3Gi (above the 1.5 GB
+          # steady-state ceiling) purely for scheduler honesty, keeping the pods Burstable.
+          #
+          # This raises the ceiling; it does not bound the cause. The durable fix is a byte
+          # budget with backpressure (Envoy's per_connection_buffer_limit_bytes + watermark
+          # model) rather than a request-count cap — concurrency is the wrong unit when one
+          # request may be a HEAD and the next a 2 GiB GET. Tracked separately.
           resources:
             requests:
               cpu: 500m
-              memory: 2Gi
+              memory: 3Gi
             limits:
               cpu: 2000m
-              memory: 4Gi
+              memory: 8Gi
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Summary

Two gateway pods were **OOMKilled (exit 137)** at 12:19Z during the #356 drain-fix recovery wave. This raises the memory limit **4Gi → 8Gi** and the request **2Gi → 3Gi**. Config-only, one file, zero-downtime (pods roll one at a time).

## It's not a leak — it's surge-driven

The 12-hour trajectory settles it. The previous pod generation sat at **0.56–1.53 GB for 8+ hours with zero drift**, and the current generation settled back to **0.4–1.1 GB** within minutes of the spike and has been flat since. A leak climbs; this doesn't.

Measured on `container_memory_working_set_bytes`. One methodological note: **at a 15-minute step Prometheus reads these peaks as only ~2.4 GB** — you have to drop to 30s resolution to see them, because the pods went from ~2.4 GB to OOM inside a single sample interval.

| | |
|---|---|
| steady state, 8h+, no drift | **0.56–1.53 GB** |
| rolling-deploy spike (11:53) | **4.10 GB** ← 95.5% of the old 4Gi limit |
| recovery-wave spike (12:19) | **4.20 GB** ← OOMKilled |

Confirmed kills: `gateway-…-fdhw2` 4.20 GB @ 12:19:30, `gateway-…-78x2x` 3.83 GB @ 12:18:30, both `reason=OOMKilled exit=137`.

## The number that actually decides this

**The 11:53 spike was the rolling deploy itself, not the incident.** When a rolling update drains one gateway, its in-flight streams shift onto the survivors — so `6xhkz` hit **4.10 GB against a 4.29 GB ceiling (95.5%)** during an entirely routine deploy, with no incident traffic involved.

So this isn't "add headroom for one unusual day". The old limit was already being breached by normal operations and we were getting away with it. That pod also carries the highest historical restart count in the fleet.

## Why memory scales this way

The gateway is a **streaming proxy**: each in-flight request is individually bounded, but total memory scales with *concurrent streams × buffered bytes*. A surge means thousands of concurrent streams each holding chunk-sized buffers plus connection state, so a few hundred concurrent large GETs is legitimately 2–4 GB.

The failure mode is what makes it urgent: an OOMKill **severs every healthy in-flight stream on that pod**, so clients retry, load shifts to the remaining pods, and the surge amplifies itself — the same cascade shape we spent 2026-07-26 unwinding.

## Sizing rationale

8Gi is **~2× the worst observed spike**. The common rule (`p99 + 30–50%`) would give ~6Gi; 8Gi buys margin on a metric we now know is easy to undersample. Capacity is a non-issue — nodes are **251–377 GB allocatable**, the whole namespace uses **~90 Gi**, and *reserved* memory only moves 10Gi → 15Gi fleet-wide (limits aren't reserved).

**Deliberate deviation:** the common pattern is `request == limit` (Guaranteed QoS). Not used here, for two reasons — it would reserve 40 Gi for a fleet that idles at ~5 Gi (the "cluster at 15% utilization" antipattern), and Guaranteed QoS only prevents **eviction, not container OOMKill**, so it would not have saved these pods. `request=3Gi` sits above the 1.5 GB steady-state ceiling purely for scheduler honesty; pods stay Burstable.

## This raises the ceiling; it does not bound the cause

Worth being explicit: 8Gi makes the OOM less likely, it doesn't make memory bounded. The durable fix is a **byte budget with backpressure** — Envoy's model of `per_connection_buffer_limit_bytes` plus high/low watermark callbacks that `readDisable` the source, so memory is bounded by configuration rather than by the OOM killer.

A `--limit-concurrency` cap is a cheap coarse backstop and worth having, but **concurrency is the wrong unit for a streaming proxy**: one request may be a HEAD and the next a 2 GiB GET, so a cap sized for large objects over-sheds small ones and a cap sized for small ones won't prevent the OOM. (Today's data makes the point — 96% of gateway stream warnings were bodyless HEADs.)

If we do add shedding, it needs a **distinct rejection reason** from day one — a shed-503 is indistinguishable in the audit log from a backend-failure 503, and we diagnosed this week's incident *by* 503 volume. Emitting a machine-readable reason (and/or 429 for policy vs 503 for saturation) keeps that signal usable. The existing ±25% `Retry-After` jitter in `fs_pressure.py` is the right precedent to reuse.

## Verification

`kubectl kustomize k8s/production` renders `gateway` with `limits.memory: 8Gi` / `requests.memory: 3Gi`; diff confirmed scoped to the gateway container only — no other component's resources changed.
