### PR TITLE
fix(gateway): stop truncating object keys at '#'

### DIFF
--- a/gateway/middlewares/input_validation.py
+++ b/gateway/middlewares/input_validation.py
@@ -8,6 +8,7 @@ import logging
 import re
 from typing import Awaitable
 from typing import Callable
+from urllib.parse import unquote
 
 from fastapi import Request
 from fastapi import Response
@@ -19,6 +20,30 @@ from gateway.utils.errors import s3_error_response
 
 logger = logging.getLogger(__name__)
 config = get_config()
+
+
+def _decoded_path(request: Request) -> str:
+    """The request path, percent-decoded exactly once, with nothing dropped.
+
+    NOT `request.url.path`. Starlette builds that with `urlsplit` over the already-decoded URL,
+    and `urlsplit` treats `#` as the fragment delimiter — so a key sent as `report%23v1.txt`
+    decodes to `report#v1.txt` and then loses everything from the `#`, leaving `report`. The
+    truncated key reached storage, so `report#v1.txt` and `report#v2.txt` both landed as
+    `report` and the second silently overwrote the first: a 200 OK on both, one object destroyed,
+    nothing in the logs. It also meant `#` could never be caught below, despite being in
+    OBJECT_KEY_AVOID_CHARS all along.
+
+    `scope["raw_path"]` is the undecoded bytes as the client sent them, so decoding it here keeps
+    the `#`. This is the same discipline `sigv4.py` already uses to canonicalize — key extraction
+    just never adopted it.
+    """
+    raw = request.scope.get("raw_path")
+    if raw is None:
+        # Not every ASGI server populates raw_path. Falling back to the truncating path is still
+        # better than 500-ing; uvicorn (what we run) always provides it.
+        return request.url.path
+    return unquote(raw.decode("utf-8", "surrogateescape"))
+
 
 # S3 bucket name validation (AWS S3 compatible)
 # Must be 3-63 characters, lowercase letters/numbers/dots/hyphens only
@@ -46,7 +71,7 @@ async def input_validation_middleware(
 ) -> Response:
     """Validate S3 inputs for security and AWS compatibility."""
 
-    path_parts = request.url.path.strip("/").split("/")
+    path_parts = _decoded_path(request).strip("/").split("/")
 
     # Skip validation for non-S3 endpoints
     if path_parts[0] in SKIP_PREFIXES:

