### PR TITLE
Trim redundant System Load panels and fix stale queries

### DIFF
--- a/k8s/base/grafana-dashboards.yaml
+++ b/k8s/base/grafana-dashboards.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: hippius-s3-dashboards
   namespace: monitoring
+  labels:
+    app: grafana
+    grafana_dashboard: "1"
 data:
   system-load.json: |
     {
@@ -27,6 +30,19 @@ data:
       "id": 5,
       "links": [],
       "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "panels": [],
+          "title": "Traffic",
+          "type": "row"
+        },
         {
           "datasource": {
             "type": "prometheus",
@@ -186,205 +202,6 @@ data:
           "description": "Gateway request rate collapsed into HTTP status classes (2xx/3xx/4xx/5xx), one line each. Individual status codes are in \"Gateway req/s\" below; this is the at-a-glance health shape."
         },
         {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 0
-          },
-          "id": 1,
-          "panels": [],
-          "title": "Traffic",
-          "type": "row"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 30,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "showValues": false,
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "reqps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 0,
-            "y": 9
-          },
-          "id": 2,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "12.3.1",
-          "targets": [
-            {
-              "expr": "sum by (status_code) (rate(http_requests_total{service_namespace=\"$namespace\", handler=~\"gateway.*\"}[5m]))",
-              "legendFormat": "{{status_code}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Gateway req/s",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 30,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "showValues": false,
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "reqps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 6,
-            "y": 9
-          },
-          "id": 3,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "12.3.1",
-          "targets": [
-            {
-              "expr": "sum by (status_code) (rate(http_requests_total{service_namespace=\"$namespace\", handler!~\"gateway.*\"}[5m]))",
-              "legendFormat": "{{status_code}}",
-              "refId": "A"
-            }
-          ],
-          "title": "API req/s",
-          "type": "timeseries"
-        },
-        {
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
@@ -448,8 +265,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 6,
-            "x": 12,
+            "w": 12,
+            "x": 0,
             "y": 9
           },
           "id": 4,
@@ -546,8 +363,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 6,
-            "x": 18,
+            "w": 12,
+            "x": 12,
             "y": 9
           },
           "id": 5,
@@ -572,105 +389,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "S3 errors/s (4xx/5xx)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "showValues": false,
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 0,
-            "y": 17
-          },
-          "id": 6,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "12.3.1",
-          "targets": [
-            {
-              "expr": "histogram_quantile(0.95, sum by (le) (rate(gateway_overhead_seconds_bucket{service_namespace=\"$namespace\"}[5m])))",
-              "legendFormat": "p95",
-              "refId": "A"
-            },
-            {
-              "expr": "histogram_quantile(0.50, sum by (le) (rate(gateway_overhead_seconds_bucket{service_namespace=\"$namespace\"}[5m])))",
-              "legendFormat": "p50",
-              "refId": "B"
-            }
-          ],
-          "title": "Gateway overhead (excl. body)",
+          "title": "Errors/s",
           "type": "timeseries"
         },
         {
@@ -737,8 +456,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 8,
-            "x": 6,
+            "w": 9,
+            "x": 0,
             "y": 17
           },
           "id": 82,
@@ -830,8 +549,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 7,
-            "x": 14,
+            "w": 9,
+            "x": 9,
             "y": 17
           },
           "id": 81,
@@ -924,8 +643,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 3,
-            "x": 21,
+            "w": 6,
+            "x": 18,
             "y": 17
           },
           "id": 83,
@@ -969,19 +688,6 @@ data:
             "w": 24,
             "x": 0,
             "y": 25
-          },
-          "id": 80,
-          "panels": [],
-          "title": "Bandwidth",
-          "type": "row"
-        },
-        {
-          "collapsed": false,
-          "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 26
           },
           "id": 10,
           "panels": [],
@@ -1054,7 +760,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 27
+            "y": 26
           },
           "id": 11,
           "options": {
@@ -1090,7 +796,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 35
+            "y": 34
           },
           "id": 20,
           "panels": [],
