### PR TITLE
hotfix: uvicorn keep-alive must outlive the pools that hold it (prod PUT 502s)

### DIFF
--- a/gateway/start-gateway.sh
+++ b/gateway/start-gateway.sh
@@ -10,6 +10,15 @@ UVICORN_MAX_REQUESTS_JITTER=${UVICORN_MAX_REQUESTS_JITTER:-1000}
 # Must be < terminationGracePeriodSeconds minus the preStop sleep, or the kubelet
 # SIGKILLs us mid-drain and we are back to severed connections.
 UVICORN_GRACEFUL_TIMEOUT=${UVICORN_GRACEFUL_TIMEOUT:-25}
+# Must stay ABOVE the ATS edge's proxy.config.http.keep_alive_no_activity_timeout_out (60s
+# on every host in hippius-ats), so ATS always retires a pooled origin connection before we
+# do. uvicorn's default is 5s, which had it closing 12x sooner than the proxy that pools it:
+# for the other 55s ATS believes those sockets are live, and a request dispatched onto one we
+# just closed dies after the header is written. ATS retries that for a GET; for a PUT it is
+# non-idempotent, so ATS marks the origin down instead and the client gets a hard 502
+# "Next Hop Connection Failed" (apache/trafficserver#7290). Raise ATS's value and this must
+# move with it.
+UVICORN_KEEP_ALIVE=${UVICORN_KEEP_ALIVE:-75}
 
 RELOAD_FLAG=""
 if [ "${DEBUG:-false}" = "true" ]; then
@@ -41,6 +50,7 @@ exec uvicorn \
     --log-level=$UVICORN_LOG_LEVEL \
     --access-log \
     --timeout-graceful-shutdown="$UVICORN_GRACEFUL_TIMEOUT" \
+    --timeout-keep-alive="$UVICORN_KEEP_ALIVE" \
     "${MAX_REQUESTS_ARGS[@]+"${MAX_REQUESTS_ARGS[@]}"}" \
     --factory \
     $RELOAD_FLAG \

--- a/start-api.sh
+++ b/start-api.sh
@@ -10,6 +10,13 @@ UVICORN_MAX_REQUESTS_JITTER=${UVICORN_MAX_REQUESTS_JITTER:-1000}
 # Must be < terminationGracePeriodSeconds minus the preStop sleep, or the kubelet
 # SIGKILLs us mid-drain and we are back to severed connections.
 UVICORN_GRACEFUL_TIMEOUT=${UVICORN_GRACEFUL_TIMEOUT:-25}
+# Must stay ABOVE the keepalive_expiry of every pool that holds a connection to us — the
+# gateway's ForwardService httpx pool is 30s (forward_service.py:109). uvicorn's default is
+# 5s, so the pooling side was holding sockets 6x longer than we keep them, and a request
+# dispatched onto one we just closed dies after the header is written. Whoever pools the
+# connection must be the one to retire it; the server closing first is what turns an idle
+# socket into a failed request.
+UVICORN_KEEP_ALIVE=${UVICORN_KEEP_ALIVE:-75}
 
 echo "Running database migrations..."
 python -m hippius_s3.scripts.migrate
@@ -45,6 +52,7 @@ exec uvicorn \
     --log-level=$UVICORN_LOG_LEVEL \
     --access-log \
     --timeout-graceful-shutdown="$UVICORN_GRACEFUL_TIMEOUT" \
+    --timeout-keep-alive="$UVICORN_KEEP_ALIVE" \
     "${MAX_REQUESTS_ARGS[@]+"${MAX_REQUESTS_ARGS[@]}"}" \
     --factory \
     $RELOAD_FLAG \

--- a/tests/unit/test_start_scripts_exec.py
+++ b/tests/unit/test_start_scripts_exec.py
@@ -57,3 +57,34 @@ def test_graceful_shutdown_timeout_is_set(script: Path) -> None:
         f"{script.name} does not pass --timeout-graceful-shutdown, so uvicorn waits "
         f"indefinitely for in-flight requests and can be SIGKILLed mid-drain instead."
     )
