### PR TITLE
fix(cache): sort AccessTracker flush batch to avoid cross-pod Postgres deadlock

### DIFF
--- a/hippius_s3/cache/access_tracker.py
+++ b/hippius_s3/cache/access_tracker.py
@@ -71,7 +71,10 @@ class AccessTracker:
         """Write pending keys in chunked batched UPDATEs. Returns rows attempted."""
         if not self._pending:
             return 0
-        batch = list(self._pending)
+        # Sort by key tuple so every pod locks the same fs_cache_inventory rows
+        # in one canonical order; set-iteration (hash) order let two pods with
+        # overlapping keys acquire locks in opposite orders and deadlock.
+        batch = sorted(self._pending)
         self._pending.clear()
         for start in range(0, len(batch), FLUSH_CHUNK_SIZE):
             chunk = batch[start : start + FLUSH_CHUNK_SIZE]

--- a/tests/unit/test_access_tracker.py
+++ b/tests/unit/test_access_tracker.py
@@ -49,6 +49,35 @@ async def test_note_read_batches_and_flushes():
 
 
 @pytest.mark.asyncio
+async def test_flush_arrays_are_sorted_regardless_of_insertion_order():
+    """The unnest arrays must come out sorted by (object_id, version, part) so
+    every pod locks the same rows in one order — cross-pod deadlock avoidance.
+    Insertion order (and set-hash order) must not leak into the emitted arrays."""
+    oid_a = "11111111-1111-1111-1111-111111111111"
+    oid_b = "22222222-2222-2222-2222-222222222222"
+    keys = [
+        (oid_b, 2, 5),
+        (oid_a, 1, 9),
+        (oid_a, 3, 1),
+        (oid_a, 1, 2),
+        (oid_b, 1, 7),
+    ]
+
+    pool = FakePool()
+    tracker = AccessTracker(pool, hot_window_seconds=14400)
+    for oid, ver, part in keys:
+        tracker.note_read(oid, ver, part)
+
+    flushed = await tracker.flush_once()
+
+    assert flushed == len(keys)
+    assert len(pool.execute_calls) == 1
+    _sql, args = pool.execute_calls[0]
+    emitted = list(zip(args[0], args[1], args[2], strict=False))
+    assert emitted == sorted(keys)
+
+
+@pytest.mark.asyncio
 async def test_sampling_suppresses_repeat_notes_within_window():
     pool = FakePool()
     tracker = AccessTracker(pool, hot_window_seconds=14400)


### PR DESCRIPTION
## Problem (F6)

`AccessTracker.flush_once` materialized the pending keys with `batch = list(self._pending)` — a `set`, so iteration was in hash order. The bulk `UPDATE ... FROM unnest(...)` against `fs_cache_inventory` therefore locked rows in a non-deterministic order.

With two API pods flushing overlapping keys concurrently, they could acquire row locks in opposite orders → Postgres deadlock. The deadlock victim's transaction aborts (caught at the `except` around line 89), and because the batch is dropped (not requeued), that read-recency is silently lost — a part becomes prematurely evictable.

## Fix

Sort the batch by its key tuple `(object_id, object_version, part_number)` before building the unnest arrays, so every pod acquires row locks in one canonical order. `sorted()` on the set of tuples gives a total order. No SQL change. One inline comment documents the deadlock-avoidance why.

## Test

Extended `tests/unit/test_access_tracker.py` with `test_flush_arrays_are_sorted_regardless_of_insertion_order`: notes keys in a scrambled order across two object IDs and asserts the emitted unnest arrays equal `sorted(keys)`. Uses the existing `FakePool` mock-execute style; no real DB.

## Local checks

- `ruff check hippius_s3 gateway` — passed
- `ruff format --check hippius_s3 gateway` — passed
- `pytest tests/unit/test_access_tracker.py` — 8 passed (run under Python 3.11; 3.13 fails only on asyncpg's C build, unrelated)
- `ty check hippius_s3 gateway` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)