### PR TITLE
fix(janitor): fail loud on missing last_access_at column; consume it from candidate query

### DIFF
--- a/hippius_s3/sql/queries/janitor_evictable_candidates.sql
+++ b/hippius_s3/sql/queries/janitor_evictable_candidates.sql
@@ -43,9 +43,19 @@
 -- candidates through a concurrent pool, so order affects only stable/deterministic processing, not
 -- correctness; matching the slice keeps oldest-first intent without re-reading cached_at here.
 --
+-- last_access_at: the read-recency signal (fs_cache_inventory.last_access_at, written by the api's
+-- AccessTracker) is LEFT-JOINed back and returned on every candidate row so the worker consumes it
+-- inline instead of a per-part fetchval (kills an N+1). Selecting the column here also makes a
+-- pre-migration schema (column absent — e.g. the janitor image rolled ahead of the API that runs
+-- migrations) fail LOUDLY once at discovery: the whole page raises UndefinedColumnError and the
+-- phase surfaces it, rather than the old per-item fetchval throwing under the worker pool's swallow,
+-- which froze eviction while logging one warning per candidate and freed zero. LEFT (not INNER) join
+-- so a row cleared between the slice and this filter yields NULL (treated as "not read"), never
+-- dropping a candidate — the candidate population is unchanged when the column is present.
+--
 -- CONTRACT (LOCKED — the SQL-eviction worker binds positionally against this exact order; do NOT
 -- reorder/renumber params or reorder the returned columns). Returns exactly (object_id,
--- object_version, part_number).
+-- object_version, part_number, last_access_at).
 --
 -- Parameters:
 --   $1 object_ids               TEXT[]   — slice tuples' object_id (parallel array; unnest WITH ORDINALITY)
@@ -74,7 +84,7 @@ required_sets AS (
         ) AS required
     FROM object_versions ov
 )
-SELECT s.oid AS object_id, s.ver AS object_version, s.pnum AS part_number
+SELECT s.oid AS object_id, s.ver AS object_version, s.pnum AS part_number, fci.last_access_at AS last_access_at
 FROM slice s
 JOIN parts p
   ON p.object_id = s.oid::uuid
@@ -82,6 +92,8 @@ JOIN parts p
  AND p.part_number = s.pnum
 JOIN required_sets rs
   ON rs.object_id = p.object_id AND rs.object_version = p.object_version
+LEFT JOIN fs_cache_inventory fci
+  ON fci.object_id = s.oid AND fci.object_version = s.ver AND fci.part_number = s.pnum
 WHERE ($7 OR p.uploaded_at < now() - make_interval(secs => $6))
   -- Expected chunk population fully present (not mid-materialisation), in ONE part_chunks probe:
   -- count >= GREATEST(expected, 1) folds in the old "> 0" guard — a part whose size implies 0 chunks

--- a/tests/e2e/test_janitor_sql_eviction.py
+++ b/tests/e2e/test_janitor_sql_eviction.py
@@ -56,15 +56,16 @@ def _part_dir(object_id: str, object_version: int, part_number: int) -> str:
     return f"/var/lib/hippius/object_cache/{object_id}/v{object_version}/part_{part_number}"
 
 