@@ -1161,9 +867,9 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 6,
+            "w": 8,
             "x": 0,
-            "y": 36
+            "y": 35
           },
           "id": 21,
           "options": {
@@ -1254,9 +960,9 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 6,
-            "x": 6,
-            "y": 36
+            "w": 8,
+            "x": 8,
+            "y": 35
           },
           "id": 22,
           "options": {
@@ -1347,9 +1053,9 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 6,
-            "x": 12,
-            "y": 36
+            "w": 8,
+            "x": 16,
+            "y": 35
           },
           "id": 23,
           "options": {
@@ -1377,105 +1083,12 @@ data:
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "showValues": false,
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "ops"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 36
-          },
-          "id": 24,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "12.3.1",
-          "targets": [
-            {
-              "expr": "sum by (backend) (rate(uploader_dlq_total{service_namespace=\"$namespace\"}[5m]))",
-              "legendFormat": "{{backend}}",
-              "refId": "A"
-            }
-          ],
-          "title": "DLQ rate",
-          "type": "timeseries"
-        },
-        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 44
+            "y": 43
           },
           "id": 30,
           "panels": [],
@@ -1548,7 +1161,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 45
+            "y": 44
           },
           "id": 31,
           "options": {
@@ -1641,7 +1254,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 45
+            "y": 44
           },
           "id": 32,
           "options": {
@@ -1734,7 +1347,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 45
+            "y": 44
           },
           "id": 33,
           "options": {
@@ -1767,7 +1380,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 53
+            "y": 52
           },
           "id": 40,
           "panels": [],
@@ -1840,7 +1453,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 54
+            "y": 53
           },
           "id": 41,
           "options": {
@@ -1933,7 +1546,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 54
+            "y": 53
           },
           "id": 42,
           "options": {
@@ -1966,7 +1579,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 62
+            "y": 61
           },
           "id": 50,
           "panels": [],
@@ -2039,7 +1652,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 63
+            "y": 62
           },
           "id": 51,
           "options": {
@@ -2166,7 +1779,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 63
+            "y": 62
           },
           "id": 52,
           "options": {
@@ -2242,7 +1855,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 63
+            "y": 62
           },
           "id": 53,
           "options": {
@@ -2270,7 +1883,7 @@ data:
           ],
           "title": "Cache disk usage (PVC quota)",
           "type": "gauge",
-          "description": "statvfs on the cache mount = the CephFS PVC QUOTA, not the backing pool. Compare with \"Ceph pool usage (data0)\" to the right \u2014 they diverge sharply when the pool fills ahead of the quota (the 2026-07-24 blind spot)."
+          "description": "statvfs on the cache mount = the CephFS PVC QUOTA, not the backing pool. The two diverge sharply when the pool fills ahead of the quota (the 2026-07-24 blind spot) \u2014 pool fullness lives on the Ceph dashboard, not here."
         },
         {
           "datasource": {
@@ -2307,8 +1920,8 @@ data:
           "gridPos": {
             "h": 8,
             "w": 6,
-            "x": 0,
-            "y": 71
+            "x": 18,
+            "y": 62
           },
           "id": 54,
           "options": {
@@ -2331,14 +1944,113 @@ data:
           "pluginVersion": "12.3.1",
           "targets": [
             {
-              "expr": "max(fs_store_parts_on_disk{service_namespace=\"$namespace\"})",
+              "expr": "max(max_over_time(fs_store_parts_on_disk{service_namespace=\"$namespace\"}[6h]))",
               "legendFormat": "parts",
               "refId": "A"
             }
           ],
           "title": "Cache parts on disk",
           "type": "stat",
-          "description": "Census from the last COMPLETED GC phase. If 'Janitor cycle health' shows a stuck/never-completed cycle, this is stale rather than zero."
+          "description": "Census from the last COMPLETED GC phase. The raw gauge starts at 0 on every janitor restart and stays there until the next sweep finishes, which is why this read 0 for hours at a time; max_over_time([6h]) carries the last real census across those gaps. A sustained 0 over a full 6h window means no sweep has completed \u2014 check 'Janitor cycle health'."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 70
+          },
+          "id": 65,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "expr": "max(fs_janitor_last_cycle_age_seconds{service_namespace=\"$namespace\"})",
+              "legendFormat": "since last completed cycle",
+              "refId": "A"
+            },
+            {
+              "expr": "max(fs_janitor_cycle_seconds{service_namespace=\"$namespace\"})",
+              "legendFormat": "last cycle duration",
+              "refId": "B"
+            }
+          ],
+          "title": "Janitor cycle health",
+          "type": "timeseries",
+          "description": "Seconds since the last COMPLETED janitor cycle (-1 = none since start). A line climbing without resetting means a phase is stuck and every census gauge on this dashboard is stale."
         },
         {
           "collapsed": false,
@@ -2346,7 +2058,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 71
+            "y": 78
           },
           "id": 60,
           "panels": [],
