### PR TITLE
fix(api): make FS-cache-pressure sheds visible in metrics

### DIFF
--- a/hippius_s3/api/middlewares/fs_cache_pressure.py
+++ b/hippius_s3/api/middlewares/fs_cache_pressure.py
@@ -9,6 +9,7 @@ from fastapi import Response
 
 from hippius_s3.api.s3 import errors as s3_errors
 from hippius_s3.fs_pressure import should_reject_fs_cache_write
+from hippius_s3.monitoring import get_metrics_collector
 from hippius_s3.pressure_signal import get_published_pressure_mode
 
 
@@ -63,6 +64,14 @@ async def fs_cache_pressure_middleware(
     reject, retry_after, pressure, reason = should_reject_fs_cache_write(config=config, published_mode=published_mode)
     if not reject:
         return await call_next(request)
+
+    # This middleware is registered LAST, i.e. it is the OUTERMOST — it has to answer before the
+    # body is read. metrics_middleware is registered first, i.e. innermost, so it never runs on a
+    # shed request: the 503 lands in no request counter and no error counter on either side (the
+    # gateway just proxies it through). Record it here or a pressure event is invisible outside
+    # the log line below.
+    # Both labels are bounded: reason is threshold|pool, published_mode is 0|1|2|None.
+    get_metrics_collector().record_fs_cache_shed(reason=reason, pressure_mode=str(published_mode))
 
     # IMPORTANT: return BEFORE reading request body to avoid moving pressure to RAM.
     logger.warning(

--- a/hippius_s3/monitoring.py
+++ b/hippius_s3/monitoring.py
@@ -84,6 +84,12 @@ class MetricsCollector:
             name="s3_errors_total", description="Total S3 errors by type", unit="1"
         )
 
+        self.fs_cache_shed_total = self.meter.create_counter(
+            name="fs_cache_shed_total",
+            description="Writes rejected by the FS-cache-pressure gate, by reason and pressure mode",
+            unit="1",
+        )
+
         self.cache_hits = self.meter.create_counter(name="cache_hits_total", description="Total cache hits", unit="1")
 
         self.cache_misses = self.meter.create_counter(
@@ -451,6 +457,16 @@ class MetricsCollector:
 
         self.s3_errors_total.add(1, attributes=attributes)
 
+    def record_fs_cache_shed(self, reason: str, pressure_mode: str) -> None:
+        """Record a write rejected by the FS-cache-pressure gate.
+
+        The gate short-circuits as the OUTERMOST middleware (it must answer before the body is
+        read), so metrics_middleware — the innermost — never runs on a shed request and the 503
+        appears in no request counter. Recording here is what makes a pressure event visible;
+        without it the only evidence is a log line.
+        """
+        self.fs_cache_shed_total.add(1, attributes={"reason": reason, "pressure_mode": pressure_mode})
+
     def record_cache_operation(
         self,
         hit: bool,
@@ -712,6 +728,9 @@ class NullMetricsCollector:
         pass
 
     def record_error(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def record_fs_cache_shed(self, *args: object, **kwargs: object) -> None:
         pass
 
     def record_cache_operation(self, *args: object, **kwargs: object) -> None:

--- a/tests/unit/test_fs_cache_pressure_middleware.py
+++ b/tests/unit/test_fs_cache_pressure_middleware.py
@@ -118,3 +118,68 @@ async def test_non_put_bypasses_the_gate_entirely(tmp_path):
 
     assert await fs_cache_pressure_middleware(request, call_next) is sentinel
     assert await FakeRedis(value=None).get(PRESSURE_KEY) is None  # signal untouched
+
+
+# ---------------------------------------------------------------------------
+# A shed request must leave a metric behind, not just a log line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shed_request_is_recorded(tmp_path, monkeypatch):
+    """This gate is the OUTERMOST middleware — it has to answer before the body is read — while
+    metrics_middleware is the innermost. So metrics never runs on a shed request and the 503
+    lands in no request or error counter on either side. Without this call a pressure event is
+    invisible outside the log.
+    """
+    recorded: list[tuple[str, str]] = []
+
+    class _Collector:
+        def record_fs_cache_shed(self, reason: str, pressure_mode: str) -> None:
+            recorded.append((reason, pressure_mode))
+
+    monkeypatch.setattr(
+        "hippius_s3.api.middlewares.fs_cache_pressure.get_metrics_collector",
+        lambda: _Collector(),
+    )
+    monkeypatch.setattr(ps, "_CACHE", None, raising=False)
+
+    config = _config(tmp_path)
+    redis_client = FakeRedis(json.dumps({"mode": 2}).encode())
+    request = _make_put_request(config, redis_client)
+
+    async def _call_next(_req):  # pragma: no cover - must not be reached
+        raise AssertionError("a shed request must not reach the handler")
+
+    response = await fs_cache_pressure_middleware(request, _call_next)
+
+    assert response.status_code == 503
+    assert recorded == [("pool", "2")], "the shed must be attributed to the pool signal"
+
+
+@pytest.mark.asyncio
+async def test_passthrough_records_nothing(tmp_path, monkeypatch):
+    """Blast-radius guard: only an actual rejection increments the counter."""
+    recorded: list[tuple[str, str]] = []
+
+    class _Collector:
+        def record_fs_cache_shed(self, reason: str, pressure_mode: str) -> None:
+            recorded.append((reason, pressure_mode))
+
+    monkeypatch.setattr(
+        "hippius_s3.api.middlewares.fs_cache_pressure.get_metrics_collector",
+        lambda: _Collector(),
+    )
+    monkeypatch.setattr(ps, "_CACHE", None, raising=False)
+
+    config = _config(tmp_path)
+    redis_client = FakeRedis(json.dumps({"mode": 0}).encode())
+    request = _make_put_request(config, redis_client)
+
+    async def _call_next(_req):
+        return Response(status_code=200)
+
+    response = await fs_cache_pressure_middleware(request, _call_next)
+
+    assert response.status_code == 200
+    assert recorded == []

--- a/tests/unit/test_metrics_cardinality.py
+++ b/tests/unit/test_metrics_cardinality.py
@@ -40,6 +40,12 @@ BOUNDED_LABELS = {
     # Cachet component status, mapped through _STATUS_LABELS from {1, 3, 4} with an
     # "unknown" fallback — four values, fixed in code.
     "status",
+    # FS-cache shed attribution. `reason` is returned by should_reject_fs_cache_write as one of
+    # "threshold" | "pool" ("ok" never reaches the counter — it is the not-rejected case), and
+    # `pressure_mode` is the janitor's published signal stringified: "0" | "1" | "2" | "None".
+    # Both are closed sets fixed in code, not caller- or object-derived.
+    "reason",
+    "pressure_mode",
 }
 
 


### PR DESCRIPTION
Second of the two follow-ups flagged in the #373 review.

## The problem

`fs_cache_pressure_middleware` is registered **last**, i.e. it is the **outermost** middleware — it has to answer before the request body is read, which is the entire point of the gate. `metrics_middleware` is registered **first**, i.e. **innermost**, so it never runs on a shed request.

The result: a shed PUT lands in **no request counter and no error counter**, on the API or the gateway (which just proxies the 503 through). During a disk-pressure event the only evidence was a log line:

```
{namespace="hippius-s3-prod",app="api"} |= "FS cache pressure: rejecting request"
```

That's a bad place to be during an incident, and it interacts badly with #373: after that PR the gateway books the client's subsequent abort as a 499, so you'd see a 499 spike with nothing anywhere explaining it.

## The fix

Adds `fs_cache_shed_total{reason,pressure_mode}` and records it at the point of rejection.

`reason` distinguishes the local statvfs threshold from the janitor's published pool signal — the distinction that mattered on 2026-07-24, when the node NVMe stayed green while the backing Ceph pool hit the read-only cliff. That's exactly the case where a generic 503 count would have told you nothing useful.

## Why a counter rather than reordering the chain

The review suggested moving `metrics_middleware` outermost, which would also work and would additionally catch `ip_whitelist` 403s. I checked it and backed off:

- `metrics_middleware` calls `trace.get_current_span()` and sets `timing.api_ms` / `timing.gateway_ms` plus the `X-Hippius-API-Time-Ms` response header. Outermost, it would sit **outside** `tracing_middleware`, whose span has already exited by the time it runs post-`call_next` — those attributes would silently stop being set.
- It would fold middleware overhead into `http_request_duration_seconds` for **every** API request, changing a metric's meaning fleet-wide.

A counter at the rejection point costs nothing, can't perturb anything else, and gives better attribution than a bare 503 would. Reordering is still worth doing for the `ip_whitelist` gap — separately, and deliberately.

## Cardinality

Both labels are closed sets fixed in code: `reason` is `threshold|pool` (`ok` never reaches the counter — it's the not-rejected case) and `pressure_mode` is `0|1|2|None`. Neither is caller- or object-derived.

The existing guard in `test_metrics_cardinality.py` caught the new labels and made me justify them, which is exactly what it's for — they're added to the allowlist with that reasoning recorded inline.

## Tests

`tests/unit/test_fs_cache_pressure_middleware.py` — a pool-signal shed records `("pool", "2")` and never reaches the handler; a pass-through records nothing.

## Verification

- `ruff check` / `ruff format --check hippius_s3 gateway` — clean
- `ty check hippius_s3 gateway` — All checks passed
- `pytest tests/unit` — **2218 passed**, 37 skipped

## Conclusion

Turns a silent load-shed into a first-class signal, with the local-vs-pool attribution that a previous incident showed is the part you actually need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)