-def _run_one_eviction_pass() -> str:
+def _run_one_eviction_pass(pressure: int = 2) -> str:
     """Exec a single evict_from_inventory pass in the janitor container and return its stdout.
 
     pressure=2 makes a fresh part eligible: ignore_age=True (age gate off) and hot_window=0 (hot
     retention disabled), so only the absolute replication gate decides — exactly what we want to
-    prove is being enforced.
+    prove is being enforced. pressure=0 (NORMAL) keeps the age gate and hot retention ACTIVE, so the
+    recency signals (write atime + last_access_at) actually decide — used by the read-recency tests.
     """
     snippet = textwrap.dedent(
-        """
+        f"""
         import asyncio
         import asyncpg
         from redis.asyncio import Redis
@@ -78,8 +79,8 @@ def _run_one_eviction_pass() -> str:
             fs = create_fs_store(c)
             r = Redis.from_url(c.redis_queues_url)
             try:
-                n = await evict_from_inventory(pool, fs, r, pressure=2)
-                print(f"EVICTED={n}")
+                n = await evict_from_inventory(pool, fs, r, pressure={pressure})
+                print(f"EVICTED={{n}}")
             finally:
                 await r.close()
                 await pool.close()
@@ -90,6 +91,53 @@ def _run_one_eviction_pass() -> str:
     rc, out, err = compose_exec("janitor", ["python", "-c", snippet])
     assert rc == 0, f"eviction exec failed rc={rc}\nstdout={out}\nstderr={err}"
     return out
+
+
+def _backdate_uploaded_at(object_id: str, object_version: int, seconds_ago: int, *, dsn: str = DEFAULT_DSN) -> None:
+    """Age a part past the janitor's max-age gate so, at NORMAL pressure (ignore_age=False), it is a
+    legitimate candidate and the recency signals — not the age gate — decide whether it is evicted."""
+    with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute(
+            "UPDATE parts SET uploaded_at = now() - make_interval(secs => %s) "
+            "WHERE object_id = %s AND object_version = %s",
+            (seconds_ago, object_id, object_version),
+        )
+        conn.commit()
+
+
+def _set_last_access(
+    object_id: str, object_version: int, part_number: int, seconds_ago: float, *, dsn: str = DEFAULT_DSN
+) -> None:
+    """Set fs_cache_inventory.last_access_at relative to now (the read-recency signal the candidate
+    query now carries inline). seconds_ago small = fresh (protects); large = stale (does not pin)."""
+    with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute(
+            "UPDATE fs_cache_inventory SET last_access_at = now() - make_interval(secs => %s) "
+            "WHERE object_id = %s AND object_version = %s AND part_number = %s",
+            (seconds_ago, object_id, object_version, part_number),
+        )
+        conn.commit()
+
+
+def _backdate_part_atime(object_id: str, object_version: int, part_number: int, seconds_ago: int) -> None:
+    """Make the part's FS write-recency (atime of its meta.json / dir, what stat_part reads) COLD so
+    the write-recency short-circuit does not pin a freshly-PUT part — isolating last_access_at as the
+    deciding recency signal at NORMAL pressure."""
+    part_dir = _part_dir(object_id, object_version, part_number)
+    snippet = textwrap.dedent(
+        f"""
+        import os, time
+        old = time.time() - {seconds_ago}
+        d = {part_dir!r}
+        for name in ("meta.json", ""):
+            p = os.path.join(d, name) if name else d
+            if os.path.exists(p):
+                os.utime(p, (old, old))
+        print("BACKDATED")
+        """
+    )
+    rc, out, err = compose_exec("janitor", ["python", "-c", snippet])
+    assert rc == 0 and "BACKDATED" in out, f"atime backdate failed rc={rc}\nstdout={out}\nstderr={err}"
 
 
 @pytest.mark.local
@@ -130,6 +178,92 @@ def test_sql_eviction_evicts_replicated_part_and_get_refetches(
 
     # And the object still reads: the GET rehydrates through the download pipeline, proving the
     # eviction was safe (the bytes were fully replicated and are re-fetchable from the backend).
+    resp = boto3_client.get_object(Bucket=bucket, Key=key)
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert resp["Body"].read() == content
+
+
+def _prepare_aged_candidate(boto3_client: Any, bucket: str, key: str, content: bytes) -> tuple[str, int, int]:
+    """PUT + wait for replication + seed inventory + age it into a NORMAL-pressure candidate whose
+    ONLY remaining recency signal is last_access_at. Returns (object_id, object_version, part_number).
+
+    At pressure=0 both gates the pressure=2 test disables are ACTIVE, so a freshly-PUT part is held
+    for two reasons unrelated to read-recency: the age gate (uploaded_at younger than max_age) and
+    write-recency (its meta.json atime is ~now). We backdate BOTH past their windows so the part is a
+    legitimate candidate whose eviction now turns solely on last_access_at.
+    """
+    boto3_client.put_object(Bucket=bucket, Key=key, Body=content)
+    assert wait_for_all_backends_ready(bucket, key, min_count=1, timeout_seconds=30.0)
+    object_id, object_version = get_object_id_and_version(bucket, key)
+    parts = _seed_inventory(object_id, object_version)
+    assert parts, "object should have at least one part"
+    part_number = parts[0]
+
+    present_rc, _, _ = compose_exec("janitor", ["test", "-d", _part_dir(object_id, object_version, part_number)])
+    assert present_rc == 0, "part must be on the FS cache before eviction"
+
+    _backdate_uploaded_at(object_id, object_version, seconds_ago=10 * 86400)  # past the 1-day age gate
+    _backdate_part_atime(object_id, object_version, part_number, seconds_ago=10 * 86400)  # cold write-recency
+    return object_id, object_version, part_number
+
+
+@pytest.mark.local
+def test_fresh_last_access_keeps_part_at_normal_pressure(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    # NORMAL pressure (recency ACTIVE): a fully-replicated, aged, write-cold part with a FRESH
+    # last_access_at must be KEPT — read-recency hot retention protects a recently-read part from
+    # eviction even though every other gate would let it go.
+    bucket = unique_bucket_name("janitor-recency-keep")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+
+    key = "recency-keep.bin"
+    content = b"janitor read-recency keep payload"
+    object_id, object_version, part_number = _prepare_aged_candidate(boto3_client, bucket, key, content)
+
+    _set_last_access(object_id, object_version, part_number, seconds_ago=5)  # read just now → hot
+
+    _run_one_eviction_pass(pressure=0)
+
+    # KEPT: the FS-cache entry survives because last_access_at is inside the hot window.
+    present_rc, _, _ = compose_exec("janitor", ["test", "-d", _part_dir(object_id, object_version, part_number)])
+    assert present_rc == 0, "freshly-read part must NOT be evicted at normal pressure"
+
+    resp = boto3_client.get_object(Bucket=bucket, Key=key)
+    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+    assert resp["Body"].read() == content
+
+
+@pytest.mark.local
+def test_stale_last_access_evicts_part_at_normal_pressure(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    # Companion to the keep test: the SAME aged, write-cold candidate but with a STALE last_access_at
+    # (read long ago) IS evicted — a stale recency value must not pin a part forever. Proves recency
+    # is a genuine gate, not an unconditional keep, and that the read-recency path lets cold parts go.
+    bucket = unique_bucket_name("janitor-recency-evict")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+
+    key = "recency-evict.bin"
+    content = b"janitor read-recency stale-evict payload"
+    object_id, object_version, part_number = _prepare_aged_candidate(boto3_client, bucket, key, content)
+
+    _set_last_access(object_id, object_version, part_number, seconds_ago=10 * 86400)  # read long ago → cold
+
+    _run_one_eviction_pass(pressure=0)
+
+    # EVICTED: stale read-recency does not pin it; the replication gate cleared it for deletion.
+    gone_rc, _, _ = compose_exec("janitor", ["test", "-e", _part_dir(object_id, object_version, part_number)])
+    assert gone_rc != 0, "stale-read part must be evicted at normal pressure"
+
     resp = boto3_client.get_object(Bucket=bucket, Key=key)
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
     assert resp["Body"].read() == content

--- a/tests/integration/test_janitor_evictable_candidates.py
+++ b/tests/integration/test_janitor_evictable_candidates.py
@@ -375,9 +375,9 @@ async def test_explain_keeps_parts_indexed_off_the_slice_arrays(pg_tx: asyncpg.C
         await _seed_candidate(pg_tx, bucket, per_chunk_live=[["arion"]], upload_backends=["arion"])
     object_ids, versions, part_numbers = await _resident_tuples(pg_tx)
 
-    # The filter no longer touches fs_cache_inventory (it unnests the given arrays); the load-bearing
-    # property is that the join into parts still drives off an object_id-leading index rather than a
-    # seq scan. The test DB is tiny, so force seqscan off to prove the query CAN be served by an index
+    # The filter only re-touches fs_cache_inventory via a PK LEFT JOIN for last_access_at (index-only);
+    # the load-bearing property is that the join into parts still drives off an object_id-leading index
+    # rather than a seq scan. The test DB is tiny, so force seqscan off to prove the query CAN be served by an index
     # — reachable only because the ::uuid cast is on the slice side (s.oid::uuid), keeping
     # parts.object_id a bare indexed column. Casting parts.object_id::text would defeat every parts
     # index and force a seq scan.

--- a/tests/unit/test_janitor_sql_evict.py
+++ b/tests/unit/test_janitor_sql_evict.py
@@ -36,12 +36,21 @@ COLD = 1.0  # atime far in the past → never hot
 HOT = None  # sentinel replaced with time.time() at build → always hot under normal pressure
 
 
-def _row(oid: str, ov: int = 1, pn: int = 1, cached_at: datetime | None = None) -> dict:
+def _row(
+    oid: str,
+    ov: int = 1,
+    pn: int = 1,
+    cached_at: datetime | None = None,
+    last_access_at: datetime | None = None,
+) -> dict:
+    # last_access_at rides on the candidate row (janitor_evictable_candidates LEFT-joins
+    # fs_cache_inventory), so the worker consumes it inline instead of a per-item fetchval.
     return {
         "object_id": oid,
         "object_version": ov,
         "part_number": pn,
         "cached_at": cached_at or datetime(2020, 1, 1, tzinfo=timezone.utc),
+        "last_access_at": last_access_at,
     }
 
 
@@ -90,15 +99,12 @@ class _RouterConn:
     serves that page's candidate rows, advancing to the next page after the filter fetch. A page's
     slice or cand entry may be an Exception instance to inject a timeout on that specific fetch."""
 
-    def __init__(self, pages: list[tuple[Any, Any]], last_access: Any = None) -> None:
+    def __init__(self, pages: list[tuple[Any, Any]]) -> None:
         self._pages = pages
         self._i = 0
         self.slice_args: list[tuple] = []
         self.filter_args: list[tuple] = []
         self.fetch = AsyncMock(side_effect=self._fetch)
-        # handle()'s read-recency probe (fs_cache_inventory.last_access_at).
-        # None = never read, which preserves the legacy write-recency-only path.
-        self.fetchval = AsyncMock(return_value=last_access)
 
     async def _fetch(self, query: str, *args: Any, **_kwargs: Any) -> Any:
         if query == "janitor_inventory_slice":
@@ -134,11 +140,11 @@ def _config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(janitor, "_janitor_deleted_counter", MagicMock())
 
 
-def _conn(*pages: tuple[Any, Any], last_access: Any = None) -> _RouterConn:
+def _conn(*pages: tuple[Any, Any]) -> _RouterConn:
     """Build a router conn from (slice_rows, cand_rows) pages. For the common case where every slice
-    row is also a candidate, pass the same list for both. `last_access` seeds the read-recency
-    probe (fs_cache_inventory.last_access_at); None = never read."""
-    return _RouterConn(list(pages), last_access=last_access)
+    row is also a candidate, pass the same list for both. Seed read-recency via a row's
+    last_access_at (it rides on the candidate row now, not a separate fetchval)."""
+    return _RouterConn(list(pages))
 
 
 def _same(rows: list[dict]) -> tuple[list[dict], list[dict]]:
@@ -222,16 +228,32 @@ async def test_replicated_cold_candidate_is_deleted_cleared_and_counted(monkeypa
 
 @pytest.mark.asyncio
 async def test_recently_read_candidate_is_protected_via_last_access(monkeypatch: pytest.MonkeyPatch) -> None:
-    # atime is COLD (the read path no longer touches it), but the inventory's
+    # atime is COLD (the read path no longer touches it), but the candidate row's
     # last_access_at is fresh — hot retention must protect the part.
     monkeypatch.setattr(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=True))
     fs = _FakeFs(stat_map={(OID_A, 1, 1): _stat(COLD)})
-    conn = _conn(_same([_row(OID_A)]), ([], []), last_access=datetime.now(timezone.utc))
+    conn = _conn(_same([_row(OID_A, last_access_at=datetime.now(timezone.utc))]), ([], []))
 
     deleted = await _evict(conn, fs)
 
     assert deleted == 0
     assert fs.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_stale_last_access_does_not_pin_and_part_is_evicted(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A STALE last_access_at (read long ago) must NOT pin the part forever: atime is COLD and the
+    # recorded read is older than the hot window, so recency lets the part fall through to the
+    # replication gate and be evicted. Guards against a stale recency value becoming a permanent pin.
+    monkeypatch.setattr(janitor, "is_replicated_on_all_backends", AsyncMock(return_value=True))
+    fs = _FakeFs(stat_map={(OID_A, 1, 1): _stat(COLD)})
+    stale = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    conn = _conn(_same([_row(OID_A, last_access_at=stale)]), ([], []))
+
+    deleted = await _evict(conn, fs)
+
+    assert deleted == 1
+    assert fs.deleted == [(OID_A, 1, 1)]
 
 
 @pytest.mark.asyncio

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -1944,8 +1944,8 @@ async def evict_from_inventory(
     async with pool.acquire() as conn:
         cursor = _load_evict_cursor(await get_janitor_state(conn, "sql_evict_cursor"))
 
-    async def handle(conn: asyncpg.Connection, item: tuple[str, int, int]) -> bool:
-        object_id, object_version, part_number = item
+    async def handle(conn: asyncpg.Connection, item: tuple[str, int, int, datetime | None]) -> bool:
+        object_id, object_version, part_number, last_access = item
         st = await asyncio.to_thread(fs_store.stat_part, object_id, object_version, part_number)
         if st is None:
             await clear_cached(conn, object_id, object_version, part_number)  # stale row: self-heal
@@ -1956,15 +1956,10 @@ async def evict_from_inventory(
             if st.st_atime > (now - hot_window):
                 return False
             # Read recency: recorded by the api's AccessTracker into
-            # last_access_at. NULL = not read since the column shipped, which
-            # degrades to the old write-recency-only behavior. PK lookup.
-            last_access = await conn.fetchval(
-                "SELECT last_access_at FROM fs_cache_inventory "
-                "WHERE object_id = $1 AND object_version = $2 AND part_number = $3",
-                object_id,
-                object_version,
-                part_number,
-            )
+            # last_access_at, carried inline on the candidate row (no per-item
+            # fetchval — the missing-column failure surfaces at discovery, not
+            # here under the pool's per-item swallow). NULL = not read since the
+            # column shipped, which degrades to the old write-recency-only path.
             if last_access is not None and last_access.timestamp() > (now - hot_window):
                 return False  # recently read — hot retention protects it
         # ABSOLUTE safety gate — identical call to the walk's, never bypassed by the prefilter.
@@ -1986,11 +1981,11 @@ async def evict_from_inventory(
             _janitor_deleted_counter.add(1, attributes={"reason": "sql_evict"})
         return True
 
-    async def candidates(page: list[Any]) -> AsyncIterator[tuple[str, int, int]]:
+    async def candidates(page: list[Any]) -> AsyncIterator[tuple[str, int, int, datetime | None]]:
         for r in page:
             if r["object_id"] in dlq_object_ids:
                 continue  # DLQ-parked: an in-flight op owns this object's data
-            yield (r["object_id"], r["object_version"], r["part_number"])
+            yield (r["object_id"], r["object_version"], r["part_number"], r["last_access_at"])
 
     deleted_total = 0
     pages = 0


### PR DESCRIPTION
## Summary

F4: silent janitor stall during a janitor-ahead-of-api rollout.

`evict_from_inventory`'s per-item recency probe did an inline `fetchval("SELECT last_access_at FROM fs_cache_inventory …")` inside the per-item `handle` worker. `_run_worker_pool` swallows any per-item Exception and continues. So with migration `20260725120000_fs_cache_inventory_last_access.sql` UNAPPLIED (the janitor image rolls ahead of the API that runs migrations), every candidate threw `UndefinedColumnError` → the phase freed ZERO with one warning per part and no page. It only recovered at CRITICAL pressure, where `hot_window==0` skips the recency query entirely.

The candidate query (`janitor_evictable_candidates.sql`) returned only `(object_id, object_version, part_number)`, so discovery succeeded with the column missing and the failure hid per-item.

## Changes

- **SQL — fail loud + de-N+1:** `janitor_evictable_candidates.sql` now LEFT-JOINs `fs_cache_inventory` (PK, index-only) and returns `last_access_at` on every candidate row. A missing column now raises `UndefinedColumnError` ONCE at discovery (surfaced as an ERROR-with-traceback by the phase's guard at the call site) instead of N per-item swallowed warnings. LEFT (not INNER) join so a row cleared between slice and filter yields NULL (treated as "not read") and the candidate population is unchanged when the column is present. Locked-contract header updated.
- **Worker:** `evict_from_inventory` consumes `last_access_at` from the candidate row; the redundant inline `fetchval` is removed (kills an N+1). Behavior is identical when the column is present; the `hot_window==0` skip is preserved.
- **Unit tests:** recency now arrives on the candidate row (mocks adjusted); FRESH + NULL cases kept; added a STALE case asserting a stale `last_access_at` does NOT pin a part forever (eviction proceeds).
- **E2E:** two new NORMAL-pressure round-trips (recency active) that age a replicated part past the age gate and cold its write-atime so `last_access_at` is the deciding signal — a fresh value KEEPS the part; a stale value EVICTS it and the GET rehydrates.

## Local checks

- `ruff check` / `ruff format --check` (hippius_s3, gateway, workers/run_janitor_in_loop.py, both test files): pass
- `ty check` (hippius_s3, gateway): pass
- `pytest tests/unit/test_janitor_sql_evict.py`: 25 passed
- `pytest tests/integration/test_janitor_evictable_candidates.py` against real Postgres (migrated): 12 passed — includes the EXPLAIN guard confirming `parts` is still index-scanned with the new LEFT JOIN.
- E2E not runnable locally (real-Postgres CI job); the new tests match the existing harness/fixtures.

## Conclusion

Turns a silent, zero-eviction stall into a loud, once-per-cycle discovery error during the rollout window, and removes a per-item DB round-trip on the hot eviction path — with the safety model (absolute replication gate, recency semantics) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)