@@ -2425,7 +2137,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 72
+            "y": 79
           },
           "id": 61,
           "options": {
@@ -2612,7 +2324,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 72
+            "y": 79
           },
           "id": 62,
           "options": {
@@ -2706,7 +2418,7 @@ data:
             "h": 8,
             "w": 4,
             "x": 16,
-            "y": 72
+            "y": 79
           },
           "id": 63,
           "options": {
@@ -2799,7 +2511,7 @@ data:
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 72
+            "y": 79
           },
           "id": 64,
           "options": {
@@ -2840,7 +2552,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 80
+            "y": 87
           },
           "id": 70,
           "panels": [],
@@ -2919,7 +2631,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 81
+            "y": 88
           },
           "id": 71,
           "options": {
@@ -3031,7 +2743,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 81
+            "y": 88
           },
           "id": 72,
           "options": {
@@ -3098,7 +2810,7 @@ data:
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 81
+            "y": 88
           },
           "id": 73,
           "options": {
@@ -3121,13 +2833,14 @@ data:
           "pluginVersion": "12.3.1",
           "targets": [
             {
-              "expr": "kube_deployment_status_replicas_ready{namespace=\"$namespace\"}",
+              "expr": "kube_deployment_status_replicas_ready{namespace=\"$namespace\", deployment!=\"api\"}",
               "legendFormat": "{{deployment}}",
               "refId": "A"
             }
           ],
           "title": "Ready replicas",
-          "type": "stat"
+          "type": "stat",
+          "description": "Ready replicas per Deployment. The `api` Deployment is excluded: the internal API now runs as the api-local DaemonSet, so the Deployment sits at 0 replicas and only added a permanent red 0 to this panel. DaemonSets are not covered by this metric."
         },
         {
           "collapsed": false,
@@ -3135,7 +2848,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 89
+            "y": 96
           },
           "id": 84,
           "panels": [],
@@ -3174,7 +2887,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 90
+            "y": 97
           },
           "id": 85,
           "options": {
@@ -3239,7 +2952,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 90
+            "y": 97
           },
           "id": 86,
           "options": {
@@ -3302,7 +3015,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 90
+            "y": 97
           },
           "id": 87,
           "options": {
@@ -3365,7 +3078,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 90
+            "y": 97
           },
           "id": 88,
           "options": {
@@ -3437,7 +3150,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 98
+            "y": 105
           },
           "id": 89,
           "options": {
@@ -3500,7 +3213,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 98
+            "y": 105
           },
           "id": 90,
           "options": {
@@ -3563,7 +3276,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 98
+            "y": 105
           },
           "id": 91,
           "options": {
@@ -3626,7 +3339,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 98
+            "y": 105
           },
           "id": 92,
           "options": {
@@ -3686,7 +3399,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 106
+            "y": 113
           },
           "id": 93,
           "options": {
@@ -3749,7 +3462,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 106
+            "y": 113
           },
           "id": 94,
           "options": {
@@ -3812,7 +3525,7 @@ data:
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 106
+            "y": 113
           },
           "id": 95,
           "options": {
@@ -3840,105 +3553,6 @@ data:
           ],
           "title": "Account cacher \u2014 cycles",
           "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 10,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "showValues": false,
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "s"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 0,
-            "y": 64
-          },
-          "id": 65,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "multi",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "12.3.1",
-          "targets": [
-            {
-              "expr": "max(fs_janitor_last_cycle_age_seconds{service_namespace=\"$namespace\"})",
-              "legendFormat": "since last completed cycle",
-              "refId": "A"
-            },
-            {
-              "expr": "max(fs_janitor_cycle_seconds{service_namespace=\"$namespace\"})",
-              "legendFormat": "last cycle duration",
-              "refId": "B"
-            }
-          ],
-          "title": "Janitor cycle health",
-          "type": "timeseries",
-          "description": "Seconds since the last COMPLETED janitor cycle (-1 = none since start). A line climbing without resetting means a phase is stuck and every census gauge on this dashboard is stale."
         }
       ],
       "preload": false,
