### PR TITLE
fix(cache): bound AccessTracker _pending, surface zero-row flushes, preserve recency on flush failure

### DIFF
--- a/hippius_s3/cache/access_tracker.py
+++ b/hippius_s3/cache/access_tracker.py
@@ -27,6 +27,17 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+
+def _parse_update_count(status: Any) -> int:
+    """Affected-row count from an asyncpg command tag ("UPDATE N"); 0 if unparseable."""
+    if not isinstance(status, str):
+        return 0
+    parts = status.split()
+    if len(parts) >= 2 and parts[-1].isdigit():
+        return int(parts[-1])
+    return 0
+
+
 FLUSH_INTERVAL_SECONDS = 30.0
 # Bound on the sampling map so a pathological key scan can't grow it forever;
 # pruning drops the oldest entries, which only means earlier re-sampling.
@@ -62,6 +73,13 @@ class AccessTracker:
         last = self._last_noted.get(key)
         if last is not None and now - last < self._sample_window:
             return
+        # _pending drains only on flush; a failing flush (DB outage) plus a
+        # key-diverse read stream would otherwise grow it without bound. Cap it
+        # at the sampling-map bound and drop-newest — leaving _last_noted
+        # untouched so the very next read re-notes the dropped part (no lost
+        # recency), same cheap outcome as a lost flush.
+        if key not in self._pending and len(self._pending) >= MAX_TRACKED_KEYS:
+            return
         self._last_noted[key] = now
         self._pending.add(key)
         if len(self._last_noted) > MAX_TRACKED_KEYS:
@@ -76,7 +94,7 @@ class AccessTracker:
         for start in range(0, len(batch), FLUSH_CHUNK_SIZE):
             chunk = batch[start : start + FLUSH_CHUNK_SIZE]
             try:
-                await self._pool.execute(
+                status = await self._pool.execute(
                     """
                     UPDATE fs_cache_inventory AS f SET last_access_at = now()
                     FROM unnest($1::text[], $2::bigint[], $3::bigint[]) AS u(oid, ver, pnum)
@@ -87,10 +105,25 @@ class AccessTracker:
                     [k[2] for k in chunk],
                 )
             except Exception as exc:
-                # Advisory data: dropping the chunk (not re-queueing) keeps a DB
-                # outage from growing an unbounded buffer; the parts re-sample
-                # on their next read after the sample window.
-                logger.warning("last_access_at flush failed (%s keys dropped): %s", len(chunk), exc)
+                # Advisory data, but a transient failure must not leave these
+                # keys sampling-suppressed with their recency silently lost.
+                # Re-queue them and drop their suppression so the next flush
+                # retries and any continued read re-notes them; _pending stays
+                # bounded (see note_read), so a sustained outage can't grow it
+                # without limit.
+                for k in chunk:
+                    self._last_noted.pop(k, None)
+                self._pending.update(chunk)
+                logger.warning("last_access_at flush failed (%s keys requeued): %s", len(chunk), exc)
+                continue
+            affected = _parse_update_count(status)
+            if affected < len(chunk):
+                # A zero/partial UPDATE means inventory rows are missing for keys
+                # we thought were hot — used to be silent. Surface it: warn when
+                # the whole chunk missed, debug for the expected trickle of parts
+                # evicted from inventory between note and flush.
+                level = logging.WARNING if affected == 0 else logging.DEBUG
+                logger.log(level, "last_access_at flush updated %s/%s rows", affected, len(chunk))
         return len(batch)
 
     def _enforce_bound(self, now: float) -> None:

--- a/tests/unit/test_access_tracker.py
+++ b/tests/unit/test_access_tracker.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 import hippius_s3.cache.access_tracker as at
@@ -63,15 +65,55 @@ async def test_sampling_suppresses_repeat_notes_within_window():
 
 
 @pytest.mark.asyncio
-async def test_flush_failure_drops_batch_without_raising():
+async def test_flush_failure_requeues_and_unsuppresses():
     pool = FakePool(fail=True)
     tracker = AccessTracker(pool, hot_window_seconds=14400)
     tracker.note_read(OID, 1, 1)
 
     assert await tracker.flush_once() == 1  # attempted
+    # A transient error must not blind a continuously-read part: the key is
+    # requeued and its sampling suppression cleared so recency is not lost.
+    assert (OID, 1, 1) in tracker._pending
+    assert (OID, 1, 1) not in tracker._last_noted
     pool.fail = False
-    # Batch was dropped, not requeued: nothing to flush now.
-    assert await tracker.flush_once() == 0
+    assert await tracker.flush_once() == 1  # retried and recorded
+
+
+def test_pending_is_bounded_under_key_diverse_storm():
+    """`_pending` drains only on flush; a key-diverse storm during a stalled
+    flush must not grow it past the bound."""
+    tracker = AccessTracker(FakePool(), hot_window_seconds=3600)
+    for i in range(at.MAX_TRACKED_KEYS + 5000):
+        tracker.note_read(OID, 1, i)
+
+    assert len(tracker._pending) <= at.MAX_TRACKED_KEYS
+
+
+@pytest.mark.asyncio
+async def test_flush_failure_then_continued_read_re_notes():
+    pool = FakePool(fail=True)
+    tracker = AccessTracker(pool, hot_window_seconds=14400)
+    tracker.note_read(OID, 1, 1)
+    assert await tracker.flush_once() == 1  # attempted, failed, unsuppressed
+
+    # Suppression was dropped, so a read still inside the sample window re-notes.
+    tracker._pending.clear()
+    tracker.note_read(OID, 1, 1)
+    assert (OID, 1, 1) in tracker._pending
+
+
+@pytest.mark.asyncio
+async def test_zero_row_flush_is_surfaced(caplog):
+    class ZeroPool:
+        async def execute(self, sql, *args):
+            return "UPDATE 0"
+
+    tracker = AccessTracker(ZeroPool(), hot_window_seconds=14400)
+    tracker.note_read(OID, 1, 1)
+
+    with caplog.at_level(logging.WARNING, logger="hippius_s3.cache.access_tracker"):
+        assert await tracker.flush_once() == 1
+    assert any("0/1" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## F5 — three freshness holes in the sampled read-recency tracker

`hippius_s3/cache/access_tracker.py` feeds `fs_cache_inventory.last_access_at`, the janitor's hot-retention "recently read" signal. Three holes let recency be silently lost or the buffer grow unbounded.

### Holes
1. **`_pending` unbounded.** `MAX_TRACKED_KEYS`/`_enforce_bound` bounded only `_last_noted`. `_pending` drains solely on flush, so a key-diverse read stream during a stalled/failing flush could grow it without limit.
2. **Recency lost on flush failure.** A failed flush dropped the batch while its keys stayed sampling-suppressed in `_last_noted` for a full sample window (default **3600s** = hot retention 14400 / 4, *not* 900s), so continued reads of a hot part could not re-note it — a transient DB error blinded a continuously-read part.
3. **Zero-row UPDATE silent.** `flush_once` returned `len(batch)` and never checked the actual rowcount, so a batch that matched no inventory rows looked identical to success.

### Fixes
- `note_read` caps `_pending` at `MAX_TRACKED_KEYS`, drop-newest on overflow, leaving `_last_noted` untouched so the very next read re-notes the dropped part (no lost recency).
- On flush failure, re-queue the chunk into `_pending` and clear its `_last_noted` suppression so a retry or continued read re-notes it; `_pending` is now bounded, so a sustained outage still can't grow it.
- Parse the asyncpg command tag (`UPDATE N`); when affected < batch, log — warn on a fully-missed chunk, debug for the expected trickle of parts evicted from inventory between note and flush.

### Tests (`tests/unit/test_access_tracker.py`, no real DB)
- `_pending` never exceeds the bound under a key-diverse storm.
- A raising flush re-queues + unsuppresses so a later read re-notes the key.
- `rowcount < batch` ("UPDATE 0") is surfaced via a warning.
- Updated the prior drop-batch test to assert the new requeue behavior.

Local: ruff check/format clean; `pytest tests/unit/test_access_tracker.py` 10 passed; ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)