### PR TITLE
fix(writer): harden UploadPart failure cleanup against duplicate concurrent uploads

### DIFF
--- a/crates/hippius-drain-agent/src/metrics.rs
+++ b/crates/hippius-drain-agent/src/metrics.rs
@@ -175,6 +175,19 @@ pub fn init(service_name: &'static str, snapshot: &Arc<SnapshotCell>, enforcer: 
             .build(),
     ));
 
+    // Durability page: the subset of write-offs whose version was still SERVABLE (or of
+    // unknown servability) — acknowledged client data declared undrainable. The 2026-07-22/26
+    // incidents left this shape observable only as WARN logs; any increase pages
+    // (`increase(drain_parts_written_off_servable_total[1h]) > 0`). Always <= the total above,
+    // which keeps counting every write-off, servable or not.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_counter("drain_parts_written_off_servable_total")
+            .with_callback(move |observer| observer.observe(snap.load().written_off_servable, &[]))
+            .build(),
+    ));
+
     // Silent-failure alarm: the Ceph breaker (trips at debug-level today) as a 0/1 gauge.
     if let Some(enforcer) = enforcer {
         let enforcer = Arc::clone(enforcer);

--- a/crates/hippius-drain-agent/src/worker.rs
+++ b/crates/hippius-drain-agent/src/worker.rs
@@ -10,8 +10,8 @@ use crate::localfs::{LocalFs, LocalSsd};
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
 use hippius_drain_core::{
-    BreakerSignal, ClaimedPart, DenyReason, DrainDecision, DrainOutcome, Enforcer, MissingSourceOutcome, PartDrainError, PartKey, PartSource,
-    SnapshotCell, Store, StoreError, UploadEnqueuer, breaker_signal_for, drain_part,
+    BreakerSignal, ClaimedPart, DenyReason, DrainDecision, DrainOutcome, Enforcer, MissingSourceOutcome, PartDrainError, PartKey,
+    PartReplicationStore, PartSource, SnapshotCell, Store, StoreError, UploadEnqueuer, breaker_signal_for, drain_part,
 };
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::Instant;
@@ -180,25 +180,76 @@ async fn resolve_missing_source(
             tracing::debug!(observations, "part source missing; part deferred, burst continues");
         }
         MissingSourceOutcome::Failed => {
-            // The only standing metric of a write-off (per-process; the WARN below is the
-            // only per-event trace): `node_undrained_count` excludes `failed` and the
-            // terminal GC deletes the row. Still NOT counted in `failed`/error_bps.
+            // The only standing metric of a write-off (per-process; the log in
+            // `report_write_off` is the only per-event trace): `node_undrained_count`
+            // excludes `failed` and the terminal GC deletes the row. Still NOT counted
+            // in `failed`/error_bps.
             if let Some(snapshot) = snapshot {
                 snapshot.record_written_off(1);
             }
-            tracing::warn!(
-                object_id = %claim.part().object().as_str(),
-                version = claim.part().version().get(),
-                part_number = claim.part().part().get(),
-                observations = MISSING_SOURCE_FAIL_ATTEMPTS,
-                "writing off part: SSD source gone after repeated observations",
-            );
+            report_write_off(store, claim, snapshot).await;
         }
         MissingSourceOutcome::Superseded => {
             tracing::debug!("part source missing but the claim was superseded; nothing recorded");
         }
     }
     Ok(ClaimOutcome::Skipped)
+}
+
+/// Classifies a just-committed write-off by its version's servability, for the signal only.
+///
+/// A write-off of a SERVABLE version is acknowledged client data the drain just declared
+/// undrainable — a durability emergency (the 2026-07-22/26 incidents wrote off 47 servable
+/// versions with only WARNs: hours of silent acknowledged-data loss). An unservable one is
+/// routine abandoned-upload cleanup. The extra `object_versions` read costs one query per
+/// write-off — a rare, terminal event — which is fine.
+///
+/// Infallible by design: the write-off already committed atomically inside
+/// `defer_part_missing_source`, so a failed servability read must not change the cycle's
+/// outcome — it degrades only the signal. On that failure we take the ERROR/counter path
+/// with servability marked UNKNOWN (counted as servable): the alert fires on the counter,
+/// and a page that cannot be ruled out beats silence.
+async fn report_write_off(store: &Store, claim: &ClaimedPart, snapshot: Option<&SnapshotCell>) {
+    let part = claim.part();
+    match store.is_version_servable(part).await {
+        Ok(false) => {
+            tracing::warn!(
+                object_id = %part.object().as_str(),
+                version = part.version().get(),
+                part_number = part.part().get(),
+                observations = MISSING_SOURCE_FAIL_ATTEMPTS,
+                "writing off part: SSD source gone after repeated observations",
+            );
+        }
+        Ok(true) => {
+            if let Some(snapshot) = snapshot {
+                snapshot.record_written_off_servable(1);
+            }
+            tracing::error!(
+                object_id = %part.object().as_str(),
+                version = part.version().get(),
+                part_number = part.part().get(),
+                observations = MISSING_SOURCE_FAIL_ATTEMPTS,
+                "DRAIN_WRITEOFF_SERVABLE: wrote off a part of a SERVABLE version — \
+                 acknowledged data lost from the drain path",
+            );
+        }
+        Err(err) => {
+            if let Some(snapshot) = snapshot {
+                snapshot.record_written_off_servable(1);
+            }
+            tracing::error!(
+                object_id = %part.object().as_str(),
+                version = part.version().get(),
+                part_number = part.part().get(),
+                observations = MISSING_SOURCE_FAIL_ATTEMPTS,
+                error = %err,
+                "DRAIN_WRITEOFF_SERVABLE: wrote off a part but its servability is UNKNOWN \
+                 (classification query failed); counted as servable — a page that cannot \
+                 be ruled out beats silence",
+            );
+        }
+    }
 }
 
 /// Claims one pending part and drains it SSD → pool, gated by `enforcer`.
@@ -926,6 +977,36 @@ mod tests {
         dir
     }
 