@@ -3984,5 +3598,5 @@ data:
       "timezone": "browser",
       "title": "Hippius S3 \u2014 System Load",
       "uid": "hippius-s3-system-load",
-      "version": 10
+      "version": 11
     }

--- a/monitoring/grafana/dashboards/system-load.json
+++ b/monitoring/grafana/dashboards/system-load.json
@@ -21,6 +21,19 @@
   "links": [],
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Traffic",
+      "type": "row"
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -179,205 +192,6 @@
       "description": "Gateway request rate collapsed into HTTP status classes (2xx/3xx/4xx/5xx), one line each. Individual status codes are in \"Gateway req/s\" below; this is the at-a-glance health shape."
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
-      "panels": [],
-      "title": "Traffic",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 30,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 0,
-        "y": 9
-      },
-      "id": 2,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "expr": "sum by (status_code) (rate(http_requests_total{service_namespace=\"$namespace\", handler=~\"gateway.*\"}[5m]))",
-          "legendFormat": "{{status_code}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Gateway req/s",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 30,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 6,
-        "y": 9
-      },
-      "id": 3,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "expr": "sum by (status_code) (rate(http_requests_total{service_namespace=\"$namespace\", handler!~\"gateway.*\"}[5m]))",
-          "legendFormat": "{{status_code}}",
-          "refId": "A"
-        }
-      ],
-      "title": "API req/s",
-      "type": "timeseries"
-    },
-    {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -441,8 +255,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 12,
+        "w": 12,
+        "x": 0,
         "y": 9
       },
       "id": 4,
@@ -539,8 +353,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 18,
+        "w": 12,
+        "x": 12,
         "y": 9
       },
       "id": 5,
@@ -565,105 +379,7 @@
           "refId": "A"
         }
       ],
-      "title": "S3 errors/s (4xx/5xx)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 0,
-        "y": 17
-      },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(gateway_overhead_seconds_bucket{service_namespace=\"$namespace\"}[5m])))",
-          "legendFormat": "p95",
-          "refId": "A"
-        },
-        {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(gateway_overhead_seconds_bucket{service_namespace=\"$namespace\"}[5m])))",
-          "legendFormat": "p50",
-          "refId": "B"
-        }
-      ],
-      "title": "Gateway overhead (excl. body)",
+      "title": "Errors/s",
       "type": "timeseries"
     },
     {
@@ -730,8 +446,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 6,
+        "w": 9,
+        "x": 0,
         "y": 17
       },
       "id": 82,
@@ -823,8 +539,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 7,
-        "x": 14,
+        "w": 9,
+        "x": 9,
         "y": 17
       },
       "id": 81,
@@ -917,8 +633,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 3,
-        "x": 21,
+        "w": 6,
+        "x": 18,
         "y": 17
       },
       "id": 83,
@@ -962,19 +678,6 @@
         "w": 24,
         "x": 0,
         "y": 25
-      },
-      "id": 80,
-      "panels": [],
-      "title": "Bandwidth",
-      "type": "row"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 26
       },
       "id": 10,
       "panels": [],
