### PR TITLE
fix(gateway): treat an unreachable Arion as a transient can_upload failure

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -107,6 +107,14 @@ ACL_CACHE_TTL_SECONDS=600
 # Keep short so an account that runs out of credit mid-burst stops slipping uploads through quickly.
 CAN_UPLOAD_CACHE_TTL_SECONDS=10
 
+# Incident levers for the can_upload billing gate, which runs inside the gateway's request path
+# (so its worst case is gateway capacity, not worker throughput). The timeout is the one that
+# actually bounds latency — retry counts cannot, because the per-attempt cost is otherwise the
+# client-wide 60s read timeout. Set CAN_UPLOAD_TRANSIENT_RETRIES=0 to stop re-driving entirely.
+CAN_UPLOAD_TIMEOUT_SECONDS=3.0
+CAN_UPLOAD_TRANSIENT_RETRIES=2
+CAN_UPLOAD_TRANSIENT_RETRY_DELAY_SECONDS=0.4
+
 # FS Cache Hot Retention
 # Chunks read within this window (seconds) are protected from janitor GC.
 HIPPIUS_FS_CACHE_HOT_RETENTION_SECONDS=10800

--- a/gateway/middlewares/account.py
+++ b/gateway/middlewares/account.py
@@ -5,6 +5,7 @@ import logging
 import re
 from typing import Callable
 
+import httpx
 from fastapi import Request
 from fastapi import Response
 from starlette import status
@@ -13,6 +14,7 @@ from gateway.config import get_config
 from gateway.services.account_service import fetch_account_by_main_address
 from gateway.utils.errors import s3_error_response
 from hippius_s3.models.account import HippiusAccount
+from hippius_s3.services.arion_service import ArionClient
 from hippius_s3.services.arion_service import CanUploadResponse
 from hippius_s3.services.ray_id_service import get_logger_with_ray_id
 
@@ -48,6 +50,44 @@ def _is_transient_billing_error(error: str | None) -> bool:
     return any(marker in lowered for marker in _TRANSIENT_BILLING_ERROR_MARKERS)
 
 