+
+
+# The longest keepalive_expiry of anything that pools connections to us: the ATS edge holds
+# idle origin connections for 60s (keep_alive_no_activity_timeout_out, hippius-ats), and the
+# gateway's ForwardService httpx pool holds them for 30s.
+LONGEST_UPSTREAM_POOL_SECONDS = 60
+
+
+@pytest.mark.parametrize("script", START_SCRIPTS, ids=lambda p: p.name)
+def test_keep_alive_outlives_upstream_pools(script: Path) -> None:
+    """Whoever pools the connection must retire it first, or idle sockets become 502s.
+
+    uvicorn defaults --timeout-keep-alive to 5s. Both of our callers pool for far longer, so
+    at the default they kept dispatching onto sockets we had already closed. A request that
+    dies after its header is written is retried when it is idempotent and fails hard when it
+    is not, which is why this surfaced as PUT-only 502s at the edge and never as a failed GET.
+    """
+    body = script.read_text()
+    assert "--timeout-keep-alive" in body, (
+        f"{script.name} does not pass --timeout-keep-alive, so uvicorn falls back to 5s and "
+        f"closes idle connections long before the pools upstream of it do."
+    )
+
+    match = re.search(r"UVICORN_KEEP_ALIVE=\$\{UVICORN_KEEP_ALIVE:-(\d+)\}", body)
+    assert match, f"{script.name} does not define an overridable UVICORN_KEEP_ALIVE default"
+
+    assert int(match.group(1)) > LONGEST_UPSTREAM_POOL_SECONDS, (
+        f"{script.name} sets UVICORN_KEEP_ALIVE={match.group(1)}s, which is not above the "
+        f"{LONGEST_UPSTREAM_POOL_SECONDS}s ATS edge pool. The server must outlive every pool "
+        f"that holds connections to it."
+    )


### PR DESCRIPTION
Cherry-pick of #389 (`2dbc674b`) onto `k8s-production`. Already merged to `staging` — this brings it to prod, where the bug actually is.

## Why this can't wait for the next release train

`staging` does not deploy to production. #389 has been on `staging` since today and the prod gateway is still running uvicorn's **5s** default keep-alive, so the incident it fixes is live right now.

## The bug

`uvicorn` defaults `--timeout-keep-alive` to 5s and neither start script passed the flag. ATS pools origin connections for **60s** (`keep_alive_no_activity_timeout_out`). For the intervening 55s ATS holds sessions the origin has already closed; dispatching onto one fails **locally and instantly** — the peer's FIN is already in the receive queue, so no packets are sent and no round trip occurs.

Measured from `ats-cache-us-1` against the prod gateway NodePort (connect costs 106ms, RTT 92ms):

```
idle 2s     3/3  OK 200,  102-107ms   (full round trip)
idle 4s     3/3  OK 200,  102-106ms
idle 5s     3/3  FAIL peer-closed,  0.09-0.12ms
idle 6-10s  9/9  FAIL peer-closed,  0.06-0.10ms
```

The cliff is exactly 5s — uvicorn's default — and identical on `.199`, `.200` and `.152`.

**It is asymmetric by request shape.** GET/HEAD carry no body, so ATS treats them as retryable, reopens and retries; the client never notices. A request *with a body* cannot be replayed (`request_buffer_enabled = 0`), so per [apache/trafficserver#7290](https://github.com/apache/trafficserver/issues/7290) ATS does not retry and returns a hard 502. On 2026-08-04 prod saw **846,523 origin-bound GETs → 0 failures; 12,476 PUTs → all 3 failures.** Buffering is not an available fix — `UploadPart` bodies run to hundreds of MB.

This was originally misattributed to a lossy network path (2026-07-22 postmortem §4.3). thenervelab/hippius-ats#10 retracts that: per-socket the origin path retransmits **0.0000%** and `mtr` shows 0.0% loss at 92.3ms StDev 0.0. The retransmit figure was a `/proc/net/snmp` artifact conflating public client traffic with origin traffic.

## Changes

Sets `UVICORN_KEEP_ALIVE=75` (above ATS's 60s) in both start scripts, plus a unit test that fails if the default ever drops back below the longest upstream pool.

3 files, +49/-0 — `gateway/start-gateway.sh`, `start-api.sh`, `tests/unit/test_start_scripts_exec.py`. No migration, no app-code coupling.

## Deploy

`production-deploy` builds images and runs `kubectl rollout status deployment/gateway`, so pods roll automatically — **no manual restart needed** (unlike a secret-only change).

## Verify after rollout

From `ats-cache-us-1`, reuse a connection after a 6s idle. Before: peer-closed in ~0.1ms. After: a full ~102ms round trip.

```bash
curl -sv --keepalive-time 6 http://192.168.1.199:30081/health \
     --next --keepalive-time 6 http://192.168.1.199:30081/health 2>&1 | grep -E "HTTP/|Connection"
```

## Blocks

⚠️ thenervelab/hippius-haproxy#10 must not merge until this has deployed. Its `-direct` backends point at the **production** gateway, and without this the gateway closes idle connections at 5s while HAProxy's `pool-purge-delay` default is also 5s.

## Note on branch hygiene

This is duplication, not divergence — #389 is already on `staging`, so the next `staging → k8s-production` release merge sees identical content and resolves cleanly. Justification is "expedited fix for a live incident", **not** the prod-only-file category that applies to e.g. `production-deploy.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)