### PR TITLE
test: cover fs_cache_pressure middleware, last-good TTL expiry, publisher pool arm

### DIFF
--- a/tests/unit/test_fs_cache_pressure_middleware.py
+++ b/tests/unit/test_fs_cache_pressure_middleware.py
@@ -1,0 +1,120 @@
+"""Unit tests for fs_cache_pressure_middleware — the pool-signal → PUT-throttle wiring."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+import hippius_s3.pressure_signal as ps
+from hippius_s3.api.middlewares.fs_cache_pressure import fs_cache_pressure_middleware
+from hippius_s3.pressure_signal import PRESSURE_KEY
+
+
+class FakeRedis:
+    def __init__(self, value=None):
+        self.value = value
+
+    async def get(self, key):
+        return self.value
+
+
+def _config(tmp_path):
+    # Local statvfs on tmp_path has ample headroom, so any rejection here is
+    # driven purely by the published pool signal (the wiring under test).
+    return SimpleNamespace(
+        object_cache_dir=str(tmp_path),
+        fs_cache_min_free_bytes=0,
+        fs_cache_min_free_ratio=0.0,
+        fs_cache_retry_after_seconds=30,
+    )
+
+
+def _make_put_request(config, redis_client):
+    app = SimpleNamespace(state=SimpleNamespace(config=config, redis_client=redis_client))
+    scope = {
+        "type": "http",
+        "method": "PUT",
+        "path": "/bucket/key",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "query_string": b"",
+        "headers": [(b"content-length", b"1024")],
+        "app": app,
+    }
+    return Request(scope)
+
+
+@pytest.fixture(autouse=True)
+def _reset_consumer_memo():
+    ps._published_cache = (None, 0.0)
+    ps._last_good = (None, 0.0)
+    yield
+    ps._published_cache = (None, 0.0)
+    ps._last_good = (None, 0.0)
+
+
+@pytest.mark.asyncio
+async def test_put_rejected_when_published_mode_is_critical(tmp_path):
+    """Published pool mode 2 must throttle the PUT even with local headroom —
+    severing this wiring (published_mode := None) is the 2026-07-24 regression."""
+    redis = FakeRedis(value=json.dumps({"mode": 2, "ratio": 0.96, "source": "janitor", "ts": 1.0}))
+    request = _make_put_request(_config(tmp_path), redis)
+
+    called = []
+
+    async def call_next(req):
+        called.append(req)
+        return Response("passed", status_code=200)
+
+    resp = await fs_cache_pressure_middleware(request, call_next)
+
+    assert called == []  # body must never be read once the gate fires
+    assert resp.status_code == 503
+    assert b"SlowDown" in resp.body
+    assert int(resp.headers["Retry-After"]) >= 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [None, json.dumps({"mode": 1, "ratio": 0.9, "source": "janitor", "ts": 1.0})])
+async def test_put_passes_when_signal_absent_or_below_critical(tmp_path, value):
+    """No signal (None) or a sub-critical mode with local headroom must pass through."""
+    request = _make_put_request(_config(tmp_path), FakeRedis(value=value))
+
+    sentinel = Response("passed", status_code=200)
+
+    async def call_next(req):
+        return sentinel
+
+    resp = await fs_cache_pressure_middleware(request, call_next)
+
+    assert resp is sentinel
+
+
+@pytest.mark.asyncio
+async def test_non_put_bypasses_the_gate_entirely(tmp_path):
+    """A GET is not an FS-cache write; the middleware must not even consult the signal."""
+    app = SimpleNamespace(state=SimpleNamespace(config=_config(tmp_path), redis_client=FakeRedis(value=None)))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/bucket/key",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "query_string": b"",
+        "headers": [],
+        "app": app,
+    }
+    request = Request(scope)
+
+    ps._published_cache = (2, -100.0)  # a stale critical memo must be irrelevant to a GET
+    sentinel = Response("passed", status_code=200)
+
+    async def call_next(req):
+        return sentinel
+
+    assert await fs_cache_pressure_middleware(request, call_next) is sentinel
+    assert await FakeRedis(value=None).get(PRESSURE_KEY) is None  # signal untouched

--- a/tests/unit/test_pressure_signal.py
+++ b/tests/unit/test_pressure_signal.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
+import httpx
 import pytest
+import respx
 
 import hippius_s3.pressure_signal as ps
 from hippius_s3.fs_pressure import should_reject_fs_cache_write
@@ -124,6 +127,37 @@ async def test_publisher_hysteresis_across_ticks(monkeypatch, tmp_path: Path):
     assert modes == [2, 2, 1]
 
 
+# The mgr pool series shape (pool 5 fullest at ~95%), mirrored from test_janitor_pool_gate.
+_HEALTHY = "ceph_cluster_total_bytes 115222679470080.0\nceph_cluster_total_used_bytes 31791022084096.0\n"
+_POOL_SERIES = (
+    'ceph_pool_metadata{pool_id="5",name="ceph-filesystem-data0",type="replicated"} 1.0\n'
+    'ceph_pool_percent_used{pool_id="5"} 0.9600000000000000\n'
+)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_publish_reflects_pool_ratio_when_it_exceeds_local(monkeypatch, tmp_path: Path):
+    """With a configured mgr URL the published mode must track the fullest pool,
+    not the local NVMe: ratio = max(local, pool). Local is calm (10%) but the
+    backing pool is at the cliff (96%) — the exact 2026-07-24 blind spot. Reducing
+    the max() back to `local` would publish mode 0 here."""
+    url = "http://mgr.test/metrics"
+    monkeypatch.setattr("hippius_s3.pressure_signal.shutil.disk_usage", lambda p: _usage(10, 100))
+    respx.get(url).mock(return_value=httpx.Response(200, text=_HEALTHY + _POOL_SERIES))
+    redis = FakeRedis()
+    pub = PressurePublisher(
+        redis, tmp_path, mgr_metrics_url=url, pools=["ceph-filesystem-data0"], probe_timeout_seconds=2.0
+    )
+
+    await pub.publish_once()
+
+    assert len(redis.set_calls) == 1
+    payload = json.loads(redis.set_calls[0][1])
+    assert payload["mode"] == 2  # driven by the 96% pool, not the 10% local disk
+    assert payload["ratio"] == pytest.approx(0.96)
+
+
 # ------------------------------------------------------------------ consumer
 
 @pytest.mark.asyncio
@@ -161,6 +195,17 @@ async def test_consumer_holds_last_good_mode_on_read_error():
     ps._published_cache = (2, -100.0)  # expire the memo, keep _last_good
     redis.fail = True
     assert await get_published_pressure_mode(redis) == 2
+
+
+@pytest.mark.asyncio
+async def test_consumer_last_good_expires_past_ttl_on_read_error():
+    """last-good only survives a read ERROR *within* the publish TTL — once it
+    ages past PRESSURE_TTL_SECONDS a dead Redis must fall back to None, never
+    pin a stale mode-2 forever (dropping the `< PRESSURE_TTL_SECONDS` clause)."""
+    ps._published_cache = (None, -100.0)  # memo expired → force a fresh read
+    ps._last_good = (2, time.monotonic() - PRESSURE_TTL_SECONDS - 5.0)  # aged past the TTL
+    redis = FakeRedis(fail=True)
+    assert await get_published_pressure_mode(redis) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Tests only, no production code changes. Closes three confirmed coverage gaps in the FS-cache pressure signal. Each new test was verified RED against the described mutation and GREEN against real code.

## Gap 1 (HIGH) — fs_cache_pressure_middleware had zero tests
New `tests/unit/test_fs_cache_pressure_middleware.py` drives the middleware end to end: a published critical pool mode (2) throttles a PUT (503 `SlowDown`, `Retry-After` header, body never read) even with local disk headroom; `None`/sub-critical passes through; a GET bypasses the gate entirely.
- Mutation caught: replacing `published_mode = await get_published_pressure_mode(...)` (fs_cache_pressure.py:62) with `None` — severs the pool-signal → PUT-throttle wiring (the 2026-07-24 incident fix). Confirmed RED.

## Gap 2 (MEDIUM) — consumer last-good TTL expiry unpinned
`test_consumer_last_good_expires_past_ttl_on_read_error` ages `_last_good` past `PRESSURE_TTL_SECONDS` and asserts a read error falls back to `None`, not the stale mode-2.
- Mutation caught: deleting the `and now - good_at < PRESSURE_TTL_SECONDS` clause (pressure_signal.py:208). Confirmed RED.

## Gap 3 (MEDIUM) — publisher pool arm never exercised
`test_publish_reflects_pool_ratio_when_it_exceeds_local` passes a non-empty `mgr_metrics_url`, mocks the httpx pool scrape (respx) at 96% over a 10% local disk, and asserts the published mode tracks the pool ratio (mode 2).
- Mutation caught: replacing `max(local, pool)` with `local` (pressure_signal.py:154). Confirmed RED.

## Checks
- `pytest tests/unit/test_pressure_signal.py tests/unit/test_fs_cache_pressure_middleware.py -q` → 22 passed
- `ruff check hippius_s3 gateway` → passed; new file format-clean; ty check passed