### PR TITLE
release: staging -> prod 2026-07-28-b (object-key '#' data loss + HEAD warning noise)

### DIFF
--- a/gateway/middlewares/input_validation.py
+++ b/gateway/middlewares/input_validation.py
@@ -8,6 +8,7 @@ import logging
 import re
 from typing import Awaitable
 from typing import Callable
+from urllib.parse import unquote
 
 from fastapi import Request
 from fastapi import Response
@@ -19,6 +20,30 @@ from gateway.utils.errors import s3_error_response
 
 logger = logging.getLogger(__name__)
 config = get_config()
+
+
+def _decoded_path(request: Request) -> str:
+    """The request path, percent-decoded exactly once, with nothing dropped.
+
+    NOT `request.url.path`. Starlette builds that with `urlsplit` over the already-decoded URL,
+    and `urlsplit` treats `#` as the fragment delimiter — so a key sent as `report%23v1.txt`
+    decodes to `report#v1.txt` and then loses everything from the `#`, leaving `report`. The
+    truncated key reached storage, so `report#v1.txt` and `report#v2.txt` both landed as
+    `report` and the second silently overwrote the first: a 200 OK on both, one object destroyed,
+    nothing in the logs. It also meant `#` could never be caught below, despite being in
+    OBJECT_KEY_AVOID_CHARS all along.
+
+    `scope["raw_path"]` is the undecoded bytes as the client sent them, so decoding it here keeps
+    the `#`. This is the same discipline `sigv4.py` already uses to canonicalize — key extraction
+    just never adopted it.
+    """
+    raw = request.scope.get("raw_path")
+    if raw is None:
+        # Not every ASGI server populates raw_path. Falling back to the truncating path is still
+        # better than 500-ing; uvicorn (what we run) always provides it.
+        return request.url.path
+    return unquote(raw.decode("utf-8", "surrogateescape"))
+
 
 # S3 bucket name validation (AWS S3 compatible)
 # Must be 3-63 characters, lowercase letters/numbers/dots/hyphens only
@@ -46,7 +71,7 @@ async def input_validation_middleware(
 ) -> Response:
     """Validate S3 inputs for security and AWS compatibility."""
 
-    path_parts = request.url.path.strip("/").split("/")
+    path_parts = _decoded_path(request).strip("/").split("/")
 
     # Skip validation for non-S3 endpoints
     if path_parts[0] in SKIP_PREFIXES:

--- a/gateway/services/forward_service.py
+++ b/gateway/services/forward_service.py
@@ -226,9 +226,16 @@ class ForwardService:
                     method=request.method,
                     status_code=upstream_response.status_code,
                 )
-                # Detect truncated responses before uvicorn raises RuntimeError
+                # Detect truncated responses before uvicorn raises RuntimeError.
+                # Skip replies that carry a Content-Length but legitimately have NO body, or this
+                # fires on every one of them: a HEAD reply advertises the length GET *would* return
+                # (RFC 9110 9.3.2) and 204/304 are defined bodyless, so bytes_sent is always 0 and
+                # always < Content-Length. That was ~561-1373/hr of pure noise on this gateway,
+                # which is enough to bury the genuine mid-stream truncations this line exists to
+                # surface — on 2026-07-28 a real one was indistinguishable from the HEAD chatter.
                 expected_raw = upstream_response.headers.get("content-length")