--- a/tests/unit/gateway/test_input_validation_key_truncation.py
+++ b/tests/unit/gateway/test_input_validation_key_truncation.py
@@ -1,0 +1,132 @@
+"""Object keys must be validated on what the client actually sent, not on a truncated path.
+
+`request.url.path` is built by Starlette with `urlsplit` over the already-decoded URL, and
+`urlsplit` treats `#` as the fragment delimiter. So a key sent as `report%23v1.txt` decoded to
+`report#v1.txt` and then lost everything from the `#` — the middleware only ever saw `report`.
+
+Two consequences, both live in prod before this fix:
+
+1. `#` could never be rejected, despite sitting in OBJECT_KEY_AVOID_CHARS the whole time.
+2. The truncated key reached storage. `report#v1.txt` and `report#v2.txt` both landed as
+   `report`, so the second silently overwrote the first — 200 OK on both, one object gone.
+
+These tests drive the middleware over a real ASGI scope, because the bug lives entirely in how
+the path is read off that scope. A test that passes an already-parsed key would not see it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+from urllib.parse import unquote
+
+import pytest
+from fastapi import Request
+from fastapi import Response
+
+from gateway.middlewares.input_validation import input_validation_middleware
+
+
+def _request(raw_path: bytes) -> Request:
+    """A Request whose scope carries `raw_path` exactly as a client would send it on the wire.
+
+    `path` is set to what Starlette actually derives — decode FIRST, then drop the fragment.
+    Order matters: decoding after splitting would leave `%23` intact, and the old code would then
+    reject it for containing `%` — the test would pass for the wrong reason and never see the
+    truncation bug at all.
+    """
+    starlette_path = unquote(raw_path.decode()).split("#", 1)[0]
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "PUT",
+            "scheme": "https",
+            "server": ("s3.hippius.com", 443),
+            "path": starlette_path,
+            "raw_path": raw_path,
+            "query_string": b"",
+            "root_path": "",
+            "headers": [(b"host", b"s3.hippius.com")],
+        }
+    )
+
+
+async def _run(raw_path: bytes) -> Response:
+    call_next = AsyncMock(return_value=Response(status_code=200))
+    return await input_validation_middleware(_request(raw_path), call_next)
+
+
+@pytest.mark.asyncio
+async def test_encoded_hash_in_key_is_rejected_not_truncated() -> None:
+    """The exact prod shape: a correctly percent-encoded `#` must not slip through."""
+    response = await _run(b"/bucket/report%23v1.txt")
+
+    assert response.status_code == 400, (
+        "a key containing '#' must be rejected; before this fix the '#' was parsed off as a URL "
+        "fragment, so the key silently became 'report' and was stored under the wrong name"
+    )
+
+
+@pytest.mark.asyncio
+async def test_literal_hash_in_key_is_rejected() -> None:
+    """Some clients send `#` unencoded; that must not bypass validation either."""
+    response = await _run(b"/bucket/report#v1.txt")
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_two_keys_differing_only_after_the_hash_cannot_collide() -> None:
+    """The data-loss case, stated as an invariant.
+
+    Both of these truncate to 'report'. If either is allowed through, they land on the same
+    destination key and one object is destroyed.
+    """
+    for raw in (b"/bucket/report%23v1.txt", b"/bucket/report%23v2.txt"):
+        assert (await _run(raw)).status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_path",
+    [
+        b"/bucket/normal.txt",
+        b"/bucket/nested/deep/file.bin",
+        b"/bucket/with%20space.txt",  # space is allowed — AWS permits it, and it is not on the avoid list
+        b"/bucket/dash-and_underscore.txt",
+        b"/bucket/unicode-%C3%A9%C3%A8.txt",
+    ],
+)
+async def test_valid_keys_still_pass(raw_path: bytes) -> None:
+    """The fix must not start rejecting keys that were always fine."""
+    assert (await _run(raw_path)).status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("encoded", ["%5B", "%7B", "%7C", "%5E", "%25"])
+async def test_other_avoid_chars_still_rejected(encoded: str) -> None:
+    """These already rejected correctly; pin them so the raw_path switch does not regress them."""
+    response = await _run(f"/bucket/bad{encoded}key.txt".encode())
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_missing_raw_path_falls_back_without_crashing() -> None:
+    """Not every ASGI server populates raw_path; degrade to the old behaviour, never 500."""
+    scope: dict[str, Any] = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "PUT",
+        "scheme": "https",
+        "server": ("s3.hippius.com", 443),
+        "path": "/bucket/normal.txt",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"host", b"s3.hippius.com")],
+    }
+    call_next = AsyncMock(return_value=Response(status_code=200))
+    response = await input_validation_middleware(Request(scope), call_next)
+
+    assert response.status_code == 200


### PR DESCRIPTION
**Silent data loss.** Found while validating the Storj migrator design against prod. Full write-up: [`s3-migration-todo.md`](s3-migration-todo.md).

## The bug

A PUT whose key contains `#` returns **200** and stores the key truncated at the `#`:

```
put-object --key 'dir/has#hash.txt'   -> 200 OK
list-objects-v2                       -> "dir/has"
```

Two keys differing only after the `#` collapse onto one destination, and the second silently overwrites the first:

```
put 'report#v1.txt' (AAAA-first-file)   -> 200
put 'report#v2.txt' (BBBB-second-file)  -> 200
list                                    -> a single object: "report"
get  "report"                           -> "BBBB-second-file"
```

One object destroyed. No error anywhere, and a GET of the *original* key also "succeeds" because it truncates identically — so a write-then-verify check passes while the data sits under the wrong name.

**Not a client bug.** A hand-signed request with a properly encoded `%23` on the wire loses the suffix too, so a fully correct S3 client cannot avoid it.

## Cause

`input_validation.py` read `request.url.path`. Starlette builds that with `urlsplit` over the **already-decoded** URL, and `urlsplit` treats `#` as the fragment delimiter — so `%23` decodes to `#` and everything after it is parsed off as the fragment. Two consequences, in order:

1. The key is truncated **before validation can see it**, so `#` could never be rejected — despite sitting in `OBJECT_KEY_AVOID_CHARS` the whole time. Every other char in that list (`[`, `{`, `%`, `|`) rejects correctly.
2. The truncated key **propagated to storage**, which is why the object lands as `report` rather than being refused.

The signing path already gets this right and says why — `sigv4.py` canonicalizes from `scope["raw_path"]` to *"preserve exact client percent-encoding"*. Key extraction never adopted the same discipline.

## The change

Read `scope["raw_path"]` and decode it exactly once, instead of `request.url.path`. Falls back to the old behaviour if an ASGI server doesn't populate `raw_path` (uvicorn always does) rather than 500-ing.

`#` now 400s like the rest of the avoid-list.

## Behaviour change worth flagging

Clients currently writing `#` keys get a **400 instead of a silent 200**. That is the point — it converts silent corruption into a loud, correct rejection — but it is a visible change for anyone relying on the broken path. Objects already stored under truncated names are unaffected and still readable.

**Deliberately not in scope:** actually *supporting* `#` in keys. AWS and Storj both allow it, so that is the better end state and the only option that migrates those objects — but it needs an audit of every other `url.path` consumer for the same assumption. Filed as follow-up in `s3-migration-todo.md`.

## Tests

`tests/unit/gateway/test_input_validation_key_truncation.py`, 14 cases driving the middleware over a **real ASGI scope**, because the bug lives entirely in how the path is read off that scope.

Two things I'd point a reviewer at:

- The scope's `path` is set the way Starlette actually derives it — **decode first, then drop the fragment**. An earlier draft split before decoding, which left `%23` intact; the old code then rejected it for containing `%`, so the test passed for the wrong reason and never exercised the truncation at all. Verified by reverting the fix: all three `#` tests now fail, and they fail on the truncation.
- Positive cases (spaces, unicode, nested paths) and the other avoid-list chars are pinned too, so the `raw_path` switch can't quietly change what's accepted.

## Verification

Full unit suite **2267 passed**, 37 skipped. `ruff check` / `ruff format --check` / `ty` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)