### PR TITLE
Fix multipart XML: escape responses, parse Complete with lxml

### DIFF
--- a/hippius_s3/api/CLAUDE.md
+++ b/hippius_s3/api/CLAUDE.md
@@ -67,6 +67,7 @@ Implication: if anything except the gateway could reach the API's port, it could
 - **PutObject object identity is DB-atomic**: the old pre-check `SELECT` was removed (WU-3); the endpoint always passes a fresh `candidate_object_id` and trusts the DB-returned id ([put_object_endpoint.py:137-142](s3/objects/put_object_endpoint.py)). See [s3/objects/CLAUDE.md](s3/objects/CLAUDE.md).
 - **CORS on PutBucket**: returns 200 OK for `?cors` query, logs an "Ignored" line, but doesn't store anything. Added in commit `afc0a94` to avoid `BucketAlreadyExists` errors from AWS SDKs attempting to configure CORS on existing buckets.
 - **Lifecycle XML parsed then discarded** — same pattern for `?lifecycle` at [bucket_create_endpoint.py:78](s3/buckets/bucket_create_endpoint.py). See [todo.md](../../todo.md) P2.
+- **Client XML goes through `parse_untrusted_xml`** ([xml_helpers.py](../xml_helpers.py)), never a bare `ET.fromstring` — a default parser loads DTDs and expands entities. Responses are built with `create_element`/`add_subelement`/`to_xml_bytes` so values are escaped: a key containing `&` is legal and an f-string template produces a document no client can parse. Match on `local-name()` when reading, since SDKs disagree about namespacing the body.
 
 ## Where things live
 

--- a/hippius_s3/api/s3/buckets/delete_objects_endpoint.py
+++ b/hippius_s3/api/s3/buckets/delete_objects_endpoint.py
@@ -15,6 +15,7 @@ from hippius_s3.queue import enqueue_unpin_request
 from hippius_s3.repositories.buckets import BucketRepository
 from hippius_s3.repositories.users import UserRepository
 from hippius_s3.utils import get_query
+from hippius_s3.xml_helpers import parse_untrusted_xml
 
 
 logger = logging.getLogger(__name__)
@@ -75,8 +76,8 @@ async def handle_delete_objects(bucket_name: str, request: Request, db: Any, red
             )
 
         try:
-            root = ET.fromstring(body)
-        except Exception:
+            root = parse_untrusted_xml(body)
+        except ValueError:
             logger.exception("Malformed XML for DeleteObjects")
             return errors.s3_error_response(
                 "MalformedXML",

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -82,6 +82,31 @@ def parse_complete_multipart_upload(body: bytes) -> list[tuple[int, str]]:
     return parts
 
 
+def build_complete_result_xml(host: str, bucket_name: str, object_key: str, etag: str) -> bytes:
+    """Serialise a CompleteMultipartUploadResult.
+
+    Shared by the success and idempotent-replay paths so both report the same Location; the
+    replay path used to hardcode ``http://localhost:8000``, which is wrong for every
+    deployment. The Host header is client-controlled, so it is written as element text and
+    escaped rather than interpolated into the document.
+
+    Args:
+        host: Value of the request's Host header.
+        bucket_name: Bucket the upload targeted.
+        object_key: Key the upload targeted.
+        etag: Final object ETag, unquoted.
+
+    Returns:
+        The serialised XML document.
+    """
+    root = create_element("CompleteMultipartUploadResult", xmlns="http://s3.amazonaws.com/doc/2006-03-01/")
+    add_subelement(root, "Location", f"http://{host}/{bucket_name}/{object_key}")
+    add_subelement(root, "Bucket", bucket_name)
+    add_subelement(root, "Key", object_key)
+    add_subelement(root, "ETag", f'"{etag}"')
+    return to_xml_bytes(root)
+
+
 def _plain_text(element: Any) -> str:
     """Text of an element that must contain nothing but text.
 
@@ -411,15 +436,11 @@ async def initiate_multipart_upload(
             uuid.UUID(object_id),
         )
 
-        # Create XML response using a hardcoded template
-        xml_string = f"""<?xml version="1.0" encoding="UTF-8"?>
-<InitiateMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-  <Bucket>{bucket_name}</Bucket>
-  <Key>{object_key}</Key>
-  <UploadId>{upload_id}</UploadId>
-</InitiateMultipartUploadResult>
-"""
-        xml_bytes = xml_string.encode("utf-8")
+        root = create_element("InitiateMultipartUploadResult", xmlns="http://s3.amazonaws.com/doc/2006-03-01/")
+        add_subelement(root, "Bucket", bucket_name)
+        add_subelement(root, "Key", object_key)
+        add_subelement(root, "UploadId", upload_id)
+        xml_bytes = to_xml_bytes(root)
 
         # Return response with proper headers
         return Response(
@@ -792,12 +813,10 @@ async def upload_part(
         # Return response
         if copy_source:
             # AWS-style XML body for UploadPartCopy
-            xml = f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<CopyPartResult>
-  <ETag>\"{part_result["etag"]}\"</ETag>
-  <LastModified>{format_s3_timestamp(datetime.now(timezone.utc))}</LastModified>
-</CopyPartResult>
-""".encode("utf-8")
+            root = create_element("CopyPartResult")
+            add_subelement(root, "ETag", f'"{part_result["etag"]}"')
+            add_subelement(root, "LastModified", format_s3_timestamp(datetime.now(timezone.utc)))
+            xml = to_xml_bytes(root)
             return Response(content=xml, media_type="application/xml", status_code=200)
         return Response(
             status_code=200,
@@ -1108,17 +1127,18 @@ async def complete_multipart_upload(
                     final_etag = await hash_all_etags(object_id, object_version, db)
                 except Exception:
                     final_etag = "completed"
-            xml_content = f"""<?xml version="1.0" encoding="UTF-8"?>
-<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-    <Location>http://localhost:8000/{bucket_name}/{object_key}</Location>
-    <Bucket>{bucket_name}</Bucket>
-    <Key>{object_key}</Key>
-    <ETag>"{final_etag}"</ETag>
-</CompleteMultipartUploadResult>"""
+            xml_content = build_complete_result_xml(
+                request.headers.get("Host", ""), bucket_name, object_key, final_etag
+            )
             return Response(
                 content=xml_content,
                 media_type="application/xml",
                 status_code=200,
+                headers={
+                    "Content-Type": "application/xml; charset=utf-8",
+                    "x-amz-request-id": str(uuid.uuid4()),
+                    "Content-Length": str(len(xml_content)),
+                },
             )
 
         try:
@@ -1257,15 +1277,9 @@ async def complete_multipart_upload(
                 exc_info=True,
             )
 
-        # Create XML response
-        xml_bytes = f"""<?xml version="1.0" encoding="UTF-8"?>
-<CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-  <Location>http://{request.headers.get("Host", "")}/{bucket_name}/{object_key}</Location>
-  <Bucket>{bucket_name}</Bucket>
-  <Key>{object_key}</Key>
-  <ETag>"{complete_res.etag}"</ETag>
-</CompleteMultipartUploadResult>
-""".encode("utf-8")
+        xml_bytes = build_complete_result_xml(
+            request.headers.get("Host", ""), bucket_name, object_key, str(complete_res.etag)
+        )
 
         get_metrics_collector().record_s3_operation(
             operation="complete_multipart_upload",

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -42,10 +42,63 @@ from hippius_s3.writer.db import set_object_version_address
 from hippius_s3.writer.object_writer import ObjectWriter
 from hippius_s3.xml_helpers import add_subelement
 from hippius_s3.xml_helpers import create_element
+from hippius_s3.xml_helpers import parse_untrusted_xml
 from hippius_s3.xml_helpers import to_xml_bytes
 
 
 logger = logging.getLogger(__name__)
+
+
+def parse_complete_multipart_upload(body: bytes) -> list[tuple[int, str]]:
+    """Parse a CompleteMultipartUpload body into (part_number, etag) pairs in document order.
+
+    Matched by local-name so a namespace-prefixed or default-namespaced body parses the same,
+    and paired within each ``<Part>`` so a stray element elsewhere in the document cannot shift
+    the pairing. ETag quoting is normalised after parsing, which is what makes every client
+    encoding agree: boto3 sends ``"abc"``, Go and Rust send the quotes escaped, and some
+    clients send bare hex — all three arrive here as ``abc``.
+
+    Args:
+        body: Raw request body.
+
+    Returns:
+        The listed parts, empty if the body carries none.
+
+    Raises:
+        ValueError: Not well-formed, or a ``<Part>`` missing/misusing PartNumber or ETag.
+    """
+    root = parse_untrusted_xml(body)
+    parts: list[tuple[int, str]] = []
+    for part in root.xpath(".//*[local-name()='Part']"):
+        numbers = part.xpath("./*[local-name()='PartNumber']")
+        etags = part.xpath("./*[local-name()='ETag']")
+        if not numbers or not etags:
+            raise ValueError("every Part must carry a PartNumber and an ETag")
+        try:
+            number = int(_plain_text(numbers[0]).strip())
+        except ValueError as exc:
+            raise ValueError(f"PartNumber {numbers[0].text!r} is not an integer") from exc
+        parts.append((number, _plain_text(etags[0]).strip().strip('"')))
+    return parts
+
+
+def _plain_text(element: Any) -> str:
+    """Text of an element that must contain nothing but text.
+
+    Entity references survive parsing as child nodes because the parser leaves them
+    unresolved, and reading ``.text`` would silently return ``None`` for them. An empty ETag
+    skips the part-ETag comparison downstream, so a body carrying ``<ETag>&bomb;</ETag>`` would
+    complete an upload without its parts ever being verified. Rejecting the body is correct:
+    no real client sends entity references here.
+
+    Raises:
+        ValueError: The element has child nodes.
+    """
+    if len(element):
+        raise ValueError("element must contain text only")
+    return element.text or ""
+
+
 router = APIRouter(tags=["s3-multipart"])
 
 config = get_config()
@@ -1068,36 +1121,20 @@ async def complete_multipart_upload(
                 status_code=200,
             )
 
-        # Parse the XML request body to get parts list
-        body_text = ""
         try:
-            body_text = (await get_request_body(request)).decode("utf-8")
-        except Exception:
-            body_text = "<CompleteMultipartUpload></CompleteMultipartUpload>"
-
-        # Parse part numbers and ETags
-        part_numbers = re.findall(r"<PartNumber>(\d+)</PartNumber>", body_text)
-        etags = re.findall(r"<ETag>([^<]+)</ETag>", body_text)
-
-        if not part_numbers or not etags or len(part_numbers) != len(etags):
+            part_info = parse_complete_multipart_upload(await get_request_body(request))
+        except ValueError:
             return s3_error_response(
-                "InvalidRequest",
-                "The XML provided was not well-formed",
+                "MalformedXML",
+                "The XML you provided was not well-formed or did not validate against our published schema",
                 status_code=400,
             )
 
-        # Create part info list
-        part_info = []
-        for num, tag in zip(
-            part_numbers,
-            etags,
-            strict=True,
-        ):
-            part_info.append(
-                (
-                    int(num),
-                    tag.replace('"', "").strip(),
-                ),
+        if not part_info:
+            return s3_error_response(
+                "MalformedXML",
+                "The XML you provided was not well-formed or did not validate against our published schema",
+                status_code=400,
             )
         # S3 requires the parts to be listed in strictly ascending part-number order.
         # We used to silently sort here, which masked a malformed part list; reject it

--- a/hippius_s3/api/s3/multipart.py
+++ b/hippius_s3/api/s3/multipart.py
@@ -54,9 +54,18 @@ def parse_complete_multipart_upload(body: bytes) -> list[tuple[int, str]]:
 
     Matched by local-name so a namespace-prefixed or default-namespaced body parses the same,
     and paired within each ``<Part>`` so a stray element elsewhere in the document cannot shift
-    the pairing. ETag quoting is normalised after parsing, which is what makes every client
-    encoding agree: boto3 sends ``"abc"``, Go and Rust send the quotes escaped, and some
-    clients send bare hex — all three arrive here as ``abc``.
+    the pairing. Parts are read as direct children of the root, the way S3 specifies the
+    document, so a ``<Part>`` buried in some unrelated wrapper is not silently honoured.
+
+    ETag quoting is normalised after parsing, which is what makes every client encoding agree:
+    boto3 sends ``"abc"``, Go and Rust send the quotes escaped, and some clients send bare hex
+    — all three arrive here as ``abc``.
+
+    Every part must name a non-empty ETag. That is a guarantee callers rely on: the handler
+    compares each ETag against the stored part, and an empty string would make that comparison
+    vacuous. Enforcing it here means one place has to be right instead of every consumer, and
+    the empty string is reachable more ways than it looks — ``<ETag/>``, whitespace, an
+    unresolved entity reference, and a literal ``""`` that survives quote-stripping.
 
     Args:
         body: Raw request body.
@@ -69,7 +78,7 @@ def parse_complete_multipart_upload(body: bytes) -> list[tuple[int, str]]:
     """
     root = parse_untrusted_xml(body)
     parts: list[tuple[int, str]] = []
-    for part in root.xpath(".//*[local-name()='Part']"):
+    for part in root.xpath("./*[local-name()='Part']"):
         numbers = part.xpath("./*[local-name()='PartNumber']")
         etags = part.xpath("./*[local-name()='ETag']")
         if not numbers or not etags:
@@ -78,7 +87,10 @@ def parse_complete_multipart_upload(body: bytes) -> list[tuple[int, str]]:
             number = int(_plain_text(numbers[0]).strip())
         except ValueError as exc:
             raise ValueError(f"PartNumber {numbers[0].text!r} is not an integer") from exc
-        parts.append((number, _plain_text(etags[0]).strip().strip('"')))
+        etag = _plain_text(etags[0]).strip().strip('"').strip()
+        if not etag:
+            raise ValueError(f"part {number} has an empty ETag")
+        parts.append((number, etag))
     return parts
 
 
@@ -111,10 +123,12 @@ def _plain_text(element: Any) -> str:
     """Text of an element that must contain nothing but text.
 
     Entity references survive parsing as child nodes because the parser leaves them
-    unresolved, and reading ``.text`` would silently return ``None`` for them. An empty ETag
-    skips the part-ETag comparison downstream, so a body carrying ``<ETag>&bomb;</ETag>`` would
-    complete an upload without its parts ever being verified. Rejecting the body is correct:
-    no real client sends entity references here.
+    unresolved, and reading ``.text`` would silently return ``None`` for them — so a body
+    carrying ``<ETag>&bomb;</ETag>`` would read as an empty ETag. Rejecting it is correct: no
+    real client sends entity references here.
+
+    This closes one route to an empty value; the caller rejects the empty string itself, which
+    covers the rest.
 
     Raises:
         ValueError: The element has child nodes.
@@ -1204,6 +1218,11 @@ async def complete_multipart_upload(
         # uploaded; S3 rejects the completion (InvalidPart) if the part is missing OR the
         # ETag does not match. Without the ETag check a client could assemble the object
         # from the wrong part bytes and still receive a 200 — a silent data-integrity hole.
+        #
+        # Compared unconditionally: this used to skip a falsy client_etag, which meant any
+        # body encoding an empty ETag opted itself out of the check the comment above
+        # describes. parse_complete_multipart_upload now rejects those bodies outright, so
+        # every ETag reaching here is non-empty and there is nothing to guard against.
         missing_parts = []
         mismatched_parts = []
         for pn, client_etag in part_info:
@@ -1212,7 +1231,7 @@ async def complete_multipart_upload(
                 missing_parts.append(pn)
                 continue
             stored_etag = str(db_part["etag"]).replace('"', "").strip()
-            if client_etag and client_etag.lower() != stored_etag.lower():
+            if client_etag.lower() != stored_etag.lower():
                 mismatched_parts.append(pn)
         if missing_parts:
             return s3_error_response(

--- a/hippius_s3/xml_helpers.py
+++ b/hippius_s3/xml_helpers.py
@@ -28,3 +28,29 @@ def to_xml_bytes(
     """Convert an element tree to bytes with XML declaration."""
     result: bytes = _ET.tostring(root, encoding=encoding, xml_declaration=xml_declaration, pretty_print=pretty_print)
     return result
+
+
+def parse_untrusted_xml(data: bytes) -> Element:
+    """Parse client-supplied XML with entity expansion, DTD loading and network access off.
+
+    The single entry point for request bodies, so no endpoint has to remember the hardening
+    flags — a default parser would expand DTD-declared entities and inflate a billion-laughs
+    body in memory. Predefined entities and numeric character references (``&quot;``,
+    ``&#34;``) are still decoded, which is what lets clients whose XML encoders escape quotes
+    round-trip correctly.
+
+    Args:
+        data: Raw request body.
+
+    Returns:
+        The parsed root element.
+
+    Raises:
+        ValueError: The body is not well-formed XML.
+    """
+    # A parser instance carries mutable state, so it is built per call rather than shared.
+    parser = _ET.XMLParser(resolve_entities=False, load_dtd=False, no_network=True, huge_tree=False)
+    try:
+        return _ET.fromstring(data, parser)
+    except _ET.XMLSyntaxError as exc:
+        raise ValueError(str(exc)) from exc

--- a/tests/e2e/test_CompleteMultipartUpload.py
+++ b/tests/e2e/test_CompleteMultipartUpload.py
@@ -47,3 +47,51 @@ def test_complete_multipart_upload_returns_combined_etag(
     # HEAD should expose the same ETag
     head = boto3_client.head_object(Bucket=bucket, Key=key)
     assert head["ETag"].strip('"') == etag_xml
+
+
+def test_multipart_upload_with_ampersand_key(
+    docker_services: Any,
+    boto3_client: Any,
+    unique_bucket_name: Callable[[str], str],
+    cleanup_buckets: Callable[[str], None],
+) -> None:
+    """'&' is legal in an object key but must be escaped in the XML responses.
+
+    Unescaped it opens an entity reference, so the document is not well-formed and botocore
+    fails to parse it — CreateMultipartUpload never yields an UploadId and the upload dies
+    before any data is sent. Only an end-to-end client proves the response is readable.
+    """
+    bucket = unique_bucket_name("mpu-amp")
+    cleanup_buckets(bucket)
+    boto3_client.create_bucket(Bucket=bucket)
+    key = "report&final.pdf"
+
+    create = boto3_client.create_multipart_upload(Bucket=bucket, Key=key, ContentType="application/pdf")
+    upload_id = create["UploadId"]
+    assert create["Key"] == key
+
+    part_size = 5 * 1024 * 1024
+    etag1 = boto3_client.upload_part(Bucket=bucket, Key=key, UploadId=upload_id, PartNumber=1, Body=b"a" * part_size)[
+        "ETag"
+    ]
+    etag2 = boto3_client.upload_part(Bucket=bucket, Key=key, UploadId=upload_id, PartNumber=2, Body=b"b" * part_size)[
+        "ETag"
+    ]
+
+    completed = boto3_client.complete_multipart_upload(
+        Bucket=bucket,
+        Key=key,
+        UploadId=upload_id,
+        MultipartUpload={
+            "Parts": [
+                {"ETag": etag1, "PartNumber": 1},
+                {"ETag": etag2, "PartNumber": 2},
+            ]
+        },
+    )
+    assert completed["Key"] == key
+    etag_xml = completed["ETag"].strip('"')
+    assert etag_xml.endswith("-2")
+
+    head = boto3_client.head_object(Bucket=bucket, Key=key)
+    assert head["ETag"].strip('"') == etag_xml

--- a/tests/unit/api/test_multipart_complete_version.py
+++ b/tests/unit/api/test_multipart_complete_version.py
@@ -395,6 +395,35 @@ async def test_complete_rejects_malformed_xml_with_malformed_xml_code(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_complete_rejects_an_empty_etag_instead_of_skipping_verification(
+    monkeypatch: Any,
+) -> None:
+    """An empty ETag must not complete an upload with its parts unverified.
+
+    The per-part comparison used to be skipped for a falsy ETag, so this body would have
+    completed with a 200 having checked nothing. A literal '""' is the sharp version: a
+    non-empty body that normalises to the empty string during quote-stripping.
+    """
+    _patch_common(monkeypatch)
+    completed: dict[str, Any] = {"ok": False}
+    _completing_writer(monkeypatch, completed)
+    monkeypatch.setattr(
+        multipart,
+        "get_request_body",
+        _body_returning(
+            b'<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>""</ETag></Part></CompleteMultipartUpload>'
+        ),
+    )
+
+    db = _FakeDb(current_version=1, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "k", "up-1", _request(), db)
+
+    assert resp.status_code == 400
+    assert b"MalformedXML" in bytes(resp.body)
+    assert completed["ok"] is False
+
+
+@pytest.mark.asyncio
 async def test_complete_does_not_expand_entity_bomb(monkeypatch: Any) -> None:
     """A DTD-declared entity must not be expanded: a parser with default settings would inflate
     this body in memory. The reference stays unresolved, and because an empty ETag would skip

--- a/tests/unit/api/test_multipart_complete_version.py
+++ b/tests/unit/api/test_multipart_complete_version.py
@@ -13,8 +13,20 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from lxml import etree
 
 from hippius_s3.api.s3 import multipart
+
+
+def _parse(body: bytes) -> Any:
+    """Parses a response body, failing the test if it is not well-formed XML."""
+    return etree.fromstring(body)
+
+
+def _text(root: Any, tag: str) -> str | None:
+    """Text of the first `tag` child, namespace-agnostically."""
+    nodes = root.xpath(f"./*[local-name()='{tag}']")
+    return str(nodes[0].text) if nodes else None
 
 
 class _FakeDb:
@@ -223,6 +235,249 @@ async def test_complete_accepts_matching_etag_case_insensitive(monkeypatch: Any)
 
     assert resp.status_code == 200
     assert completed["ok"] is True, "a case-differing but matching ETag must complete"
+
+
+def _completing_writer(monkeypatch: Any, completed: dict[str, Any]) -> None:
+    """Writer + address stubs that record completion, for the interop tests below."""
+
+    class _FakeWriter:
+        def __init__(self, **_: Any) -> None: ...
+
+        async def mpu_complete(self, **_: Any) -> Any:
+            completed["ok"] = True
+            return SimpleNamespace(etag="abc", size_bytes=100)
+
+    async def _addr(*_: Any, **__: Any) -> None:
+        return None
+
+    monkeypatch.setattr(multipart, "ObjectWriter", _FakeWriter)
+    monkeypatch.setattr(multipart, "set_object_version_address", _addr)
+
+
+def _body_returning(payload: bytes) -> Any:
+    async def _body(_req: Any) -> bytes:
+        return payload
+
+    return _body
+
+
+@pytest.mark.asyncio
+async def test_complete_accepts_predefined_entity_quoted_etag(monkeypatch: Any) -> None:
+    """aws-sdk-rust escapes the ETag's quotes as &quot;. Scraping element text with a regex
+    captured the raw entity and matched no stored part, so every part failed InvalidPart and
+    multipart was unusable from Rust clients."""
+    _patch_common(monkeypatch)
+    completed: dict[str, Any] = {"ok": False}
+    _completing_writer(monkeypatch, completed)
+    monkeypatch.setattr(
+        multipart,
+        "get_request_body",
+        _body_returning(
+            b"<CompleteMultipartUpload><Part><PartNumber>1</PartNumber>"
+            b"<ETag>&quot;abc&quot;</ETag></Part></CompleteMultipartUpload>"
+        ),
+    )
+
+    db = _FakeDb(current_version=1, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "k", "up-1", _request(), db)
+
+    assert resp.status_code == 200, bytes(resp.body)
+    assert completed["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_complete_accepts_numeric_charref_quoted_etag(monkeypatch: Any) -> None:
+    """aws-sdk-go (rclone, minio-go, the Terraform S3 provider) escapes the quotes as &#34;."""
+    _patch_common(monkeypatch)
+    completed: dict[str, Any] = {"ok": False}
+    _completing_writer(monkeypatch, completed)
+    monkeypatch.setattr(
+        multipart,
+        "get_request_body",
+        _body_returning(
+            b"<CompleteMultipartUpload><Part><PartNumber>1</PartNumber>"
+            b"<ETag>&#34;abc&#34;</ETag></Part></CompleteMultipartUpload>"
+        ),
+    )
+
+    db = _FakeDb(current_version=1, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "k", "up-1", _request(), db)
+
+    assert resp.status_code == 200, bytes(resp.body)
+    assert completed["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_complete_accepts_prefixed_namespace_body(monkeypatch: Any) -> None:
+    """A namespace-prefixed body is valid S3 XML; the regex only matched bare <PartNumber>."""
+    _patch_common(monkeypatch)
+    completed: dict[str, Any] = {"ok": False}
+    _completing_writer(monkeypatch, completed)
+    monkeypatch.setattr(
+        multipart,
+        "get_request_body",
+        _body_returning(
+            b'<m:CompleteMultipartUpload xmlns:m="http://s3.amazonaws.com/doc/2006-03-01/">'
+            b"<m:Part><m:PartNumber>1</m:PartNumber><m:ETag>abc</m:ETag></m:Part>"
+            b"</m:CompleteMultipartUpload>"
+        ),
+    )
+
+    db = _FakeDb(current_version=1, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "k", "up-1", _request(), db)
+
+    assert resp.status_code == 200, bytes(resp.body)
+    assert completed["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_complete_accepts_default_namespace_body(monkeypatch: Any) -> None:
+    """Guard for the common boto3 shape: a default xmlns on the root must keep working."""
+    _patch_common(monkeypatch)
+    completed: dict[str, Any] = {"ok": False}
+    _completing_writer(monkeypatch, completed)
+    monkeypatch.setattr(
+        multipart,
+        "get_request_body",
+        _body_returning(
+            b'<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+            b'<Part><PartNumber>1</PartNumber><ETag>"abc"</ETag></Part>'
+            b"</CompleteMultipartUpload>"
+        ),
+    )
+
+    db = _FakeDb(current_version=1, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "k", "up-1", _request(), db)
+
+    assert resp.status_code == 200, bytes(resp.body)
+    assert completed["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_complete_ignores_etag_outside_part(monkeypatch: Any) -> None:
+    """Part numbers and ETags were scraped as two flat lists and zipped, so a stray ETag
+    anywhere in the document shifted the pairing (or failed the length check) instead of
+    being ignored. Pairing must happen within each <Part>."""
+    _patch_common(monkeypatch)
+    completed: dict[str, Any] = {"ok": False}
+    _completing_writer(monkeypatch, completed)
+    monkeypatch.setattr(
+        multipart,
+        "get_request_body",
+        _body_returning(
+            b"<CompleteMultipartUpload><ETag>zzz</ETag>"
+            b"<Part><PartNumber>1</PartNumber><ETag>abc</ETag></Part>"
+            b"</CompleteMultipartUpload>"
+        ),
+    )
+
+    db = _FakeDb(current_version=1, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "k", "up-1", _request(), db)
+
+    assert resp.status_code == 200, bytes(resp.body)
+    assert completed["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_complete_rejects_malformed_xml_with_malformed_xml_code(monkeypatch: Any) -> None:
+    """A body that is not well-formed gets S3's MalformedXML, matching DeleteObjects."""
+    _patch_common(monkeypatch)
+    completed: dict[str, Any] = {"ok": False}
+    _completing_writer(monkeypatch, completed)
+    monkeypatch.setattr(multipart, "get_request_body", _body_returning(b"<CompleteMultipartUpload><Part>"))
+
+    db = _FakeDb(current_version=1, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "k", "up-1", _request(), db)
+
+    assert resp.status_code == 400
+    assert b"MalformedXML" in bytes(resp.body)
+    assert completed["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_complete_does_not_expand_entity_bomb(monkeypatch: Any) -> None:
+    """A DTD-declared entity must not be expanded: a parser with default settings would inflate
+    this body in memory. The reference stays unresolved, and because an empty ETag would skip
+    the part comparison downstream, the body is rejected outright rather than completed."""
+    _patch_common(monkeypatch)
+    completed: dict[str, Any] = {"ok": False}
+    _completing_writer(monkeypatch, completed)
+    bomb = (
+        b"<?xml version='1.0'?><!DOCTYPE lolz ["
+        b"<!ENTITY lol 'lollollollollollollollollollol'>"
+        b"<!ENTITY lol2 '&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;'>"
+        b"<!ENTITY lol3 '&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;'>"
+        b"]><CompleteMultipartUpload><Part><PartNumber>1</PartNumber>"
+        b"<ETag>&lol3;</ETag></Part></CompleteMultipartUpload>"
+    )
+    monkeypatch.setattr(multipart, "get_request_body", _body_returning(bomb))
+
+    db = _FakeDb(current_version=1, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "k", "up-1", _request(), db)
+
+    assert resp.status_code == 400
+    assert b"MalformedXML" in bytes(resp.body)
+    assert b"lollol" not in bytes(resp.body), "entity was expanded into the response"
+    assert completed["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_complete_response_parses_with_ampersand_key(monkeypatch: Any) -> None:
+    """'&' is legal in a Hippius object key but must be escaped in XML text. Interpolated raw,
+    it opens an entity reference and every conforming parser rejects the whole document."""
+    _patch_common(monkeypatch)
+    completed: dict[str, Any] = {"ok": False}
+    _completing_writer(monkeypatch, completed)
+
+    db = _FakeDb(current_version=1, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "a&b.txt", "up-1", _request(), db)
+
+    assert resp.status_code == 200, bytes(resp.body)
+    root = _parse(bytes(resp.body))
+    assert _text(root, "Key") == "a&b.txt"
+    assert _text(root, "ETag") == '"abc"'
+
+
+@pytest.mark.asyncio
+async def test_complete_response_escapes_host_header_in_location(monkeypatch: Any) -> None:
+    """The Host header is client-controlled and lands in Location; unescaped it injects XML."""
+    _patch_common(monkeypatch)
+    completed: dict[str, Any] = {"ok": False}
+    _completing_writer(monkeypatch, completed)
+    request = _request()
+    request.headers = {"Host": "h&x"}
+
+    db = _FakeDb(current_version=1, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "k", "up-1", request, db)
+
+    assert resp.status_code == 200, bytes(resp.body)
+    root = _parse(bytes(resp.body))
+    assert _text(root, "Location") == "http://h&x/b/k"
+
+
+@pytest.mark.asyncio
+async def test_complete_idempotent_replay_is_wellformed_and_uses_host(monkeypatch: Any) -> None:
+    """Replaying a completed upload returned a str body with no Content-Length and a
+    hardcoded localhost:8000 Location, wrong for every deployment."""
+    _patch_common(monkeypatch)
+
+    class _CompletedDb(_FakeDb):
+        async def fetchrow(self, query: str, *args: Any) -> Any:
+            if query == "get_multipart_upload":
+                return {"object_id": "obj-1", "is_completed": True, "current_object_version": 1}
+            if query == "get_object_by_path":
+                return {"md5_hash": "m"}
+            return await super().fetchrow(query, *args)
+
+    db = _CompletedDb(current_version=1, upload_version=1)
+    resp = await multipart.complete_multipart_upload("b", "a&b.txt", "up-1", _request(), db)
+
+    assert resp.status_code == 200
+    body = bytes(resp.body)
+    root = _parse(body)
+    assert _text(root, "Location") == "http://h/b/a&b.txt"
+    assert _text(root, "Key") == "a&b.txt"
+    assert resp.headers["content-length"] == str(len(body))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/test_multipart_envelope.py
+++ b/tests/unit/api/test_multipart_envelope.py
@@ -189,3 +189,28 @@ async def test_kek_lookup_happens_outside_the_reserve_transaction(monkeypatch: A
 
     ops = _op_names(db)
     assert ops.index("kek_lookup") < ops.index("txn_enter"), f"KEK must resolve before the txn; {ops}"
+
+
+@pytest.mark.asyncio
+async def test_initiate_response_is_wellformed_with_ampersand_key(stub_crypto: None) -> None:
+    """'&' is legal in a Hippius object key. Interpolated into the response unescaped it opens an
+    entity reference, so the document is not well-formed and clients cannot read the UploadId —
+    the upload fails before any data is sent."""
+    from lxml import etree
+
+    db = _FakeDb()
+
+    resp = await multipart.initiate_multipart_upload(
+        bucket_name="b",
+        object_key="a&b.txt",
+        request=_fake_request(),
+        db=db,
+    )
+
+    assert resp.status_code == 200, resp.body
+    body = bytes(resp.body)
+    root = etree.fromstring(body)
+    keys = root.xpath("./*[local-name()='Key']")
+    assert keys[0].text == "a&b.txt"
+    assert root.xpath("./*[local-name()='UploadId']")[0].text
+    assert resp.headers["content-length"] == str(len(body))

--- a/tests/unit/api/test_parse_complete_multipart_upload.py
+++ b/tests/unit/api/test_parse_complete_multipart_upload.py
@@ -128,8 +128,7 @@ def test_raises_on_body_that_is_not_well_formed() -> None:
 
 
 def test_raises_on_entity_reference_in_etag() -> None:
-    """An unresolved entity would read as an empty ETag, and an empty ETag skips the part
-    comparison downstream — so the body must be refused rather than silently accepted."""
+    """An unresolved entity reads as an empty ETag, so the body must be refused."""
     body = (
         "<?xml version='1.0'?><!DOCTYPE d [<!ENTITY e 'xxxxxxxxxx'>]>"
         "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber>"
@@ -137,3 +136,46 @@ def test_raises_on_entity_reference_in_etag() -> None:
     )
     with pytest.raises(ValueError):
         _parse(body)
+
+
+@pytest.mark.parametrize(
+    ("label", "etag"),
+    [
+        ("empty element", ""),
+        ("whitespace only", "   "),
+        ("quotes with nothing between them", '""'),
+        ("quotes around whitespace", '"  "'),
+    ],
+)
+def test_raises_on_an_empty_etag(label: str, etag: str) -> None:
+    """Callers treat the ETag as present, so an empty one must never get through.
+
+    The handler compares each client-asserted ETag against the stored part and rejects a
+    mismatch with InvalidPart. An empty string makes that comparison vacuous, which is the
+    integrity check quietly opting itself out. Quote-stripping is what makes this more than
+    a theoretical case: a literal '""' is a non-empty body that normalises to nothing.
+    """
+    with pytest.raises(ValueError, match="empty ETag"):
+        _parse(_one_part(etag))
+
+
+def test_raises_on_a_self_closing_etag() -> None:
+    """Same hole as an empty element, spelled the way a serialiser would emit it."""
+    body = "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag/></Part></CompleteMultipartUpload>"
+    with pytest.raises(ValueError, match="empty ETag"):
+        _parse(body)
+
+
+def test_ignores_a_part_nested_below_the_root() -> None:
+    """S3 specifies Part as a direct child of CompleteMultipartUpload.
+
+    Accepting one at any depth means a body whose real part list is empty can still smuggle
+    parts in through an unrelated wrapper — leniency that buys nothing, since no client sends
+    this shape.
+    """
+    body = (
+        "<CompleteMultipartUpload><Wrapper>"
+        "<Part><PartNumber>1</PartNumber><ETag>abc</ETag></Part>"
+        "</Wrapper></CompleteMultipartUpload>"
+    )
+    assert _parse(body) == []

--- a/tests/unit/api/test_parse_complete_multipart_upload.py
+++ b/tests/unit/api/test_parse_complete_multipart_upload.py
@@ -1,0 +1,139 @@
+"""Edge cases for the CompleteMultipartUpload body parser.
+
+The handler tests cover the interop failures end to end; these pin the parser's contract
+directly, one behaviour per test, so a future refactor cannot quietly change how a client
+encoding is normalised.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hippius_s3.api.s3.multipart import parse_complete_multipart_upload
+
+
+def _parse(body: str) -> list[tuple[int, str]]:
+    return parse_complete_multipart_upload(body.encode("utf-8"))
+
+
+def _one_part(etag: str) -> str:
+    return (
+        f"<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>{etag}</ETag></Part></CompleteMultipartUpload>"
+    )
+
+
+def test_parses_boto3_quoted_etags() -> None:
+    assert _parse(_one_part('"abc"')) == [(1, "abc")]
+
+
+def test_parses_rust_predefined_entity_etags() -> None:
+    assert _parse(_one_part("&quot;abc&quot;")) == [(1, "abc")]
+
+
+def test_parses_go_numeric_charref_etags() -> None:
+    assert _parse(_one_part("&#34;abc&#34;")) == [(1, "abc")]
+
+
+def test_parses_bare_etag_workaround_clients() -> None:
+    """Clients that worked around the old parser by sending unquoted hex keep working."""
+    assert _parse(_one_part("abc")) == [(1, "abc")]
+
+
+def test_parses_default_namespace() -> None:
+    body = (
+        '<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        "<Part><PartNumber>2</PartNumber><ETag>xyz</ETag></Part>"
+        "</CompleteMultipartUpload>"
+    )
+    assert _parse(body) == [(2, "xyz")]
+
+
+def test_parses_prefixed_namespace() -> None:
+    body = (
+        '<m:CompleteMultipartUpload xmlns:m="http://s3.amazonaws.com/doc/2006-03-01/">'
+        "<m:Part><m:PartNumber>2</m:PartNumber><m:ETag>xyz</m:ETag></m:Part>"
+        "</m:CompleteMultipartUpload>"
+    )
+    assert _parse(body) == [(2, "xyz")]
+
+
+def test_pairs_within_each_part_regardless_of_child_order() -> None:
+    """ETag before PartNumber inside a Part still pairs correctly."""
+    body = (
+        "<CompleteMultipartUpload>"
+        "<Part><ETag>first</ETag><PartNumber>1</PartNumber></Part>"
+        "<Part><PartNumber>2</PartNumber><ETag>second</ETag></Part>"
+        "</CompleteMultipartUpload>"
+    )
+    assert _parse(body) == [(1, "first"), (2, "second")]
+
+
+def test_ignores_etag_outside_any_part() -> None:
+    """Two independent findall lists zipped together mispaired on a stray element."""
+    body = (
+        "<CompleteMultipartUpload><ETag>stray</ETag>"
+        "<Part><PartNumber>1</PartNumber><ETag>real</ETag></Part>"
+        "</CompleteMultipartUpload>"
+    )
+    assert _parse(body) == [(1, "real")]
+
+
+def test_preserves_document_order_for_the_ascending_check() -> None:
+    """The handler rejects non-ascending parts, so the parser must not sort."""
+    body = (
+        "<CompleteMultipartUpload>"
+        "<Part><PartNumber>2</PartNumber><ETag>b</ETag></Part>"
+        "<Part><PartNumber>1</PartNumber><ETag>a</ETag></Part>"
+        "</CompleteMultipartUpload>"
+    )
+    assert _parse(body) == [(2, "b"), (1, "a")]
+
+
+def test_strips_whitespace_around_values() -> None:
+    body = (
+        "<CompleteMultipartUpload><Part>"
+        '<PartNumber> 1 </PartNumber><ETag>  "abc"  </ETag>'
+        "</Part></CompleteMultipartUpload>"
+    )
+    assert _parse(body) == [(1, "abc")]
+
+
+def test_returns_empty_for_a_body_with_no_parts() -> None:
+    assert _parse("<CompleteMultipartUpload></CompleteMultipartUpload>") == []
+
+
+def test_raises_on_missing_partnumber() -> None:
+    body = "<CompleteMultipartUpload><Part><ETag>abc</ETag></Part></CompleteMultipartUpload>"
+    with pytest.raises(ValueError):
+        _parse(body)
+
+
+def test_raises_on_missing_etag() -> None:
+    body = "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber></Part></CompleteMultipartUpload>"
+    with pytest.raises(ValueError):
+        _parse(body)
+
+
+def test_raises_on_non_integer_partnumber() -> None:
+    body = (
+        "<CompleteMultipartUpload><Part><PartNumber>one</PartNumber><ETag>abc</ETag></Part></CompleteMultipartUpload>"
+    )
+    with pytest.raises(ValueError):
+        _parse(body)
+
+
+def test_raises_on_body_that_is_not_well_formed() -> None:
+    with pytest.raises(ValueError):
+        _parse("<CompleteMultipartUpload><Part>")
+
+
+def test_raises_on_entity_reference_in_etag() -> None:
+    """An unresolved entity would read as an empty ETag, and an empty ETag skips the part
+    comparison downstream — so the body must be refused rather than silently accepted."""
+    body = (
+        "<?xml version='1.0'?><!DOCTYPE d [<!ENTITY e 'xxxxxxxxxx'>]>"
+        "<CompleteMultipartUpload><Part><PartNumber>1</PartNumber>"
+        "<ETag>&e;</ETag></Part></CompleteMultipartUpload>"
+    )
+    with pytest.raises(ValueError):
+        _parse(body)

--- a/tests/unit/test_xml_helpers_untrusted.py
+++ b/tests/unit/test_xml_helpers_untrusted.py
@@ -1,0 +1,72 @@
+"""Contract of the hardened parser every request body goes through."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from hippius_s3.xml_helpers import parse_untrusted_xml
+
+
+def test_parses_a_namespaced_body() -> None:
+    root = parse_untrusted_xml(b'<Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Quiet>true</Quiet></Delete>')
+    assert root.xpath("./*[local-name()='Quiet']")[0].text == "true"
+
+
+def test_decodes_predefined_entities_and_character_references() -> None:
+    """This is what makes Go and Rust clients work: their encoders escape quotes, and the
+    values must arrive decoded even though DTD entity resolution is off."""
+    root = parse_untrusted_xml(b"<D><K>&quot;a&#34;b&amp;c</K></D>")
+    assert root.xpath("./*[local-name()='K']")[0].text == '"a"b&c'
+
+
+def test_raises_valueerror_on_a_malformed_body() -> None:
+    with pytest.raises(ValueError):
+        parse_untrusted_xml(b"<D><K>")
+
+
+def test_does_not_expand_internal_entities_while_parsing() -> None:
+    """Billion laughs: a default parser inflates this during the parse itself.
+
+    With resolution off the reference is kept as an unexpanded child node, so the parse stays
+    cheap and ``.text`` reads as None rather than as megabytes of payload. That None is the
+    property callers depend on — reading text is how every endpoint pulls values out, and an
+    absent value is refused. Note lxml WILL still expand on demand if asked (``string(.)``),
+    so callers must not reach for that on untrusted input.
+    """
+    bomb = (
+        b"<?xml version='1.0'?><!DOCTYPE lolz ["
+        b"<!ENTITY lol 'lollollollollollollollollollol'>"
+        b"<!ENTITY lol2 '&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;'>"
+        b"<!ENTITY lol3 '&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;'>"
+        b"<!ENTITY lol4 '&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;'>"
+        b"<!ENTITY lol5 '&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;'>"
+        b"<!ENTITY lol6 '&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;'>"
+        b"<!ENTITY lol7 '&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;'>"
+        b"]><D><K>&lol7;</K></D>"
+    )
+    started = time.monotonic()
+    # libxml2's own amplification guard refuses a payload this size outright, which surfaces
+    # through the ValueError contract as a malformed body.
+    with pytest.raises(ValueError):
+        parse_untrusted_xml(bomb)
+    elapsed = time.monotonic() - started
+
+    # 30 GB if expanded; rejection must be immediate, not after materialising it.
+    assert elapsed < 1.0, f"parsing took {elapsed:.2f}s, entities were expanded"
+
+
+def test_leaves_a_modest_entity_unresolved_in_element_text() -> None:
+    """Below the amplification guard the body parses, and the reference is kept as an
+    unexpanded child node — so ``.text`` reads None rather than the payload. That None is the
+    property callers depend on: reading text is how endpoints pull values out, and an absent
+    value is refused. lxml will still expand on demand (``string(.)``), so callers must not
+    reach for that on untrusted input.
+    """
+    body = b"<?xml version='1.0'?><!DOCTYPE d [<!ENTITY e 'payload'>]><D><K>&e;</K></D>"
+
+    root = parse_untrusted_xml(body)
+
+    key = root.xpath("./*[local-name()='K']")[0]
+    assert key.text is None, "entity resolved into element text"


### PR DESCRIPTION
# Fix multipart XML: escape responses, parse Complete with lxml

Fixes #383. Targets `staging`.

- **Replace the regex `CompleteMultipartUpload` parser with lxml.** The old code scraped
  `PartNumber` and `ETag` with two independent regexes and stripped literal quote characters,
  so it never decoded entities. aws-sdk-go (rclone, minio-go, the Terraform S3 provider) and
  aws-sdk-rust escape the ETag's quotes, arriving as `&#34;abc&#34;` or `&quot;abc&quot;`,
  which matched no stored part and failed every part with `InvalidPart` — multipart upload was
  unusable from those SDKs. Parsing is now namespace-agnostic and pairs values within each
  `<Part>`, so a stray element can no longer mispair parts, and quote normalisation happens
  after the parse so boto3, Go/Rust and bare-hex clients all agree.

- **Build the multipart XML responses via `xml_helpers`.** `InitiateMultipartUploadResult`,
  both `CompleteMultipartUploadResult` paths and `CopyPartResult` were f-string templates, so
  a key containing `&` — legal in a Hippius key — produced a document no conforming parser
  accepts. For `CreateMultipartUpload` the client cannot read the `UploadId`, so the upload
  fails before any data is sent. The reflected `Host` header in `Location` was unescaped for
  the same reason. Both Complete paths now share one builder, which replaces the
  idempotent-replay branch's hardcoded `http://localhost:8000` Location with the Host-derived
  URL the success path already used, and gives that branch the bytes body and `Content-Length`
  the others had.

- **Parse client XML with entity resolution, DTD loading and network access disabled.** Both
  request-parsing paths (multipart Complete and DeleteObjects) now go through
  `xml_helpers.parse_untrusted_xml`; DeleteObjects previously used a default lxml parser and
  was exposed to entity-expansion DoS.

- **Malformed Complete bodies now return `MalformedXML`** instead of `InvalidRequest`, matching
  DeleteObjects and real S3. No test or known client pins the old code. The parser also refuses
  entity references in `PartNumber` and `ETag`: they survive parsing as unresolved nodes, and
  an empty ETag skips the part-ETag comparison downstream, which would complete an upload
  without its parts ever being verified.

- **Tests:** +22 unit (2 files extended, 2 added) and +1 e2e; the 16 existing tests across the
  touched files stay green. The e2e case is what proves the response is readable, since
  botocore itself fails to parse the unescaped form.

## Verification

`pytest tests/unit` (2304 passed, 37 skipped), `ruff check`, `ruff format --check` and
`ty check` are clean on Python 3.12. The integration suite's 50 failures reproduce unchanged on
`origin/staging` — they need the Postgres that CI provides — and are unrelated to this change.

## Rollout

Stricter parsing is the one regression vector: a real parser rejects bodies the regex tolerated
(junk around the document, empty bodies). Real SDKs emit well-formed XML and no repo test pins
the old behaviour, but a staging canary rather than a straight rollout is worth it.

Response byte shapes change (lxml indentation; the replay branch gains `Content-Length`), and a
body-read failure mid-POST now surfaces as a 500 instead of being masked as a 400 — the
swallow-to-empty-body `except` that hid it is gone.

The `Location` scheme stays literal `http`, matching today's success-path behaviour;
`X-Forwarded-Proto` detection is deliberately out of scope.