-                if expected_raw and bytes_sent < int(expected_raw):
+                bodyless = request.method == "HEAD" or upstream_response.status_code in (204, 304)
+                if not bodyless and expected_raw and bytes_sent < int(expected_raw):
                     logger.warning(
                         "Incomplete upstream stream: sent=%d expected=%s method=%s path=%s status=%d",
                         bytes_sent,

--- a/tests/unit/gateway/test_forward_service_incomplete_stream_warning.py
+++ b/tests/unit/gateway/test_forward_service_incomplete_stream_warning.py
@@ -1,0 +1,122 @@
+"""`Incomplete upstream stream` must only fire for a genuinely truncated body.
+
+The check compares bytes_sent against the upstream Content-Length. Some replies carry a
+Content-Length but legitimately send no body at all — a HEAD reply advertises the length GET
+*would* return (RFC 9110 9.3.2), and 204/304 are defined bodyless. For those, bytes_sent is
+always 0 and always < Content-Length, so the warning fired unconditionally: ~561-1373/hr on
+the production gateway, which buried the real mid-stream truncations it exists to surface.
+
+These tests pin the suppression AND pin that a real truncation still warns.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from gateway.services.forward_service import ForwardService
+
+
+def _request(method: str) -> Any:
+    request = Mock()
+    request.method = method
+    request.headers = {}
+    request.scope = {"path": "/bucket/key.bin"}
+    request.url.query = ""
+    request.url.path = "/bucket/key.bin"
+    request.state = Mock(spec=[])
+
+    async def _stream():
+        return
+        yield  # pragma: no cover - never reached, keeps this an async generator
+
+    request.stream = _stream
+    return request
+
+
+def _stream_stub(*, status_code: int, content_length: int, body: bytes) -> Any:
+    """Upstream that advertises `content_length` but actually emits `body`."""
+
+    def _call(**kwargs: Any) -> Any:
+        @asynccontextmanager
+        async def _cm():
+            response = Mock()
+            response.status_code = status_code
+            response.headers = httpx.Headers({"content-length": str(content_length)})
+
+            async def _aiter_bytes():
+                if body:
+                    yield body
+
+            response.aiter_bytes = _aiter_bytes
+            yield response
+
+        return _cm()
+
+    return _call
+
+
+async def _drain(service: ForwardService, request: Any) -> None:
+    response = await service.forward_request(request)
+    body = getattr(response, "body_iterator", None)
+    if body is not None:
+        async for _ in body:
+            pass
+
+
+@pytest.fixture
+def service() -> ForwardService:
+    return ForwardService("http://api:8000")
+
+
+@pytest.mark.asyncio
+async def test_head_reply_does_not_warn(service: ForwardService, caplog: Any) -> None:
+    """A HEAD reply sends no body by definition — that is not a truncation."""
+    service.client.stream = _stream_stub(status_code=200, content_length=25165824, body=b"")  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.WARNING, logger="gateway.services.forward_service"):
+        await _drain(service, _request("HEAD"))
+
+    assert "Incomplete upstream stream" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [204, 304])
+async def test_bodyless_status_codes_do_not_warn(service: ForwardService, caplog: Any, status_code: int) -> None:
+    """204 and 304 are defined to carry no body, whatever Content-Length says."""
+    service.client.stream = _stream_stub(status_code=status_code, content_length=1024, body=b"")  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.WARNING, logger="gateway.services.forward_service"):
+        await _drain(service, _request("GET"))
+
+    assert "Incomplete upstream stream" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_real_truncation_still_warns(service: ForwardService, caplog: Any) -> None:
+    """The signal has to survive: a GET that stops short of Content-Length must still warn.
+
+    This is the 2026-07-28 shape — 200 OK, full Content-Length, body dies partway.
+    """
+    service.client.stream = _stream_stub(status_code=200, content_length=25165824, body=b"x" * 5242880)  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.WARNING, logger="gateway.services.forward_service"):
+        await _drain(service, _request("GET"))
+
+    assert "Incomplete upstream stream" in caplog.text
+    assert "sent=5242880" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_complete_get_does_not_warn(service: ForwardService, caplog: Any) -> None:
+    service.client.stream = _stream_stub(status_code=200, content_length=7, body=b"payload")  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.WARNING, logger="gateway.services.forward_service"):
+        await _drain(service, _request("GET"))
+
+    assert "Incomplete upstream stream" not in caplog.text

--- a/tests/unit/gateway/test_input_validation_key_truncation.py
+++ b/tests/unit/gateway/test_input_validation_key_truncation.py
@@ -1,0 +1,132 @@
+"""Object keys must be validated on what the client actually sent, not on a truncated path.
+
+`request.url.path` is built by Starlette with `urlsplit` over the already-decoded URL, and
+`urlsplit` treats `#` as the fragment delimiter. So a key sent as `report%23v1.txt` decoded to
+`report#v1.txt` and then lost everything from the `#` — the middleware only ever saw `report`.
+
+Two consequences, both live in prod before this fix:
+
+1. `#` could never be rejected, despite sitting in OBJECT_KEY_AVOID_CHARS the whole time.
+2. The truncated key reached storage. `report#v1.txt` and `report#v2.txt` both landed as
+   `report`, so the second silently overwrote the first — 200 OK on both, one object gone.
+
+These tests drive the middleware over a real ASGI scope, because the bug lives entirely in how
+the path is read off that scope. A test that passes an already-parsed key would not see it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+from urllib.parse import unquote
+
+import pytest
+from fastapi import Request
+from fastapi import Response
+
+from gateway.middlewares.input_validation import input_validation_middleware
+
+
+def _request(raw_path: bytes) -> Request:
+    """A Request whose scope carries `raw_path` exactly as a client would send it on the wire.
+
+    `path` is set to what Starlette actually derives — decode FIRST, then drop the fragment.
+    Order matters: decoding after splitting would leave `%23` intact, and the old code would then
+    reject it for containing `%` — the test would pass for the wrong reason and never see the
+    truncation bug at all.
+    """
+    starlette_path = unquote(raw_path.decode()).split("#", 1)[0]
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "PUT",
+            "scheme": "https",
+            "server": ("s3.hippius.com", 443),
+            "path": starlette_path,
+            "raw_path": raw_path,
+            "query_string": b"",
+            "root_path": "",
+            "headers": [(b"host", b"s3.hippius.com")],
+        }
+    )
+
+
+async def _run(raw_path: bytes) -> Response:
+    call_next = AsyncMock(return_value=Response(status_code=200))
+    return await input_validation_middleware(_request(raw_path), call_next)
+
+
+@pytest.mark.asyncio
+async def test_encoded_hash_in_key_is_rejected_not_truncated() -> None:
+    """The exact prod shape: a correctly percent-encoded `#` must not slip through."""
+    response = await _run(b"/bucket/report%23v1.txt")
+
+    assert response.status_code == 400, (
+        "a key containing '#' must be rejected; before this fix the '#' was parsed off as a URL "
+        "fragment, so the key silently became 'report' and was stored under the wrong name"
+    )
+
+
+@pytest.mark.asyncio
+async def test_literal_hash_in_key_is_rejected() -> None:
+    """Some clients send `#` unencoded; that must not bypass validation either."""
+    response = await _run(b"/bucket/report#v1.txt")
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_two_keys_differing_only_after_the_hash_cannot_collide() -> None:
+    """The data-loss case, stated as an invariant.
+
+    Both of these truncate to 'report'. If either is allowed through, they land on the same
+    destination key and one object is destroyed.
+    """
+    for raw in (b"/bucket/report%23v1.txt", b"/bucket/report%23v2.txt"):
+        assert (await _run(raw)).status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw_path",
+    [
+        b"/bucket/normal.txt",
+        b"/bucket/nested/deep/file.bin",
+        b"/bucket/with%20space.txt",  # space is allowed — AWS permits it, and it is not on the avoid list
+        b"/bucket/dash-and_underscore.txt",
+        b"/bucket/unicode-%C3%A9%C3%A8.txt",
+    ],
+)
+async def test_valid_keys_still_pass(raw_path: bytes) -> None:
+    """The fix must not start rejecting keys that were always fine."""
+    assert (await _run(raw_path)).status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("encoded", ["%5B", "%7B", "%7C", "%5E", "%25"])
+async def test_other_avoid_chars_still_rejected(encoded: str) -> None:
+    """These already rejected correctly; pin them so the raw_path switch does not regress them."""
+    response = await _run(f"/bucket/bad{encoded}key.txt".encode())
+
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_missing_raw_path_falls_back_without_crashing() -> None:
+    """Not every ASGI server populates raw_path; degrade to the old behaviour, never 500."""
+    scope: dict[str, Any] = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "PUT",
+        "scheme": "https",
+        "server": ("s3.hippius.com", 443),
+        "path": "/bucket/normal.txt",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"host", b"s3.hippius.com")],
+    }
+    call_next = AsyncMock(return_value=Response(status_code=200))
+    response = await input_validation_middleware(Request(scope), call_next)
+
+    assert response.status_code == 200