+async def _can_upload(
+    arion_client: ArionClient,
+    main_account: str,
+    content_length: int,
+) -> CanUploadResponse:
+    """Call Arion can_upload, mapping an unreachable billing backend onto a transient verdict.
+
+    ArionClient.can_upload ends in `raise_for_status()`, so an upstream 5xx — in practice
+    `502 Next Hop Connection Failed` from the ATS edge in front of Arion — leaves as an
+    exception rather than a CanUploadResponse. That skips the transient handling below
+    entirely and lands in account_middleware's blanket `except Exception`, which answers
+    `AccountVerificationError`: a non-standard code no S3 SDK knows to retry. The retry ladder
+    and SlowDown response that were written for exactly this case never got a chance to run.
+
+    Translating the failure into `result=False` with a transient marker lets the existing path
+    do its job. Transport errors are folded in for the same reason: "billing backend is
+    unreachable" is not a credit verdict however it manifests.
+    """
+    try:
+        return await arion_client.can_upload(main_account, content_length)
+    except httpx.HTTPStatusError as exc:
+        # Only unreachability is transient. A 4xx means we sent Arion something it rejected —
+        # our bug, and retrying it into a SlowDown would hide it — so let those keep falling
+        # through to the blanket handler. 429 is Arion explicitly asking us to back off.
+        status = exc.response.status_code
+        if status < 500 and status != 429:
+            raise
+        return CanUploadResponse(
+            result=False,
+            error=f"billing service unavailable (upstream {status})",
+        )
+    except httpx.RequestError as exc:
+        return CanUploadResponse(
+            result=False,
+            error=f"billing service unavailable ({type(exc).__name__})",
+        )
+
+
 async def _check_can_upload(
     request: Request,
     logger: logging.Logger | logging.LoggerAdapter,
@@ -77,7 +117,7 @@ async def _check_can_upload(
         logger.debug(f"can_upload cache hit for {main_account}, skipping Arion call")
         return None
 
-    response: CanUploadResponse = await arion_client.can_upload(main_account, content_length)
+    response: CanUploadResponse = await _can_upload(arion_client, main_account, content_length)
     logger.info(
         f"can_upload billing check for {main_account}: size_bytes={content_length}, result={response.result}, error={response.error}"
     )
@@ -94,7 +134,7 @@ async def _check_can_upload(
             f"can_upload transient billing failure for {main_account} (attempt {attempts}/{config.can_upload_transient_retries}): {response.error}"
         )
         await asyncio.sleep(config.can_upload_transient_retry_delay_seconds)
-        response = await arion_client.can_upload(main_account, content_length)
+        response = await _can_upload(arion_client, main_account, content_length)
 
     if not response.result:
         # Still failing on a transient billing error after retries: surface a retryable 503

--- a/gateway/middlewares/account.py
+++ b/gateway/middlewares/account.py
@@ -50,42 +50,47 @@ def _is_transient_billing_error(error: str | None) -> bool:
     return any(marker in lowered for marker in _TRANSIENT_BILLING_ERROR_MARKERS)
 
 
+# Transport failures that mean "we could not reach Arion". Deliberately NOT httpx.RequestError,
+# which also covers UnsupportedProtocol (a malformed HIPPIUS_ARION_BASE_URL), LocalProtocolError
+# (we built an invalid request), DecodingError and TooManyRedirects. Those are our bugs; folding
+# them in would turn a total upload outage into a fleet-wide "please retry" that never resolves
+# and carries no stack trace. They stay on the blanket handler where they stay loud.
+_UNREACHABLE_ERRORS = (httpx.TimeoutException, httpx.NetworkError, httpx.ProxyError, httpx.RemoteProtocolError)
+
+
 async def _can_upload(
     arion_client: ArionClient,
     main_account: str,
     content_length: int,
-) -> CanUploadResponse:
+) -> tuple[CanUploadResponse, bool]:
     """Call Arion can_upload, mapping an unreachable billing backend onto a transient verdict.
 
     ArionClient.can_upload ends in `raise_for_status()`, so an upstream 5xx — in practice
     `502 Next Hop Connection Failed` from the ATS edge in front of Arion — leaves as an
     exception rather than a CanUploadResponse. That skips the transient handling below
     entirely and lands in account_middleware's blanket `except Exception`, which answers
-    `AccountVerificationError`: a non-standard code no S3 SDK knows to retry. The retry ladder
-    and SlowDown response that were written for exactly this case never got a chance to run.
+    `AccountVerificationError`, a non-standard code. The retry ladder and SlowDown response
+    written for exactly this case never got a chance to run.
 
-    Translating the failure into `result=False` with a transient marker lets the existing path
-    do its job. Transport errors are folded in for the same reason: "billing backend is
-    unreachable" is not a credit verdict however it manifests.
+    Returns (verdict, worth_retrying). The flag exists so a backend that told us to slow down
+    is not immediately hammered again — see the 429 branch.
     """
     try:
-        return await arion_client.can_upload(main_account, content_length)
+        return await arion_client.can_upload(main_account, content_length), True
     except httpx.HTTPStatusError as exc:
-        # Only unreachability is transient. A 4xx means we sent Arion something it rejected —
-        # our bug, and retrying it into a SlowDown would hide it — so let those keep falling
-        # through to the blanket handler. 429 is Arion explicitly asking us to back off.
-        status = exc.response.status_code
-        if status < 500 and status != 429:
+        status_code = exc.response.status_code
+        # 429 IS transient, but re-driving it is the one response guaranteed to be wrong: Arion
+        # just said "too many requests". Surface the SlowDown without running the ladder.
+        if status_code == 429:
+            return CanUploadResponse(result=False, error="billing service unavailable (upstream 429)"), False
+        # 507 means Arion is full; retry_on_error re-raises it precisely because retrying cannot
+        # help, so don't undo that here. Other 4xx means we sent something it rejected — our bug,
+        # and retrying it into a SlowDown would hide it. Both fall through to the blanket handler.
+        if status_code == 507 or status_code < 500:
             raise
-        return CanUploadResponse(
-            result=False,
-            error=f"billing service unavailable (upstream {status})",
-        )
-    except httpx.RequestError as exc:
-        return CanUploadResponse(
-            result=False,
-            error=f"billing service unavailable ({type(exc).__name__})",
-        )
+        return CanUploadResponse(result=False, error=f"billing service unavailable (upstream {status_code})"), True
+    except _UNREACHABLE_ERRORS as exc:
+        return CanUploadResponse(result=False, error=f"billing service unavailable ({type(exc).__name__})"), True
 
 
 async def _check_can_upload(
@@ -117,7 +122,7 @@ async def _check_can_upload(
         logger.debug(f"can_upload cache hit for {main_account}, skipping Arion call")
         return None
 
-    response: CanUploadResponse = await _can_upload(arion_client, main_account, content_length)
+    response, worth_retrying = await _can_upload(arion_client, main_account, content_length)
     logger.info(
         f"can_upload billing check for {main_account}: size_bytes={content_length}, result={response.result}, error={response.error}"
     )
@@ -126,6 +131,7 @@ async def _check_can_upload(
     attempts = 0
     while (
         not response.result
+        and worth_retrying
         and _is_transient_billing_error(response.error)
         and attempts < config.can_upload_transient_retries
     ):
@@ -134,7 +140,7 @@ async def _check_can_upload(
             f"can_upload transient billing failure for {main_account} (attempt {attempts}/{config.can_upload_transient_retries}): {response.error}"
         )
         await asyncio.sleep(config.can_upload_transient_retry_delay_seconds)
-        response = await _can_upload(arion_client, main_account, content_length)
+        response, worth_retrying = await _can_upload(arion_client, main_account, content_length)
 
     if not response.result:
         # Still failing on a transient billing error after retries: surface a retryable 503

--- a/gateway/services/CLAUDE.md
+++ b/gateway/services/CLAUDE.md
@@ -111,4 +111,10 @@ Proxies `/docs` to the internal Swagger UI when `ENABLE_API_DOCS=true`. Redis-ca
 | ID | Time | T | Title | Read |
 |----|------|---|-------|------|
 | #8876 | 11:36 AM | 🔵 | Current Upload Architecture Uses Streaming Encryption with 16-Slot AsyncIO Queue | ~810 |
+
+### Jul 1, 2026
+
+| ID | Time | T | Title | Read |
+|----|------|---|-------|------|
+| #9719 | 1:29 PM | 🔵 | Account service has fallback for missing credits cache | ~347 |
 </claude-mem-context>

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -101,6 +101,10 @@ class Config:
     arion_rate_limiting_proxy_bypass_key: str = env("ARION_RATE_LIMITING_PROXY_BYPASS_KEY:")
     arion_base_url: str = env("HIPPIUS_ARION_BASE_URL:https://arion.hippius.com/")
     arion_verify_ssl: bool = env("HIPPIUS_ARION_VERIFY_SSL:true", convert=lambda x: x.lower() == "true")
+    # Per-attempt cap for the can_upload billing gate specifically. Unlike every other call on
+    # ArionClient this one runs inside the gateway's request path, so its worst case is gateway
+    # capacity, not worker throughput. Tunable so an incident can shorten it without a deploy.
+    can_upload_timeout_seconds: float = env("CAN_UPLOAD_TIMEOUT_SECONDS:3.0", convert=float)
 
     # Redis for caching/rate limiting
     redis_url: str = env("REDIS_URL")

--- a/hippius_s3/services/arion_service.py
+++ b/hippius_s3/services/arion_service.py
@@ -550,6 +550,13 @@ class ArionClient:
             "/can_upload",
             json=payload.model_dump(),
             headers=headers,
+            # The client-wide 60s read timeout is sized for bulk uploads. This is a small JSON
+            # RPC on the request path, and retry COUNTS cannot bound latency when the per-attempt
+            # cost is unbounded: a blackholed Arion (TCP accepted, nothing returned) would cost
+            # 60s per attempt. Transport errors are not retried by retry_on_error, so pre-cap that
+            # was one 60s stall; once the caller treats them as transient and re-drives, it becomes
+            # minutes. Cap the attempt instead of trusting the ladder.
+            timeout=httpx.Timeout(self._config.can_upload_timeout_seconds, connect=2.0),
         )
         logger.info(f"Raw response content {response.content}")
         response.raise_for_status()

--- a/hippius_s3/services/arion_service.py
+++ b/hippius_s3/services/arion_service.py
@@ -517,7 +517,13 @@ class ArionClient:
         upload_response.size_bytes = len(file_data)
         return upload_response
 
-    @retry_on_error(retries=3, backoff=5.0)
+    # Unlike every other call on this client, can_upload runs inside the gateway's request path:
+    # account_middleware awaits it before a PUT/POST is allowed through. The shared 3x5s ladder
+    # would pin a worker for 15s per request while the billing backend is down — with a few
+    # hundred concurrent uploads that is the gateway's capacity, spent waiting. Keep it short and
+    # let the caller's own transient-retry loop own the backoff; between them there are still
+    # more attempts than before, inside ~2s instead of 15s.
+    @retry_on_error(retries=1, backoff=0.5)
     async def can_upload(
         self,
         account_ss58: str,

--- a/tests/unit/gateway/test_account_middleware.py
+++ b/tests/unit/gateway/test_account_middleware.py
@@ -458,9 +458,7 @@ async def test_can_upload_cache_key_is_per_account(mock_config_no_bypass: Any, m
 
 
 @pytest.mark.asyncio
-async def test_gw4_get_skips_account_fetch_but_put_fetches(
-    mock_config_no_bypass: Any, monkeypatch: Any
-) -> None:
+async def test_gw4_get_skips_account_fetch_but_put_fetches(mock_config_no_bypass: Any, monkeypatch: Any) -> None:
     """GW-4: access-key GET/HEAD carry no credit gate and the API ignores the credit fields, so the
     redis-accounts fetch is skipped on reads; mutating methods still fetch and gate."""
     from gateway.middlewares import account as account_mod
@@ -500,3 +498,103 @@ async def test_gw4_get_skips_account_fetch_but_put_fetches(
         r_put = await client.put("/b/k", content=b"x", headers={"content-length": "1"})
         assert r_put.status_code == 200
         assert calls["n"] == 1, "PUT must still fetch the account for the credit gate"
+
+
+# ---------------------------------------------------------------------------
+# Arion unreachable => transient, not a hard verification failure
+# ---------------------------------------------------------------------------
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    """What ArionClient.can_upload's raise_for_status() produces on an upstream 5xx."""
+    request = httpx.Request("POST", "https://arion.hippius.com/can_upload")
+    response = httpx.Response(status, request=request, text="Next Hop Connection Failed")
+    return httpx.HTTPStatusError("server error", request=request, response=response)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [500, 502, 503, 504])
+async def test_arion_5xx_surfaces_slowdown_not_account_verification_error(
+    mock_config_no_bypass: Any, monkeypatch: Any, status: int
+) -> None:
+    """ArionClient.can_upload ends in raise_for_status(), so an upstream 5xx leaves as an
+    exception rather than a CanUploadResponse. That used to skip the transient ladder entirely
+    and land in the blanket `except Exception`, answering AccountVerificationError — a code no
+    S3 SDK knows to retry. Observed on prod when the ATS edge in front of Arion had all next
+    hops down: 5948 such failures in 48h on 2026-07-26..28.
+    """
+    mock_arion = MockArionService(raise_on_can_upload=_http_status_error(status))
+    app = _make_can_upload_app(mock_config_no_bypass, mock_arion, monkeypatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.put("/test-bucket/test-key", content=b"hello", headers={"content-length": "5"})
+
+    assert response.status_code == 503
+    assert b"SlowDown" in response.content
+    assert b"AccountVerificationError" not in response.content
+
+
+@pytest.mark.asyncio
+async def test_arion_5xx_is_retried_before_giving_up(mock_config_no_bypass: Any, monkeypatch: Any) -> None:
+    mock_arion = MockArionService(raise_on_can_upload=_http_status_error(502))
+    app = _make_can_upload_app(mock_config_no_bypass, mock_arion, monkeypatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.put("/test-bucket/test-key", content=b"hello", headers={"content-length": "5"})
+
+    # initial attempt + can_upload_transient_retries
+    assert len(mock_arion.can_upload_calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_arion_transport_failure_is_also_transient(mock_config_no_bypass: Any, monkeypatch: Any) -> None:
+    """'Billing backend is unreachable' is not a credit verdict however it manifests."""
+    mock_arion = MockArionService(raise_on_can_upload=httpx.ConnectError("connection refused"))
+    app = _make_can_upload_app(mock_config_no_bypass, mock_arion, monkeypatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.put("/test-bucket/test-key", content=b"hello", headers={"content-length": "5"})
+
+    assert response.status_code == 503
+    assert b"SlowDown" in response.content
+
+
+@pytest.mark.asyncio
+async def test_genuine_denial_still_hard_fails(mock_config_no_bypass: Any, monkeypatch: Any) -> None:
+    """Blast-radius guard: only unreachability became transient. A real out-of-credit verdict
+    must stay a 402, never get softened into a retry-forever SlowDown."""
+    mock_arion = MockArionService(allow_upload=False, upload_error="insufficient billing balance")
+    app = _make_can_upload_app(mock_config_no_bypass, mock_arion, monkeypatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.put("/test-bucket/test-key", content=b"hello", headers={"content-length": "5"})
+
+    assert response.status_code == 402
+    assert len(mock_arion.can_upload_calls) == 1, "a genuine denial must not be retried"
+
+
+@pytest.mark.asyncio
+async def test_arion_4xx_is_not_treated_as_transient(mock_config_no_bypass: Any, monkeypatch: Any) -> None:
+    """A 4xx from Arion is a bad request on our side, not a blip — it must not be retried into
+    a SlowDown that hides the bug."""
+    mock_arion = MockArionService(raise_on_can_upload=_http_status_error(400))
+    app = _make_can_upload_app(mock_config_no_bypass, mock_arion, monkeypatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.put("/test-bucket/test-key", content=b"hello", headers={"content-length": "5"})
+
+    assert response.status_code == 503
+    assert b"AccountVerificationError" in response.content
+
+
+@pytest.mark.asyncio
+async def test_arion_429_is_transient(mock_config_no_bypass: Any, monkeypatch: Any) -> None:
+    """429 is Arion explicitly asking us to back off — the one 4xx that is a blip."""
+    mock_arion = MockArionService(raise_on_can_upload=_http_status_error(429))
+    app = _make_can_upload_app(mock_config_no_bypass, mock_arion, monkeypatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.put("/test-bucket/test-key", content=b"hello", headers={"content-length": "5"})
+
+    assert response.status_code == 503
+    assert b"SlowDown" in response.content

--- a/tests/unit/gateway/test_account_middleware.py
+++ b/tests/unit/gateway/test_account_middleware.py
@@ -588,8 +588,9 @@ async def test_arion_4xx_is_not_treated_as_transient(mock_config_no_bypass: Any,
 
 
 @pytest.mark.asyncio
-async def test_arion_429_is_transient(mock_config_no_bypass: Any, monkeypatch: Any) -> None:
-    """429 is Arion explicitly asking us to back off — the one 4xx that is a blip."""
+async def test_arion_429_is_transient_but_not_hammered(mock_config_no_bypass: Any, monkeypatch: Any) -> None:
+    """429 is transient, but re-driving it is the one response guaranteed to be wrong: Arion just
+    said 'too many requests'. Surface the SlowDown without running the retry ladder."""
     mock_arion = MockArionService(raise_on_can_upload=_http_status_error(429))
     app = _make_can_upload_app(mock_config_no_bypass, mock_arion, monkeypatch)
 
@@ -598,3 +599,108 @@ async def test_arion_429_is_transient(mock_config_no_bypass: Any, monkeypatch: A
 
     assert response.status_code == 503
     assert b"SlowDown" in response.content
+    assert len(mock_arion.can_upload_calls) == 1, "must not re-drive a backend that asked us to back off"
+
+
+@pytest.mark.asyncio
+async def test_arion_507_stays_non_retryable(mock_config_no_bypass: Any, monkeypatch: Any) -> None:
+    """retry_on_error re-raises 507 precisely because 'server is full' cannot be retried away.
+    Treating it as a 5xx blip here would silently undo that."""
+    mock_arion = MockArionService(raise_on_can_upload=_http_status_error(507))
+    app = _make_can_upload_app(mock_config_no_bypass, mock_arion, monkeypatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.put("/test-bucket/test-key", content=b"hello", headers={"content-length": "5"})
+
+    assert b"AccountVerificationError" in response.content
+    assert len(mock_arion.can_upload_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_broken_base_url_stays_loud(mock_config_no_bypass: Any, monkeypatch: Any) -> None:
+    """A malformed HIPPIUS_ARION_BASE_URL is a config bug, not a blip. If it were folded into the
+    transient set it would become a fleet-wide 'please retry' that never resolves."""
+    mock_arion = MockArionService(raise_on_can_upload=httpx.UnsupportedProtocol("missing scheme"))
+    app = _make_can_upload_app(mock_config_no_bypass, mock_arion, monkeypatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.put("/test-bucket/test-key", content=b"hello", headers={"content-length": "5"})
+
+    assert b"AccountVerificationError" in response.content
+    assert b"SlowDown" not in response.content
+
+
+# ---------------------------------------------------------------------------
+# Real ArionClient: what actually lands on Arion, and the latency bound
+#
+# MockArionService raises the injected exception directly, so every test above
+# measures middleware-level attempts and never exercises @retry_on_error. These
+# drive the real client over a MockTransport so the numbers are the real ones.
+# ---------------------------------------------------------------------------
+
+
+def _real_arion_over(handler: Any, monkeypatch: Any) -> Any:
+    from hippius_s3.services import arion_service as arion_mod
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(arion_mod.asyncio, "sleep", _no_sleep)
+
+    client = arion_mod.ArionClient(base_url="http://arion.test", service_key="k")
+    client._client = httpx.AsyncClient(
+        base_url="http://arion.test",
+        transport=httpx.MockTransport(handler),
+    )
+    return client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,expected_requests",
+    [
+        (502, 6),  # decorator 2 x middleware 3
+        (429, 2),  # decorator 2, ladder skipped
+        (400, 2),  # decorator 2, then re-raised to the blanket handler
+        (507, 1),  # decorator re-raises immediately
+    ],
+)
+async def test_real_request_amplification_against_arion(
+    mock_config_no_bypass: Any, monkeypatch: Any, status: int, expected_requests: int
+) -> None:
+    """Pins how many requests a single client PUT actually costs a struggling billing backend."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(status)
+
+    app = _make_can_upload_app(mock_config_no_bypass, _real_arion_over(handler, monkeypatch), monkeypatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.put("/test-bucket/test-key", content=b"hello", headers={"content-length": "5"})
+
+    assert len(seen) == expected_requests
+
+
+@pytest.mark.asyncio
+async def test_can_upload_attempt_is_time_bounded(mock_config_no_bypass: Any, monkeypatch: Any) -> None:
+    """Regression guard: retry COUNTS cannot bound latency when the per-attempt cost is unbounded.
+
+    A blackholed Arion (TCP accepted, nothing returned) would otherwise cost the client-wide 60s
+    read timeout per attempt, and the transient ladder re-drives it — minutes on a single PUT,
+    holding a gateway worker the whole time. can_upload must carry its own short cap.
+    """
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(502)
+
+    app = _make_can_upload_app(mock_config_no_bypass, _real_arion_over(handler, monkeypatch), monkeypatch)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.put("/test-bucket/test-key", content=b"hello", headers={"content-length": "5"})
+
+    read_timeouts = {r.extensions["timeout"]["read"] for r in seen}
+    assert read_timeouts == {3.0}, "can_upload must not inherit the client-wide 60s bulk-upload timeout"

--- a/tests/unit/gateway/test_sub_token_scope.py
+++ b/tests/unit/gateway/test_sub_token_scope.py
@@ -178,9 +178,7 @@ def test_evaluate_create_bucket_denied_on_specific_scope() -> None:
         bucket_scope="specific",
         bucket_ids=("b",),
     )
-    allowed, reason = evaluate(
-        scope=scope_admin_specific, bucket_id=None, method="PUT", has_key=False, query_params={}
-    )
+    allowed, reason = evaluate(scope=scope_admin_specific, bucket_id=None, method="PUT", has_key=False, query_params={})
     assert allowed is False
     assert reason == "create_bucket_requires_scope_all"
 
@@ -253,9 +251,7 @@ def _expected(tier: str, bucket_scope: str, target_in_scope: bool, op: str) -> t
 @pytest.mark.parametrize("bucket_scope", ["all", "specific"])
 @pytest.mark.parametrize("target_in_scope", [True, False])
 @pytest.mark.parametrize("op_input", OP_INPUTS, ids=lambda oi: oi[3])
-def test_full_evaluate_matrix(
-    tier: str, bucket_scope: str, target_in_scope: bool, op_input: tuple
-) -> None:
+def test_full_evaluate_matrix(tier: str, bucket_scope: str, target_in_scope: bool, op_input: tuple) -> None:
     method, has_key, qparams, op = op_input
 
     # Under bucket_scope='all', target_in_scope is irrelevant — skip one duplicate.
@@ -310,8 +306,11 @@ def test_full_evaluate_matrix(
 def test_object_read_on_scoped_bucket_mirrors_r2_readonly_token() -> None:
     """R2 'Object Read only' → GET/HEAD allowed on listed bucket; writes/deletes denied."""
     scope = SubTokenScope(
-        access_key_id="hip_r", account_id="acct",
-        permission="object_read", bucket_scope="specific", bucket_ids=("books",),
+        access_key_id="hip_r",
+        account_id="acct",
+        permission="object_read",
+        bucket_scope="specific",
+        bucket_ids=("books",),
     )
     assert evaluate(scope=scope, bucket_id="books", method="GET", has_key=True, query_params={})[0] is True
     assert evaluate(scope=scope, bucket_id="books", method="HEAD", has_key=True, query_params={})[0] is True
@@ -322,8 +321,11 @@ def test_object_read_on_scoped_bucket_mirrors_r2_readonly_token() -> None:
 def test_object_read_write_on_scoped_bucket_mirrors_r2_rw_token() -> None:
     """R2 'Object Read & Write' → GET/HEAD/PUT/DELETE all allowed on listed bucket."""
     scope = SubTokenScope(
-        access_key_id="hip_rw", account_id="acct",
-        permission="object_read_write", bucket_scope="specific", bucket_ids=("books",),
+        access_key_id="hip_rw",
+        account_id="acct",
+        permission="object_read_write",
+        bucket_scope="specific",
+        bucket_ids=("books",),
     )
     for method in ("GET", "HEAD", "PUT", "DELETE"):
         ok, _ = evaluate(scope=scope, bucket_id="books", method=method, has_key=True, query_params={})
@@ -333,8 +335,11 @@ def test_object_read_write_on_scoped_bucket_mirrors_r2_rw_token() -> None:
 def test_admin_read_only_mirrors_r2_admin_read_token() -> None:
     """R2 'Admin Read only' → object reads + bucket listing + metadata reads; no writes."""
     scope = SubTokenScope(
-        access_key_id="hip_ar", account_id="acct",
-        permission="admin_read", bucket_scope="all", bucket_ids=(),
+        access_key_id="hip_ar",
+        account_id="acct",
+        permission="admin_read",
+        bucket_scope="all",
+        bucket_ids=(),
     )
     assert evaluate(scope=scope, bucket_id="b", method="GET", has_key=True, query_params={})[0] is True
     # list_bucket (object listing within a bucket) permitted
@@ -351,8 +356,11 @@ def test_admin_read_only_mirrors_r2_admin_read_token() -> None:
 def test_admin_read_write_with_scope_all_can_create_and_delete_buckets() -> None:
     """R2 'Admin Read & Write' with all-buckets scope → full control including create/delete."""
     scope = SubTokenScope(
-        access_key_id="hip_arw", account_id="acct",
-        permission="admin_read_write", bucket_scope="all", bucket_ids=(),
+        access_key_id="hip_arw",
+        account_id="acct",
+        permission="admin_read_write",
+        bucket_scope="all",
+        bucket_ids=(),
     )
     # CreateBucket
     assert evaluate(scope=scope, bucket_id=None, method="PUT", has_key=False, query_params={})[0] is True
@@ -367,8 +375,11 @@ def test_admin_read_write_specific_scope_cannot_create_new_buckets() -> None:
     """Admin R&W scoped to specific buckets: full access *within* those buckets,
     but no CreateBucket because the new bucket wouldn't be in the list."""
     scope = SubTokenScope(
-        access_key_id="hip_arw_specific", account_id="acct",
-        permission="admin_read_write", bucket_scope="specific", bucket_ids=("alpha",),
+        access_key_id="hip_arw_specific",
+        account_id="acct",
+        permission="admin_read_write",
+        bucket_scope="specific",
+        bucket_ids=("alpha",),
     )
     # Full control of listed bucket
     for method in ("GET", "HEAD", "PUT", "DELETE"):


### PR DESCRIPTION
## Summary

`ArionClient.can_upload` ends in `raise_for_status()`, so an upstream 5xx leaves as an `httpx.HTTPStatusError` rather than a `CanUploadResponse`. That skipped `_is_transient_billing_error` entirely and landed in `account_middleware`'s blanket `except Exception`, answering **`AccountVerificationError`** — a non-standard code no S3 SDK knows to retry. The retry-then-`SlowDown` ladder written for exactly this case never got to run.

This maps 5xx/429 and transport errors onto a transient verdict so the existing path does its job, and bounds the in-request retry.

## ⚠️ This is not the issue it started as

I originally diagnosed this as a **cache stampede**: `can_upload` runs per `UploadPart` behind only a 10s Redis TTL with no single-flight, so ~500 concurrent parts should herd on every expiry. Per-minute correlation on prod refuted that:

| UTC (2026-07-27) | can_upload calls/min | failures/min |
|---|---|---|
| `06:38` | **343** (peak — a customer's 500-way parallel upload) | **0** |
| `08:42–08:55` | **0** | **100–704** |

The busiest minute had zero failures; the failure bursts had zero call volume. Arion was simply unreachable — the ATS edge in front of it had both next hops marked down (`Transport endpoint is not connected [107] ... marking down` in `/var/log/trafficserver/error.log`). Per-account measurement showed at most 6–9 calls landing in the same 10s bucket, which is mild and was never the thing failing.

**A single-flight lock would have fixed nothing.** Dropped that idea; this PR fixes what the data actually supports.

## Changes

- `gateway/middlewares/account.py` — new `_can_upload` wrapper translating "billing backend unreachable" into `result=False` + a transient marker, so the existing retry/`SlowDown` path handles it. **4xx deliberately keeps falling through** to the blanket handler: that's us sending Arion something it rejected, and retrying it into a `SlowDown` would hide the bug. 429 is included as transient — that's Arion explicitly asking us to back off.
- `hippius_s3/services/arion_service.py` — `can_upload` is the only call on this client that runs inside the gateway's request path. The shared `@retry_on_error(retries=3, backoff=5.0)` pinned a worker for **15s per PUT/POST** while billing was down; with a few hundred concurrent uploads that is the gateway's capacity, spent waiting. Dropped to `retries=1, backoff=0.5` and let the caller's transient loop own the backoff — **more total attempts than before (6 vs 4), inside ~2s instead of 15s**.
- `tests/unit/gateway/test_account_middleware.py` — 5xx→`SlowDown` (parametrized 500/502/503/504), retry count, transport errors, 429, and two blast-radius guards: a genuine out-of-credit verdict still hard-fails 402 un-retried, and a 4xx still yields `AccountVerificationError`.

The 4xx guard test caught a real over-reach in the first draft of this patch, which had been swallowing 4xx too.

## Impact

Prod, 2026-07-26..28: **5,948** `can_upload` failures in 48h, in bursts up to 704/min. Every one of those was a write rejected with a code clients don't retry, during what were mostly sub-minute Arion blips.

## Verification

- `ruff check hippius_s3 gateway` — clean
- `ruff format --check hippius_s3 gateway` — clean
- `ty check hippius_s3 gateway` — All checks passed
- `pytest tests/unit` — **2225 passed**, 37 skipped
- `pytest tests/integration` — 39 pre-existing failures from a stale local schema (`crs.upload_enqueued_at does not exist`); verified byte-identical on an unmodified `origin/staging` worktree, so not from this change

## Conclusion

Makes a billing-backend blip look like a blip: a retryable `SlowDown` after ~2s, instead of a non-retryable error after 15s of held gateway capacity. Behaviour for genuine credit denials is unchanged and now pinned by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)