@@ -1047,7 +750,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 26
       },
       "id": 11,
       "options": {
@@ -1083,7 +786,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 34
       },
       "id": 20,
       "panels": [],
@@ -1154,9 +857,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
+        "w": 8,
         "x": 0,
-        "y": 36
+        "y": 35
       },
       "id": 21,
       "options": {
@@ -1247,9 +950,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 6,
-        "y": 36
+        "w": 8,
+        "x": 8,
+        "y": 35
       },
       "id": 22,
       "options": {
@@ -1340,9 +1043,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 6,
-        "x": 12,
-        "y": 36
+        "w": 8,
+        "x": 16,
+        "y": 35
       },
       "id": 23,
       "options": {
@@ -1370,105 +1073,12 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ops"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 36
-      },
-      "id": 24,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "expr": "sum by (backend) (rate(uploader_dlq_total{service_namespace=\"$namespace\"}[5m]))",
-          "legendFormat": "{{backend}}",
-          "refId": "A"
-        }
-      ],
-      "title": "DLQ rate",
-      "type": "timeseries"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 43
       },
       "id": 30,
       "panels": [],
@@ -1541,7 +1151,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 45
+        "y": 44
       },
       "id": 31,
       "options": {
@@ -1634,7 +1244,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 45
+        "y": 44
       },
       "id": 32,
       "options": {
@@ -1727,7 +1337,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 45
+        "y": 44
       },
       "id": 33,
       "options": {
@@ -1760,7 +1370,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 52
       },
       "id": 40,
       "panels": [],
@@ -1833,7 +1443,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 54
+        "y": 53
       },
       "id": 41,
       "options": {
@@ -1926,7 +1536,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 54
+        "y": 53
       },
       "id": 42,
       "options": {
@@ -1959,7 +1569,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 61
       },
       "id": 50,
       "panels": [],
@@ -2032,7 +1642,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 63
+        "y": 62
       },
       "id": 51,
       "options": {
@@ -2159,7 +1769,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 63
+        "y": 62
       },
       "id": 52,
       "options": {
@@ -2235,7 +1845,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 63
+        "y": 62
       },
       "id": 53,
       "options": {
@@ -2263,7 +1873,7 @@
       ],
       "title": "Cache disk usage (PVC quota)",
       "type": "gauge",
-      "description": "statvfs on the cache mount = the CephFS PVC QUOTA, not the backing pool. Compare with \"Ceph pool usage (data0)\" to the right \u2014 they diverge sharply when the pool fills ahead of the quota (the 2026-07-24 blind spot)."
+      "description": "statvfs on the cache mount = the CephFS PVC QUOTA, not the backing pool. The two diverge sharply when the pool fills ahead of the quota (the 2026-07-24 blind spot) \u2014 pool fullness lives on the Ceph dashboard, not here."
     },
     {
       "datasource": {
@@ -2300,8 +1910,8 @@
       "gridPos": {
         "h": 8,
         "w": 6,
-        "x": 0,
-        "y": 71
+        "x": 18,
+        "y": 62
       },
       "id": 54,
       "options": {
@@ -2324,14 +1934,113 @@
       "pluginVersion": "12.3.1",
       "targets": [
         {
-          "expr": "max(fs_store_parts_on_disk{service_namespace=\"$namespace\"})",
+          "expr": "max(max_over_time(fs_store_parts_on_disk{service_namespace=\"$namespace\"}[6h]))",
           "legendFormat": "parts",
           "refId": "A"
         }
       ],
       "title": "Cache parts on disk",
       "type": "stat",
-      "description": "Census from the last COMPLETED GC phase. If 'Janitor cycle health' shows a stuck/never-completed cycle, this is stale rather than zero."
+      "description": "Census from the last COMPLETED GC phase. The raw gauge starts at 0 on every janitor restart and stays there until the next sweep finishes, which is why this read 0 for hours at a time; max_over_time([6h]) carries the last real census across those gaps. A sustained 0 over a full 6h window means no sweep has completed \u2014 check 'Janitor cycle health'."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 70
+      },
+      "id": 65,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "expr": "max(fs_janitor_last_cycle_age_seconds{service_namespace=\"$namespace\"})",
+          "legendFormat": "since last completed cycle",
+          "refId": "A"
+        },
+        {
+          "expr": "max(fs_janitor_cycle_seconds{service_namespace=\"$namespace\"})",
+          "legendFormat": "last cycle duration",
+          "refId": "B"
+        }
+      ],
+      "title": "Janitor cycle health",
+      "type": "timeseries",
+      "description": "Seconds since the last COMPLETED janitor cycle (-1 = none since start). A line climbing without resetting means a phase is stuck and every census gauge on this dashboard is stale."
     },
     {
       "collapsed": false,
@@ -2339,7 +2048,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 71
+        "y": 78
       },
       "id": 60,
       "panels": [],