### PR DESCRIPTION
Second promotion today. Small and surgical: **2 gateway files, +38/-3 code**, plus 254 lines of new tests. Both changes came out of validating the Storj migrator design against prod.

## What's in it

### #381 — object keys containing `#` were silently truncated (data loss)

A PUT whose key contained `#` returned **200** and stored the key cut at the `#`. Two keys differing only after it collapsed onto one destination and the second silently overwrote the first:

```
put 'report#v1.txt' (AAAA)  -> 200
put 'report#v2.txt' (BBBB)  -> 200
list                        -> a single object: "report"
get  "report"               -> "BBBB"      # first object destroyed
```

No error anywhere, and a GET of the *original* key also "succeeded" because it truncated identically — so write-then-verify passed while the data sat under the wrong name.

Not a client bug: a hand-signed request with a properly encoded `%23` on the wire lost the suffix too.

**Cause:** `input_validation` read `request.url.path`. Starlette builds that with `urlsplit` over the already-decoded URL, and `urlsplit` treats `#` as the fragment delimiter. So the key was truncated *before* validation could see it — which is why `#` never rejected despite being in `OBJECT_KEY_AVOID_CHARS` all along — and the truncated key propagated to storage.

**Fix:** read `scope["raw_path"]` and decode once, the same discipline `sigv4.py` already uses.

