### PR TITLE
fix(janitor): honor read recency (last_access_at) in age-GC and stale-reap paths

### DIFF
--- a/tests/unit/test_janitor_unified_walk.py
+++ b/tests/unit/test_janitor_unified_walk.py
@@ -20,6 +20,9 @@ import os
 import shutil
 import time
 import uuid
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 from pathlib import Path
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -99,12 +102,21 @@ class _FakePool:
 
 
 class _FakeConn:
-    """Answers only the stale-phase `parts` recency query; replication / abandoned checks are
-    patched at module level so they never touch this conn."""
+    """Answers the stale-phase `parts` recency query (fetchrow) and the F3 read-recency
+    last_access_at lookup (fetchval); replication / abandoned checks are patched at module level so
+    they never touch this conn. `last_access` maps object_id -> a tz-aware datetime for the walk's
+    read-recency gate; a missing key returns None (no inventory row -> write-recency-only, as prod)."""
+
+    def __init__(self, last_access: dict[str, "datetime"] | None = None):
+        self._last_access = last_access or {}
 
     async def fetchrow(self, query, *args):
         object_id = args[0]
         return PARTS_ROWS.get(object_id)
+
+    async def fetchval(self, query, *args):
+        object_id = args[0]
+        return self._last_access.get(object_id)
 
 
 class _FakeFsStore:
@@ -532,3 +544,120 @@ async def test_unified_backfill_flushes_at_batch_size_boundary(tmp_path: Path, m
     assert sorted(len(b) for b in batch.batches) == [1, 2, 2], "flushes at each boundary plus a final partial"
     assert batch.rows == {(oid, 1, 1) for oid in survivors}
     assert store.deleted == []
+
+
+# ============================================================================================
+# F3: read-recency (last_access_at) KEEP gate in the FS-walk age-GC + stale-reap paths
+# ============================================================================================
+#
+# After the read path stopped bumping atime (it records fs_cache_inventory.last_access_at via the
+# AccessTracker instead), the walk's atime/mtime are WRITE recency only. A fully-replicated part
+# that is actively READ but not re-written would be reaped by age-GC (>gc_max_age) or stale-reap
+# (>mpu_stale) and re-hydrated from Arion (read amplification). The unified walk now consults
+# last_access_at and KEEPS a part read within the effective hot window — unless hot_window==0
+# (critical pressure), where reaping resumes to free space. Replication stays the absolute gate.
+
+READ_HOT_GC = f"{0x11:032x}"  # replicated, gc-aged mtime, write-cold atime -> age-GC would delete
+READ_HOT_STALE = f"{0x12:032x}"  # orphan (no parts row), stale-aged -> stale-reap would reap
+
+
+async def _always_replicated(conn, oid, ov, pn):
+    return True
+
+
+def _fresh_access() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _stale_access() -> datetime:
+    return datetime.now(timezone.utc) - timedelta(hours=6)
+
+
+@pytest.mark.asyncio
+async def test_read_recency_keeps_age_gc_part_with_fresh_last_access(tmp_path: Path, monkeypatch):
+    """(a) A replicated, write-cold, gc-aged part that age-GC would otherwise evict is KEPT when it
+    was READ within the hot window (fresh last_access_at), even though its atime/mtime are old."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    janitor.config.fs_cache_hot_retention_seconds = 3600
+    root = tmp_path / "t"
+    _make_part(root, READ_HOT_GC, mtime_ago=7200, atime_ago=7200)  # gc-aged + write-cold
+    store = _FakeFsStore(root)
+    conn = _FakeConn(last_access={READ_HOT_GC: _fresh_access()})
+    with (
+        patch.object(janitor, "is_replicated_on_all_backends", _always_replicated),
+        patch.object(janitor, "is_terminally_abandoned", _fake_abandoned),
+        patch.object(janitor.fs_cache_inventory, "record_cached_batch", AsyncMock()),
+    ):
+        res = await janitor.cleanup_parts_unified(
+            _FakePool(conn), store, _redis(), pressure=0, shard=0, shards=1, walk_concurrency=1
+        )
+    assert store.deleted == [], "read-hot part must NOT be evicted by age-GC despite old atime/mtime"
+    assert res["gc"] == 0
+
+
+@pytest.mark.asyncio
+async def test_read_recency_keeps_stale_reap_part_with_fresh_last_access(tmp_path: Path, monkeypatch):
+    """(b) An orphan (no parts row), stale-aged part that stale-reap would otherwise reap is KEPT
+    when it was READ within the hot window (fresh last_access_at), despite its old mtime."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    janitor.config.fs_cache_hot_retention_seconds = 3600
+    root = tmp_path / "t"
+    _make_part(root, READ_HOT_STALE, mtime_ago=200_000, atime_ago=200_000)  # stale-aged, orphan
+    store = _FakeFsStore(root)
+    conn = _FakeConn(last_access={READ_HOT_STALE: _fresh_access()})
+    with (
+        patch.object(janitor, "is_replicated_on_all_backends", _always_replicated),
+        patch.object(janitor, "is_terminally_abandoned", _fake_abandoned),
+        patch.object(janitor.fs_cache_inventory, "record_cached_batch", AsyncMock()),
+    ):
+        res = await janitor.cleanup_parts_unified(
+            _FakePool(conn), store, _redis(), pressure=0, shard=0, shards=1, walk_concurrency=1
+        )
+    assert store.deleted == [], "read-hot part must NOT be reaped by stale-reap despite old mtime"
+    assert res["stale_mtime"] == 0 and res["abandoned"] == 0
+
+
+@pytest.mark.asyncio
+async def test_read_recency_stale_last_access_still_evicts_both_paths(tmp_path: Path, monkeypatch):
+    """(c) With a STALE last_access_at (read outside the hot window) both an age-GC candidate and a
+    stale-reap candidate are still evicted/reaped exactly as before the read-recency gate."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 0)
+    janitor.config.fs_cache_hot_retention_seconds = 3600
+    root = tmp_path / "t"
+    _make_part(root, READ_HOT_GC, mtime_ago=7200, atime_ago=7200)  # gc-aged + write-cold
+    _make_part(root, READ_HOT_STALE, mtime_ago=200_000, atime_ago=200_000)  # stale-aged, orphan
+    store = _FakeFsStore(root)
+    conn = _FakeConn(last_access={READ_HOT_GC: _stale_access(), READ_HOT_STALE: _stale_access()})
+    with (
+        patch.object(janitor, "is_replicated_on_all_backends", _always_replicated),
+        patch.object(janitor, "is_terminally_abandoned", _fake_abandoned),
+        patch.object(janitor.fs_cache_inventory, "record_cached_batch", AsyncMock()),
+    ):
+        res = await janitor.cleanup_parts_unified(
+            _FakePool(conn), store, _redis(), pressure=0, shard=0, shards=1, walk_concurrency=1
+        )
+    assert set(store.deleted) == {(READ_HOT_GC, 1, 1), (READ_HOT_STALE, 1, 1)}
+    assert res["gc"] == 1 and res["stale_mtime"] == 1
+
+
+@pytest.mark.asyncio
+async def test_read_recency_bypassed_under_critical_pressure(tmp_path: Path, monkeypatch):
+    """(d) Under CRITICAL pressure hot_window==0, so the read-recency check is bypassed: even a part
+    with FRESH last_access_at is evicted — matching the SQL-evict path and freeing space to survive
+    the disk-full spiral (replication remains the absolute gate)."""
+    monkeypatch.setattr(janitor, "_pressure_mode", lambda root: 2)
+    janitor.config.fs_cache_hot_retention_seconds = 3600
+    root = tmp_path / "t"
+    _make_part(root, READ_HOT_GC, mtime_ago=7200, atime_ago=7200)  # gc-aged, replicated
+    store = _FakeFsStore(root)
+    conn = _FakeConn(last_access={READ_HOT_GC: _fresh_access()})
+    with (
+        patch.object(janitor, "is_replicated_on_all_backends", _always_replicated),
+        patch.object(janitor, "is_terminally_abandoned", _fake_abandoned),
+        patch.object(janitor.fs_cache_inventory, "record_cached_batch", AsyncMock()),
+    ):
+        res = await janitor.cleanup_parts_unified(
+            _FakePool(conn), store, _redis(), pressure=2, shard=0, shards=1, walk_concurrency=1
+        )
+    assert store.deleted == [(READ_HOT_GC, 1, 1)], "critical pressure (hot_window==0) bypasses read recency"
+    assert res["gc"] == 1

--- a/workers/run_janitor_in_loop.py
+++ b/workers/run_janitor_in_loop.py
@@ -1742,6 +1742,30 @@ async def cleanup_parts_unified(
         await _flush_backfill()  # final partial batch of kept parts
 
     async def handle(conn: asyncpg.Connection, item: _UnifiedCandidate) -> bool:
+        # F3 read-recency KEEP gate. On this walk path atime/mtime are WRITE recency only — the read
+        # path stopped bumping atime (fs_store.get_chunk's per-read os.utime was removed) and now
+        # records fs_cache_inventory.last_access_at via the AccessTracker. So a part that is actively
+        # READ but not re-written for >gc_max_age (age-GC) or >mpu_stale (stale-reap) would be reaped
+        # and re-hydrated from Arion (read amplification). Protect it here: if it was read within the
+        # effective hot window, KEEP it — regardless of which rule (stale-reap or age-GC) fired.
+        # Gated behind hot_window>0 so CRITICAL pressure (hot_window==0) still reaps, exactly like the
+        # SQL-evict path. A part with NO inventory row (last_access_at NULL/absent) falls through to
+        # the write-recency-only behavior — a missing row is never made un-evictable. The absolute
+        # replication gate below is untouched; this only changes WHEN a part becomes evictable.
+        # TODO: batch this last_access_at lookup across the walk's delete-candidates (mirror the
+        # producer's backfill_batch) rather than one fetchval per candidate. Only delete-candidates —
+        # a small fraction of the O(resident) walk — reach here, so the per-part cost is bounded now.
+        if hot_window > 0:
+            last_access = await conn.fetchval(
+                "SELECT last_access_at FROM fs_cache_inventory "
+                "WHERE object_id = $1 AND object_version = $2 AND part_number = $3",
+                item.object_id,
+                item.object_version,
+                item.part_number,
+            )
+            if last_access is not None and last_access.timestamp() > (now - hot_window):
+                return False  # recently read — hot retention protects it from stale-reap and age-GC
+
         # Evaluate stale-reap FIRST (matches the old serial order: stale phase ran before age-GC,
         # so a part deletable by both is attributed to stale). If stale protects it, fall through
         # to age-GC — a not-replicated part is protected by both, a stale-recent-but-replicated


### PR DESCRIPTION
## F3: age-GC + stale-reap FS-walk delete paths were read-blind

After the read path stopped bumping atime (it now records `fs_cache_inventory.last_access_at` via the AccessTracker), the janitor FS walk's `atime`/`mtime` reflect the last **WRITE** only. Two of the three delete paths never consulted `last_access_at`:

- **age-GC** (`_age_gc_decision`, gc_max_age default 24h) — atime-only.
- **stale-reap** (`_stale_reap_decision` / `_stale_fs_eligible`, mpu_stale default 2d) — mtime-only.

So a fully-replicated part that is actively **READ** but not re-written was evicted daily/every-2-days and re-hydrated from Arion (read amplification; feeds F1 truncation). Only the SQL-evict path (`evict_from_inventory`) honored read recency.

## Change

Add a read-recency KEEP check to the unified FS-walk `handle` (`cleanup_parts_unified`, the prod path) so a part read within the effective hot window is kept by **both** the stale-reap and age-GC rules — mirroring the SQL-evict path's `last_access_at` check and tz-aware comparison.

- Gated behind `hot_window > 0` so CRITICAL pressure (`hot_window == 0`) still reaps to free space, same as the SQL path.
- Parts with **no** inventory row (`last_access_at` NULL/absent) degrade to write-recency-only — missing-row parts are never made un-evictable.
- The replication gate (`is_replicated_on_all_backends`) is **unchanged** and stays the absolute safety net in front of every delete. This changes *when* a part becomes evictable, never whether it is safe.
- **Per-candidate** `fetchval` (mirrors `evict_from_inventory`), gated to delete-candidates only — a `# TODO:` marks batching as a follow-up. The FS walk is a streaming producer→worker-pool with no natural page, so per-candidate is the low-risk first cut; only delete-candidates (a small fraction of the O(resident) walk) reach `handle`.
- Confined to the walk/age-GC/stale-reap functions; does **not** touch `evict_from_inventory` or `janitor_evictable_candidates.sql` (sibling PR territory).

## Tests

New unit tests in `test_janitor_unified_walk.py`:
- (a) old atime + fresh `last_access_at` → **kept** by age-GC.
- (b) old mtime + fresh `last_access_at` → **kept** by stale-reap.
- (c) stale `last_access_at` → still evicted/reaped on both paths.
- (d) `hot_window == 0` (critical) → recency check bypassed, still evicted.

Local: ruff check + format clean; `ty check` clean; all 160 janitor unit tests pass (incl. the 4 new + the union-equivalence suite unchanged).

## Conclusion

Closes the read-blind gap so all three janitor delete paths now honor `last_access_at`; durability is untouched (replication gate unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)