@@ -2418,7 +2127,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 72
+        "y": 79
       },
       "id": 61,
       "options": {
@@ -2605,7 +2314,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 72
+        "y": 79
       },
       "id": 62,
       "options": {
@@ -2699,7 +2408,7 @@
         "h": 8,
         "w": 4,
         "x": 16,
-        "y": 72
+        "y": 79
       },
       "id": 63,
       "options": {
@@ -2792,7 +2501,7 @@
         "h": 8,
         "w": 4,
         "x": 20,
-        "y": 72
+        "y": 79
       },
       "id": 64,
       "options": {
@@ -2833,7 +2542,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 80
+        "y": 87
       },
       "id": 70,
       "panels": [],
@@ -2912,7 +2621,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 81
+        "y": 88
       },
       "id": 71,
       "options": {
@@ -3024,7 +2733,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 81
+        "y": 88
       },
       "id": 72,
       "options": {
@@ -3091,7 +2800,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 81
+        "y": 88
       },
       "id": 73,
       "options": {
@@ -3114,13 +2823,14 @@
       "pluginVersion": "12.3.1",
       "targets": [
         {
-          "expr": "kube_deployment_status_replicas_ready{namespace=\"$namespace\"}",
+          "expr": "kube_deployment_status_replicas_ready{namespace=\"$namespace\", deployment!=\"api\"}",
           "legendFormat": "{{deployment}}",
           "refId": "A"
         }
       ],
       "title": "Ready replicas",
-      "type": "stat"
+      "type": "stat",
+      "description": "Ready replicas per Deployment. The `api` Deployment is excluded: the internal API now runs as the api-local DaemonSet, so the Deployment sits at 0 replicas and only added a permanent red 0 to this panel. DaemonSets are not covered by this metric."
     },
     {
       "collapsed": false,
@@ -3128,7 +2838,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 89
+        "y": 96
       },
       "id": 84,
       "panels": [],
@@ -3167,7 +2877,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 90
+        "y": 97
       },
       "id": 85,
       "options": {
@@ -3232,7 +2942,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 90
+        "y": 97
       },
       "id": 86,
       "options": {
@@ -3295,7 +3005,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 90
+        "y": 97
       },
       "id": 87,
       "options": {
@@ -3358,7 +3068,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 90
+        "y": 97
       },
       "id": 88,
       "options": {
@@ -3430,7 +3140,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 98
+        "y": 105
       },
       "id": 89,
       "options": {
@@ -3493,7 +3203,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 98
+        "y": 105
       },
       "id": 90,
       "options": {
@@ -3556,7 +3266,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 98
+        "y": 105
       },
       "id": 91,
       "options": {
@@ -3619,7 +3329,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 98
+        "y": 105
       },
       "id": 92,
       "options": {
@@ -3679,7 +3389,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 106
+        "y": 113
       },
       "id": 93,
       "options": {
@@ -3742,7 +3452,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 106
+        "y": 113
       },
       "id": 94,
       "options": {
@@ -3805,7 +3515,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 106
+        "y": 113
       },
       "id": 95,
       "options": {
@@ -3833,105 +3543,6 @@
       ],
       "title": "Account cacher \u2014 cycles",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 4,
