### PR TITLE
fix(gateway): stop warning "Incomplete upstream stream" on bodyless replies

### DIFF
--- a/gateway/services/forward_service.py
+++ b/gateway/services/forward_service.py
@@ -226,9 +226,16 @@ class ForwardService:
                     method=request.method,
                     status_code=upstream_response.status_code,
                 )
-                # Detect truncated responses before uvicorn raises RuntimeError
+                # Detect truncated responses before uvicorn raises RuntimeError.
+                # Skip replies that carry a Content-Length but legitimately have NO body, or this
+                # fires on every one of them: a HEAD reply advertises the length GET *would* return
+                # (RFC 9110 9.3.2) and 204/304 are defined bodyless, so bytes_sent is always 0 and
+                # always < Content-Length. That was ~561-1373/hr of pure noise on this gateway,
+                # which is enough to bury the genuine mid-stream truncations this line exists to
+                # surface — on 2026-07-28 a real one was indistinguishable from the HEAD chatter.
                 expected_raw = upstream_response.headers.get("content-length")
-                if expected_raw and bytes_sent < int(expected_raw):
+                bodyless = request.method == "HEAD" or upstream_response.status_code in (204, 304)
+                if not bodyless and expected_raw and bytes_sent < int(expected_raw):
                     logger.warning(
                         "Incomplete upstream stream: sent=%d expected=%s method=%s path=%s status=%d",
                         bytes_sent,

--- a/tests/unit/gateway/test_forward_service_incomplete_stream_warning.py
+++ b/tests/unit/gateway/test_forward_service_incomplete_stream_warning.py
@@ -1,0 +1,122 @@
+"""`Incomplete upstream stream` must only fire for a genuinely truncated body.
+
+The check compares bytes_sent against the upstream Content-Length. Some replies carry a
+Content-Length but legitimately send no body at all — a HEAD reply advertises the length GET
+*would* return (RFC 9110 9.3.2), and 204/304 are defined bodyless. For those, bytes_sent is
+always 0 and always < Content-Length, so the warning fired unconditionally: ~561-1373/hr on
+the production gateway, which buried the real mid-stream truncations it exists to surface.
+
+These tests pin the suppression AND pin that a real truncation still warns.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from gateway.services.forward_service import ForwardService
+
+
+def _request(method: str) -> Any:
+    request = Mock()
+    request.method = method
+    request.headers = {}
+    request.scope = {"path": "/bucket/key.bin"}
+    request.url.query = ""
+    request.url.path = "/bucket/key.bin"
+    request.state = Mock(spec=[])
+
+    async def _stream():
+        return
+        yield  # pragma: no cover - never reached, keeps this an async generator
+
+    request.stream = _stream
+    return request
+
+
+def _stream_stub(*, status_code: int, content_length: int, body: bytes) -> Any:
+    """Upstream that advertises `content_length` but actually emits `body`."""
+
+    def _call(**kwargs: Any) -> Any:
+        @asynccontextmanager
+        async def _cm():
+            response = Mock()
+            response.status_code = status_code
+            response.headers = httpx.Headers({"content-length": str(content_length)})
+
+            async def _aiter_bytes():
+                if body:
+                    yield body
+
+            response.aiter_bytes = _aiter_bytes
+            yield response
+
+        return _cm()
+
+    return _call
+
+
+async def _drain(service: ForwardService, request: Any) -> None:
+    response = await service.forward_request(request)
+    body = getattr(response, "body_iterator", None)
+    if body is not None:
+        async for _ in body:
+            pass
+
+
+@pytest.fixture
+def service() -> ForwardService:
+    return ForwardService("http://api:8000")
+
+
+@pytest.mark.asyncio
+async def test_head_reply_does_not_warn(service: ForwardService, caplog: Any) -> None:
+    """A HEAD reply sends no body by definition — that is not a truncation."""
+    service.client.stream = _stream_stub(status_code=200, content_length=25165824, body=b"")  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.WARNING, logger="gateway.services.forward_service"):
+        await _drain(service, _request("HEAD"))
+
+    assert "Incomplete upstream stream" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [204, 304])
+async def test_bodyless_status_codes_do_not_warn(service: ForwardService, caplog: Any, status_code: int) -> None:
+    """204 and 304 are defined to carry no body, whatever Content-Length says."""
+    service.client.stream = _stream_stub(status_code=status_code, content_length=1024, body=b"")  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.WARNING, logger="gateway.services.forward_service"):
+        await _drain(service, _request("GET"))
+
+    assert "Incomplete upstream stream" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_real_truncation_still_warns(service: ForwardService, caplog: Any) -> None:
+    """The signal has to survive: a GET that stops short of Content-Length must still warn.
+
+    This is the 2026-07-28 shape — 200 OK, full Content-Length, body dies partway.
+    """
+    service.client.stream = _stream_stub(status_code=200, content_length=25165824, body=b"x" * 5242880)  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.WARNING, logger="gateway.services.forward_service"):
+        await _drain(service, _request("GET"))
+
+    assert "Incomplete upstream stream" in caplog.text
+    assert "sent=5242880" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_complete_get_does_not_warn(service: ForwardService, caplog: Any) -> None:
+    service.client.stream = _stream_stub(status_code=200, content_length=7, body=b"payload")  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.WARNING, logger="gateway.services.forward_service"):
+        await _drain(service, _request("GET"))
+
+    assert "Incomplete upstream stream" not in caplog.text


### PR DESCRIPTION
Found while verifying the #378 hotfix in production.

## The problem

`forward_service` warns when `bytes_sent < Content-Length`. But some replies carry a Content-Length and legitimately send **no body**:

- a **HEAD** reply advertises the length a GET *would* return (RFC 9110 §9.3.2)
- **204** and **304** are defined bodyless

For all of those `bytes_sent` is 0, so the condition is unconditionally true. The warning fires on every one.

Measured on the production gateway: **561–1373/hr**, and **all 51 sampled lines were `method=HEAD` with `sent=0`**:

```
Incomplete upstream stream: sent=0 expected=25165824 method=HEAD path=/... status=200
```

## Why it matters

This isn't just log volume. This line is the *only* thing that surfaces a genuinely truncated response body — and it earned that job today.

When PR #369 caused real truncations in prod this morning (a GET that sent 5,242,880 of 25,165,824 bytes before dying), the real warnings were sitting in a stream of ~1000/hr of HEAD false positives. I only found the real one because I was already grepping for a specific object id. Nobody would spot it in a dashboard.

A signal that fires constantly on healthy traffic is not a signal.

## The change

Skip the check when the reply is bodyless by definition. Everything else is untouched.

```python
bodyless = request.method == "HEAD" or upstream_response.status_code in (204, 304)
if not bodyless and expected_raw and bytes_sent < int(expected_raw):
```

I covered 204/304 as well as HEAD rather than just the case I observed — they're the same class of bug and would have surfaced as the next round of noise.

## Tests

`tests/unit/gateway/test_forward_service_incomplete_stream_warning.py`, 5 cases pinning **both** halves:

- HEAD / 204 / 304 → silent
- a GET that stops short of Content-Length → **still warns** (uses today's real shape: 5242880 of 25165824)
- a complete GET → silent

Verified by reverting the fix: exactly the 3 bodyless tests fail, and the two guarding the real signal keep passing — so the fix demonstrably suppresses only the false positives.

## Verification

Full unit suite **2257 passed**, 37 skipped. `ruff` and `ty` clean on both changed files. (`ruff check tests/unit/gateway` reports 5 pre-existing issues in `test_account_middleware.py` / `test_auth_service.py`, untouched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)