### PR TITLE
fix(reader): re-enqueue a download on mid-stream chunk miss instead of waiting to timeout

### DIFF
--- a/hippius_s3/reader/streamer.py
+++ b/hippius_s3/reader/streamer.py
@@ -107,8 +107,30 @@ async def stream_plan(
     # Fallback only; object_reader passes the wired default HTTP_STREAM_PREFETCH_CHUNKS (16 in prod).
     prefetch_chunks: int = 0,
     chunk_timeout: float | None = None,
+    # F1: called with a part_number when a chunk is missing from FS at stream time, to (idempotently)
+    # re-enqueue that part's download. Without it a mid-stream eviction on a cache-source read waits on
+    # a `notify:` no producer will ever publish and times out inside the response body (silent
+    # truncation). None (HEAD/copy/migrate callers) keeps the pure wait-on-pub/sub behavior.
+    ensure_part_fn: Callable[[int], Awaitable[None]] | None = None,
 ) -> AsyncGenerator[bytes, None]:
     prefetch = max(0, int(prefetch_chunks))
+
+    # Parts we've already re-enqueued this stream. ensure_part_fn covers the WHOLE part's needed
+    # chunks in one call, so a part is only ensured once even if several of its chunks miss.
+    ensured_parts: set[int] = set()
+
+    async def _maybe_ensure(item: ChunkPlanItem) -> None:
+        # Only a genuine FS miss triggers the enqueue — a present chunk (the common case) pays a
+        # single stat and no Redis/DB work, keeping the cache-source fast path fast.
+        if ensure_part_fn is None:
+            return
+        pn = int(item.part_number)
+        if pn in ensured_parts:
+            return
+        if await obj_cache.chunk_exists(object_id, int(object_version), pn, int(item.chunk_index)):
+            return
+        ensured_parts.add(pn)
+        await ensure_part_fn(pn)
 
     async def _decrypt(c: bytes, item: ChunkPlanItem) -> bytes:
         return await decrypt_chunk_if_needed(
@@ -132,6 +154,7 @@ async def stream_plan(
         async with obj_cache.stream_subscription(object_id, int(object_version)) as sub:
 
             async def _wait_sub(item: ChunkPlanItem) -> bytes:
+                await _maybe_ensure(item)
                 return await sub.wait_for_chunk(int(item.part_number), int(item.chunk_index), timeout=sub_timeout)
 
             async for out in _emit(
@@ -146,6 +169,7 @@ async def stream_plan(
         return
 
     async def _wait(item: ChunkPlanItem) -> bytes:
+        await _maybe_ensure(item)
         return await obj_cache.wait_for_chunk(
             object_id,
             int(object_version),

--- a/hippius_s3/services/object_reader.py
+++ b/hippius_s3/services/object_reader.py
@@ -7,6 +7,8 @@ import time
 from dataclasses import dataclass
 from typing import Any
 from typing import AsyncGenerator
+from typing import Awaitable
+from typing import Callable
 
 from fastapi import Response
 from fastapi.responses import StreamingResponse
@@ -47,6 +49,10 @@ class StreamContext:
     suite_id: str | None
     bucket_id: str
     upload_id: str
+    # F1: idempotent per-part re-enqueue hook the streamer calls when a chunk is missing from FS at
+    # stream time (e.g. the janitor evicted a still-to-be-streamed part on a cache-source read). None
+    # for non-streaming callers (HEAD/copy) that never hit the streamer miss path.
+    ensure_part_download: Callable[[int], Awaitable[None]] | None = None
 
 
 # RQ-4: compare-and-delete Lua — delete the coalesce lock only while it still holds our token, so we
@@ -82,33 +88,27 @@ async def _release_coalesce_locks(
 _CID_ADDRESSED_BACKENDS: frozenset[str] = frozenset({"ipfs"})
 
 
-async def _enqueue_missing_downloads(
+async def _enqueue_download_for_parts(
     db: Any,
     redis: Any,
     info: dict,
     *,
     object_version: int,
     storage_version: int,
-    plan: list[ChunkPlanItem],
-    exist_results: list[bool],
+    indices_by_part: dict[int, set[int]],
     address: str,
     cfg: Any,
 ) -> None:
-    """Enqueue a DownloadChainRequest for the chunks in `plan` that are missing from the FS cache.
+    """Coalesce-lock the given parts and enqueue ONE DownloadChainRequest for the un-coalesced ones.
 
-    Coalesces concurrent misses per (object_id, version, part) via a Redis NX lock so only one
-    streamer enqueues; the rest wait on the downloader's pub/sub notification. Shared by the primary
-    read path AND the envelope-race version fallback — the fallback used to return a `pipeline`
-    source without enqueuing anything, so a cold read of the fallback version hung on pub/sub until
-    the wait timed out.
+    Shared core of three call sites: the primary cold-read miss, the envelope-race version fallback,
+    and F1's mid-stream re-enqueue (`ensure_part_download_enqueued`). Idempotent: the per-part SET NX
+    lock guarantees only one enqueue per (object_id, version, part) until the lock TTL, so calling it
+    again for a part already being fetched is a no-op.
     """
-    object_id = info["object_id"]
-    indices_by_part: dict[int, set[int]] = {}
-    for item, cached in zip(plan, exist_results, strict=True):
-        if not cached:
-            indices_by_part.setdefault(int(item.part_number), set()).add(int(item.chunk_index))
     if not indices_by_part:
         return
+    object_id = info["object_id"]
 
     # Coalesce concurrent misses on the same part: only one streamer
     # actually enqueues a download request per (object_id, version, part).
@@ -211,6 +211,75 @@ async def _enqueue_missing_downloads(
         await enqueue_download_request(req)
 
 
+async def _enqueue_missing_downloads(
+    db: Any,
+    redis: Any,
+    info: dict,
+    *,
+    object_version: int,
+    storage_version: int,
+    plan: list[ChunkPlanItem],
+    exist_results: list[bool],
+    address: str,
+    cfg: Any,
+) -> None:
+    """Enqueue a DownloadChainRequest for the chunks in `plan` that are missing from the FS cache.
+
+    Coalesces concurrent misses per (object_id, version, part) via a Redis NX lock so only one
+    streamer enqueues; the rest wait on the downloader's pub/sub notification. Shared by the primary
+    read path AND the envelope-race version fallback — the fallback used to return a `pipeline`
+    source without enqueuing anything, so a cold read of the fallback version hung on pub/sub until
+    the wait timed out.
+    """
+    indices_by_part: dict[int, set[int]] = {}
+    for item, cached in zip(plan, exist_results, strict=True):
+        if not cached:
+            indices_by_part.setdefault(int(item.part_number), set()).add(int(item.chunk_index))
+    await _enqueue_download_for_parts(
+        db,
+        redis,
+        info,
+        object_version=object_version,
+        storage_version=storage_version,
+        indices_by_part=indices_by_part,
+        address=address,
+        cfg=cfg,
+    )
+
+
+async def ensure_part_download_enqueued(
+    db: Any,
+    redis: Any,
+    info: dict,
+    *,
+    object_version: int,
+    storage_version: int,
+    part_number: int,
+    chunk_indices: set[int],
+    address: str,
+    cfg: Any,
+) -> None:
+    """F1: idempotently ensure `part_number`'s `chunk_indices` are being fetched to the FS cache.
+
+    Called by the streamer when a chunk is missing at stream time. Enqueues the WHOLE part's needed
+    chunks (not just the one that missed) so a mid-stream eviction of a multi-chunk part is refetched
+    in one DCR. Idempotent via the same per-part coalesce lock as the cold-read path, so a part
+    already in flight (e.g. enqueued by `build_stream_context`) is not re-enqueued.
+    """
+    if not chunk_indices:
+        return
+    await _enqueue_download_for_parts(
+        db,
+        redis,
+        info,
+        object_version=object_version,
+        storage_version=storage_version,
+        indices_by_part={int(part_number): {int(i) for i in chunk_indices}},
+        address=address,
+        cfg=cfg,
+    )
+
+
 async def build_stream_context(
     db: Any,
     redis: Any,
@@ -224,6 +293,30 @@ async def build_stream_context(
     cfg = get_config()
     storage_version = require_supported_storage_version(int(info["storage_version"]))
     # v4-only policy: always decrypt at read time.
+
+    def _make_ensure_part(
+        info_local: dict, ov_local: int, plan_local: list[ChunkPlanItem]
+    ) -> Callable[[int], Awaitable[None]]:
+        # Precompute the plan's needed chunk indices per part so a mid-stream miss re-enqueues the
+        # whole part (all chunks this stream still needs), not just the one chunk that missed.
+        idx_by_part: dict[int, set[int]] = {}
+        for it in plan_local:
+            idx_by_part.setdefault(int(it.part_number), set()).add(int(it.chunk_index))
+
+        async def _ensure(part_number: int) -> None:
+            await ensure_part_download_enqueued(
+                db,
+                redis,
+                info_local,
+                object_version=ov_local,
+                storage_version=storage_version,
+                part_number=int(part_number),
+                chunk_indices=idx_by_part.get(int(part_number), set()),
+                address=address,
+                cfg=cfg,
+            )
+
+        return _ensure
 
     ov = int(info.get("object_version") or info.get("current_object_version") or 1)
     # RD-3: the GET endpoint already built the parts catalog; reuse it instead of re-reading. HEAD and
@@ -325,6 +418,7 @@ async def build_stream_context(
                     suite_id=suite_id,
                     bucket_id=bucket_id,
                     upload_id=str(info.get("upload_id") or ""),
+                    ensure_part_download=_make_ensure_part(info, object_version, plan),
                 )
         raise RuntimeError("v5_missing_envelope_metadata")
     kek_bytes = await get_bucket_kek_bytes(bucket_id=bucket_id, kek_id=kek_id)
@@ -341,6 +435,7 @@ async def build_stream_context(
         suite_id=suite_id,
         bucket_id=bucket_id,
         upload_id=upload_id,
+        ensure_part_download=_make_ensure_part(info, object_version, plan),
     )
 
 
@@ -382,6 +477,7 @@ async def read_response(
         bucket_name=str(info.get("bucket_name", "")),
         prefetch_chunks=int(getattr(cfg, "http_stream_prefetch_chunks", 0) or 0),
         chunk_timeout=float(cfg.stream_chunk_timeout_seconds),
+        ensure_part_fn=ctx.ensure_part_download,
     )
     # A2: bound the wait for the FIRST chunk. `stream_plan` otherwise waits up to cache_ttl_seconds
     # (~1h) per chunk, so an un-drained object whose part is on no backend yet would hang the whole
@@ -486,6 +582,7 @@ async def stream_object(
         bucket_name=str(info.get("bucket_name", "")),
         prefetch_chunks=int(getattr(cfg, "http_stream_prefetch_chunks", 0) or 0),
         chunk_timeout=float(cfg.stream_chunk_timeout_seconds),
+        ensure_part_fn=ctx.ensure_part_download,
     )
     if not bound_first_chunk:
         return gen

--- a/tests/e2e/test_MidStreamEviction.py
+++ b/tests/e2e/test_MidStreamEviction.py
@@ -1,0 +1,67 @@
+"""E2E (F1): a cache-source read survives its data being evicted MID-STREAM.
+
+`build_stream_context` decides `source="cache"` from a single existence check taken before the body
+streams. If the janitor evicts a still-to-be-streamed chunk after that decision, the streamer used to
+wait on a `notify:` no producer would ever publish and time out INSIDE the response body — silent
+truncation after the 200 was already committed. The fix re-enqueues a download on the mid-stream miss
+so a producer fills + notifies the chunk and the stream completes byte-exact.
+
+Timing note: this drives a large object so the streamer's in-memory prefetch window cannot cover the
+whole object; reading a small prefix then evicting the FS cache forces a genuine miss on the
+not-yet-streamed tail. With the fix the read always completes byte-exact regardless of exactly where
+the eviction lands (a late eviction is simply a no-op); without it a mid-stream eviction truncates.
+"""
+
+import os
+import time
+from typing import Any
+from typing import Callable
+
+import pytest
+
+from .support.cache import clear_object_cache
+from .support.cache import get_object_id
+from .support.cache import wait_for_all_backends_ready
+from .support.compose import compose_exec
+
+
+_E2E_DSN = os.environ.get("HIPPIUS_E2E_DB_DSN", "postgresql://postgres:postgres@localhost:5432/hippius")
+
+
+def _evict(object_id: str) -> None:
+    clear_object_cache(object_id, dsn=_E2E_DSN)
+    compose_exec("api", ["rm", "-rf", f"/var/lib/hippius/object_cache/{object_id}"])
+
+
+@pytest.mark.local
+def test_read_survives_mid_stream_eviction(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    bucket = unique_bucket_name("midstream-evict")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+
+    key = "midstream.bin"
+    # 96 MiB => 24 chunks at the 4 MiB default, larger than the streamer's prefetch window (16), so
+    # the tail is not yet read from FS when we evict after a small prefix.
+    content = os.urandom(96 * 1024 * 1024)
+    boto3_client.put_object(Bucket=bucket, Key=key, Body=content)
+    assert wait_for_all_backends_ready(bucket, key, min_count=1, timeout_seconds=120.0, dsn=_E2E_DSN)
+
+    object_id = get_object_id(bucket, key, dsn=_E2E_DSN)
+
+    # Warm read decision: this GET's context sees a fully-cached object (source="cache").
+    body = boto3_client.get_object(Bucket=bucket, Key=key)["Body"]
+
+    # Drain a small prefix so the stream is genuinely open and committed, then evict the object's FS
+    # cache out from under the still-streaming tail.
+    prefix = body.read(1 * 1024 * 1024)
+    _evict(object_id)
+    time.sleep(0.2)
+
+    rest = body.read()
+    got = prefix + rest
+    assert got == content, "mid-stream eviction must re-enqueue the tail and reassemble byte-exact"

--- a/tests/unit/reader/test_stream_plan_reenqueue_on_miss.py
+++ b/tests/unit/reader/test_stream_plan_reenqueue_on_miss.py
@@ -1,0 +1,146 @@
+"""F1: the streamer re-enqueues a part's download when a chunk is missing from FS at stream time.
+
+A cache-source read whose later part is evicted mid-stream (by the janitor) used to wait on a
+`notify:` no producer would ever publish and time out INSIDE the response body — silent truncation.
+The fix: on a genuine FS miss the streamer calls `ensure_part_fn(part_number)` (idempotent download
+re-enqueue) before waiting on pub/sub, so a producer actually fills + notifies the chunk.
+
+These tests isolate the streamer's miss->enqueue wiring with a fake cache; decrypt is a passthrough.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+import pytest
+
+from hippius_s3.reader import streamer
+from hippius_s3.reader.types import ChunkPlanItem
+
+
+OBJ = "11111111-2222-3333-4444-555555555555"
+
+
+def _plan() -> list[ChunkPlanItem]:
+    # Part 1 is warm (both chunks present); part 2 was evicted mid-stream (both chunks missing).
+    return [
+        ChunkPlanItem(part_number=1, chunk_index=0, slice_start=None, slice_end_excl=None),
+        ChunkPlanItem(part_number=1, chunk_index=1, slice_start=None, slice_end_excl=None),
+        ChunkPlanItem(part_number=2, chunk_index=0, slice_start=None, slice_end_excl=None),
+        ChunkPlanItem(part_number=2, chunk_index=1, slice_start=None, slice_end_excl=None),
+    ]
+
+
+_DATA = {(1, 0): b"aaaa", (1, 1): b"bbbb", (2, 0): b"cccc", (2, 1): b"dddd"}
+
+
+class _FakeSub:
+    def __init__(self, data: dict[tuple[int, int], bytes]) -> None:
+        self._data = data
+        self.waits: list[tuple[int, int]] = []
+
+    async def wait_for_chunk(self, part_number: int, chunk_index: int, *, timeout: float) -> bytes:  # noqa: ASYNC109
+        self.waits.append((part_number, chunk_index))
+        return self._data[(part_number, chunk_index)]
+
+
+class _FakeCache:
+    def __init__(self, data: dict[tuple[int, int], bytes], present: set[tuple[int, int]]) -> None:
+        self._data = data
+        self._present = present
+        self.exists_checks: list[tuple[int, int]] = []
+        self.subs: list[_FakeSub] = []
+
+    async def chunk_exists(self, _oid: str, _v: int, pn: int, ci: int) -> bool:
+        self.exists_checks.append((pn, ci))
+        return (pn, ci) in self._present
+
+    async def wait_for_chunk(self, _oid: str, _v: int, pn: int, ci: int, *, timeout: Any) -> bytes:  # noqa: ASYNC109
+        return self._data[(pn, ci)]
+
+    def stream_subscription(self, _object_id: str, _object_version: int) -> Any:
+        sub = _FakeSub(self._data)
+        self.subs.append(sub)
+
+        @contextlib.asynccontextmanager
+        async def _cm() -> Any:
+            yield sub
+
+        return _cm()
+
+
+async def _run(cache: _FakeCache, *, ensure_part_fn: Any, prefetch: int, monkeypatch: Any) -> bytes:
+    async def _identity(cbytes: bytes, **_kw: Any) -> bytes:
+        return cbytes
+
+    monkeypatch.setattr(streamer, "decrypt_chunk_if_needed", _identity)
+    gen = streamer.stream_plan(
+        obj_cache=cache,
+        object_id=OBJ,
+        object_version=1,
+        plan=_plan(),
+        storage_version=5,
+        key_bytes=b"\x11" * 32,
+        suite_id="hip-enc/aes256gcm",
+        bucket_id="bkt",
+        upload_id="",
+        prefetch_chunks=prefetch,
+        chunk_timeout=5.0,
+        ensure_part_fn=ensure_part_fn,
+    )
+    return b"".join([chunk async for chunk in gen])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("single_sub", [False, True])
+@pytest.mark.parametrize("prefetch", [0, 4])
+async def test_missing_part_triggers_single_reenqueue(monkeypatch: Any, single_sub: bool, prefetch: int) -> None:
+    monkeypatch.setattr(streamer, "_single_subscription_enabled", lambda: single_sub)
+    present = {(1, 0), (1, 1)}  # part 2 evicted mid-stream
+    cache = _FakeCache(_DATA, present)
+
+    ensured: list[int] = []
+
+    async def _ensure(part_number: int) -> None:
+        ensured.append(int(part_number))
+
+    out = await _run(cache, ensure_part_fn=_ensure, prefetch=prefetch, monkeypatch=monkeypatch)
+
+    # Stream completes byte-exact (with the fix a producer is re-enqueued instead of hanging).
+    assert out == b"aaaabbbbccccdddd"
+    # Only the evicted part is re-enqueued, and exactly once despite both its chunks missing.
+    assert ensured == [2], "the evicted part must be re-enqueued exactly once"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("single_sub", [False, True])
+async def test_all_present_never_enqueues(monkeypatch: Any, single_sub: bool) -> None:
+    """The cache-source fast path (every chunk present) must never call the enqueue hook."""
+    monkeypatch.setattr(streamer, "_single_subscription_enabled", lambda: single_sub)
+    present = {(1, 0), (1, 1), (2, 0), (2, 1)}
+    cache = _FakeCache(_DATA, present)
+
+    ensured: list[int] = []
+
+    async def _ensure(part_number: int) -> None:
+        ensured.append(int(part_number))
+
+    out = await _run(cache, ensure_part_fn=_ensure, prefetch=0, monkeypatch=monkeypatch)
+
+    assert out == b"aaaabbbbccccdddd"
+    assert ensured == [], "a fully-cached stream must not re-enqueue any part"
+
+
+@pytest.mark.asyncio
+async def test_no_ensure_fn_keeps_pure_wait_path(monkeypatch: Any) -> None:
+    """Callers that pass no ensure_part_fn (HEAD/copy/migrate) keep the pure wait-on-pub/sub path:
+    no existence pre-check at all."""
+    monkeypatch.setattr(streamer, "_single_subscription_enabled", lambda: False)
+    present: set[tuple[int, int]] = set()
+    cache = _FakeCache(_DATA, present)
+
+    out = await _run(cache, ensure_part_fn=None, prefetch=0, monkeypatch=monkeypatch)
+
+    assert out == b"aaaabbbbccccdddd"
+    assert cache.exists_checks == [], "no ensure_part_fn must skip the per-chunk existence pre-check"

--- a/tests/unit/services/test_ensure_part_download_enqueued.py
+++ b/tests/unit/services/test_ensure_part_download_enqueued.py
@@ -1,0 +1,145 @@
+"""F1: `ensure_part_download_enqueued` is the streamer's idempotent per-part re-enqueue helper.
+
+It shares the cold-read path's coalesce lock, so the FIRST call for a part acquires the
+`download_in_progress:{oid}:v:{v}:part:{pn}` lock and enqueues ONE DownloadChainRequest covering the
+part's needed chunks; a SECOND call while the lock is held is a no-op (another producer is already
+fetching). This is what makes a mid-stream miss safe to hit repeatedly without stacking downloads.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+
+OBJ = "11111111-2222-3333-4444-555555555555"
+
+
+class _RedisStub:
+    def __init__(self, held_keys: set[str] | None = None) -> None:
+        self._held = set(held_keys or ())
+        self.set_calls: list[tuple[str, Any, bool, int | None]] = []
+
+    def pipeline(self, transaction: bool = False) -> "_RedisPipelineStub":
+        return _RedisPipelineStub(self)
+
+
+class _RedisPipelineStub:
+    def __init__(self, parent: "_RedisStub") -> None:
+        self._parent = parent
+        self._ops: list[tuple[str, Any, bool, int | None]] = []
+
+    def set(self, key: str, value: Any, *, nx: bool = False, ex: int | None = None) -> "_RedisPipelineStub":
+        self._ops.append((key, value, nx, ex))
+        return self
+
+    async def execute(self) -> list[Any]:
+        results: list[Any] = []
+        for key, value, nx, ex in self._ops:
+            self._parent.set_calls.append((key, value, nx, ex))
+            if nx and key in self._parent._held:
+                results.append(None)
+            else:
+                self._parent._held.add(key)
+                results.append(True)
+        return results
+
+
+def _cfg() -> MagicMock:
+    cfg = MagicMock()
+    cfg.substrate_url = ""
+    cfg.download_coalesce_lock_ttl_seconds = 120
+    cfg.cache_ttl_seconds = 3600
+    return cfg
+
+
+def _info() -> dict:
+    return {
+        "object_id": OBJ,
+        "object_key": "key",
+        "bucket_name": "b",
+        "size_bytes": 8192,
+        "multipart": True,
+        "ray_id": "ray-XYZ",
+    }
+
+
+@pytest.mark.asyncio
+@patch("hippius_s3.services.object_reader.resolve_object_backends", new=AsyncMock(return_value=["arion"]))
+@patch("hippius_s3.services.object_reader.enqueue_download_request", new_callable=AsyncMock)
+async def test_first_call_locks_and_enqueues_whole_part(mock_enqueue: AsyncMock) -> None:
+    from hippius_s3.services.object_reader import ensure_part_download_enqueued
+
+    redis = _RedisStub()
+    await ensure_part_download_enqueued(
+        db=MagicMock(),
+        redis=redis,
+        info=_info(),
+        object_version=1,
+        storage_version=5,
+        part_number=2,
+        chunk_indices={0, 1},
+        address="addr",
+        cfg=_cfg(),
+    )
+
+    key, value, nx, ex = redis.set_calls[0]
+    assert key == f"download_in_progress:{OBJ}:v:1:part:2"
+    assert value == "ray-XYZ"
+    assert nx is True and ex == 120
+    mock_enqueue.assert_awaited_once()
+
+    dcr = mock_enqueue.call_args.args[0]
+    assert [p.part_number for p in dcr.chunks] == [2]
+    assert sorted(spec.index for spec in dcr.chunks[0].chunks) == [0, 1], "the whole part's chunks are enqueued"
+
+
+@pytest.mark.asyncio
+@patch("hippius_s3.services.object_reader.resolve_object_backends", new=AsyncMock(return_value=["arion"]))
+@patch("hippius_s3.services.object_reader.enqueue_download_request", new_callable=AsyncMock)
+async def test_second_call_with_lock_held_is_noop(mock_enqueue: AsyncMock) -> None:
+    from hippius_s3.services.object_reader import ensure_part_download_enqueued
+
+    redis = _RedisStub(held_keys={f"download_in_progress:{OBJ}:v:1:part:2"})
+    await ensure_part_download_enqueued(
+        db=MagicMock(),
+        redis=redis,
+        info=_info(),
+        object_version=1,
+        storage_version=5,
+        part_number=2,
+        chunk_indices={0, 1},
+        address="addr",
+        cfg=_cfg(),
+    )
+
+    assert len(redis.set_calls) == 1, "lock attempted once"
+    # Lock held by another producer -> no duplicate enqueue.
+    mock_enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@patch("hippius_s3.services.object_reader.resolve_object_backends", new=AsyncMock(return_value=["arion"]))
+@patch("hippius_s3.services.object_reader.enqueue_download_request", new_callable=AsyncMock)
+async def test_empty_chunk_indices_is_noop(mock_enqueue: AsyncMock) -> None:
+    from hippius_s3.services.object_reader import ensure_part_download_enqueued
+
+    redis = _RedisStub()
+    await ensure_part_download_enqueued(
+        db=MagicMock(),
+        redis=redis,
+        info=_info(),
+        object_version=1,
+        storage_version=5,
+        part_number=2,
+        chunk_indices=set(),
+        address="addr",
+        cfg=_cfg(),
+    )
+
+    assert redis.set_calls == []
+    mock_enqueue.assert_not_awaited()


### PR DESCRIPTION
## Problem (F1)

`build_stream_context` (`hippius_s3/services/object_reader.py`) checks chunk existence **once** and only acquires the coalesce lock + enqueues a `DownloadChainRequest` when `source == "pipeline"`. On a `source == "cache"` read, if the janitor evicts a still-to-be-streamed part **mid-stream**, the streamer's `wait_for_chunk` subscribes to a `notify:{chunk_key}` that no producer will ever publish, polls to `stream_chunk_timeout_seconds` (300s), then raises **inside the response body** — after the 200/206 + `Content-Length` are already on the wire. Result: silent truncation, the connection pinned ~5 min, self-heals only on the next GET.

## Fix (surgical, hot-path-safe)

- Extract the coalesce-lock + DCR-build logic into a shared core `_enqueue_download_for_parts(indices_by_part)`; `_enqueue_missing_downloads` (cold-read + envelope-fallback paths) now delegates to it, unchanged in behavior.
- Add an idempotent `ensure_part_download_enqueued(part_number, chunk_indices)` that reuses the **same per-part `SET NX` coalesce lock**, so a part already in flight is never re-enqueued.
- `StreamContext` carries an `ensure_part_download` closure (built at both return sites, capturing the possibly envelope-fallback-swapped `info`/version and the plan's needed chunks per part).
- `stream_plan` gains `ensure_part_fn`; on a **genuine FS miss** (`obj_cache.chunk_exists` is False) it calls the hook **before** waiting on pub/sub, deduped per part via a local `ensured_parts` set (the hook enqueues the whole part's needed chunks in one DCR). Present chunks pay a single stat and no Redis/DB — the cache-source fast path stays fast. `HEAD`/copy/migrate callers pass no hook and keep the pure wait-on-pub/sub behavior.

## Tests

- `tests/unit/reader/test_stream_plan_reenqueue_on_miss.py` — miss→enqueue wiring across the per-chunk **and** single-subscription paths (`prefetch` 0/4): one re-enqueue per evicted part (dedup), byte-exact completion, all-present never enqueues, no-hook skips the existence pre-check.
- `tests/unit/services/test_ensure_part_download_enqueued.py` — helper locks + enqueues the whole part on first call, no-ops when the lock is held, no-ops on empty indices.
- `tests/e2e/test_MidStreamEviction.py` — 96 MiB object (> prefetch window): drain a prefix, evict the FS cache, read the tail; must reassemble byte-exact.

## e2e limitation

A truly *deterministic* mid-stream eviction e2e is racy (the in-API prefetch window + client backpressure make the exact miss point non-deterministic). The added e2e is designed to be **non-flaky with the fix in place** — a late eviction is simply a no-op and the read still succeeds; a mid-stream eviction recovers via re-enqueue — while still catching a regression when the eviction lands mid-stream. The deterministic proof of the miss→enqueue behavior is the two unit suites. e2e cannot run locally; the existing `ColdReadPubSub` / `Backend_Resilience` behavior is untouched.

## Local checks

- `ruff check hippius_s3 gateway` — clean; `ruff format --check` — clean.
- `ty check hippius_s3 gateway` — clean.
- `pytest tests/unit -k "stream or reader or coalesc or download or envelope or read_response or read_path or ensure"` — 176 passed (the lone `RuntimeWarning` is a pre-existing `AsyncMock` pipeline artifact, unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)