-        "x": 0,
-        "y": 64
-      },
-      "id": 65,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "expr": "max(fs_janitor_last_cycle_age_seconds{service_namespace=\"$namespace\"})",
-          "legendFormat": "since last completed cycle",
-          "refId": "A"
-        },
-        {
-          "expr": "max(fs_janitor_cycle_seconds{service_namespace=\"$namespace\"})",
-          "legendFormat": "last cycle duration",
-          "refId": "B"
-        }
-      ],
-      "title": "Janitor cycle health",
-      "type": "timeseries",
-      "description": "Seconds since the last COMPLETED janitor cycle (-1 = none since start). A line climbing without resetting means a phase is stuck and every census gauge on this dashboard is stale."
     }
   ],
   "preload": false,
@@ -3977,5 +3588,5 @@
   "timezone": "browser",
   "title": "Hippius S3 \u2014 System Load",
   "uid": "hippius-s3-system-load",
-  "version": 10
+  "version": 11
 }


### PR DESCRIPTION
Cleanup pass on the **Hippius S3 — System Load** dashboard. Two of the panels below weren't just noisy, they were reporting a zero that wasn't true.

Worth knowing before reviewing: the deployed ConfigMap was `version 9` while the repo was `version 10`, so prod was missing 14 panels that had already been merged — including the wide `Gateway Type/s` chart, the whole `Drain & background workers` row and the DLQ pushed/requeued pair. This PR rebases the cleanup on top of the repo state; deploying it closes that gap too.

## Changes

### Removed
- **`Gateway req/s`** and **`API req/s`** — both re-plot what `Gateway Type/s` already shows, just uncollapsed into individual status codes.
- **`Gateway overhead (excl. body)`**.
- **`DLQ rate`** — superseded by the `DLQ — pushed` / `DLQ — requeued` pair in the drain row.
- **The `Bandwidth` row header.** It sat at `y=25` while its three panels sat at `y=17`, so it rendered as an empty section *below* the charts it was supposed to head — those had already been absorbed into `Traffic`. The panels themselves are **not** empty (prod is doing ~4 MB/s egress, ~640 KB/s ingress right now) so `Egress`, `Ingress` and `Total transferred` are kept where they were already rendering. Say the word if you wanted the throughput charts gone as well.

### Fixed
- **`Ready replicas` excludes the `api` Deployment.** The internal API runs as the `api-local` DaemonSet now, so `kube_deployment_status_replicas_ready{deployment="api"}` sits at a permanent `0` and contributed nothing but a red tile. Note DaemonSets aren't covered by this metric at all, so `api-local` health isn't visible here either way.
- **`Cache parts on disk` now reads `max_over_time(...[6h])`.** `fs_store_parts_on_disk` is a census gauge published only after a *completed* janitor sweep, so it resets to `0` on every janitor restart and holds there until the next sweep lands. Over the last 7 days on prod it read `0` for two multi-hour stretches while the cache actually held ~4.5M parts. The window carries the last real census across those gaps.
- **`S3 errors/s (4xx/5xx)` → `Errors/s`.**
- Dropped the dangling pointer in `Cache disk usage (PVC quota)`'s description to a `Ceph pool usage (data0)` panel that merge `1698cef4` removed from this dashboard.

### Layout
The removals left holes, and two panels were already colliding before this PR — `Janitor cycle health` (`y=64 x=0 w=4`) overlapped `DB pool connections` (`y=63 x=0 w=6`), and `Cache parts on disk` overlapped the `Service Health` row header — which meant Grafana silently reflowed them somewhere nobody picked. The grid is recomputed with no overlaps and panels sorted so each row precedes the panels it owns.

### Manifest
`k8s/base/grafana-dashboards.yaml` embeds the dashboard and is regenerated in lockstep (verified byte-identical to the JSON). It also regains the `app: grafana` / `grafana_dashboard: "1"` labels that the live ConfigMap carries — the repo manifest had drifted without them, and `kubectl apply` would have **pruned both labels** off the deployed object.

47 panels, down from 52. Every query touched was validated against the live prod Prometheus before being written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)