### PR TITLE
fix(s3): accept DeleteObjects bodies without the S3 xmlns

### DIFF
--- a/hippius_s3/api/s3/buckets/delete_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/delete_objects_endpoint.py
@@ -21,6 +21,30 @@ logger = logging.getLogger(__name__)
 config = get_config()
 
 
+def parse_delete_request(root: Any) -> tuple[bool, list[tuple[str, str]]]:
+    """Parse a DeleteObjects body into (quiet, [(key, version_id), ...]).
+
+    S3 clients disagree on whether to namespace this body: botocore/aws-cli send
+    xmlns="http://s3.amazonaws.com/doc/2006-03-01/", minio-go (mc, and anything
+    built on it) sends bare elements. Real S3 accepts both, so match on
+    local-name() instead of a namespace-qualified path — a namespace-qualified
+    XPath silently yields zero <Object> nodes for the bare form, which turns a
+    delete into a 200 OK that deletes nothing.
+    """
+    quiet_nodes = root.xpath("./*[local-name()='Quiet']")
+    quiet = bool(quiet_nodes) and str(quiet_nodes[0].text or "").strip().lower() == "true"
+
+    objects: list[tuple[str, str]] = []
+    for obj in root.xpath(".//*[local-name()='Object']"):
+        key_nodes = obj.xpath("./*[local-name()='Key']")
+        version_nodes = obj.xpath("./*[local-name()='VersionId']")
+        key = str(key_nodes[0].text) if key_nodes and key_nodes[0].text else ""
+        version_id = str(version_nodes[0].text) if version_nodes and version_nodes[0].text else ""
+        objects.append((key, version_id))
+
+    return quiet, objects
+
+
 async def handle_delete_objects(bucket_name: str, request: Request, db: Any, redis_client: Any) -> Response:
     """Implements S3 DeleteObjects: POST /{bucket}?delete
 
@@ -60,17 +84,9 @@ async def handle_delete_objects(bucket_name: str, request: Request, db: Any, red
                 status_code=400,
             )
 
-        ns = {"s3": "http://s3.amazonaws.com/doc/2006-03-01/"}
-
-        # Quiet flag
-        quiet_nodes = root.xpath("./s3:Quiet", namespaces=ns)
-        quiet = False
-        if quiet_nodes and quiet_nodes[0].text:
-            quiet = str(quiet_nodes[0].text).strip().lower() == "true"
-
-        # Collect objects
-        object_elems = root.xpath(".//s3:Object", namespaces=ns)
-        if len(object_elems) > 1000:
+        # Quiet flag + collect objects
+        quiet, object_entries = parse_delete_request(root)
+        if len(object_entries) > 1000:
             return errors.s3_error_response(
                 "MalformedXML",
                 "The XML you provided was not well-formed or did not validate against our published schema.",
@@ -81,12 +97,7 @@ async def handle_delete_objects(bucket_name: str, request: Request, db: Any, red
         deleted_keys: list[str] = []
         errors_list: list[dict[str, str]] = []
 
-        for obj in object_elems:
-            key_nodes = obj.xpath("./s3:Key", namespaces=ns)
-            version_nodes = obj.xpath("./s3:VersionId", namespaces=ns)
-            key = str(key_nodes[0].text) if key_nodes and key_nodes[0].text else ""
-            version_id = str(version_nodes[0].text) if version_nodes and version_nodes[0].text else ""
-
+        for key, version_id in object_entries:
             if not key:
                 # Skip invalid entries
                 errors_list.append({"Key": "", "Code": "MalformedXML", "Message": "Invalid Delete Object entry"})

--- a/tests/unit/test_delete_objects_xml.py
+++ b/tests/unit/test_delete_objects_xml.py
@@ -1,0 +1,64 @@
+from lxml import etree as ET  # ty: ignore[unresolved-import]
+
+from hippius_s3.api.s3.buckets.delete_objects_endpoint import parse_delete_request
+
+
+S3_NS = "http://s3.amazonaws.com/doc/2006-03-01/"
+
+
+def _parse(body: str) -> tuple[bool, list[tuple[str, str]]]:
+    return parse_delete_request(ET.fromstring(body.encode()))
+
+
+def test_parses_namespaced_body() -> None:
+    """botocore / aws-cli send the body with the S3 xmlns."""
+    quiet, objects = _parse(f'<Delete xmlns="{S3_NS}"><Object><Key>a.txt</Key></Object></Delete>')
+
+    assert quiet is False
+    assert objects == [("a.txt", "")]
+
+
+def test_parses_bare_body() -> None:
+    """minio-go (mc) sends bare elements with no xmlns.
+
+    Regression: a namespace-qualified XPath matched zero <Object> nodes here, so
+    DeleteObjects returned 200 OK with an empty <DeleteResult/> and deleted nothing.
+    """
+    quiet, objects = _parse("<Delete><Object><Key>a.txt</Key></Object></Delete>")
+
+    assert quiet is False
+    assert objects == [("a.txt", "")]
+
+
+def test_parses_bare_body_with_quiet_and_multiple_keys() -> None:
+    """The exact shape minio-go emits for `mc rm`."""
+    quiet, objects = _parse(
+        "<Delete><Quiet>true</Quiet>"
+        "<Object><Key>a.txt</Key></Object>"
+        "<Object><Key>nested/deep/b.txt</Key></Object>"
+        "</Delete>"
+    )
+
+    assert quiet is True
+    assert objects == [("a.txt", ""), ("nested/deep/b.txt", "")]
+
+
+def test_quiet_is_detected_in_both_forms() -> None:
+    assert _parse(f'<Delete xmlns="{S3_NS}"><Quiet>true</Quiet></Delete>')[0] is True
+    assert _parse("<Delete><Quiet>true</Quiet></Delete>")[0] is True
+    assert _parse("<Delete><Quiet>false</Quiet></Delete>")[0] is False
+    assert _parse("<Delete></Delete>")[0] is False
+
+
+def test_version_id_is_extracted_in_both_forms() -> None:
+    """VersionId drives the per-key NotImplemented error, so it must survive parsing."""
+    namespaced = f'<Delete xmlns="{S3_NS}"><Object><Key>a.txt</Key><VersionId>v2</VersionId></Object></Delete>'
+    bare = "<Delete><Object><Key>a.txt</Key><VersionId>v2</VersionId></Object></Delete>"
+
+    assert _parse(namespaced)[1] == [("a.txt", "v2")]
+    assert _parse(bare)[1] == [("a.txt", "v2")]
+
+
+def test_missing_key_yields_empty_string() -> None:
+    """Empty keys are reported as per-key MalformedXML rather than dropped silently."""
+    assert _parse("<Delete><Object></Object></Delete>")[1] == [("", "")]


### PR DESCRIPTION
## Summary

`mc rm` against `s3.hippius.com` silently deletes nothing — it exits 0, prints no output, and the object survives. `aws-cli` deletes fine with the same credentials.

Root cause is one XPath. `handle_delete_objects` parsed the request body with a **namespace-qualified** path:

```python
ns = {"s3": "http://s3.amazonaws.com/doc/2006-03-01/"}
object_elems = root.xpath(".//s3:Object", namespaces=ns)
```

botocore/aws-cli send the body with `xmlns="http://s3.amazonaws.com/doc/2006-03-01/"`, so they matched. **minio-go sends bare elements with no xmlns** — and minio-go is what `mc` and everything built on it uses. Those bodies matched **zero** `<Object>` nodes, so we walked an empty list and returned `200 OK` with an empty `<DeleteResult/>`.

The `xmlns` is optional per the S3 API; real S3 accepts both forms.

This is the dangerous kind of failure: a user who migrates onto Hippius and later cleans up believes their objects are deleted when they are not, and may then delete their source copy.

## Reproduction (against prod, before this change)

Two hand-signed `POST /{bucket}?delete` requests, identical except for the `xmlns`:

| Body | HTTP | Object actually deleted |
|---|---|---|
| `<Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/">…` | 200 | **yes** |
| `<Delete>…` (minio-go / mc) | 200 | **no** |

Both returned `200 OK`; the bare one returned an empty `<DeleteResult/>`.

Ruled out along the way — none of these were the discriminator: the `?delete` vs `?delete=` query form, the trailing slash (`/bucket/` vs `/bucket`), and `Content-Md5`. All four URL permutations failed identically with a bare body.

## Changes

- Match on `local-name()` instead of a namespace-qualified path, so both namespaced and bare bodies parse. Applied to `Quiet`, `Object`, `Key` and `VersionId` — `Quiet` and `VersionId` had the same blind spot.
- Extract parsing into `parse_delete_request()` so it is directly testable.
- Add `tests/unit/test_delete_objects_xml.py` — 6 tests covering both body forms, quiet mode, `VersionId` extraction, and empty keys.

## Why this was never caught

Every existing test in `tests/e2e/test_DeleteObjects.py` goes through boto3, which always namespaces the body. The bug is only reachable from a non-botocore client.

## Verification

- 6 new unit tests pass; full unit suite green (2187 passed, 37 skipped).
- `ruff check` / `ruff format` / `ty` clean.
- Confirmed the new XPath returns 1 object for both forms where the old one returned 0 for the bare form.

## Note

This is one of two independent blockers for S3-client compatibility found together. The other is `rclone` failing entirely with `SignatureDoesNotMatch`, which is an edge-proxy issue fixed separately in `hippius-ats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)