+    /// Stands up the `object_versions` table the write-off servability classification
+    /// reads — prod-shaped like the runtime reclaim tests' twin (the drain-core
+    /// migrations are cephor-only). A write-off test WITHOUT this table exercises the
+    /// classification-failure (unknown-servability) path.
+    async fn create_object_versions_table(pool: &PgPool) {
+        sqlx::query(
+            "CREATE TABLE object_versions (object_id uuid NOT NULL, object_version bigint NOT NULL, \
+             address text, size_bytes bigint, md5_hash text, \
+             PRIMARY KEY (object_id, object_version))",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// Seeds one `object_versions` row with explicit servability columns. An abandoned
+    /// upload is `(None, Some(0), Some(""))` (unservable); a live object is any row with
+    /// an address, a real size, or an md5 (servable).
+    async fn seed_object_version(pool: &PgPool, part: &PartKey, address: Option<&str>, size_bytes: Option<i64>, md5: Option<&str>) {
+        sqlx::query("INSERT INTO object_versions (object_id, object_version, address, size_bytes, md5_hash) VALUES ($1::uuid, $2, $3, $4, $5)")
+            .bind(part.object().as_str())
+            .bind(i64::from(part.version().get()))
+            .bind(address)
+            .bind(size_bytes)
+            .bind(md5)
+            .execute(pool)
+            .await
+            .unwrap();
+    }
+
     /// The row's `missing_source_attempts` — the write-off escalation counter.
     async fn missing_source_count(db: &PgPool, part: &PartKey) -> i64 {
         sqlx::query_scalar(
@@ -959,6 +1040,10 @@ mod tests {
 
         let part = part_at(5, 1);
         store.record_landed_part(&part).await.unwrap();
+        // An UNSERVABLE version (the abandoned-upload shape): this write-off is routine
+        // cleanup, so it must stay a WARN and out of the page-worthy servable counter.
+        create_object_versions_table(&db).await;
+        seed_object_version(&db, &part, None, Some(0), Some("")).await;
         // Threshold-1 prior observations: this claim's ENOENT is the deciding one.
         sqlx::query("UPDATE cephor_replication_status SET missing_source_attempts = $1 WHERE object_id = $2")
             .bind(i64::from(super::MISSING_SOURCE_FAIL_ATTEMPTS - 1))
@@ -985,9 +1070,107 @@ mod tests {
             "the write-off is counted in the snapshot — the WARN log and the (GC'd) failed row are not a metric"
         );
         assert_eq!(
+            counts.written_off_servable, 0,
+            "an unservable (abandoned-upload) write-off is routine cleanup, not a durability page",
+        );
+        assert_eq!(
             enforcer.lock().unwrap().try_drain(1, Instant::now()),
             DrainDecision::Allowed,
             "the write-off must not trip the Ceph breaker",
+        );
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn a_servable_versions_write_off_records_the_page_worthy_counter(pool: PgPool) {
+        // The detection gap behind the 2026-07-22/26 incidents: 47 SERVABLE versions —
+        // acknowledged client data — were written off with only WARN logs, hours of
+        // silent data loss. A write-off whose version is still servable must record the
+        // dedicated servable counter (the alert source) ON TOP of the total, and still
+        // skip (the write-off outcome itself is unchanged — the data is already gone).
+        let db = pool.clone();
+        let ssd_dir = mounted_ssd_dir();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = Store::from_pool(pool);
+        let snapshot = SnapshotCell::new();
+        let enforcer = enforcer_with(1_000_000);
+
+        let part = part_at(5, 1);
+        store.record_landed_part(&part).await.unwrap();
+        // A SERVABLE version: address finalized — a live object a GET would serve.
+        create_object_versions_table(&db).await;
+        seed_object_version(&db, &part, Some("addr"), Some(4096), Some("d41d8cd9")).await;
+        sqlx::query("UPDATE cephor_replication_status SET missing_source_attempts = $1 WHERE object_id = $2")
+            .bind(i64::from(super::MISSING_SOURCE_FAIL_ATTEMPTS - 1))
+            .bind(part.object().as_str())
+            .execute(&db)
+            .await
+            .unwrap();
+
+        let step = drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), Some(&snapshot))
+            .await
+            .unwrap();
+        assert_eq!(step, ClaimOutcome::Skipped, "classification changes the signal, never the outcome");
+
+        assert_eq!(
+            status_of(&store, &part).await,
+            Some(ReplicationState::Failed),
+            "the write-off itself is unchanged — the escalation already committed atomically",
+        );
+        let counts = snapshot.load();
+        assert_eq!(counts.written_off, 1, "the total stays the total: every write-off counts in it");
+        assert_eq!(
+            counts.written_off_servable, 1,
+            "a servable version's write-off is acknowledged-data loss — the page-worthy counter must fire",
+        );
+        assert_eq!(counts.error_bps(), 0, "still not a Ceph-write failure");
+    }
+
+    #[sqlx::test(migrations = "../hippius-drain-core/migrations")]
+    async fn a_write_off_with_unknown_servability_pages_conservatively(pool: PgPool) {
+        // The servability read can fail (object_versions missing on a deploy, transient
+        // PG error) AFTER the write-off already committed. The write-off outcome must
+        // not change — but the signal must be the conservative one: a page you cannot
+        // rule out beats silence, so unknown counts as servable. No object_versions
+        // table here: that absence IS the classification failure under test.
+        let db = pool.clone();
+        let ssd_dir = mounted_ssd_dir();
+        let pool_dir = tempfile::tempdir().unwrap();
+        let ssd = LocalSsd::new(ssd_dir.path());
+        let ceph = LocalFs::new(pool_dir.path());
+        let store = Store::from_pool(pool);
+        let snapshot = SnapshotCell::new();
+        let enforcer = enforcer_with(1_000_000);
+
+        let part = part_at(5, 1);
+        store.record_landed_part(&part).await.unwrap();
+        sqlx::query("UPDATE cephor_replication_status SET missing_source_attempts = $1 WHERE object_id = $2")
+            .bind(i64::from(super::MISSING_SOURCE_FAIL_ATTEMPTS - 1))
+            .bind(part.object().as_str())
+            .execute(&db)
+            .await
+            .unwrap();
+
+        let step = drain_next(&ceph, &ssd, &store, &NoopEnqueuer, Some(&enforcer), Some(&snapshot))
+            .await
+            .unwrap();
+        assert_eq!(
+            step,
+            ClaimOutcome::Skipped,
+            "a classification failure must not fail the cycle — the write-off already happened",
+        );
+
+        assert_eq!(
+            status_of(&store, &part).await,
+            Some(ReplicationState::Failed),
+            "the terminal write-off stands regardless of the classification read",
+        );
+        let counts = snapshot.load();
+        assert_eq!(counts.written_off, 1, "the total still counts the write-off");
+        assert_eq!(
+            counts.written_off_servable, 1,
+            "unknown servability counts as servable — the page fires when loss cannot be ruled out",
         );
     }
 

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -116,6 +116,15 @@ pub struct AgentSnapshot {
     /// Kept OUT of [`error_bps`](Self::error_bps) like `deferred`: a write-off is a data
     /// disposition, not a Ceph-write failure.
     pub written_off: u64,
+    /// The subset of [`written_off`](Self::written_off) whose `object_versions` row was
+    /// still SERVABLE (or whose servability could not be determined) at write-off time:
+    /// acknowledged client data the drain just declared undrainable — a durability
+    /// emergency, unlike the routine abandoned-upload write-off. The 2026-07-22/26
+    /// incidents wrote off 47 servable versions with only WARN logs; this counter is the
+    /// page (`increase(drain_parts_written_off_servable_total[1h]) > 0`). The caller
+    /// records the total alongside, so `written_off_servable <= written_off` always.
+    /// Out of [`error_bps`](Self::error_bps) for the same reason as the total.
+    pub written_off_servable: u64,
 }
 
 impl AgentSnapshot {
@@ -157,6 +166,7 @@ pub struct SnapshotCell {
     reclaim_backing_errors: AtomicU64,
     throttled: AtomicU64,
     written_off: AtomicU64,
+    written_off_servable: AtomicU64,
     /// Current SSD backlog (undrained bytes) — a LEVEL, not a monotonic counter, so it
     /// has its own atomic (set, not accumulated) rather than living in [`AgentSnapshot`].
     /// The heartbeat worker writes it (`usage.used_bytes`) each tick; the metrics layer
@@ -283,6 +293,14 @@ impl SnapshotCell {
         self.written_off.fetch_add(n, Ordering::Relaxed);
     }
 
+    /// Records `n` write-offs of parts whose version was still servable (or of unknown
+    /// servability) — the page-worthy subset. Callers record the total alongside so
+    /// `written_off_servable <= written_off` holds (see
+    /// [`AgentSnapshot::written_off_servable`]).
+    pub fn record_written_off_servable(&self, n: u64) {
+        self.written_off_servable.fetch_add(n, Ordering::Relaxed);
+    }
+
     /// Records the current SSD disk saturation in basis points (`0..=10000`). A gauge:
     /// `store`, not add. The heartbeat writes it from the `statvfs` pressure each tick.
     pub fn record_disk_pressure(&self, bps: u16) {
@@ -340,6 +358,7 @@ impl SnapshotCell {
             reclaim_backing_errors: self.reclaim_backing_errors.load(Ordering::Relaxed),
             throttled: self.throttled.load(Ordering::Relaxed),
             written_off: self.written_off.load(Ordering::Relaxed),
+            written_off_servable: self.written_off_servable.load(Ordering::Relaxed),
         }
     }
 }
@@ -458,6 +477,26 @@ mod tests {
     }
 
     #[test]
+    fn servable_write_offs_count_in_both_counters_without_polluting_error_bps() {
+        // Task 4 (2026-07-22/26 incidents): a write-off of a SERVABLE version is
+        // acknowledged-data loss and needs its own alertable counter, while the total
+        // stays the total — the caller records BOTH, so servable ≤ total always holds
+        // and `drain_parts_written_off_total` keeps meaning every write-off. Like
+        // `written_off`, the servable counter is a data disposition, not a Ceph-write
+        // failure, so it stays out of error_bps.
+        let cell = SnapshotCell::new();
+        cell.record_drained(7);
+        cell.record_failed(3);
+        cell.record_written_off(1);
+        cell.record_written_off_servable(1);
+        cell.record_written_off(1);
+        let snap = cell.load();
+        assert_eq!(snap.written_off, 2, "the total counts every write-off, servable or not");
+        assert_eq!(snap.written_off_servable, 1, "only the servable write-off pages");
+        assert_eq!(snap.error_bps(), 3000, "servable write-offs stay out of the Ceph failure rate");
+    }
+
+    #[test]
     fn records_accumulate_per_counter() {
         let cell = SnapshotCell::new();
         cell.record_drained(3);
@@ -477,6 +516,7 @@ mod tests {
                 reclaim_backing_errors: 0,
                 throttled: 9,
                 written_off: 0,
+                written_off_servable: 0,
             },
         );
     }
@@ -542,6 +582,7 @@ mod tests {
             reclaim_backing_errors: 0,
             throttled: 0,
             written_off: 0,
+            written_off_servable: 0,
         };
         assert_eq!(snapshot.error_bps(), 10_000);
     }
@@ -557,6 +598,7 @@ mod tests {
             reclaim_backing_errors: 0,
             throttled: 0,
             written_off: 0,
+            written_off_servable: 0,
         };
         // 3 failed attempts of 10 total attempts = 30%, i.e. 3000 basis points.
         assert_eq!(snapshot.error_bps(), 3000);

--- a/docs/plans/2026-07-26-upload-part-cleanup-race-fix.md
+++ b/docs/plans/2026-07-26-upload-part-cleanup-race-fix.md
@@ -1,0 +1,114 @@
+# UploadPart Cleanup Race Fix — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (or subagent-driven-development) task-by-task.
+> Call `mcp__hippius-mem__recall` with "UploadPart cleanup race data loss" before starting — full forensics in
+> `mem_01KYFXNWZYMHN2X0D299KTCJDX` (supersedes the PR #359 narrative).
+
+**Goal:** A failed or client-cancelled UploadPart/append stream must never destroy data another attempt of the
+same part has already published — closing the race that corrupted `beam-dev/100gbdestination1` v5 (2026-07-26)
+and destroyed 44 `tora-m365` objects (2026-07-22).
+
+**Architecture:** Duplicate PUTs for one `(object_id, object_version, part_number)` share one SSD directory.
+Chunk writes are already safe (atomic tmp+rename; deterministic AES-GCM nonce ⇒ byte-identical files across
+same-upload duplicates). The only destructive ops are directory-level deletes: `_cleanup_partial` (MPU),
+`_cleanup_part` (append), and any delete-old-on-reupload path. The fix removes FS deletion from all
+failure-path cleanups (Redis key cleanup stays), adds a publish-time trim for the shrinking-reupload edge, and
+adds a page-worthy signal when the drain writes off a part of a *servable* version (the detection gap that let
+both incidents run silently).
+
+**Tech Stack:** Python (`hippius_s3/writer/object_writer.py`, `hippius_s3/cache/fs_store.py`), one small Rust
+change (`crates/hippius-drain-agent/src/worker.rs` + core store), pytest + sqlx tests.
+
+---
+
+## Verified facts (do NOT re-derive; re-verify only if the code moved)
+
+- `_cleanup_partial` at [object_writer.py:740](../../hippius_s3/writer/object_writer.py) deletes the whole part
+  dir via `fs_store.delete_part`; append's `_cleanup_part` at ~:1121 does the same for `(object, cov, next_part)`.
+- `fs_store.delete_part` logs "FS: failed to delete part" at [fs_store.py:466](../../hippius_s3/cache/fs_store.py).
+- Nonce derivation is deterministic per (key, bucket, object, part, chunk_index, upload_id)
+  ([crypto_service.py:107-141](../../hippius_s3/services/crypto_service.py)) — same-upload duplicates produce
+  byte-identical ciphertext. Meta.json is written last and is the readiness signal; the drain reconciler only
+  registers meta-complete parts.
+- Simple PUT is NOT affected (each PUT gets a fresh version → no shared dir).
+- Incident signature: `parts.uploaded_at` AFTER `cephor_replication_status.landed_at` + gateway showing
+  duplicate `partNumber` PUTs + api-local "failed to delete part" WARNs milliseconds after the final 200.
+
+## Open questions Task 1 must answer before any edit
+
+1. **Every** `fs_store.delete_part` caller in the upload path (rg it): is there a delete-old-before-write on
+   part re-upload in `mpu_upload_part_stream`? Each caller gets an explicit keep/remove/guard decision.
+2. Drain-side chunk enumeration: does the Rust drain copy **all** `chunk_*.bin` present or exactly
+   `meta.num_chunks`? (crates/hippius-drain-agent localfs `list_chunks` + copy path.) This decides whether the
+   publish-time trim (Task 3) is required for correctness or only hygiene.
+3. Which crypto suite serves storage_version=5 writes in prod — confirm the deterministic-nonce AESGCM variant
+   is the active one (the file also documents a legacy random-nonce suite).
+
+---
+
+### Task 1: Fact verification + failing regression test (the race, reproduced)
+
+**Files:** `tests/unit/test_upload_part_cleanup_race.py` (new)
+
+- Answer the three open questions; record answers in the task report (they gate Tasks 2-3 design details).
+- Write the failing test first: drive `mpu_upload_part_stream` twice concurrently for the same
+  (object, version, part) against a real `FileSystemPartsStore` (tmpdir) with mocked DB/Redis — winner
+  completes (meta + parts row), loser's stream raises mid-write (client disconnect) AFTER the winner published.
+  Assert: meta.json + all chunk files still present, and a follow-up `get_chunk` serves. This MUST fail on
+  current code (loser's `_cleanup_partial` deletes the dir). Mirror the fixture style of the existing writer
+  unit tests (`ls tests/unit | rg -i writer|mpu`).
+- Same-shape test for the append path (`_cleanup_part` after a CAS loser).
+- Commit: `test(writer): reproduce the duplicate-UploadPart cleanup race` (failing tests marked xfail-strict
+  or committed together with Task 2 — follow TDD: see them fail, then fix in Task 2 and flip).
+
+### Task 2: Remove FS deletion from failure-path cleanups
+
+**Files:** `hippius_s3/writer/object_writer.py` (`_cleanup_partial`, `_cleanup_part`, any Task-1-found callers)
+
+- Failure cleanups no longer call `fs_store.delete_part`. They keep: Redis chunk-key cleanup (best-effort,
+  keyed per chunk) and the parts-row delete where the flow already does it (`_delete_part_row` — DB rows are
+  per-attempt-upserted and safe).
+- Why-comment on each site: chunk files are atomic-rename, byte-identical across same-upload duplicates, and
+  invisible to readers/reconciler without meta.json — deleting them is pure hazard (2026-07-26 incident: a
+  cancelled duplicate's cleanup destroyed a completed part's data after the 200). A never-published dir leaks
+  until the SSD GC path handles it — leak beats loss (same doctrine as the drain reclaim).
+- If Task 1 found a delete-old-on-reupload call: replace with the Task 3 publish-time trim (or drop it if the
+  drain is meta-driven; decide from Task 1's answer and document).
+- Run Task 1's tests → green. Full gates: `ruff check`, `ruff format --check`, `pytest tests/unit -q`
+  (~2150 tests), `ty check hippius_s3` (CI's type checker — CLAUDE.md's mypy line is stale).
+- Commit: `fix(writer): failed upload streams no longer delete shared part data`
+
+### Task 3: Publish-time trim (only if Task 1 says the drain enumerates all files)
+
+**Files:** `hippius_s3/writer/object_writer.py` (meta-write site), `hippius_s3/cache/fs_store.py` if a helper
+is needed.
+
+- After writing meta with `num_chunks=N`, delete chunk files with index >= N (the shrinking different-content
+  reupload edge). Skip entirely (with a doc note) if the drain/read path is meta-driven — YAGNI.
+- Tests: reupload-with-fewer-chunks leaves exactly N chunks + meta; concurrent identical attempt racing the
+  trim loses nothing (indices < N never trimmed).
+- Commit: `fix(writer): trim stale chunk tail at publish instead of pre-delete`
+
+### Task 4: Page-worthy signal for servable write-offs (Rust, small)
+
+**Files:** `crates/hippius-drain-core/src/store.rs`, `crates/hippius-drain-agent/src/worker.rs`,
+`crates/hippius-drain-agent/src/metrics.rs`
+
+- At the missing-source write-off site (`MissingSourceOutcome::Failed` arm): one extra store query —
+  `is_version_servable(object, version)` (reuse the existing servability predicate helper if present from the
+  mark path; check what #359 left — `is_version_servable` was explicitly kept). Servable → log ERROR (not WARN)
+  with a distinct marker (`DRAIN_WRITEOFF_SERVABLE`) + new counter `drain_parts_written_off_servable_total`.
+  Unservable → current WARN path unchanged. One query per write-off (rare) — no hot-path cost.
+- Tests: sqlx test for the servability query; worker test asserting ERROR-path counter on a servable version
+  and the plain path on an unservable one.
+- Commit: `feat(drain): servable write-offs log ERROR + dedicated counter`
+- Follow-up note (do NOT do here): hippius-otel rule `increase(drain_parts_written_off_servable_total[1h]) > 0`
+  — would have caught both incidents within ~2.5h.
+
+### Task 5: Full gates + wrap-up
+
+- Full workspace: cargo fmt/clippy/test (drain crates), ruff + pytest tests/unit, the Task 1 race tests.
+- Verify no interaction with PR #359's reclaim change (it holds failed row-present parts; our leaked meta-less
+  dirs have NO cephor row + present ov row → held post-#359: confirm the leak lifecycle is documented in both
+  places and the ov-row-cleanup follow-up is filed in todo.md or an issue).
+- Update `mem_01KYFXNWZYMHN2X0D299KTCJDX` with the fix landing; rollout: staging first per repo rules.

--- a/hippius_s3/cache/fs_store.py
+++ b/hippius_s3/cache/fs_store.py
@@ -356,6 +356,92 @@ class FileSystemPartsStore:
             logger.error(f"FS meta write failed: object_id={object_id} v={object_version} part={part_number}: {e}")
             raise
 
+    async def trim_chunks_from(self, object_id: str, object_version: int, part_number: int, first_index: int) -> int:
+        """Delete chunk files with index >= first_index; the publish-time exact-set trim.
+
+        Called right after meta.json lands with num_chunks == first_index. The drain
+        replicates a part only when the SSD chunk set is EXACTLY {0..num_chunks-1}
+        (partdrain.rs completeness gate → IncompleteSource); a stale tail left by a
+        larger earlier attempt would strand the part forever — never replicated, never
+        evicted. Never touches meta.json or chunks below first_index.
+
+        Per-file failures are logged at ERROR — a surviving tail IS the stranded-part
+        risk and operators must see it — but never raised: the upload itself is durable
+        on SSD and the client's success must not hinge on tail cleanup.
+
+        Returns:
+            Number of chunk files removed.
+        """
+        part_dir = Path(self.part_path(object_id, object_version, part_number))
+
+        def _trim() -> int:
+            removed = 0
+            try:
+                entries = list(part_dir.iterdir())
+            except FileNotFoundError:
+                return 0
+            except OSError as e:
+                # Same loudness as a per-file failure: an unscannable dir may hide a tail.
+                logger.error(
+                    f"FS trim failed — could not scan part dir, a stale chunk tail may strand the "
+                    f"part as IncompleteSource in the drain: object_id={object_id} "
+                    f"v={object_version} part={part_number}: {e}"
+                )
+                return 0
+            for entry in entries:
+                name = entry.name
+                if not (name.startswith("chunk_") and name.endswith(".bin")):
+                    continue
+                try:
+                    idx = int(name[len("chunk_") : -len(".bin")])
+                except ValueError:
+                    continue  # tmp files etc. — the janitor's orphan sweep owns those
+                if idx < int(first_index):
+                    continue
+                try:
+                    entry.unlink()
+                    removed += 1
+                except OSError as e:
+                    logger.error(
+                        f"FS trim failed — stale chunk tail survives and the part may strand as "
+                        f"IncompleteSource in the drain: object_id={object_id} v={object_version} "
+                        f"part={part_number} chunk={idx}: {e}"
+                    )
+            return removed
+
+        removed = await asyncio.to_thread(_trim)
+        if removed:
+            logger.debug(
+                f"FS: trimmed {removed} stale chunk(s) >= {first_index}: "
+                f"object_id={object_id} v={object_version} part={part_number}"
+            )
+        return removed
+
+    async def delete_meta(self, object_id: str, object_version: int, part_number: int) -> None:
+        """Delete meta.json only, un-publishing a part dir while keeping its chunks.
+
+        Used by the append CAS-loser cleanup: part-number reservation is FOR-UPDATE
+        serialized, so no live winner shares the loser's dir — removing meta makes the
+        dir invisible to readers and the drain reconciler again (restores meta-last)
+        and stops a future append that reuses the number from inheriting stale
+        readiness over mixed content. Idempotent; failures are logged at ERROR (stale
+        readiness left behind) but not raised — the caller is already propagating the
+        CAS failure.
+        """
+        part_dir = Path(self.part_path(object_id, object_version, part_number))
+        meta_path = self._meta_file(part_dir)
+
+        def _unlink() -> None:
+            meta_path.unlink(missing_ok=True)
+
+        try:
+            await asyncio.to_thread(_unlink)
+        except OSError as e:
+            logger.error(
+                f"FS meta delete failed — part stays published with stale readiness: "
+                f"object_id={object_id} v={object_version} part={part_number}: {e}"
+            )
+
     async def get_meta(self, object_id: str, object_version: int, part_number: int) -> Optional[dict]:
         """Read metadata from filesystem.
 

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -870,6 +870,23 @@ class ObjectWriter:
                 plain_size=int(total_size),
             )
             meta_written = True
+            # Publish-time exact-set trim (covers MPU and append, which materializes its delta
+            # part here). The drain replicates a part only when the SSD chunk set is EXACTLY
+            # {0..num_chunks-1} (partdrain.rs completeness gate → IncompleteSource); a stale tail
+            # from a LARGER earlier attempt would strand the part forever — never replicated,
+            # never evicted. Races, honestly: an identical concurrent duplicate never writes
+            # indices >= our N (same content ⇒ same N), so this only ever deletes another
+            # attempt's bytes when that attempt has DIFFERENT content — and there S3 semantics
+            # are already last-writer-wins for concurrent same-part uploads. Different-content
+            # attempts interleave arbitrarily; whichever publishes last rewrites meta and its
+            # trim enforces its own N, so any transiently mixed (meta, chunk set) state resolves
+            # to the last publisher's. A drain that catches the mid-window mismatch defers once
+            # as IncompleteSource and retries — benign, not permanent, because the settled state
+            # is exact. Trim failures are ERROR-logged inside (stranded-part risk) but never
+            # fail the request: the part itself is durable on SSD.
+            await self.fs_store.trim_chunks_from(
+                str(object_id), int(object_version), int(part_number), int(next_chunk_index)
+            )
         except Exception:
             if not meta_written:
                 await _cleanup_partial()
@@ -1115,12 +1132,16 @@ class ObjectWriter:
             )
 
         async def _cleanup_part(num_chunks: int | None) -> None:
-            # Deliberately NO fs_store.delete_part here. A CAS loser shares (object, cov,
-            # next_part) — and therefore one part dir — with the append that won; chunk files
-            # are atomic-rename + byte-identical across duplicates and invisible to
-            # readers/reconciler until meta.json lands, so deleting the dir from this failure
-            # path can destroy the winner's already-acknowledged data (the 2026-07-22/26
-            # incidents). A never-finalized dir merely leaks until SSD GC; leak beats loss.
+            # This runs ONLY from the finalize-CAS-loser branch, AFTER mpu_upload_part_stream
+            # returned — so the loser's meta.json HAS landed and the dir IS visible to readers
+            # and the drain reconciler, while _delete_part_row is about to remove its parts row.
+            # Part-number reservation is FOR-UPDATE-serialized, so no live winner shares this
+            # dir: deleting ONLY meta.json is safe and un-publishes it (restores the meta-last
+            # invariant), preventing (a) the drain replicating a part with no DB row and (b) a
+            # future append that reuses this part number inheriting stale readiness over mixed
+            # content (nonce-reuse-on-disk for different plaintext). Chunk files stay — failure
+            # paths never delete chunk data (the 2026-07-22/26 incidents); leak beats loss.
+            await self.fs_store.delete_meta(str(object_id), int(cov), int(next_part))
             try:
                 meta_key = self.obj_cache.build_meta_key(str(object_id), int(cov), int(next_part))
                 keys = [meta_key]

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -870,27 +870,29 @@ class ObjectWriter:
                 plain_size=int(total_size),
             )
             meta_written = True
-            # Publish-time exact-set trim (covers MPU and append, which materializes its delta
-            # part here). The drain replicates a part only when the SSD chunk set is EXACTLY
-            # {0..num_chunks-1} (partdrain.rs completeness gate → IncompleteSource); a stale tail
-            # from a LARGER earlier attempt would strand the part forever — never replicated,
-            # never evicted. Races, honestly: an identical concurrent duplicate never writes
-            # indices >= our N (same content ⇒ same N), so this only ever deletes another
-            # attempt's bytes when that attempt has DIFFERENT content — and there S3 semantics
-            # are already last-writer-wins for concurrent same-part uploads. Different-content
-            # attempts interleave arbitrarily; whichever publishes last rewrites meta and its
-            # trim enforces its own N, so any transiently mixed (meta, chunk set) state resolves
-            # to the last publisher's. A drain that catches the mid-window mismatch defers once
-            # as IncompleteSource and retries — benign, not permanent, because the settled state
-            # is exact. Trim failures are ERROR-logged inside (stranded-part risk) but never
-            # fail the request: the part itself is durable on SSD.
-            await self.fs_store.trim_chunks_from(
-                str(object_id), int(object_version), int(part_number), int(next_chunk_index)
-            )
         except Exception:
             if not meta_written:
                 await _cleanup_partial()
             raise
+
+        # Publish-time exact-set trim (covers MPU and append, which materializes its delta
+        # part here). The drain replicates a part only when the SSD chunk set is EXACTLY
+        # {0..num_chunks-1} (partdrain.rs completeness gate → IncompleteSource); a stale tail
+        # from a LARGER earlier attempt would strand the part forever — never replicated,
+        # never evicted. Races, honestly: an identical concurrent duplicate never writes
+        # indices >= our N (same content ⇒ same N), so this only ever deletes another
+        # attempt's bytes when that attempt has DIFFERENT content — and there S3 semantics
+        # are already last-writer-wins for concurrent same-part uploads. Different-content
+        # attempts interleave arbitrarily; whichever publishes last rewrites meta and its
+        # trim enforces its own N, so any transiently mixed (meta, chunk set) state resolves
+        # to the last publisher's. A drain that catches the mid-window mismatch defers once
+        # as IncompleteSource and retries — benign, not permanent, because the settled state
+        # is exact. Trim never raises by contract (failures are ERROR-logged inside —
+        # stranded-part risk — but the part itself is durable on SSD), and it sits outside
+        # the try above so a bug in it can never masquerade as a stream failure.
+        await self.fs_store.trim_chunks_from(
+            str(object_id), int(object_version), int(part_number), int(next_chunk_index)
+        )
 
         perf_stream_total_ms = (time.monotonic() - perf_stream_start) * 1000
         md5_hash = hasher.hexdigest()

--- a/hippius_s3/writer/object_writer.py
+++ b/hippius_s3/writer/object_writer.py
@@ -736,15 +736,13 @@ class ObjectWriter:
         consumer_error: BaseException | None = None
 
         async def _cleanup_partial() -> None:
-            try:
-                await self.fs_store.delete_part(str(object_id), int(object_version), int(part_number))
-            except Exception:
-                logger.warning(
-                    "Failed to cleanup partial part on FS: object_id=%s v=%s part=%s",
-                    object_id,
-                    int(object_version),
-                    int(part_number),
-                )
+            # Deliberately NO fs_store.delete_part here. Hedged duplicate UploadPart attempts
+            # share one part dir; chunk files are atomic-rename + byte-identical across
+            # duplicates and invisible to readers/reconciler until meta.json lands — so a
+            # failure-path deletion is pure hazard: on 2026-07-26 a cancelled duplicate's
+            # cleanup wiped a completed part's data after its 200 was already returned.
+            # A never-published dir merely leaks until SSD GC; leak beats loss (same doctrine
+            # as the drain reclaim).
             if written_chunk_indices:
                 try:
                     keys = [
@@ -1117,15 +1115,12 @@ class ObjectWriter:
             )
 
         async def _cleanup_part(num_chunks: int | None) -> None:
-            try:
-                await self.fs_store.delete_part(str(object_id), int(cov), int(next_part))
-            except Exception:
-                logging.getLogger(__name__).warning(
-                    "Failed to cleanup append part on FS: object_id=%s v=%s part=%s",
-                    object_id,
-                    int(cov),
-                    int(next_part),
-                )
+            # Deliberately NO fs_store.delete_part here. A CAS loser shares (object, cov,
+            # next_part) — and therefore one part dir — with the append that won; chunk files
+            # are atomic-rename + byte-identical across duplicates and invisible to
+            # readers/reconciler until meta.json lands, so deleting the dir from this failure
+            # path can destroy the winner's already-acknowledged data (the 2026-07-22/26
+            # incidents). A never-finalized dir merely leaks until SSD GC; leak beats loss.
             try:
                 meta_key = self.obj_cache.build_meta_key(str(object_id), int(cov), int(next_part))
                 keys = [meta_key]

--- a/tests/unit/cache/test_fs_store_trim_and_unpublish.py
+++ b/tests/unit/cache/test_fs_store_trim_and_unpublish.py
@@ -1,0 +1,99 @@
+"""fs_store helpers backing the publish-time trim and the append CAS-loser un-publish.
+
+The drain replicates a part only when the SSD chunk set is EXACTLY
+{0..meta.num_chunks-1} (partdrain.rs IncompleteSource gate) — a stale chunk tail
+left by a larger earlier attempt strands the part forever: never replicated,
+never evicted. `trim_chunks_from` enforces the exact set at publish time.
+`delete_meta` un-publishes a part dir (append CAS loser) without touching chunks.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from pathlib import Path
+
+import pytest
+
+from hippius_s3.cache import FileSystemPartsStore
+
+
+@pytest.fixture()
+def store(tmp_path) -> FileSystemPartsStore:
+    return FileSystemPartsStore(str(tmp_path))
+
+
+async def _seed_part(store: FileSystemPartsStore, object_id: str, *, indices: list[int], with_meta: bool) -> Path:
+    for i in indices:
+        await store.set_chunk(object_id, 1, 1, i, f"chunk-{i}".encode())
+    if with_meta:
+        await store.set_meta(object_id, 1, 1, chunk_size=4, num_chunks=len(indices), size_bytes=8)
+    return Path(store.part_path(object_id, 1, 1))
+
+
+@pytest.mark.asyncio
+async def test_trim_removes_only_tail_indices(store):
+    object_id = str(uuid.uuid4())
+    part_dir = await _seed_part(store, object_id, indices=[0, 1, 2, 3, 4], with_meta=True)
+
+    removed = await store.trim_chunks_from(object_id, 1, 1, 2)
+
+    assert removed == 3
+    assert sorted(p.name for p in part_dir.iterdir()) == ["chunk_0.bin", "chunk_1.bin", "meta.json"]
+
+
+@pytest.mark.asyncio
+async def test_trim_noop_when_no_tail(store):
+    object_id = str(uuid.uuid4())
+    part_dir = await _seed_part(store, object_id, indices=[0, 1], with_meta=True)
+
+    removed = await store.trim_chunks_from(object_id, 1, 1, 2)
+
+    assert removed == 0
+    assert sorted(p.name for p in part_dir.iterdir()) == ["chunk_0.bin", "chunk_1.bin", "meta.json"]
+
+
+@pytest.mark.asyncio
+async def test_trim_noop_on_missing_dir(store):
+    removed = await store.trim_chunks_from(str(uuid.uuid4()), 1, 1, 0)
+    assert removed == 0
+
+
+@pytest.mark.asyncio
+async def test_trim_per_file_failure_logs_error_and_continues(store, caplog):
+    object_id = str(uuid.uuid4())
+    part_dir = await _seed_part(store, object_id, indices=[0, 1, 2], with_meta=True)
+    # A directory named like a chunk makes unlink raise — a real-FS failure injection.
+    (part_dir / "chunk_3.bin").mkdir()
+
+    with caplog.at_level(logging.ERROR, logger="hippius_s3.cache.fs_store"):
+        removed = await store.trim_chunks_from(object_id, 1, 1, 2)
+
+    assert removed == 1  # chunk_2 removed despite chunk_3 failing
+    assert not (part_dir / "chunk_2.bin").exists()
+    error_lines = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_lines, "surviving stale tail must be loud (stranded-part risk)"
+    assert any(object_id in r.getMessage() for r in error_lines)
+
+
+@pytest.mark.asyncio
+async def test_delete_meta_unpublishes_but_keeps_chunks(store):
+    object_id = str(uuid.uuid4())
+    part_dir = await _seed_part(store, object_id, indices=[0, 1], with_meta=True)
+
+    await store.delete_meta(object_id, 1, 1)
+
+    assert not (part_dir / "meta.json").exists()
+    assert (part_dir / "chunk_0.bin").exists()
+    assert (part_dir / "chunk_1.bin").exists()
+    assert await store.get_meta(object_id, 1, 1) is None
+    # meta-gated reads now miss: the dir is un-published.
+    assert await store.get_chunk(object_id, 1, 1, 0) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_meta_idempotent_on_missing(store):
+    object_id = str(uuid.uuid4())
+    await store.delete_meta(object_id, 1, 1)  # no dir at all — must not raise
+    await _seed_part(store, object_id, indices=[0], with_meta=False)
+    await store.delete_meta(object_id, 1, 1)  # dir without meta — must not raise

--- a/tests/unit/test_mpu_upload_part_stream_cleanup.py
+++ b/tests/unit/test_mpu_upload_part_stream_cleanup.py
@@ -10,7 +10,11 @@ from hippius_s3.writer.object_writer import ObjectWriter
 
 
 @pytest.mark.asyncio
-async def test_mpu_upload_part_stream_cleans_up_on_oversize(tmp_path, monkeypatch):
+async def test_mpu_upload_part_stream_oversize_leaves_no_published_part(tmp_path, monkeypatch):
+    """A failed stream must leave the part unpublished (no meta.json) but must NOT delete the
+    part dir: hedged duplicate attempts share it, so a failure-path dir wipe can destroy a
+    concurrent winner's acknowledged data (2026-07-22/26 incidents). Orphan chunk files are an
+    accepted leak until SSD GC."""
     cfg = get_config()
     original_chunk_size = cfg.object_chunk_size_bytes
     original_max_part = cfg.max_multipart_part_size
@@ -66,7 +70,9 @@ async def test_mpu_upload_part_stream_cleans_up_on_oversize(tmp_path, monkeypatc
             )
 
         part_dir = Path(fs_store.part_path(object_id, 1, 1))
-        assert not part_dir.exists()
+        assert not (part_dir / "meta.json").exists(), "a failed stream must never publish meta.json"
+        assert await fs_store.get_meta(object_id, 1, 1) is None
+        assert await fs_store.get_chunk(object_id, 1, 1, 0) is None, "unpublished chunks must be unreadable"
     finally:
         cfg.object_chunk_size_bytes = original_chunk_size
         cfg.max_multipart_part_size = original_max_part
@@ -120,8 +126,8 @@ async def test_mpu_part_uses_passed_bucket_id_no_internal_query(tmp_path, monkey
                 part_number=1,
                 body_iter=body_iter(),
             )
-        assert not any(
-            "bucket_id" in (q or "") for q in fetchrow_queries
-        ), "must not run the internal bucket_id/storage_version resolution query"
+        assert not any("bucket_id" in (q or "") for q in fetchrow_queries), (
+            "must not run the internal bucket_id/storage_version resolution query"
+        )
     finally:
         cfg.object_chunk_size_bytes, cfg.max_multipart_part_size, cfg.cache_ttl_seconds = saved

--- a/tests/unit/test_upload_part_cleanup_race.py
+++ b/tests/unit/test_upload_part_cleanup_race.py
@@ -1,0 +1,251 @@
+"""Duplicate-UploadPart cleanup race (2026-07-22 / 2026-07-26 prod data loss).
+
+Clients hedge UploadPart with concurrent duplicate PUTs of the same
+(object, version, part_number); all attempts share ONE part dir on the SSD.
+Chunk writes are atomic tmp+rename and byte-identical across duplicates
+(deterministic AES-GCM nonces), so concurrent writers are harmless — but a
+loser that fails/cancels AFTER another attempt published (meta.json + parts
+row + 200 to the client) must NOT delete the shared part dir: that destroys
+acknowledged data.
+
+These tests publish a part as attempt A, then drive attempt B through each
+failure path and assert A's published data survives B's cleanup.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+from typing import AsyncIterator
+
+import pytest
+
+from hippius_s3.cache import FileSystemPartsStore
+from hippius_s3.config import get_config
+from hippius_s3.writer.object_writer import ObjectWriter
+from hippius_s3.writer.types import AppendPreconditionFailed
+
+
+PART_BODY = b"abcdefgh"  # 2 chunks at chunk_size=4
+
+
+class DummyRedis:
+    async def delete(self, *_args: Any, **_kwargs: Any) -> int:
+        return 1
+
+    async def setex(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+class DummyPool:
+    async def fetchrow(self, *_args: Any, **_kwargs: Any) -> dict:
+        return {"bucket_id": "bucket", "storage_version": 5}
+
+    async def fetchval(self, *_args: Any, **_kwargs: Any) -> str:
+        return "part-id"
+
+    async def execute(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def _make_writer(pool: Any, fs_store: FileSystemPartsStore, monkeypatch: pytest.MonkeyPatch) -> ObjectWriter:
+    writer = ObjectWriter(pool=pool, redis_client=DummyRedis(), fs_store=fs_store)
+
+    async def fake_ensure_dek(*_args: Any, **_kwargs: Any) -> bytes:
+        return b"\x00" * 32
+
+    monkeypatch.setattr(writer, "_ensure_and_get_v5_dek", fake_ensure_dek)
+    return writer
+
+
+async def _publish_attempt_a(
+    writer: ObjectWriter,
+    *,
+    object_id: str,
+    object_version: int,
+    part_number: int,
+    upload_id: str,
+) -> None:
+    """Attempt A completes fully: all chunks + meta.json on FS + parts row + 200 to the client."""
+
+    async def body() -> AsyncIterator[bytes]:
+        yield PART_BODY
+
+    res = await writer.mpu_upload_part_stream(
+        upload_id=upload_id,
+        object_id=object_id,
+        object_version=object_version,
+        bucket_name="bucket",
+        bucket_id="bucket",
+        account_address="acct",
+        part_number=part_number,
+        body_iter=body(),
+    )
+    assert res.size_bytes == len(PART_BODY)
+
+
+def _read_chunks(fs_store: FileSystemPartsStore, object_id: str, version: int, part: int) -> dict[str, bytes]:
+    part_dir = Path(fs_store.part_path(object_id, version, part))
+    return {p.name: p.read_bytes() for p in part_dir.glob("chunk_*.bin")}
+
+
+@pytest.fixture()
+def small_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = get_config()
+    monkeypatch.setattr(cfg, "object_chunk_size_bytes", 4)
+    monkeypatch.setattr(cfg, "cache_ttl_seconds", 60)
+    monkeypatch.setattr("hippius_s3.writer.object_writer.get_config", lambda: cfg)
+
+
+@pytest.mark.xfail(strict=True, reason="RED: _cleanup_partial still wipes the shared part dir")
+@pytest.mark.asyncio
+async def test_mpu_duplicate_failure_after_publish_preserves_part(tmp_path, monkeypatch, small_chunks):
+    """A duplicate UploadPart attempt that dies mid-stream must not wipe the published part dir."""
+    object_id = str(uuid.uuid4())
+    fs_store = FileSystemPartsStore(str(tmp_path))
+    writer = _make_writer(DummyPool(), fs_store, monkeypatch)
+
+    await _publish_attempt_a(writer, object_id=object_id, object_version=1, part_number=1, upload_id="upload")
+    published = _read_chunks(fs_store, object_id, 1, 1)
+    assert set(published) == {"chunk_0.bin", "chunk_1.bin"}
+
+    async def dying_body() -> AsyncIterator[bytes]:
+        yield PART_BODY[:4]
+        raise ConnectionError("client disconnected mid-stream")
+
+    with pytest.raises(ConnectionError):
+        await writer.mpu_upload_part_stream(
+            upload_id="upload",
+            object_id=object_id,
+            object_version=1,
+            bucket_name="bucket",
+            bucket_id="bucket",
+            account_address="acct",
+            part_number=1,
+            body_iter=dying_body(),
+        )
+
+    meta = await fs_store.get_meta(object_id, 1, 1)
+    assert meta is not None, "published meta.json was destroyed by the loser's cleanup"
+    assert int(meta["num_chunks"]) == 2
+    assert _read_chunks(fs_store, object_id, 1, 1) == published
+    assert await fs_store.get_chunk(object_id, 1, 1, 0) == published["chunk_0.bin"]
+    assert await fs_store.get_chunk(object_id, 1, 1, 1) == published["chunk_1.bin"]
+
+
+class _AppendFakeConn:
+    """Just enough of an asyncpg connection for append_stream's two transactions."""
+
+    def __init__(self, pool: "_AppendFakePool") -> None:
+        self._pool = pool
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        return self._pool.route_fetchrow(query)
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        return self._pool.route_fetchval(query)
+
+    async def fetch(self, query: str, *args: Any) -> list:
+        return []
+
+    async def execute(self, query: str, *args: Any) -> None:
+        return None
+
+    def transaction(self) -> Any:
+        @asynccontextmanager
+        async def _cm() -> Any:
+            yield
+
+        return _cm()
+
+
+class _AppendFakePool:
+    """Drives append_stream to the finalize CAS, where a concurrent winner already bumped
+    append_version — the exact shape of a hedged duplicate losing after the winner published."""
+
+    def __init__(self, *, object_id: str, expected_version: int, next_part: int) -> None:
+        self.object_id = object_id
+        self.expected_version = expected_version
+        self.next_part = next_part
+
+    def route_fetchrow(self, query: str) -> Any:
+        if "md5_hash" in query and "FOR UPDATE" in query:
+            # Finalize CAS read: the winner already advanced append_version.
+            return {
+                "append_version": self.expected_version + 1,
+                "md5_hash": "0" * 32,
+                "has_etag_md5s": True,
+            }
+        if "append_version" in query:
+            return {"append_version": self.expected_version}
+        if "upload_id FROM multipart_uploads" in query:
+            return {"upload_id": "11111111-2222-3333-4444-555555555555"}
+        raise AssertionError(f"unexpected fetchrow: {query}")
+
+    def route_fetchval(self, query: str) -> Any:
+        if "MAX(part_number)" in query:
+            return self.next_part
+        if "append_version" in query:
+            return self.expected_version
+        if "INSERT INTO parts" in query:
+            return "part-id"
+        raise AssertionError(f"unexpected fetchval: {query}")
+
+    async def fetchrow(self, query: str, *args: Any) -> Any:
+        if "o.object_id" in query:
+            return {"object_id": self.object_id, "cov": 1}
+        return self.route_fetchrow(query)
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        return self.route_fetchval(query)
+
+    async def execute(self, query: str, *args: Any) -> None:
+        return None
+
+    def acquire(self, **_kwargs: Any) -> Any:
+        conn = _AppendFakeConn(self)
+
+        @asynccontextmanager
+        async def _cm() -> Any:
+            yield conn
+
+        return _cm()
+
+
+@pytest.mark.xfail(strict=True, reason="RED: _cleanup_part still wipes the shared part dir")
+@pytest.mark.asyncio
+async def test_append_cas_loser_cleanup_preserves_published_part(tmp_path, monkeypatch, small_chunks):
+    """An append CAS loser (winner finalized the same part first) must not wipe the part dir."""
+    object_id = str(uuid.uuid4())
+    fs_store = FileSystemPartsStore(str(tmp_path))
+
+    pool = _AppendFakePool(object_id=object_id, expected_version=7, next_part=3)
+    writer = _make_writer(pool, fs_store, monkeypatch)
+
+    # The winner's publish of (object, cov=1, part=3): same bytes the loser will re-write
+    # (deterministic nonces make duplicate ciphertexts identical).
+    await _publish_attempt_a(writer, object_id=object_id, object_version=1, part_number=3, upload_id="upload")
+    published = _read_chunks(fs_store, object_id, 1, 3)
+    assert set(published) == {"chunk_0.bin", "chunk_1.bin"}
+
+    async def body() -> AsyncIterator[bytes]:
+        yield PART_BODY
+
+    with pytest.raises(AppendPreconditionFailed):
+        await writer.append_stream(
+            bucket_id="bucket",
+            bucket_name="bucket",
+            object_key="k",
+            expected_version=7,
+            account_address="acct",
+            body_iter=body(),
+        )
+
+    meta = await fs_store.get_meta(object_id, 1, 3)
+    assert meta is not None, "published meta.json was destroyed by the CAS loser's cleanup"
+    assert int(meta["num_chunks"]) == 2
+    assert _read_chunks(fs_store, object_id, 1, 3) == published
+    assert await fs_store.get_chunk(object_id, 1, 3, 0) == published["chunk_0.bin"]
+    assert await fs_store.get_chunk(object_id, 1, 3, 1) == published["chunk_1.bin"]

--- a/tests/unit/test_upload_part_cleanup_race.py
+++ b/tests/unit/test_upload_part_cleanup_race.py
@@ -99,7 +99,6 @@ def small_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("hippius_s3.writer.object_writer.get_config", lambda: cfg)
 
 
-@pytest.mark.xfail(strict=True, reason="RED: _cleanup_partial still wipes the shared part dir")
 @pytest.mark.asyncio
 async def test_mpu_duplicate_failure_after_publish_preserves_part(tmp_path, monkeypatch, small_chunks):
     """A duplicate UploadPart attempt that dies mid-stream must not wipe the published part dir."""
@@ -214,7 +213,6 @@ class _AppendFakePool:
         return _cm()
 
 
-@pytest.mark.xfail(strict=True, reason="RED: _cleanup_part still wipes the shared part dir")
 @pytest.mark.asyncio
 async def test_append_cas_loser_cleanup_preserves_published_part(tmp_path, monkeypatch, small_chunks):
     """An append CAS loser (winner finalized the same part first) must not wipe the part dir."""

--- a/tests/unit/test_upload_part_cleanup_race.py
+++ b/tests/unit/test_upload_part_cleanup_race.py
@@ -167,7 +167,9 @@ async def test_failed_attempt_preserves_unpublished_chunks(tmp_path, monkeypatch
             body_iter=dying_body(),
         )
 
-    # B overwrote chunk_0 (atomic rename, its own ciphertext) but deleted nothing.
+    # B's failure deleted nothing: both chunk files survive and chunk_1 still holds A's
+    # bytes. chunk_0's content is deliberately unasserted — B's consumer may or may not
+    # have flushed its first chunk (atomic rename over A's) before the failure propagated.
     on_disk = _read_chunks(fs_store, object_id, 1, 1)
     assert {"chunk_0.bin", "chunk_1.bin"}.issubset(set(on_disk))
     assert on_disk["chunk_1.bin"] == b"A-chunk-1"

--- a/tests/unit/test_upload_part_cleanup_race.py
+++ b/tests/unit/test_upload_part_cleanup_race.py
@@ -134,6 +134,93 @@ async def test_mpu_duplicate_failure_after_publish_preserves_part(tmp_path, monk
     assert await fs_store.get_chunk(object_id, 1, 1, 1) == published["chunk_1.bin"]
 
 
+@pytest.mark.asyncio
+async def test_failed_attempt_preserves_unpublished_chunks(tmp_path, monkeypatch, small_chunks):
+    """B fails while A is mid-write (A's chunks on disk, meta NOT yet written): A's chunks survive.
+
+    Pins "failure paths never delete chunk files" even for a dir that is not yet published —
+    guards against a future meta-guarded delete creeping back into the failure cleanup.
+    """
+    object_id = str(uuid.uuid4())
+    fs_store = FileSystemPartsStore(str(tmp_path))
+    writer = _make_writer(DummyPool(), fs_store, monkeypatch)
+
+    # Attempt A mid-write: chunks landed, meta.json not yet written.
+    await fs_store.set_chunk(object_id, 1, 1, 0, b"A-chunk-0")
+    await fs_store.set_chunk(object_id, 1, 1, 1, b"A-chunk-1")
+    part_dir = Path(fs_store.part_path(object_id, 1, 1))
+    assert not (part_dir / "meta.json").exists()
+
+    async def dying_body() -> AsyncIterator[bytes]:
+        yield PART_BODY[:4]
+        raise ConnectionError("client disconnected mid-stream")
+
+    with pytest.raises(ConnectionError):
+        await writer.mpu_upload_part_stream(
+            upload_id="upload",
+            object_id=object_id,
+            object_version=1,
+            bucket_name="bucket",
+            bucket_id="bucket",
+            account_address="acct",
+            part_number=1,
+            body_iter=dying_body(),
+        )
+
+    # B overwrote chunk_0 (atomic rename, its own ciphertext) but deleted nothing.
+    on_disk = _read_chunks(fs_store, object_id, 1, 1)
+    assert {"chunk_0.bin", "chunk_1.bin"}.issubset(set(on_disk))
+    assert on_disk["chunk_1.bin"] == b"A-chunk-1"
+    assert not (part_dir / "meta.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_publish_trims_stale_chunk_tail(tmp_path, monkeypatch, small_chunks):
+    """Publishing with num_chunks=N must delete stale chunk files with index >= N.
+
+    The drain replicates a part only when the SSD chunk set is EXACTLY
+    {0..num_chunks-1} (partdrain.rs IncompleteSource gate); a tail left by a
+    larger earlier attempt would strand the part — never replicated, never evicted.
+    """
+    object_id = str(uuid.uuid4())
+    fs_store = FileSystemPartsStore(str(tmp_path))
+    writer = _make_writer(DummyPool(), fs_store, monkeypatch)
+
+    # A larger earlier attempt died after writing 5 chunks (no meta).
+    for i in range(5):
+        await fs_store.set_chunk(object_id, 1, 1, i, f"stale-{i}".encode())
+
+    await _publish_attempt_a(writer, object_id=object_id, object_version=1, part_number=1, upload_id="upload")
+
+    part_dir = Path(fs_store.part_path(object_id, 1, 1))
+    assert sorted(p.name for p in part_dir.iterdir()) == ["chunk_0.bin", "chunk_1.bin", "meta.json"]
+    meta = await fs_store.get_meta(object_id, 1, 1)
+    assert meta is not None and int(meta["num_chunks"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_trim_failure_is_loud_but_publish_succeeds(tmp_path, monkeypatch, small_chunks, caplog):
+    """A trim failure leaves a stranded-part risk: log ERROR, but the client's 200 stands."""
+    import logging
+
+    object_id = str(uuid.uuid4())
+    fs_store = FileSystemPartsStore(str(tmp_path))
+    writer = _make_writer(DummyPool(), fs_store, monkeypatch)
+
+    # Stale tail where one entry is a directory — unlink fails on it (real-FS fault injection).
+    await fs_store.set_chunk(object_id, 1, 1, 2, b"stale-2")
+    part_dir = Path(fs_store.part_path(object_id, 1, 1))
+    (part_dir / "chunk_3.bin").mkdir()
+
+    with caplog.at_level(logging.ERROR, logger="hippius_s3.cache.fs_store"):
+        await _publish_attempt_a(writer, object_id=object_id, object_version=1, part_number=1, upload_id="upload")
+
+    assert not (part_dir / "chunk_2.bin").exists()
+    assert (part_dir / "meta.json").exists()
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert any(object_id in r.getMessage() for r in errors), "surviving tail must be loud"
+
+
 class _AppendFakeConn:
     """Just enough of an asyncpg connection for append_stream's two transactions."""
 
@@ -168,6 +255,7 @@ class _AppendFakePool:
         self.object_id = object_id
         self.expected_version = expected_version
         self.next_part = next_part
+        self.executed: list[str] = []
 
     def route_fetchrow(self, query: str) -> Any:
         if "md5_hash" in query and "FOR UPDATE" in query:
@@ -201,6 +289,7 @@ class _AppendFakePool:
         return self.route_fetchval(query)
 
     async def execute(self, query: str, *args: Any) -> None:
+        self.executed.append(query)
         return None
 
     def acquire(self, **_kwargs: Any) -> Any:
@@ -214,19 +303,19 @@ class _AppendFakePool:
 
 
 @pytest.mark.asyncio
-async def test_append_cas_loser_cleanup_preserves_published_part(tmp_path, monkeypatch, small_chunks):
-    """An append CAS loser (winner finalized the same part first) must not wipe the part dir."""
+async def test_append_cas_loser_unpublishes_part_and_number_is_reusable(tmp_path, monkeypatch, small_chunks):
+    """A CAS loser must un-publish its part dir: meta.json deleted, chunks kept, parts row gone.
+
+    Part-number reservation is FOR-UPDATE-serialized, so no live winner shares the loser's
+    dir — but the loser's meta.json already landed (mpu_upload_part_stream returned before the
+    finalize CAS ran). Leaving it would let a future append that reuses the number inherit
+    stale readiness over mixed content. Chunks stay: failure paths never delete chunk files.
+    """
     object_id = str(uuid.uuid4())
     fs_store = FileSystemPartsStore(str(tmp_path))
 
     pool = _AppendFakePool(object_id=object_id, expected_version=7, next_part=3)
     writer = _make_writer(pool, fs_store, monkeypatch)
-
-    # The winner's publish of (object, cov=1, part=3): same bytes the loser will re-write
-    # (deterministic nonces make duplicate ciphertexts identical).
-    await _publish_attempt_a(writer, object_id=object_id, object_version=1, part_number=3, upload_id="upload")
-    published = _read_chunks(fs_store, object_id, 1, 3)
-    assert set(published) == {"chunk_0.bin", "chunk_1.bin"}
 
     async def body() -> AsyncIterator[bytes]:
         yield PART_BODY
@@ -241,9 +330,28 @@ async def test_append_cas_loser_cleanup_preserves_published_part(tmp_path, monke
             body_iter=body(),
         )
 
+    part_dir = Path(fs_store.part_path(object_id, 1, 3))
+    assert not (part_dir / "meta.json").exists(), "CAS loser must un-publish its meta.json"
+    loser_chunks = _read_chunks(fs_store, object_id, 1, 3)
+    assert set(loser_chunks) == {"chunk_0.bin", "chunk_1.bin"}, "chunks must survive (leak beats loss)"
+    assert any("DELETE FROM parts" in q for q in pool.executed), "loser's parts row must be deleted"
+
+    # A later append reuses part 3 with different, SHORTER content: it must publish cleanly
+    # and its trim must remove the loser's stale chunk_1 tail (exact-set drain gate).
+    async def reuse_body() -> AsyncIterator[bytes]:
+        yield b"zzzz"  # 1 chunk at chunk_size=4
+
+    res = await writer.mpu_upload_part_stream(
+        upload_id="11111111-2222-3333-4444-555555555555",
+        object_id=object_id,
+        object_version=1,
+        bucket_name="bucket",
+        bucket_id="bucket",
+        account_address="acct",
+        part_number=3,
+        body_iter=reuse_body(),
+    )
+    assert res.size_bytes == 4
+    assert sorted(p.name for p in part_dir.iterdir()) == ["chunk_0.bin", "meta.json"]
     meta = await fs_store.get_meta(object_id, 1, 3)
-    assert meta is not None, "published meta.json was destroyed by the CAS loser's cleanup"
-    assert int(meta["num_chunks"]) == 2
-    assert _read_chunks(fs_store, object_id, 1, 3) == published
-    assert await fs_store.get_chunk(object_id, 1, 3, 0) == published["chunk_0.bin"]
-    assert await fs_store.get_chunk(object_id, 1, 3, 1) == published["chunk_1.bin"]
+    assert meta is not None and int(meta["num_chunks"]) == 1

--- a/todo.md
+++ b/todo.md
@@ -149,6 +149,27 @@ param that is stored but never read (`hippius_s3/writer/write_through_writer.py:
 the `ExplodingCache` arg in `tests/unit/test_write_through_writer.py` in a dedicated cleanup;
 consider renaming the class to `FSPartsWriter`.
 
+### P1 — Accepted SSD leak from the UploadPart cleanup-race fix (unbounded until ov-row cleanup lands)
+
+**Context**: branch `fix/upload-part-cleanup-race` stopped failure-path cleanups from deleting shared FS part data — a duplicate UploadPart's loser used to destroy the winner's *published* chunks (drain then wrote the part off as unrecoverable). The fix deletes nothing on failure and enforces the exact chunk set at publish time instead ([hippius_s3/writer/object_writer.py:893](hippius_s3/writer/object_writer.py), [hippius_s3/cache/fs_store.py:359 `trim_chunks_from`](hippius_s3/cache/fs_store.py)).
+
+**The accepted cost** — two leak shapes now accumulate on SSD:
+
+1. **Meta-less MPU orphan dirs**: a failed UploadPart attempt that never published leaves its chunk files behind with no `meta.json`.
+2. **Append CAS-loser chunk-only dirs**: the CAS loser is un-published (`meta.json` deleted) but its chunks are deliberately kept.
+
+Both shapes have no cephor row, or a failed one. Post-PR-#359 reclaim semantics HOLD any part whose `object_versions` row exists, and **nothing today deletes an abandoned version's `object_versions` row** — so the leak is unbounded, not self-limiting.
+
+**Follow-up that closes it**: a reaper that deletes the abandoned version's `object_versions` row once its parts are dropped. That is the unlock — with the ov row gone, #359's absence-proof reclaim takes over and the leaked dirs become reclaimable instead of held forever.
+
+### Follow-up — janitor exact-set sweep for stale chunk tails
+
+The publish-time trim only covers parts published after the fix. For inventoried parts with meta present, a janitor sweep should delete `chunk_i` where `i >= meta.num_chunks`. This retro-heals the pre-existing stranded stale-tail population and self-heals publish-time trim failures (trim is best-effort by contract — ERROR-logged, never raised). It matters because the drain gate ([crates/hippius-drain-core/src/partdrain.rs:445-461](crates/hippius-drain-core/src/partdrain.rs)) requires the on-disk set to be EXACTLY `{0..num_chunks-1}` — extras mean permanent IncompleteSource deferral: never replicated, never evicted.
+
+### Follow-up — hippius-otel alert on servable write-offs
+
+Add `increase(drain_parts_written_off_servable_total[1h]) > 0` to hippius-otel. A servable write-off is data loss for a part a client could still read — always operator-worthy, and the counter exists precisely so this alert can be cheap.
+
 ### P1 — Meta.json rewrites on concurrent upload + download
 
 **What**: Upload writes `meta.json` once after all chunks ([object_writer.py:420](hippius_s3/writer/object_writer.py), [object_writer.py:~865 `mpu_upload_part_stream`](hippius_s3/writer/object_writer.py)). Downloader writes `meta.json` **eagerly** per part at the start of processing ([hippius_s3/workers/downloader.py:49-91](hippius_s3/workers/downloader.py)). For an object that was just uploaded and is immediately read via a cold-miss downloader path, the meta is written twice with identical content.
@@ -305,6 +326,7 @@ Low-risk deletions; each one should be a one-PR cleanup:
 2. **Redis download-cache residue**. Grep for `REDIS_DOWNLOAD_CACHE_URL`, `redis_download_cache_url`, `DOWNLOAD_CACHE_TTL`, `redis-download-cache`. Should all be gone after the FS migration. Patch any stragglers in docker-compose files and k8s manifests.
 3. **`set_download_chunk`** shim in [hippius_s3/cache/object_parts.py](hippius_s3/cache/object_parts.py) — if still present (prior memory says it was removed), verify. Old download-cache API.
 4. **Any references to `manifest_cid` or `manifest_service`**. Replaced by `chunk_backend` tracking long ago.
+5. **[hippius_s3/workers/fs_cleanup.py](hippius_s3/workers/fs_cleanup.py)** — zero importers (`rg fs_cleanup` hits only the module itself; no entry point in `workers/` runs it). Confirm and delete.
 
 ---
 


### PR DESCRIPTION
## Summary

Hardens the UploadPart write path against a cleanup race that can occur when a client sends duplicate/hedged concurrent PUTs for the same `(object, version, part_number)`. Those duplicates share a single on-disk part directory, so a cancelled attempt's failure cleanup could remove data a concurrent attempt had already committed. This makes the failure-path cleanups non-destructive and adds related robustness guards.

- **Failure-path cleanups no longer delete shared FS part data** (`_cleanup_partial`, `_cleanup_part`). Chunk writes are atomic tmp+rename and byte-identical across duplicates (deterministic AES-GCM nonce excludes upload_id), so the directory delete was the only destructive interference. Regression tests reproduce the race (verified failing on the old code).
- **Publish-time trim**: after writing `meta.json` with N chunks, stale `chunk_i` files with `i >= N` are removed. The drain requires the exact chunk set `{0..N-1}`; a stale tail from a larger earlier attempt would otherwise strand the part in permanent deferral.
- **Append CAS-losers un-publish**: the loser deletes only its `meta.json` (chunks stay), preventing a future append that reuses the part number from inheriting stale readiness.
- **Servable write-offs are now surfaced**: when the drain writes off a part of a servable version it logs ERROR with marker `DRAIN_WRITEOFF_SERVABLE` and bumps a new counter `drain_parts_written_off_servable_total`, so the condition is alertable rather than silent.
- todo.md documents the SSD-leak lifecycle tradeoff and follow-ups: janitor exact-set sweep, otel alert on the new counter, `fs_cleanup.py` dead-code removal.

## Test plan

- [x] `pytest tests/unit` — 2163 passed (11 new: race regressions incl. mid-write survival, trim, CAS un-publish)
- [x] `cargo test --workspace --all-features --locked -- --include-ignored` — 443 passed
- [x] ruff / fmt / clippy `-D warnings` / ty — clean

## Rollout

No migrations. api + drain-agent images both change; no ordering constraint.
