### PR TITLE
fix(cache): thread chunk_exists stats off the event loop

### DIFF
--- a/hippius_s3/cache/fs_store.py
+++ b/hippius_s3/cache/fs_store.py
@@ -217,12 +217,18 @@ class FileSystemPartsStore:
         """
         part_dir = Path(self.part_path(object_id, object_version, part_number))
         meta_path = self._meta_file(part_dir)
-
-        if not meta_path.exists():
-            return False
-
         chunk_path = self._chunk_file(part_dir, chunk_index)
-        return chunk_path.exists()
+
+        # Threaded like every other stat in this store: each exists() is a CephFS metadata
+        # round-trip, and the streamer's mid-stream-miss check now calls this once per chunk
+        # on every read, so doing it inline would block the API event loop for all requests
+        # on the pod. Path building above is pure CPU and stays out of the thread.
+        def _check() -> bool:
+            if not meta_path.exists():
+                return False
+            return chunk_path.exists()
+
+        return await asyncio.to_thread(_check)
 
     async def chunks_exist_batch(
         self, object_id: str, object_version: int, checks: list[tuple[int, int]]


### PR DESCRIPTION
Found while reviewing the 2026-07-28-a prod release (#372).

`FileSystemPartsStore.chunk_exists` performs two `Path.exists()` calls **inline on the event loop**:

```python
if not meta_path.exists():
    return False
chunk_path = self._chunk_file(part_dir, chunk_index)
return chunk_path.exists()
```

Every other FS operation in `fs_store.py` wraps its I/O in `asyncio.to_thread` — reads, writes, meta, touch, delete, and notably its own sibling `chunks_exist_batch`. The module even documents the reason on another method: *"BLOCKING — callers wrap in `asyncio.to_thread` (each stat is a CephFS metadata …)"*.

## Why it matters now

This was harmless while nothing hot called it — on `k8s-production` today, `chunk_exists` has **no caller in the streaming path** at all.

#369 changed that. Its `_maybe_ensure` mid-stream-miss check calls `obj_cache.chunk_exists(...)` **once per chunk, on every streamed read** (`hippius_s3/reader/streamer.py:130`). So as of that PR, two unthreaded CephFS metadata round-trips per 4 MiB chunk run on the API event loop — blocking *every* request on that pod, not just the stream that caused them.

The dentry/attr cache will absorb most of these in practice (the part is actively being read), so this is a tail-latency risk rather than a correctness bug — but it is on the single hottest path in the system, on a cluster with a history of CephFS metadata latency incidents.

## Change

Move the two stats into `asyncio.to_thread`, matching `chunks_exist_batch`. Path construction stays outside the thread since it is pure CPU.

## Verification

- Full unit suite green (2216 passed, 37 skipped); `tests/unit/cache` and `tests/unit/reader` targeted runs green.
- `ruff check` / `ruff format` clean.

No behaviour change — same return value, same semantics, just off the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)