### #379 — `Incomplete upstream stream` fired on every bodyless reply

HEAD replies advertise the Content-Length a GET *would* return (RFC 9110 §9.3.2), and 204/304 are defined bodyless — so `bytes_sent(0) < Content-Length` was unconditionally true. **561–1373/hr** of false positives; all 51 lines sampled in prod were `method=HEAD`.

That volume defeated the line's purpose: when a *real* truncation happened this morning (a GET sending 5,242,880 of 25,165,824 bytes), it was indistinguishable from the HEAD chatter. Skipped for HEAD/204/304 only.

## Behaviour changes to expect

- **`#` keys now 400 instead of silently succeeding.** That is the point — silent corruption becomes a loud rejection — but it is user-visible for anyone relying on the broken path. Objects already stored under truncated names are unaffected and still readable.
- **Gateway warn volume drops by ~561–1373/hr.** If a dashboard alerts on gateway warn *rate*, expect a step down.

## Deliberately not in scope

Actually *supporting* `#` in keys. AWS and Storj both allow it, so that is the better end state and the only way those objects ever migrate — but it needs an audit of every other `url.path` consumer for the same assumption. Follow-up is written up in `s3-migration-todo.md`.

## Verification

- Full unit suite on the release SHA: **2272 passed**, 37 skipped. `ruff check` clean across `hippius_s3`/`gateway`/`workers`.
- Both PRs green on CI including E2E before merge.
- Both regression suites were verified by **reverting the fix and confirming the right tests fail** — for #381 an earlier draft passed for the wrong reason (old code rejecting on `%` rather than exercising the truncation), which is called out in the test's own docstring.

## Risk

Low. Both changes are in the gateway request path, both are narrowly conditioned, neither touches storage, crypto, the drain, or the reader. The `raw_path` read falls back to the old behaviour if an ASGI server doesn't populate it (uvicorn always does) rather than 500-ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)