### PR TITLE
Close the SSD read tier's space and discovery control loops

### DIFF
--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -97,9 +97,11 @@ const DEFAULT_EVICT_RESERVE_PERMILLE: u16 = 150;
 /// every poll and pins the disk at the threshold.
 const DEFAULT_EVICT_HEADROOM_PERMILLE: u16 = 50;
 
-/// Parts considered per eviction pass when `CEPHOR_EVICT_BATCH` is unset. At a 4 MiB chunk
-/// and typical part sizes this frees tens of GB per pass — enough to close a breach in a few
-/// polls without one pass monopolising the disk.
+/// Rows fetched per eviction worklist QUERY when `CEPHOR_EVICT_BATCH` is unset — the page size,
+/// **not** the pass budget. The pass keeps paging until its byte goal is met (see
+/// `DEFAULT_EVICT_MAX_PASS`), because a part count says almost nothing about bytes freed: prod
+/// part sizes are bimodal, measured 2026-08-07 at p50 686 bytes against a 408 KB shard mean, so
+/// a page walking the small-part tail frees ~350 KB against a ~175 GB deficit.
 const DEFAULT_EVICT_BATCH: u32 = 512;
 
 /// Wall-clock ceiling on ONE eviction pass when `CEPHOR_EVICT_MAX_PASS_SECS` is unset.
@@ -485,8 +487,9 @@ fn duration_secs(get: &impl Fn(&str) -> Option<String>, var: &'static str, defau
 mod tests {
     use super::{
         Config, ConfigError, DEFAULT_ALLOCATION_POLL, DEFAULT_CLAIM_LEASE, DEFAULT_DECAY_HALF_LIFE, DEFAULT_DEFER_BACKOFF_CAP,
-        DEFAULT_DRAIN_CONCURRENCY, DEFAULT_DRAIN_POLL, DEFAULT_FLOOR_RATE_BPS, DEFAULT_HEARTBEAT_POLL, DEFAULT_HEARTBEAT_TTL,
-        DEFAULT_MAX_DRAIN_RATE_BPS, DEFAULT_ORPHAN_RECLAIM_GRACE, DEFAULT_RECLAIM_GRACE, DEFAULT_RECLAIM_POLL,
+        DEFAULT_DRAIN_CONCURRENCY, DEFAULT_DRAIN_POLL, DEFAULT_EVICT_HEADROOM_PERMILLE, DEFAULT_EVICT_RESERVE_PERMILLE, DEFAULT_FLOOR_RATE_BPS,
+        DEFAULT_HEARTBEAT_POLL, DEFAULT_HEARTBEAT_TTL, DEFAULT_MAX_DRAIN_RATE_BPS, DEFAULT_ORPHAN_RECLAIM_GRACE, DEFAULT_RECLAIM_GRACE,
+        DEFAULT_RECLAIM_POLL,
     };
     use core::str::FromStr;
     use hippius_drain_core::{ByteRate, NodeId};
@@ -859,5 +862,30 @@ mod tests {
         pairs.push(("HIPPIUS_UPLOAD_BACKENDS", "arion"));
         let config = Config::from_lookup(lookup(&pairs)).unwrap();
         assert_eq!(config.enqueue_backends(), vec!["arion".to_owned()]);
+    }
+
+    #[test]
+    fn the_eviction_band_matches_what_the_api_assumes_when_gating_promotion() {
+        // Cross-language contract pin. The api refuses to promote onto local flash below
+        // `HIPPIUS_PROMOTE_MIN_FREE_RATIO` (0.175), and that floor is only correct if it sits
+        // strictly inside THIS evictor's band: above the reserve, below reserve + headroom.
+        //
+        // There is no runtime coupling between the two processes, so the api mirrors these
+        // numbers in `hippius_s3/fs_pressure.py` (EVICT_RESERVE_RATIO / EVICT_HEADROOM_RATIO)
+        // and each side pins its own. Moving either default without the other silently breaks
+        // the loop: a floor at or above the target can never be restored, because the evictor
+        // never frees past its target, and promotion would stop for good.
+        assert_eq!(DEFAULT_EVICT_RESERVE_PERMILLE, 150, "api mirrors this as EVICT_RESERVE_RATIO = 0.150");
+        assert_eq!(DEFAULT_EVICT_HEADROOM_PERMILLE, 50, "api mirrors this as EVICT_HEADROOM_RATIO = 0.050");
+
+        let promote_floor_permille = 175;
+        assert!(
+            DEFAULT_EVICT_RESERVE_PERMILLE < promote_floor_permille,
+            "promotion must yield before eviction arms"
+        );
+        assert!(
+            promote_floor_permille < DEFAULT_EVICT_RESERVE_PERMILLE + DEFAULT_EVICT_HEADROOM_PERMILLE,
+            "the evictor must be able to free back past the promote floor, or promotion deadlocks"
+        );
     }
 }

--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -117,6 +117,14 @@ const DEFAULT_EVICT_MAX_PASS: Duration = Duration::from_secs(10);
 /// short. An empty queue costs one RPOP, so polling fast is close to free.
 const DEFAULT_LANDED_POLL: Duration = Duration::from_secs(1);
 
+/// DB-driven `failed`-reclaim poll when `CEPHOR_FAILED_RECLAIM_POLL_SECS` is unset.
+///
+/// Deliberately independent of the reclaim WALK, which now runs hourly: decoupling debris
+/// cleanup from the walk is the whole point of driving this from the database, so a rare walk
+/// does not mean abandoned-upload parts sit on the disk for an hour. Matches the walk's former
+/// cadence, so `failed` reclaim latency is unchanged by that move.
+const DEFAULT_FAILED_RECLAIM_POLL: Duration = Duration::from_mins(5);
+
 /// Default path of the liveness file the runtime touches each heartbeat tick; the
 /// k8s `livenessProbe` checks its freshness. Container-local `/tmp` is always writable.
 const DEFAULT_LIVENESS_FILE: &str = "/tmp/hippius-drain-agent.alive";
@@ -204,6 +212,8 @@ pub struct Config {
     pub evict_headroom_permille: u16,
     /// Rows fetched per eviction worklist query — the page size, not the pass budget.
     pub evict_batch: u32,
+    /// How often the DB-driven `failed`-part reclaim runs, independent of the reclaim walk.
+    pub failed_reclaim_poll: Duration,
     /// How often the landed-part announcement queue is drained (discovery latency for a
     /// freshly-written part).
     pub landed_poll: Duration,
@@ -289,6 +299,7 @@ impl Config {
             grace: self.grace,
             drain_concurrency: self.drain_concurrency,
             redrive_max_attempts: self.redrive_max_attempts,
+            failed_reclaim_poll: self.failed_reclaim_poll,
             landed_poll: self.landed_poll,
             evict_poll: self.evict_poll,
             evict_policy: EvictionPolicy {
@@ -377,6 +388,7 @@ impl Config {
             evict_batch: positive_u32_or(&get, "CEPHOR_EVICT_BATCH", DEFAULT_EVICT_BATCH)?,
             evict_max_pass: duration_secs(&get, "CEPHOR_EVICT_MAX_PASS_SECS", DEFAULT_EVICT_MAX_PASS)?,
             landed_poll: duration_secs(&get, "CEPHOR_LANDED_POLL_SECS", DEFAULT_LANDED_POLL)?,
+            failed_reclaim_poll: duration_secs(&get, "CEPHOR_FAILED_RECLAIM_POLL_SECS", DEFAULT_FAILED_RECLAIM_POLL)?,
             liveness_file: path_or(&get, "CEPHOR_LIVENESS_FILE", DEFAULT_LIVENESS_FILE),
             readiness_file: path_or(&get, "CEPHOR_READINESS_FILE", DEFAULT_READINESS_FILE),
         })

--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -112,6 +112,11 @@ const DEFAULT_EVICT_BATCH: u32 = 512;
 /// starvation: a deficit spanning many passes is the design, not a fault.
 const DEFAULT_EVICT_MAX_PASS: Duration = Duration::from_secs(10);
 
+/// Landed-announcement poll when `CEPHOR_LANDED_POLL_SECS` is unset. This is the discovery
+/// latency for a freshly-written part — the job the 15 s reconciler walk used to do — so it is
+/// short. An empty queue costs one RPOP, so polling fast is close to free.
+const DEFAULT_LANDED_POLL: Duration = Duration::from_secs(1);
+
 /// Default path of the liveness file the runtime touches each heartbeat tick; the
 /// k8s `livenessProbe` checks its freshness. Container-local `/tmp` is always writable.
 const DEFAULT_LIVENESS_FILE: &str = "/tmp/hippius-drain-agent.alive";
@@ -199,6 +204,9 @@ pub struct Config {
     pub evict_headroom_permille: u16,
     /// Rows fetched per eviction worklist query — the page size, not the pass budget.
     pub evict_batch: u32,
+    /// How often the landed-part announcement queue is drained (discovery latency for a
+    /// freshly-written part).
+    pub landed_poll: Duration,
     /// Wall-clock ceiling on one eviction pass; the remainder resumes on the next poll.
     pub evict_max_pass: Duration,
     /// Path of the liveness file the runtime touches each heartbeat tick; a k8s
@@ -281,6 +289,7 @@ impl Config {
             grace: self.grace,
             drain_concurrency: self.drain_concurrency,
             redrive_max_attempts: self.redrive_max_attempts,
+            landed_poll: self.landed_poll,
             evict_poll: self.evict_poll,
             evict_policy: EvictionPolicy {
                 reserve_permille: self.evict_reserve_permille,
@@ -367,6 +376,7 @@ impl Config {
             evict_headroom_permille: permille_or(&get, "CEPHOR_EVICT_HEADROOM_PERMILLE", DEFAULT_EVICT_HEADROOM_PERMILLE)?,
             evict_batch: positive_u32_or(&get, "CEPHOR_EVICT_BATCH", DEFAULT_EVICT_BATCH)?,
             evict_max_pass: duration_secs(&get, "CEPHOR_EVICT_MAX_PASS_SECS", DEFAULT_EVICT_MAX_PASS)?,
+            landed_poll: duration_secs(&get, "CEPHOR_LANDED_POLL_SECS", DEFAULT_LANDED_POLL)?,
             liveness_file: path_or(&get, "CEPHOR_LIVENESS_FILE", DEFAULT_LIVENESS_FILE),
             readiness_file: path_or(&get, "CEPHOR_READINESS_FILE", DEFAULT_READINESS_FILE),
         })

--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -102,6 +102,14 @@ const DEFAULT_EVICT_HEADROOM_PERMILLE: u16 = 50;
 /// polls without one pass monopolising the disk.
 const DEFAULT_EVICT_BATCH: u32 = 512;
 
+/// Wall-clock ceiling on ONE eviction pass when `CEPHOR_EVICT_MAX_PASS_SECS` is unset.
+///
+/// The pass pages until its byte goal is met, so without a time bound a large deficit would hold
+/// the disk — which the drain and ingest are also writing to — for as long as it took. The
+/// remainder resumes on the next poll and is reported as `budget_exhausted`, deliberately NOT as
+/// starvation: a deficit spanning many passes is the design, not a fault.
+const DEFAULT_EVICT_MAX_PASS: Duration = Duration::from_secs(10);
+
 /// Default path of the liveness file the runtime touches each heartbeat tick; the
 /// k8s `livenessProbe` checks its freshness. Container-local `/tmp` is always writable.
 const DEFAULT_LIVENESS_FILE: &str = "/tmp/hippius-drain-agent.alive";
@@ -187,8 +195,10 @@ pub struct Config {
     pub evict_reserve_permille: u16,
     /// How far past the floor an armed eviction pass frees, in permille of the disk.
     pub evict_headroom_permille: u16,
-    /// Parts considered per eviction pass.
+    /// Rows fetched per eviction worklist query — the page size, not the pass budget.
     pub evict_batch: u32,
+    /// Wall-clock ceiling on one eviction pass; the remainder resumes on the next poll.
+    pub evict_max_pass: Duration,
     /// Path of the liveness file the runtime touches each heartbeat tick; a k8s
     /// `livenessProbe` checks its freshness to restart a wedged (not crashed) pod.
     pub liveness_file: PathBuf,
@@ -274,6 +284,7 @@ impl Config {
                 reserve_permille: self.evict_reserve_permille,
                 headroom_permille: self.evict_headroom_permille,
                 batch: self.evict_batch,
+                max_pass: self.evict_max_pass,
             },
         }
     }
@@ -353,6 +364,7 @@ impl Config {
             evict_reserve_permille: permille_or(&get, "CEPHOR_EVICT_RESERVE_PERMILLE", DEFAULT_EVICT_RESERVE_PERMILLE)?,
             evict_headroom_permille: permille_or(&get, "CEPHOR_EVICT_HEADROOM_PERMILLE", DEFAULT_EVICT_HEADROOM_PERMILLE)?,
             evict_batch: positive_u32_or(&get, "CEPHOR_EVICT_BATCH", DEFAULT_EVICT_BATCH)?,
+            evict_max_pass: duration_secs(&get, "CEPHOR_EVICT_MAX_PASS_SECS", DEFAULT_EVICT_MAX_PASS)?,
             liveness_file: path_or(&get, "CEPHOR_LIVENESS_FILE", DEFAULT_LIVENESS_FILE),
             readiness_file: path_or(&get, "CEPHOR_READINESS_FILE", DEFAULT_READINESS_FILE),
         })

--- a/crates/hippius-drain-agent/src/landed.rs
+++ b/crates/hippius-drain-agent/src/landed.rs
@@ -1,0 +1,179 @@
+//! The api's landed-part announcements: a per-node Redis queue the api pushes to when it
+//! finishes writing a part, so the drain learns about it without walking the disk.
+//!
+//! # Why this exists
+//!
+//! Until now the reconciler was the SOLE discovery mechanism: every 15 s it walked the whole
+//! SSD cache, materialised every part it found, and asked the database which of them it had
+//! never seen. That was cheap while the SSD held only the undrained backlog — a drained part
+//! was unlinked, so the tree was small. Retention broke that assumption: the disk now holds the
+//! node's entire replicated shard, measured on prod 2026-08-07 at **2.28 M parts / ~930 GB per
+//! node**, so the walk became ~2.28 M `stat` calls and ~4,560 batched Postgres round-trips
+//! *every 15 seconds, per node*, to discover a handful of new parts.
+//!
+//! The announcement makes discovery O(new parts). The reconciler stays, demoted to a backstop
+//! on a long poll: it is what recovers a part whose announcement was lost.
+//!
+//! # Why a queue and not a direct write from the api
+//!
+//! `cephor_replication_status` is the drain's table, owned by the drain's migrations. Letting
+//! the api `INSERT` into it directly would give one table two writers across two services with
+//! two independent migration systems. The repo already settled this shape for the mirror-image
+//! handoff — the drain is the sole producer of upload requests and publishes them over Redis
+//! rather than writing the consumer's state — so this follows it: the api announces, the agent
+//! records.
+//!
+//! # Delivery guarantees, and why weak ones are enough
+//!
+//! At-most-once, deliberately. A lost message (Redis restart, a trimmed queue, an agent down
+//! longer than the queue bound) costs latency and nothing else: the reconciler's next sweep
+//! finds the part and records it exactly as it does today. So this is a fast path over a
+//! correct-but-slow one, never a replacement for it — which is what lets the api treat its
+//! publish as best-effort and lets this consumer drop a malformed message without ceremony.
+
+use core::str::FromStr;
+use hippius_drain_core::{ObjectId, PartKey, PartNumber, Version};
+use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
+use serde::Deserialize;
+use thiserror::Error;
+
+/// Redis key holding one node's landed-part announcements. Per node, because a part is only
+/// ever on the SSD of the node that ingested it — a peer could not act on the message.
+#[must_use]
+pub fn landed_queue_key(node: &str) -> String {
+    format!("cephor:landed:{node}")
+}
+
+/// A failure draining the announcement queue.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum LandedError {
+    /// The Redis pop failed. Transient; the next poll retries and the reconciler backstops.
+    #[error("reading the landed-part queue failed")]
+    Redis(#[from] redis::RedisError),
+}
+
+/// One announcement as the api publishes it.
+///
+/// Field names are the wire contract with `hippius_s3/writer/landed.py`; changing either side
+/// alone silently drops every message, since a parse failure is discarded by design.
+#[derive(Debug, Deserialize)]
+struct LandedMessage {
+    object_id: String,
+    version: u32,
+    part_number: u32,
+}
+
+impl LandedMessage {
+    /// The typed key, or `None` when the payload does not describe a real part.
+    ///
+    /// A malformed announcement is dropped rather than retried: it can only come from a
+    /// version skew or a corrupted value, neither of which a retry fixes, and the reconciler
+    /// still discovers the part from the disk.
+    fn into_part(self) -> Option<PartKey> {
+        let object = ObjectId::from_str(&self.object_id).ok()?;
+        Some(PartKey::new(object, Version::new(self.version), PartNumber::new(self.part_number)))
+    }
+}
+
+/// Pops landed-part announcements for one node.
+///
+/// Cheap to clone — the `ConnectionManager` is a shared multiplexed handle.
+#[derive(Clone)]
+pub struct LandedQueue {
+    redis: ConnectionManager,
+    key: String,
+}
+
+// Manual Debug: redis's `ConnectionManager` is not `Debug`, so derive cannot apply.
+impl core::fmt::Debug for LandedQueue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LandedQueue").field("key", &self.key).finish_non_exhaustive()
+    }
+}
+
+impl LandedQueue {
+    /// Binds a queue to `node`'s announcement key.
+    #[must_use]
+    pub fn new(redis: ConnectionManager, node: &str) -> Self {
+        Self {
+            redis,
+            key: landed_queue_key(node),
+        }
+    }
+
+    /// Pops up to `limit` announcements, oldest first.
+    ///
+    /// `RPOP key count` takes the tail, which is the oldest end of an `LPUSH`ed list — so the
+    /// queue is FIFO and a burst is drained in arrival order rather than newest-first.
+    ///
+    /// Unparseable entries are counted, not returned: see [`LandedMessage::into_part`].
+    ///
+    /// # Errors
+    ///
+    /// [`LandedError::Redis`] if the pop fails. Nothing is lost — the entries stay queued.
+    pub async fn pop(&self, limit: usize) -> Result<(Vec<PartKey>, u64), LandedError> {
+        let mut conn = self.redis.clone();
+        let raw: Vec<String> = conn.rpop(&self.key, core::num::NonZeroUsize::new(limit)).await?;
+        let mut parts = Vec::with_capacity(raw.len());
+        let mut dropped = 0u64;
+        for entry in raw {
+            match serde_json::from_str::<LandedMessage>(&entry).ok().and_then(LandedMessage::into_part) {
+                Some(part) => parts.push(part),
+                None => dropped = dropped.saturating_add(1),
+            }
+        }
+        Ok((parts, dropped))
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::{LandedMessage, landed_queue_key};
+
+    const UUID: &str = "466916c0-d61b-4518-b81b-9576b574270a";
+
+    #[test]
+    fn the_queue_is_scoped_to_one_node() {
+        // A part lives only on the SSD of the node that ingested it, so a peer receiving the
+        // announcement could record a row pointing at a disk that does not hold the data —
+        // and `claim_part` is node-scoped, so that part would never drain at all.
+        assert_eq!(landed_queue_key("k8s-v3-node1"), "cephor:landed:k8s-v3-node1");
+        assert_ne!(landed_queue_key("k8s-v3-node1"), landed_queue_key("k8s-v3-node2"));
+    }
+
+    #[test]
+    fn a_well_formed_announcement_becomes_a_part_key() {
+        // The wire contract with hippius_s3/writer/landed.py. These three field names are the
+        // whole protocol; renaming one on either side silently drops every message, because a
+        // parse failure is discarded by design.
+        let raw = format!(r#"{{"object_id":"{UUID}","version":7,"part_number":3}}"#);
+        let part = serde_json::from_str::<LandedMessage>(&raw).unwrap().into_part().unwrap();
+
+        assert_eq!(part.object().as_str(), UUID);
+        assert_eq!(part.version().get(), 7);
+        assert_eq!(part.part().get(), 3);
+    }
+
+    #[test]
+    fn a_non_uuid_object_id_is_dropped_rather_than_recorded() {
+        // `object_id` reaches a SQL bind and a filesystem path, so an unvalidated value is both
+        // a correctness and a traversal concern. Dropping is safe: the reconciler still finds
+        // the part on disk, so a bad message costs latency, never the part.
+        let raw = r#"{"object_id":"../../etc/passwd","version":1,"part_number":1}"#;
+        assert!(serde_json::from_str::<LandedMessage>(raw).unwrap().into_part().is_none());
+    }
+
+    #[test]
+    fn a_message_missing_a_field_does_not_parse() {
+        let raw = format!(r#"{{"object_id":"{UUID}","version":1}}"#);
+        assert!(serde_json::from_str::<LandedMessage>(&raw).is_err());
+    }
+
+    #[test]
+    fn garbage_does_not_parse() {
+        assert!(serde_json::from_str::<LandedMessage>("not json").is_err());
+    }
+}

--- a/crates/hippius-drain-agent/src/lib.rs
+++ b/crates/hippius-drain-agent/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod config;
 pub mod disk;
 pub mod enqueue;
+pub mod landed;
 pub mod localfs;
 #[cfg(feature = "otel")]
 pub mod metrics;

--- a/crates/hippius-drain-agent/src/localfs.rs
+++ b/crates/hippius-drain-agent/src/localfs.rs
@@ -12,9 +12,10 @@
 //! implement the GC-only [`CephFs`]/[`SsdCache`] `remove_object` reclaim (by
 //! `<object_id>` folder).
 
+use core::future::Future;
 use hippius_drain_core::{
-    CephFs, ChunkIndex, DiscoveredPart, FileId, META_FILE_NAME, PartKey, PartMeta, PartPool, PartRemover, PartScan, PartSource, SsdCache,
-    chunk_file_name, parse_part_dir,
+    CephFs, ChunkIndex, DiscoveredPart, FileId, FreeSpaceProbe, META_FILE_NAME, PartKey, PartMeta, PartPool, PartRemover, PartScan, PartSource,
+    SsdCache, chunk_file_name, parse_part_dir,
 };
 use sha2::{Digest, Sha256};
 use std::ffi::OsStr;
@@ -724,6 +725,30 @@ impl PartRemover for LocalSsd {
         // re-drive after a crash — is harmless. The drain itself no longer unlinks at all:
         // it retains its copy to serve reads.
         remove_part_dir(&self.root, part).await
+    }
+}
+
+impl FreeSpaceProbe for LocalSsd {
+    type Error = io::Error;
+
+    /// Re-probes free space between eviction pages, so a long pass converges on the disk's
+    /// real state rather than on the single reading it started with.
+    ///
+    /// This matters more than a periodic refresh usually would: the evictor's own accounting
+    /// sums `cephor_ssd_residency.bytes`, which is denormalized at residency time and records
+    /// zero for a part whose size was unknown. A pass trusting that sum alone could believe it
+    /// had freed nothing while reclaiming real space, and page until its time budget.
+    ///
+    /// `statvfs` blocks, so it goes to the blocking pool (axiom `r4r_ch10_01`) exactly as the
+    /// heartbeat and the pass's initial probe do.
+    fn free_bytes(&self) -> impl Future<Output = io::Result<u64>> + Send {
+        let root = self.root.clone();
+        async move {
+            tokio::task::spawn_blocking(move || crate::disk::disk_usage(&root))
+                .await
+                .map_err(io::Error::other)?
+                .map(|usage| usage.free_bytes)
+        }
     }
 }
 

--- a/crates/hippius-drain-agent/src/main.rs
+++ b/crates/hippius-drain-agent/src/main.rs
@@ -8,6 +8,7 @@
 
 use hippius_drain_agent::config::{Config, ConfigError};
 use hippius_drain_agent::enqueue::RedisEnqueuer;
+use hippius_drain_agent::landed::LandedQueue;
 use hippius_drain_agent::localfs::{LocalFs, LocalSsd};
 use hippius_drain_agent::runtime::{AgentRuntime, RateControl, default_enforcer};
 use hippius_drain_agent::supervisor::{RunReport, ShutdownTrigger};
@@ -81,6 +82,9 @@ async fn main() -> Result<ExitCode, StartupError> {
     // The Redis-backed coordinator: the heartbeat worker upserts this node's state under
     // `heartbeat_ttl`, and the allocation-pull worker reads its budget. The agent never
     // writes allocations, so its alloc TTL is unused (the allocator owns that key's TTL).
+    // Bound before the coordinator takes ownership of the manager. Cloning is cheap — it is a
+    // shared multiplexed handle, the same one the enqueuer holds.
+    let landed = LandedQueue::new(redis.clone(), config.node_id.as_str());
     let coordinator = Arc::new(Coordinator::new(redis, config.heartbeat_ttl, AGENT_ALLOC_TTL_UNUSED));
 
     // The enforcer starts at the floor (conservative) with a one-second burst of
@@ -114,6 +118,11 @@ async fn main() -> Result<ExitCode, StartupError> {
         .with_coordinator(coordinator)
         .with_heartbeat(config.heartbeat_config())
         .with_rate_control(rate_control)
+        // Shares the queue Redis with the upload enqueuer: the api publishes a landed-part
+        // announcement there when it finishes writing a part, so discovery is one RPOP instead
+        // of a walk of this node's whole replicated shard. An api that does not publish yet
+        // simply leaves the queue empty and the reconciler keeps doing the job.
+        .with_landed_queue(landed)
         .with_liveness(config.liveness_file.clone())
         .with_readiness(config.readiness_file.clone());
 

--- a/crates/hippius-drain-agent/src/metrics.rs
+++ b/crates/hippius-drain-agent/src/metrics.rs
@@ -7,7 +7,9 @@
 //! [`SnapshotCell`] / [`Enforcer`], so a metric scrape never measures anything itself.
 
 use hippius_drain_core::Enforcer;
+use hippius_drain_core::ScanWorker;
 use hippius_drain_core::SnapshotCell;
+use opentelemetry::KeyValue;
 use opentelemetry_otlp::MetricExporter;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::Resource;
@@ -147,20 +149,38 @@ fn register_discovery_instruments(
     // What the SSD walks actually cost. Retention grew their input from "the undrained backlog"
     // to "this node's whole replicated shard" — 2.28 M parts measured on prod 2026-08-07 — and
     // nothing reported that, which is how the cost stayed invisible until it was looked for.
+    //
+    // Labelled per worker rather than summed. The two walk on cadences three orders of magnitude
+    // apart, so a merged total is dominated by the reconciler's short poll — and lengthening
+    // that poll is exactly the follow-up these metrics gate, after which a sum could not say
+    // which walk any residual cost belonged to. `ScanWorker` is a closed enum, so the label
+    // cannot grow past two values.
+    let reconcile = [KeyValue::new("worker", ScanWorker::Reconcile.as_str())];
+    let reclaim = [KeyValue::new("worker", ScanWorker::Reclaim.as_str())];
     let snap = Arc::clone(snapshot);
     instruments.push(Box::new(
         meter
             .u64_observable_counter("drain_scan_parts_total")
-            .with_callback(move |observer| observer.observe(snap.load().scan_parts_total, &[]))
+            .with_callback(move |observer| {
+                let s = snap.load();
+                observer.observe(s.reconcile_scan_parts, &reconcile);
+                observer.observe(s.reclaim_scan_parts, &reclaim);
+            })
             .build(),
     ));
-    // Watched against the poll interval: a walk approaching its own period means the worker
-    // never stops walking, which is the state that must not be reached again.
+    // Watched against each worker's OWN poll interval: a walk approaching its period means that
+    // worker never stops walking, which is the state that must not be reached again.
+    let reconcile = [KeyValue::new("worker", ScanWorker::Reconcile.as_str())];
+    let reclaim = [KeyValue::new("worker", ScanWorker::Reclaim.as_str())];
     let snap = Arc::clone(snapshot);
     instruments.push(Box::new(
         meter
             .u64_observable_gauge("drain_scan_duration_ms")
-            .with_callback(move |observer| observer.observe(snap.load().scan_duration_ms, &[]))
+            .with_callback(move |observer| {
+                let s = snap.load();
+                observer.observe(s.reconcile_scan_ms, &reconcile);
+                observer.observe(s.reclaim_scan_ms, &reclaim);
+            })
             .build(),
     ));
 

--- a/crates/hippius-drain-agent/src/metrics.rs
+++ b/crates/hippius-drain-agent/src/metrics.rs
@@ -166,6 +166,27 @@ pub fn init(service_name: &'static str, snapshot: &Arc<SnapshotCell>, enforcer: 
 
     register_ssd_tier_instruments(&meter, snapshot, &mut instruments);
 
+    // Discovery path split. `landed_recorded` climbing while `reconciler_recovered` stays near
+    // zero is what says the api's announcements are carrying discovery and the reconciler's
+    // whole-disk walk is genuinely idle. Both near zero means ingest stopped — NOT that the
+    // fast path is working — which is why the pair has to be read together.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_counter("drain_landed_recorded_total")
+            .with_callback(move |observer| observer.observe(snap.load().landed_recorded, &[]))
+            .build(),
+    ));
+    // Must stay at zero. Nonzero means the api and this agent disagree about the message shape,
+    // so every announcement is being discarded and discovery has silently reverted to the walk.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_counter("drain_landed_dropped_total")
+            .with_callback(move |observer| observer.observe(snap.load().landed_dropped, &[]))
+            .build(),
+    ));
+
     // Reclaim throughput: terminal SSD parts the reclaim worker unlinked (monotonic counter).
     // The SSD-ingest tier's eviction rate — distinct from the drain's CephFS throughput — so a
     // stalled reclaim (backlog rising while this stays flat) is visible without reading logs.

--- a/crates/hippius-drain-agent/src/metrics.rs
+++ b/crates/hippius-drain-agent/src/metrics.rs
@@ -132,6 +132,60 @@ fn register_ssd_tier_instruments(meter: &opentelemetry::metrics::Meter, snapshot
     ));
 }
 
+/// Registers how a part gets DISCOVERED: what the SSD walks cost, and how much of the work the
+/// api's announcements are taking off them.
+///
+/// Split out of [`init`] for the 100-line limit, and because the four read as one story: a
+/// healthy fleet has `landed_recorded` climbing while `reconciler_recovered` sits near zero and
+/// `scan_parts_total` grows only at the reclaimer's slow cadence. Any other shape means
+/// discovery has fallen back to walking the disk.
+fn register_discovery_instruments(
+    meter: &opentelemetry::metrics::Meter,
+    snapshot: &Arc<SnapshotCell>,
+    instruments: &mut Vec<Box<dyn std::any::Any>>,
+) {
+    // What the SSD walks actually cost. Retention grew their input from "the undrained backlog"
+    // to "this node's whole replicated shard" — 2.28 M parts measured on prod 2026-08-07 — and
+    // nothing reported that, which is how the cost stayed invisible until it was looked for.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_counter("drain_scan_parts_total")
+            .with_callback(move |observer| observer.observe(snap.load().scan_parts_total, &[]))
+            .build(),
+    ));
+    // Watched against the poll interval: a walk approaching its own period means the worker
+    // never stops walking, which is the state that must not be reached again.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_gauge("drain_scan_duration_ms")
+            .with_callback(move |observer| observer.observe(snap.load().scan_duration_ms, &[]))
+            .build(),
+    ));
+
+    // Discovery path split. `landed_recorded` climbing while `reconciler_recovered` stays near
+    // zero is what says the api's announcements are carrying discovery and the reconciler's
+    // whole-disk walk is genuinely idle. Both near zero means ingest stopped — NOT that the
+    // fast path is working — which is why the pair has to be read together.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_counter("drain_landed_recorded_total")
+            .with_callback(move |observer| observer.observe(snap.load().landed_recorded, &[]))
+            .build(),
+    ));
+    // Must stay at zero. Nonzero means the api and this agent disagree about the message shape,
+    // so every announcement is being discarded and discovery has silently reverted to the walk.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_counter("drain_landed_dropped_total")
+            .with_callback(move |observer| observer.observe(snap.load().landed_dropped, &[]))
+            .build(),
+    ));
+}
+
 /// Builds the meter provider and registers the agent's metrics, or returns `None` when
 /// monitoring is disabled or the exporter cannot be built. `enforcer` is `None` for an
 /// ungated drain (no breaker to observe).
@@ -166,26 +220,7 @@ pub fn init(service_name: &'static str, snapshot: &Arc<SnapshotCell>, enforcer: 
 
     register_ssd_tier_instruments(&meter, snapshot, &mut instruments);
 
-    // Discovery path split. `landed_recorded` climbing while `reconciler_recovered` stays near
-    // zero is what says the api's announcements are carrying discovery and the reconciler's
-    // whole-disk walk is genuinely idle. Both near zero means ingest stopped — NOT that the
-    // fast path is working — which is why the pair has to be read together.
-    let snap = Arc::clone(snapshot);
-    instruments.push(Box::new(
-        meter
-            .u64_observable_counter("drain_landed_recorded_total")
-            .with_callback(move |observer| observer.observe(snap.load().landed_recorded, &[]))
-            .build(),
-    ));
-    // Must stay at zero. Nonzero means the api and this agent disagree about the message shape,
-    // so every announcement is being discarded and discovery has silently reverted to the walk.
-    let snap = Arc::clone(snapshot);
-    instruments.push(Box::new(
-        meter
-            .u64_observable_counter("drain_landed_dropped_total")
-            .with_callback(move |observer| observer.observe(snap.load().landed_dropped, &[]))
-            .build(),
-    ));
+    register_discovery_instruments(&meter, snapshot, &mut instruments);
 
     // Reclaim throughput: terminal SSD parts the reclaim worker unlinked (monotonic counter).
     // The SSD-ingest tier's eviction rate — distinct from the drain's CephFS throughput — so a

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -25,7 +25,7 @@ use crate::worker::drain_until_empty;
 use hippius_drain_core::{
     BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, CoordError, Coordinator, Enforcer, EvictionPass, EvictionTarget,
     NodeId, NodeObservation, PartReplicationStore, ReclaimError, ReclaimGraces, SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket,
-    UploadEnqueuer, decay_rate, evict_to_target, jittered, reclaim_ssd, reconcile_parts,
+    UploadEnqueuer, decay_rate, evict_to_target, jittered, reclaim_failed, reclaim_ssd, reconcile_parts,
 };
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -88,6 +88,9 @@ pub struct RuntimeConfig {
     pub reconcile_poll: Duration,
     /// How often the reclaim worker scans the SSD for `failed` (abandoned-upload) parts.
     pub reclaim_poll: Duration,
+    /// How often the DB-driven `failed`-part reclaim runs. Independent of the reclaim WALK:
+    /// decoupling debris cleanup from the walk is the point, so the walk can be rare.
+    pub failed_reclaim_poll: Duration,
     /// How often the landed-part announcement queue is drained. Short: this is the discovery
     /// latency for a freshly-written part, the role the 15 s reconciler walk used to fill, and
     /// an empty queue costs one `RPOP`.
@@ -555,6 +558,48 @@ async fn redrive_corrupt_once(store: &Store, snapshot: &SnapshotCell, max_attemp
     }
 }
 
+/// Aged `failed` parts adjudicated per DB-driven reclaim pass. Bounded so one pass is a small
+/// indexed query plus one batched servability read, never a sweep of a pathological backlog.
+const FAILED_RECLAIM_BATCH: u32 = 512;
+
+/// One DB-driven `failed`-reclaim pass: unlink this node's aged abandoned-upload debris.
+///
+/// The walk used to find these by scanning every part on the SSD and asking the database about
+/// each one — work proportional to the whole tree (2.28 M parts on prod after retention) to find
+/// a population that is tiny and directly queryable (22,123 `failed` rows fleet-wide). This asks
+/// for them instead, which is why the walk's cadence could drop to hourly without leaving debris
+/// on the disk for an hour.
+///
+/// Errors log and retry next poll. Every failure mode here removes NOTHING: the worklist read,
+/// the servability read, and the unlink each abort the pass rather than proceeding on a
+/// half-answered question.
+async fn failed_reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, grace: Duration) {
+    match reclaim_failed(store, store, ssd, grace, FAILED_RECLAIM_BATCH).await {
+        Ok(report) => {
+            snapshot.record_reclaimed(report.reclaimed);
+            if report.reclaimed > 0 {
+                tracing::info!(reclaimed = report.reclaimed, "reclaimed broken/abandoned-upload SSD parts");
+            }
+            // R4: the part is a live object's last good source because its pool copy is corrupt.
+            // Same signal the walk's `skipped_corrupt` carries — a standing nonzero value across
+            // cycles is the incident, not a single pass.
+            if report.held_servable > 0 {
+                tracing::warn!(
+                    held_servable = report.held_servable,
+                    "corrupt-live SSD parts held (pool copy corrupt) — last good source preserved (R4)"
+                );
+            }
+        }
+        // A backing-read abort leaves every candidate unjudged, so the pass removed nothing and
+        // this GC is DISABLED rather than merely slow — the same distinction the walk draws.
+        Err(ReclaimError::Backing(err)) => {
+            snapshot.record_reclaim_backing_error();
+            tracing::error!(error = %err, "failed-part reclaim disabled: object-backing read failed; removed nothing");
+        }
+        Err(err) => tracing::warn!(error = ?err, "failed-part reclaim pass failed; will retry next poll"),
+    }
+}
+
 /// Announcements drained per landed-queue poll. Generous: the work per message is one
 /// idempotent UPSERT, and a burst (a large multipart upload completing) should be absorbed in
 /// one tick rather than trickled at the poll rate, which is what a small batch would do.
@@ -945,6 +990,20 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
             run_periodic(token, evict_poll, move || {
                 let (ssd, store, snapshot) = (Arc::clone(&ssd), Arc::clone(&store), Arc::clone(&snapshot));
                 async move { evict_once(&ssd, &store, &snapshot, evict_policy).await }
+            })
+        });
+
+        // Failed-part reclaim worker: unlink aged abandoned-upload debris, found by an indexed
+        // query rather than by walking the disk. Separate from the reclaim WALK above and on its
+        // own poll deliberately — decoupling debris cleanup from the walk is what let the walk
+        // drop to hourly without leaving debris around for an hour.
+        let (ssd, store, snapshot) = (Arc::clone(&self.ssd), Arc::clone(&self.store), Arc::clone(&self.snapshot));
+        let failed_reclaim_poll = self.config.failed_reclaim_poll;
+        let failed_grace = self.config.reclaim_grace;
+        supervisor.spawn(WorkerName::new("failed_reclaim"), move |token| {
+            run_periodic(token, failed_reclaim_poll, move || {
+                let (ssd, store, snapshot) = (Arc::clone(&ssd), Arc::clone(&store), Arc::clone(&snapshot));
+                async move { failed_reclaim_once(&ssd, &store, &snapshot, failed_grace).await }
             })
         });
 
@@ -1426,6 +1485,7 @@ mod tests {
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
                 landed_poll: Duration::from_secs(1),
+                failed_reclaim_poll: Duration::from_mins(5),
                 evict_poll: Duration::from_secs(30),
                 evict_policy: EvictionPolicy {
                     reserve_permille: 150,
@@ -1519,6 +1579,7 @@ mod tests {
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
                 landed_poll: Duration::from_secs(1),
+                failed_reclaim_poll: Duration::from_mins(5),
                 evict_poll: Duration::from_secs(30),
                 evict_policy: EvictionPolicy {
                     reserve_permille: 150,
@@ -1646,6 +1707,7 @@ mod tests {
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
                 landed_poll: Duration::from_secs(1),
+                failed_reclaim_poll: Duration::from_mins(5),
                 evict_poll: Duration::from_secs(30),
                 evict_policy: EvictionPolicy {
                     reserve_permille: 150,
@@ -1719,6 +1781,7 @@ mod tests {
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
                 landed_poll: Duration::from_secs(1),
+                failed_reclaim_poll: Duration::from_mins(5),
                 evict_poll: Duration::from_secs(30),
                 evict_policy: EvictionPolicy {
                     reserve_permille: 150,
@@ -1775,6 +1838,7 @@ mod tests {
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
                 landed_poll: Duration::from_secs(1),
+                failed_reclaim_poll: Duration::from_mins(5),
                 evict_poll: Duration::from_secs(30),
                 evict_policy: EvictionPolicy {
                     reserve_permille: 150,

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -17,6 +17,7 @@
 //! `rust_quality_129_async_graceful_shutdown`).
 
 use crate::disk::{DiskUsage, disk_usage};
+use crate::landed::LandedQueue;
 use crate::localfs::{LocalFs, LocalSsd};
 use crate::readiness::ReadinessTracker;
 use crate::supervisor::{RunReport, Supervisor, WorkerName};
@@ -87,6 +88,10 @@ pub struct RuntimeConfig {
     pub reconcile_poll: Duration,
     /// How often the reclaim worker scans the SSD for `failed` (abandoned-upload) parts.
     pub reclaim_poll: Duration,
+    /// How often the landed-part announcement queue is drained. Short: this is the discovery
+    /// latency for a freshly-written part, the role the 15 s reconciler walk used to fill, and
+    /// an empty queue costs one `RPOP`.
+    pub landed_poll: Duration,
     /// How often the read-tier evictor checks the ingest disk's free space.
     pub evict_poll: Duration,
     /// The free-space floor the evictor maintains, and how far past it to free.
@@ -545,6 +550,53 @@ async fn redrive_corrupt_once(store: &Store, snapshot: &SnapshotCell, max_attemp
     }
 }
 
+/// Announcements drained per landed-queue poll. Generous: the work per message is one
+/// idempotent UPSERT, and a burst (a large multipart upload completing) should be absorbed in
+/// one tick rather than trickled at the poll rate, which is what a small batch would do.
+const LANDED_POP_BATCH: usize = 512;
+
+/// One landed-queue pass: record every part the api announced since the last tick.
+///
+/// This is the fast discovery path that replaces the reconciler's whole-disk walk. It is
+/// deliberately thin — pop, record, count — because everything that makes discovery *correct*
+/// still lives in the reconciler, which remains as the backstop for any announcement that was
+/// never delivered.
+///
+/// Failures are logged and dropped rather than retried in-tick: a Redis error leaves the
+/// entries queued for the next poll, and a `record_landed_part` error leaves the part for the
+/// reconciler. Neither can lose the part, because the disk is the source of truth in both cases.
+async fn landed_once(queue: &LandedQueue, store: &Store, snapshot: &SnapshotCell) {
+    let (parts, dropped) = match queue.pop(LANDED_POP_BATCH).await {
+        Ok(batch) => batch,
+        Err(err) => {
+            tracing::warn!(error = %err, "landed-queue read failed; entries stay queued for the next poll");
+            return;
+        }
+    };
+    if parts.is_empty() && dropped == 0 {
+        return;
+    }
+    let mut recorded = 0u64;
+    for part in &parts {
+        // Idempotent, and the same call the reconciler makes — so an announcement racing the
+        // backstop is a no-op rather than a conflict.
+        match store.record_landed_part(part).await {
+            Ok(()) => recorded += 1,
+            Err(err) => tracing::warn!(error = %err, "recording an announced part failed; the reconciler will recover it"),
+        }
+    }
+    snapshot.record_landed(recorded, dropped);
+    if dropped > 0 {
+        // The api and this agent disagree about the message shape, so EVERY announcement is
+        // being lost and discovery has silently fallen back to the reconciler's walk — the
+        // thing this path exists to avoid. Loud, because nothing else would show it.
+        tracing::error!(dropped, "landed announcements were unparseable; the api/agent wire contract has diverged");
+    }
+    if recorded > 0 {
+        tracing::debug!(recorded, "recorded announced parts");
+    }
+}
+
 /// How many replicated-but-unenqueued parts one enqueue-sweep pass publishes. Bounded so a
 /// large post-CompleteMPU burst is drained over a few passes rather than one giant query +
 /// Redis fan-out; the partial index keeps each scan cheap, and the leftover is picked up on
@@ -708,6 +760,10 @@ pub struct AgentRuntime<E: UploadEnqueuer> {
     /// Opt-in readiness file the heartbeat worker touches only while the drain is progressing
     /// (C8), for the k8s `readinessProbe`. `None` writes no file.
     readiness_path: Option<Arc<PathBuf>>,
+    /// Opt-in landed-part announcement queue. `None` (tests, and any deployment whose api does
+    /// not publish yet) leaves the reconciler as the sole discovery path — i.e. today's
+    /// behaviour — so the two sides roll independently.
+    landed: Option<LandedQueue>,
 }
 
 impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
@@ -728,6 +784,7 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
             clock: Arc::new(SystemClock),
             liveness_path: None,
             readiness_path: None,
+            landed: None,
         }
     }
 
@@ -782,6 +839,15 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
     #[must_use]
     pub fn with_readiness(mut self, path: PathBuf) -> Self {
         self.readiness_path = Some(Arc::new(path));
+        self
+    }
+
+    /// Enables the landed-announcement worker, so a part the api just wrote is discovered by
+    /// one `RPOP` rather than by the reconciler's walk of the whole SSD tree. Without it the
+    /// reconciler remains the sole trigger, which is exactly the pre-announcement behaviour.
+    #[must_use]
+    pub fn with_landed_queue(mut self, queue: LandedQueue) -> Self {
+        self.landed = Some(queue);
         self
     }
 
@@ -868,6 +934,22 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
                 async move { evict_once(&ssd, &store, &snapshot, evict_policy).await }
             })
         });
+
+        // Landed-announcement worker (opt-in): record parts the api says it just wrote, so
+        // discovery costs one RPOP instead of a walk of the node's entire replicated shard
+        // (2.28 M parts on prod). Without a queue configured the agent behaves exactly as
+        // before — the reconciler is still the sole trigger — which is what makes the api-side
+        // publish and this consumer independently deployable in either order.
+        if let Some(queue) = self.landed.as_ref() {
+            let (queue, store, snapshot) = (queue.clone(), Arc::clone(&self.store), Arc::clone(&self.snapshot));
+            let landed_poll = self.config.landed_poll;
+            supervisor.spawn(WorkerName::new("landed"), move |token| {
+                run_periodic(token, landed_poll, move || {
+                    let (queue, store, snapshot) = (queue.clone(), Arc::clone(&store), Arc::clone(&snapshot));
+                    async move { landed_once(&queue, &store, &snapshot).await }
+                })
+            });
+        }
 
         // Enqueue-sweep worker: publish the backend upload for `replicated` parts whose
         // address was NULL at drain time (an in-flight MPU) — the decoupled counterpart to the
@@ -1330,6 +1412,7 @@ mod tests {
                 orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
+                landed_poll: Duration::from_secs(1),
                 evict_poll: Duration::from_secs(30),
                 evict_policy: EvictionPolicy {
                     reserve_permille: 150,
@@ -1422,6 +1505,7 @@ mod tests {
                 orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
+                landed_poll: Duration::from_secs(1),
                 evict_poll: Duration::from_secs(30),
                 evict_policy: EvictionPolicy {
                     reserve_permille: 150,
@@ -1548,6 +1632,7 @@ mod tests {
                 orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
+                landed_poll: Duration::from_secs(1),
                 evict_poll: Duration::from_secs(30),
                 evict_policy: EvictionPolicy {
                     reserve_permille: 150,
@@ -1620,6 +1705,7 @@ mod tests {
                 orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
+                landed_poll: Duration::from_secs(1),
                 evict_poll: Duration::from_secs(30),
                 evict_policy: EvictionPolicy {
                     reserve_permille: 150,
@@ -1675,6 +1761,7 @@ mod tests {
                 orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
                 drain_concurrency: 4,
+                landed_poll: Duration::from_secs(1),
                 evict_poll: Duration::from_secs(30),
                 evict_policy: EvictionPolicy {
                     reserve_permille: 150,

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -459,8 +459,13 @@ async fn heartbeat_once(ssd: &LocalSsd, store: &Store, coord: &Coordinator, node
 /// is ever removed without a successful status read (fail-safe). The store is both the
 /// replication log and the object-backing log for the reclaim.
 async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, graces: ReclaimGraces) {
+    let started = Instant::now();
     match reclaim_ssd(ssd, ssd, store, store, graces).await {
         Ok(report) => {
+            // The walk's cost, from the pass that just paid it. `scanned` is every part on this
+            // node's SSD — which retention grew from the undrained backlog to the whole
+            // replicated shard, with nothing reporting the change until now.
+            snapshot.record_scan(report.scanned, started.elapsed());
             // Both debris dispositions free SSD bytes, so the reclaimed gauge counts their sum.
             // Retained `replicated` parts are NOT counted here — they are cache, not reclaimed
             // debris, and the evictor reports their reclamation separately.
@@ -889,8 +894,16 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
             run_periodic(token, reconcile_poll, move || {
                 let (ssd, store, snapshot) = (Arc::clone(&ssd), Arc::clone(&store), Arc::clone(&snapshot));
                 async move {
+                    let started = Instant::now();
                     match reconcile_parts(ssd.as_ref(), store.as_ref()).await {
-                        Ok(report) => snapshot.record_reconciled(report.recovered),
+                        Ok(report) => {
+                            // The reconciler's walk is the expensive one: it runs on the
+                            // shortest poll of any worker, and `scanned` is every part on the
+                            // disk. Recording it is what makes the landed-announcement path's
+                            // benefit visible — and what would show F1 returning.
+                            snapshot.record_scan(report.scanned, started.elapsed());
+                            snapshot.record_reconciled(report.recovered);
+                        }
                         Err(err) => tracing::warn!(error = %err, "reconcile cycle failed"),
                     }
                 }

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -24,8 +24,8 @@ use crate::supervisor::{RunReport, Supervisor, WorkerName};
 use crate::worker::drain_until_empty;
 use hippius_drain_core::{
     BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, CoordError, Coordinator, Enforcer, EvictionPass, EvictionTarget,
-    NodeId, NodeObservation, PartReplicationStore, ReclaimError, ReclaimGraces, SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket,
-    UploadEnqueuer, decay_rate, evict_to_target, jittered, reclaim_failed, reclaim_ssd, reconcile_parts,
+    NodeId, NodeObservation, PartReplicationStore, ReclaimError, ReclaimGraces, ScanWorker, SnapshotCell, Store, StoredAllocation, SystemClock,
+    TokenBucket, UploadEnqueuer, decay_rate, evict_to_target, jittered, reclaim_failed, reclaim_ssd, reconcile_parts,
 };
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -468,7 +468,7 @@ async fn reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, gr
             // The walk's cost, from the pass that just paid it. `scanned` is every part on this
             // node's SSD — which retention grew from the undrained backlog to the whole
             // replicated shard, with nothing reporting the change until now.
-            snapshot.record_scan(report.scanned, started.elapsed());
+            snapshot.record_scan(ScanWorker::Reclaim, report.scanned, started.elapsed());
             // Both debris dispositions free SSD bytes, so the reclaimed gauge counts their sum.
             // Retained `replicated` parts are NOT counted here — they are cache, not reclaimed
             // debris, and the evictor reports their reclamation separately.
@@ -946,7 +946,7 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
                             // shortest poll of any worker, and `scanned` is every part on the
                             // disk. Recording it is what makes the landed-announcement path's
                             // benefit visible — and what would show F1 returning.
-                            snapshot.record_scan(report.scanned, started.elapsed());
+                            snapshot.record_scan(ScanWorker::Reconcile, report.scanned, started.elapsed());
                             snapshot.record_reconciled(report.recovered);
                         }
                         Err(err) => tracing::warn!(error = %err, "reconcile cycle failed"),

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -22,8 +22,8 @@ use crate::readiness::ReadinessTracker;
 use crate::supervisor::{RunReport, Supervisor, WorkerName};
 use crate::worker::drain_until_empty;
 use hippius_drain_core::{
-    BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, CoordError, Coordinator, Enforcer, EvictionTarget, NodeId,
-    NodeObservation, PartReplicationStore, ReclaimError, ReclaimGraces, SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket,
+    BreakerConfig, ByteRate, Bytes, CircuitBreaker, Clock, ConcurrencyLimiter, CoordError, Coordinator, Enforcer, EvictionPass, EvictionTarget,
+    NodeId, NodeObservation, PartReplicationStore, ReclaimError, ReclaimGraces, SnapshotCell, Store, StoredAllocation, SystemClock, TokenBucket,
     UploadEnqueuer, decay_rate, evict_to_target, jittered, reclaim_ssd, reconcile_parts,
 };
 use std::future::Future;
@@ -276,9 +276,13 @@ pub struct EvictionPolicy {
     /// How far past the floor to free once armed, in permille of the disk. Without this the
     /// evictor re-arms on nearly every cycle and pins the disk at the threshold.
     pub headroom_permille: u16,
-    /// Most parts to consider in one pass, bounding both the worklist query and how long a
-    /// single pass can hold the disk busy.
+    /// Rows fetched per worklist query. **Not** the pass budget — see [`EvictionPass`]. Prod's
+    /// part sizes are bimodal (measured p50 686 bytes against a 408 KB shard mean), so a part
+    /// count says almost nothing about bytes freed; the pass pages until the byte goal is met.
     pub batch: u32,
+    /// Wall-clock ceiling on one pass, so eviction cannot monopolise the disk the drain is also
+    /// writing to. Whatever is left over resumes on the next poll.
+    pub max_pass: Duration,
 }
 
 /// Resolves a policy against a probed disk into the concrete byte target for one pass.
@@ -327,7 +331,11 @@ async fn evict_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, poli
     // None means the allocator has not published a reserve for this node (pre-Phase-4
     // leader, expired allocation key, or a malformed value); the static floor then applies.
     let target = eviction_target(usage, policy, snapshot.allocated_reserve_permille());
-    match evict_to_target(store, ssd, target, policy.batch).await {
+    let pass = EvictionPass {
+        page: policy.batch,
+        max_duration: policy.max_pass,
+    };
+    match evict_to_target(store, ssd, ssd, &SystemClock, target, pass).await {
         Ok(report) => {
             snapshot.record_evicted(report.evicted, report.freed_bytes);
             snapshot.record_evict_blocked_unreplicated(report.skipped_unreplicated);
@@ -335,8 +343,21 @@ async fn evict_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, poli
                 tracing::info!(
                     evicted = report.evicted,
                     freed_bytes = report.freed_bytes,
+                    pages = report.pages,
                     free_bytes = usage.free_bytes,
                     "evicted resident SSD parts to restore the free-space floor"
+                );
+            }
+            // Ran out of the pass's wall clock with work still queued. Routine and
+            // self-correcting — the next poll resumes the cursor — so INFO. Keeping this
+            // OUT of `starved` is the point: a large deficit takes many passes by design,
+            // and reporting that as starvation is what made the ERROR meaningless.
+            if report.budget_exhausted {
+                tracing::info!(
+                    evicted = report.evicted,
+                    pages = report.pages,
+                    free_bytes = usage.free_bytes,
+                    "eviction pass hit its time budget; resuming next poll"
                 );
             }
             // Eviction could not reach its target: the disk is filling with something it
@@ -346,6 +367,7 @@ async fn evict_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotCell, poli
                 tracing::error!(
                     free_bytes = usage.free_bytes,
                     deficit = target.deficit(),
+                    evicted = report.evicted,
                     "eviction ran out of resident parts before restoring the free-space floor"
                 );
             }
@@ -1081,6 +1103,7 @@ mod tests {
             reserve_permille: 150,
             headroom_permille: 50,
             batch: 128,
+            max_pass: Duration::from_secs(10),
         };
 
         let target = eviction_target(usage, policy, None);
@@ -1106,6 +1129,7 @@ mod tests {
             reserve_permille: 150,
             headroom_permille: 50,
             batch: 128,
+            max_pass: Duration::from_secs(10),
         };
 
         let target = eviction_target(usage, policy, Some(400));
@@ -1126,6 +1150,7 @@ mod tests {
             reserve_permille: 150,
             headroom_permille: 50,
             batch: 128,
+            max_pass: Duration::from_secs(10),
         };
 
         assert_eq!(eviction_target(usage, policy, None).reserve, 600 * GIB);
@@ -1145,6 +1170,7 @@ mod tests {
             reserve_permille: 0,
             headroom_permille: 50,
             batch: 128,
+            max_pass: Duration::from_secs(10),
         };
 
         assert_eq!(eviction_target(usage, policy, None).deficit(), 0, "a zero reserve never arms");
@@ -1309,6 +1335,7 @@ mod tests {
                     reserve_permille: 150,
                     headroom_permille: 50,
                     batch: 512,
+                    max_pass: Duration::from_secs(10),
                 },
                 redrive_max_attempts: 3,
             },
@@ -1400,6 +1427,7 @@ mod tests {
                     reserve_permille: 150,
                     headroom_permille: 50,
                     batch: 512,
+                    max_pass: Duration::from_secs(10),
                 },
                 redrive_max_attempts: 3,
             },
@@ -1525,6 +1553,7 @@ mod tests {
                     reserve_permille: 150,
                     headroom_permille: 50,
                     batch: 512,
+                    max_pass: Duration::from_secs(10),
                 },
                 redrive_max_attempts: 3,
             },
@@ -1596,6 +1625,7 @@ mod tests {
                     reserve_permille: 150,
                     headroom_permille: 50,
                     batch: 512,
+                    max_pass: Duration::from_secs(10),
                 },
                 redrive_max_attempts: 3,
             },
@@ -1650,6 +1680,7 @@ mod tests {
                     reserve_permille: 150,
                     headroom_permille: 50,
                     batch: 512,
+                    max_pass: Duration::from_secs(10),
                 },
                 redrive_max_attempts: 3,
             },
@@ -1777,6 +1808,7 @@ mod tests {
                 reserve_permille: 1_000,
                 headroom_permille: 0,
                 batch: 512,
+                max_pass: Duration::from_secs(10),
             },
         )
         .await;
@@ -1823,6 +1855,7 @@ mod tests {
                 reserve_permille: 1_000,
                 headroom_permille: 0,
                 batch: 512,
+                max_pass: Duration::from_secs(10),
             },
         )
         .await;

--- a/crates/hippius-drain-core/migrations/0017_residency_last_read.sql
+++ b/crates/hippius-drain-core/migrations/0017_residency_last_read.sql
@@ -1,0 +1,35 @@
+-- Make read-tier eviction recency-aware instead of FIFO.
+--
+-- Eviction ordered on `resident_at` — when a part JOINED the cache, which says nothing about
+-- whether anyone is still reading it. That is FIFO replacement, and FIFO is a poor fit for the
+-- workload this tier exists for: a training set re-read every epoch is maximally skewed, and
+-- FIFO evicts by arrival order, so the parts about to be re-read are exactly the ones most
+-- likely to go. Each eviction then costs a peer-or-pool read plus a local write to put the same
+-- part back — thrash that gets worse the more valuable the cache is.
+--
+-- WHY A NEW COLUMN RATHER THAN BUMPING resident_at
+--
+-- Overloading `resident_at` was considered and rejected. It would leave the column meaning
+-- "when it became resident OR when it was last read", contradicting migration 0016's own
+-- description and the evictor's FIFO documentation, and there would be no way afterwards to ask
+-- how long a part had actually been cached. A nullable column keeps both facts and makes the
+-- fallback explicit at the point of use: COALESCE(last_read_at, resident_at).
+--
+-- NULL is the correct default and needs no backfill. A part nobody has read since this shipped
+-- has no read recency, and treating its residency time as its last-read time is exactly the old
+-- behaviour — so the change degrades to FIFO for the existing population and becomes recency as
+-- reads land. There is no window where eviction is ordered on nothing.
+ALTER TABLE cephor_ssd_residency
+    ADD COLUMN IF NOT EXISTS last_read_at TIMESTAMPTZ;
+
+-- The eviction cursor's index has to match the ORDER BY expression or the planner sorts the
+-- whole resident set (~2M rows per node) on every pass — which would reintroduce, in Postgres,
+-- precisely the O(resident) cost the walk-free evictor was built to avoid.
+CREATE INDEX IF NOT EXISTS cephor_ssd_residency_recency_idx
+    ON cephor_ssd_residency (node_id, (COALESCE(last_read_at, resident_at)));
+
+-- The FIFO index is now dead: every eviction query orders on the expression above, and the
+-- part-lookup index (cephor_ssd_residency_part_idx) serves the peer resolver. Dropped rather
+-- than left in place — an unused index on a table taking a write per promotion and per sampled
+-- read is pure write amplification.
+DROP INDEX IF EXISTS cephor_ssd_residency_evict_idx;

--- a/crates/hippius-drain-core/migrations/0017_residency_last_read.sql
+++ b/crates/hippius-drain-core/migrations/0017_residency_last_read.sql
@@ -19,9 +19,6 @@
 -- has no read recency, and treating its residency time as its last-read time is exactly the old
 -- behaviour — so the change degrades to FIFO for the existing population and becomes recency as
 -- reads land. There is no window where eviction is ordered on nothing.
-ALTER TABLE cephor_ssd_residency
-    ADD COLUMN IF NOT EXISTS last_read_at TIMESTAMPTZ;
-
 -- lock_timeout is the load-bearing line, as it is in 0013. CREATE INDEX takes SHARE, which
 -- conflicts with ROW EXCLUSIVE: with no timeout it waits out any open writer AND blocks every
 -- new writer on this table behind it — which for this table is every promotion, every drain
@@ -35,6 +32,9 @@ ALTER TABLE cephor_ssd_residency
 -- silently refuses to rebuild (a dead index with no operator-visible apply job to catch it),
 -- and waits out all older snapshots twice.
 SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE cephor_ssd_residency
+    ADD COLUMN IF NOT EXISTS last_read_at TIMESTAMPTZ;
 
 -- The eviction cursor's index has to match the ORDER BY expression or the planner sorts the
 -- whole resident set (~2M rows per node) on every pass — which would reintroduce, in Postgres,

--- a/crates/hippius-drain-core/migrations/0017_residency_last_read.sql
+++ b/crates/hippius-drain-core/migrations/0017_residency_last_read.sql
@@ -22,6 +22,20 @@
 ALTER TABLE cephor_ssd_residency
     ADD COLUMN IF NOT EXISTS last_read_at TIMESTAMPTZ;
 
+-- lock_timeout is the load-bearing line, as it is in 0013. CREATE INDEX takes SHARE, which
+-- conflicts with ROW EXCLUSIVE: with no timeout it waits out any open writer AND blocks every
+-- new writer on this table behind it — which for this table is every promotion, every drain
+-- commit, and every sampled read stamp. migrate() runs in the allocator's startup path BEFORE
+-- its liveness file is first touched, and that probe SIGKILLs at ~50-65s, so a long lock wait
+-- means CrashLoopBackOff with each restart re-queuing the lock. Fail fast, retry next start.
+--
+-- Plain build, NOT CONCURRENTLY — the same judgement 0013 recorded for a table of this
+-- cardinality: it builds in seconds and rolls back cleanly if aborted, whereas CONCURRENTLY
+-- needs `-- no-transaction`, leaves an INVALID index on failure that `IF NOT EXISTS` then
+-- silently refuses to rebuild (a dead index with no operator-visible apply job to catch it),
+-- and waits out all older snapshots twice.
+SET LOCAL lock_timeout = '5s';
+
 -- The eviction cursor's index has to match the ORDER BY expression or the planner sorts the
 -- whole resident set (~2M rows per node) on every pass — which would reintroduce, in Postgres,
 -- precisely the O(resident) cost the walk-free evictor was built to avoid.

--- a/crates/hippius-drain-core/migrations/0018_replication_reclaimed_marker.sql
+++ b/crates/hippius-drain-core/migrations/0018_replication_reclaimed_marker.sql
@@ -1,0 +1,43 @@
+-- Let the DB-driven `failed` reclaim advance its cursor, and give its worklist an index.
+--
+-- THE BUG THIS FIXES. The walk-driven reclaim was disk-keyed: once a part's directory was
+-- unlinked, the next scan simply did not find it, so the cursor advanced for free. The
+-- DB-driven worklist is status-keyed, and unlinking a part changes nothing about its row — so
+-- every poll re-selected the same oldest LIMIT page, re-unlinked it (idempotent, a no-op), and
+-- re-counted it as reclaimed. Metrics and logs looked productive while the cursor never moved.
+--
+-- `gc_terminal_status_rows` does eventually delete these rows, but at a 7-day retention. So a
+-- node with more than one page of aged `failed` parts would churn its oldest 512 every poll for
+-- a week and never reach the rest — which then waited for the hourly walk this path exists to
+-- make unnecessary. Prod carries 22,123 `failed` rows fleet-wide, ~4.4k per node against a
+-- 512-row page, so this was the normal case, not an edge one.
+--
+-- WHY A MARKER AND NOT A DELETE. Deleting the row on unlink would also advance the cursor, and
+-- is tempting because the row is inert once its disk copy is gone. It is rejected because
+-- `gc_terminal_status_rows` owns that deletion on a deliberate 7-day retention — the row is the
+-- only record that this part failed, and reclaiming disk is not a reason to discard the
+-- diagnosis a week early. The marker takes the row off the worklist and leaves the GC's
+-- semantics untouched.
+ALTER TABLE cephor_replication_status
+    ADD COLUMN IF NOT EXISTS reclaimed_at TIMESTAMPTZ;
+
+-- lock_timeout is the load-bearing line, exactly as in 0013. CREATE INDEX takes SHARE, which
+-- conflicts with ROW EXCLUSIVE: with no timeout it waits out any open writer AND blocks every
+-- new writer on this table behind it — claim_part, release_part, mark_replicated,
+-- record_landed_part, i.e. the whole drain fleet. migrate() runs in the allocator's startup path
+-- BEFORE its liveness file is first touched, and that probe SIGKILLs at ~50-65s, so a long lock
+-- wait means CrashLoopBackOff with each restart re-queuing the lock. Failing fast and retrying
+-- on the next start is strictly better.
+SET LOCAL lock_timeout = '5s';
+
+-- Partial, so the index covers only the ~22k `failed` rows rather than all 11.4M. Without it the
+-- worklist query is a scan on a table the drain writes to constantly, every poll, per node.
+-- Ordered by updated_at to match the query's ORDER BY, so the LIMIT reads straight off the index.
+--
+-- Plain build, NOT CONCURRENTLY — the same judgement 0013 recorded for this table: at this
+-- cardinality it builds in seconds and rolls back cleanly if aborted, whereas CONCURRENTLY needs
+-- `-- no-transaction`, leaves an INVALID index on failure that `IF NOT EXISTS` then silently
+-- refuses to rebuild, and waits out all older snapshots twice.
+CREATE INDEX IF NOT EXISTS cephor_replication_status_failed_reclaimable
+    ON cephor_replication_status (node_id, updated_at)
+    WHERE status = 'failed' AND reclaimed_at IS NULL;

--- a/crates/hippius-drain-core/migrations/0018_replication_reclaimed_marker.sql
+++ b/crates/hippius-drain-core/migrations/0018_replication_reclaimed_marker.sql
@@ -18,9 +18,6 @@
 -- only record that this part failed, and reclaiming disk is not a reason to discard the
 -- diagnosis a week early. The marker takes the row off the worklist and leaves the GC's
 -- semantics untouched.
-ALTER TABLE cephor_replication_status
-    ADD COLUMN IF NOT EXISTS reclaimed_at TIMESTAMPTZ;
-
 -- lock_timeout is the load-bearing line, exactly as in 0013. CREATE INDEX takes SHARE, which
 -- conflicts with ROW EXCLUSIVE: with no timeout it waits out any open writer AND blocks every
 -- new writer on this table behind it — claim_part, release_part, mark_replicated,
@@ -28,7 +25,15 @@ ALTER TABLE cephor_replication_status
 -- BEFORE its liveness file is first touched, and that probe SIGKILLs at ~50-65s, so a long lock
 -- wait means CrashLoopBackOff with each restart re-queuing the lock. Failing fast and retrying
 -- on the next start is strictly better.
+--
+-- Set BEFORE the ALTER, not after it. `ADD COLUMN` without a default is metadata-only and
+-- fast once it HOLDS the lock, but it still needs ACCESS EXCLUSIVE to take it, and that
+-- acquisition queues behind any open reader and then blocks every statement arriving after
+-- it. 0013 puts the guard ahead of its first DDL for this reason.
 SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE cephor_replication_status
+    ADD COLUMN IF NOT EXISTS reclaimed_at TIMESTAMPTZ;
 
 -- Partial, so the index covers only the ~22k `failed` rows rather than all 11.4M. Without it the
 -- worklist query is a scan on a table the drain writes to constantly, every poll, per node.

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -44,7 +44,9 @@ pub use partdrain::{
 pub use reconcile::{DiscoveredPart, PartLandingLog, PartScan, PartStatus, ReconcileError, ReconcileReport, reconcile_parts};
 pub use snapshot::{AgentSnapshot, SnapshotCell};
 pub use ssd_evict::{EvictionError, EvictionPass, EvictionReport, EvictionTarget, FreeSpaceProbe, ResidentLog, ResidentPart, evict_to_target};
-pub use ssd_reclaim::{PartRemover, PartStatusAge, ReclaimError, ReclaimGraces, ReclaimLog, ReclaimReport, reclaim_ssd};
+pub use ssd_reclaim::{
+    FailedReclaimReport, PartRemover, PartStatusAge, ReclaimError, ReclaimGraces, ReclaimLog, ReclaimReport, reclaim_failed, reclaim_ssd,
+};
 pub use state::{CephCeiling, PressureZone, ReplicationState};
 pub use units::{ByteRate, Bytes, DiskPressure};
 

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -43,7 +43,7 @@ pub use partdrain::{
 };
 pub use reconcile::{DiscoveredPart, PartLandingLog, PartScan, PartStatus, ReconcileError, ReconcileReport, reconcile_parts};
 pub use snapshot::{AgentSnapshot, SnapshotCell};
-pub use ssd_evict::{EvictionError, EvictionReport, EvictionTarget, ResidentLog, ResidentPart, evict_to_target};
+pub use ssd_evict::{EvictionError, EvictionPass, EvictionReport, EvictionTarget, FreeSpaceProbe, ResidentLog, ResidentPart, evict_to_target};
 pub use ssd_reclaim::{PartRemover, PartStatusAge, ReclaimError, ReclaimGraces, ReclaimLog, ReclaimReport, reclaim_ssd};
 pub use state::{CephCeiling, PressureZone, ReplicationState};
 pub use units::{ByteRate, Bytes, DiskPressure};

--- a/crates/hippius-drain-core/src/lib.rs
+++ b/crates/hippius-drain-core/src/lib.rs
@@ -42,7 +42,7 @@ pub use partdrain::{
     breaker_signal_for, drain_part,
 };
 pub use reconcile::{DiscoveredPart, PartLandingLog, PartScan, PartStatus, ReconcileError, ReconcileReport, reconcile_parts};
-pub use snapshot::{AgentSnapshot, SnapshotCell};
+pub use snapshot::{AgentSnapshot, ScanWorker, SnapshotCell};
 pub use ssd_evict::{EvictionError, EvictionPass, EvictionReport, EvictionTarget, FreeSpaceProbe, ResidentLog, ResidentPart, evict_to_target};
 pub use ssd_reclaim::{
     FailedReclaimReport, PartRemover, PartStatusAge, ReclaimError, ReclaimGraces, ReclaimLog, ReclaimReport, reclaim_failed, reclaim_ssd,

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -89,6 +89,15 @@ pub struct AgentSnapshot {
     pub deferred: u64,
     /// Chunks the reconciler recovered after a dropped `chunk_landed` trigger.
     pub reconciler_recovered: u64,
+    /// Parts recorded from the api's landed-part announcements — the fast discovery path.
+    /// Read together with `reconciler_recovered`: this climbing while that stays near zero is
+    /// what says the announcement path is carrying discovery. Both near zero means ingest
+    /// stopped, not that the fast path is working.
+    pub landed_recorded: u64,
+    /// Announcements dropped as unparseable. Must stay at zero; nonzero means the api and the
+    /// agent disagree about the wire contract, in which case every message is being lost and
+    /// discovery has silently fallen back to the reconciler's walk.
+    pub landed_dropped: u64,
     /// `failed` (broken/abandoned-upload) SSD parts the reclaim worker unlinked — the
     /// SSD-ingest tier's eviction throughput, distinct from the drain's `CephFS` work.
     pub reclaimed: u64,
@@ -158,6 +167,8 @@ pub struct SnapshotCell {
     failed: AtomicU64,
     deferred: AtomicU64,
     reconciler_recovered: AtomicU64,
+    landed_recorded: AtomicU64,
+    landed_dropped: AtomicU64,
     reclaimed: AtomicU64,
     /// Resident parts the read-tier evictor unlinked, and the bytes they freed. Separate from
     /// `reclaimed` (debris the reclaim worker removed) because the two answer different
@@ -251,6 +262,12 @@ impl SnapshotCell {
     /// Adds `n` to the reconciler-recovered total.
     pub fn record_reconciled(&self, n: u64) {
         self.reconciler_recovered.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Records one landed-announcement batch: `recorded` parts written, `dropped` unparseable.
+    pub fn record_landed(&self, recorded: u64, dropped: u64) {
+        self.landed_recorded.fetch_add(recorded, Ordering::Relaxed);
+        self.landed_dropped.fetch_add(dropped, Ordering::Relaxed);
     }
 
     /// Adds `n` to the SSD-reclaim total (terminal parts the reclaim worker unlinked).
@@ -448,6 +465,8 @@ impl SnapshotCell {
             failed: self.failed.load(Ordering::Relaxed),
             deferred: self.deferred.load(Ordering::Relaxed),
             reconciler_recovered: self.reconciler_recovered.load(Ordering::Relaxed),
+            landed_recorded: self.landed_recorded.load(Ordering::Relaxed),
+            landed_dropped: self.landed_dropped.load(Ordering::Relaxed),
             reclaimed: self.reclaimed.load(Ordering::Relaxed),
             reclaim_backing_errors: self.reclaim_backing_errors.load(Ordering::Relaxed),
             throttled: self.throttled.load(Ordering::Relaxed),
@@ -606,6 +625,8 @@ mod tests {
                 failed: 1,
                 deferred: 0,
                 reconciler_recovered: 4,
+                landed_recorded: 0,
+                landed_dropped: 0,
                 reclaimed: 6,
                 reclaim_backing_errors: 0,
                 throttled: 9,
@@ -672,6 +693,8 @@ mod tests {
             failed: u64::MAX,
             deferred: 0,
             reconciler_recovered: 0,
+            landed_recorded: 0,
+            landed_dropped: 0,
             reclaimed: 0,
             reclaim_backing_errors: 0,
             throttled: 0,
@@ -688,6 +711,8 @@ mod tests {
             failed: 3,
             deferred: 0,
             reconciler_recovered: 0,
+            landed_recorded: 0,
+            landed_dropped: 0,
             reclaimed: 0,
             reclaim_backing_errors: 0,
             throttled: 0,

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -68,6 +68,29 @@ impl LatencyWindow {
     }
 }
 
+/// Which worker performed an SSD walk.
+///
+/// A closed enum, not a string: it becomes a metric label, and two values fixed in code cannot
+/// become a cardinality problem the way a caller-supplied name could.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScanWorker {
+    /// The reconciler — the discovery walk, on the short poll.
+    Reconcile,
+    /// The reclaim worker — the debris walk, on the long poll.
+    Reclaim,
+}
+
+impl ScanWorker {
+    /// The metric label for this worker.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Reconcile => "reconcile",
+            Self::Reclaim => "reclaim",
+        }
+    }
+}
+
 /// A point-in-time view of the agent's drain activity, for metrics.
 ///
 /// Plain monotonic counters the runtime accumulates; the observability layer
@@ -89,16 +112,25 @@ pub struct AgentSnapshot {
     pub deferred: u64,
     /// Chunks the reconciler recovered after a dropped `chunk_landed` trigger.
     pub reconciler_recovered: u64,
-    /// Parts visited by the SSD walks (reconciler + reclaimer), summed across passes.
+    /// Parts visited by the RECONCILER's walk, summed across passes.
     ///
     /// The signal that F1 has returned. The walks are O(everything on disk), and retention took
     /// that from "the undrained backlog" to "this node's entire replicated shard" — 2.28 M parts
-    /// on prod — without anything reporting the change. A rate derived from this against the
-    /// poll interval is the walk's real cost per second.
-    pub scan_parts_total: u64,
-    /// How long the last SSD walk took, in milliseconds. Watched against the poll interval: a
-    /// scan that approaches its own period means the worker is walking continuously.
-    pub scan_duration_ms: u64,
+    /// on prod — without anything reporting the change.
+    ///
+    /// Split per worker rather than summed, because the two answer different questions and run
+    /// on cadences three orders of magnitude apart. A merged counter is readable only while the
+    /// reconciler's short poll dominates it — and lengthening that poll is precisely the
+    /// follow-up this metric exists to gate, after which a merged total could not say which
+    /// walk any residual cost belonged to.
+    pub reconcile_scan_parts: u64,
+    /// How long the reconciler's last walk took, in milliseconds. Watched against ITS poll
+    /// interval: a scan approaching its own period means the worker never stops walking.
+    pub reconcile_scan_ms: u64,
+    /// Parts visited by the RECLAIMER's walk, summed across passes.
+    pub reclaim_scan_parts: u64,
+    /// How long the reclaimer's last walk took, in milliseconds.
+    pub reclaim_scan_ms: u64,
     /// Parts recorded from the api's landed-part announcements — the fast discovery path.
     /// Read together with `reconciler_recovered`: this climbing while that stays near zero is
     /// what says the announcement path is carrying discovery. Both near zero means ingest
@@ -177,8 +209,10 @@ pub struct SnapshotCell {
     failed: AtomicU64,
     deferred: AtomicU64,
     reconciler_recovered: AtomicU64,
-    scan_parts_total: AtomicU64,
-    scan_duration_ms: AtomicU64,
+    reconcile_scan_parts: AtomicU64,
+    reconcile_scan_ms: AtomicU64,
+    reclaim_scan_parts: AtomicU64,
+    reclaim_scan_ms: AtomicU64,
     landed_recorded: AtomicU64,
     landed_dropped: AtomicU64,
     reclaimed: AtomicU64,
@@ -276,15 +310,22 @@ impl SnapshotCell {
         self.reconciler_recovered.fetch_add(n, Ordering::Relaxed);
     }
 
-    /// Records one SSD walk: how many parts it visited and how long it took.
+    /// Records one SSD walk against the worker that performed it.
     ///
-    /// Called by every worker that walks the cache, so the counter is the fleet's total walk
-    /// cost rather than any one worker's. Both halves matter: the count says how big the tree
-    /// got, the duration says whether the walk still fits inside its own poll interval.
-    pub fn record_scan(&self, parts: u64, duration: Duration) {
-        self.scan_parts_total.fetch_add(parts, Ordering::Relaxed);
-        self.scan_duration_ms
-            .store(u64::try_from(duration.as_millis()).unwrap_or(u64::MAX), Ordering::Relaxed);
+    /// Attributed rather than summed: the two walkers run on cadences three orders of magnitude
+    /// apart, and the point of the announcement path is to lengthen the reconciler's poll — at
+    /// which point a merged counter could no longer say which walk any residual cost was.
+    ///
+    /// Both halves matter per worker: the count says how big the tree got, the duration says
+    /// whether that worker's walk still fits inside its own poll interval.
+    pub fn record_scan(&self, worker: ScanWorker, parts: u64, duration: Duration) {
+        let millis = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+        let (count, last) = match worker {
+            ScanWorker::Reconcile => (&self.reconcile_scan_parts, &self.reconcile_scan_ms),
+            ScanWorker::Reclaim => (&self.reclaim_scan_parts, &self.reclaim_scan_ms),
+        };
+        count.fetch_add(parts, Ordering::Relaxed);
+        last.store(millis, Ordering::Relaxed);
     }
 
     /// Records one landed-announcement batch: `recorded` parts written, `dropped` unparseable.
@@ -488,8 +529,10 @@ impl SnapshotCell {
             failed: self.failed.load(Ordering::Relaxed),
             deferred: self.deferred.load(Ordering::Relaxed),
             reconciler_recovered: self.reconciler_recovered.load(Ordering::Relaxed),
-            scan_parts_total: self.scan_parts_total.load(Ordering::Relaxed),
-            scan_duration_ms: self.scan_duration_ms.load(Ordering::Relaxed),
+            reconcile_scan_parts: self.reconcile_scan_parts.load(Ordering::Relaxed),
+            reconcile_scan_ms: self.reconcile_scan_ms.load(Ordering::Relaxed),
+            reclaim_scan_parts: self.reclaim_scan_parts.load(Ordering::Relaxed),
+            reclaim_scan_ms: self.reclaim_scan_ms.load(Ordering::Relaxed),
             landed_recorded: self.landed_recorded.load(Ordering::Relaxed),
             landed_dropped: self.landed_dropped.load(Ordering::Relaxed),
             reclaimed: self.reclaimed.load(Ordering::Relaxed),
@@ -504,7 +547,7 @@ impl SnapshotCell {
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::{AgentSnapshot, SnapshotCell};
+    use super::{AgentSnapshot, ScanWorker, SnapshotCell};
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -650,8 +693,10 @@ mod tests {
                 failed: 1,
                 deferred: 0,
                 reconciler_recovered: 4,
-                scan_parts_total: 0,
-                scan_duration_ms: 0,
+                reconcile_scan_parts: 0,
+                reconcile_scan_ms: 0,
+                reclaim_scan_parts: 0,
+                reclaim_scan_ms: 0,
                 landed_recorded: 0,
                 landed_dropped: 0,
                 reclaimed: 6,
@@ -670,12 +715,17 @@ mod tests {
         // NOT summed: it is compared against one poll interval to answer "is this worker walking
         // continuously", and a running total could not answer that.
         let cell = SnapshotCell::new();
-        cell.record_scan(2_000_000, Duration::from_millis(400));
-        cell.record_scan(280_000, Duration::from_millis(90));
+        cell.record_scan(ScanWorker::Reconcile, 2_000_000, Duration::from_millis(400));
+        cell.record_scan(ScanWorker::Reconcile, 280_000, Duration::from_millis(90));
+        cell.record_scan(ScanWorker::Reclaim, 5_000, Duration::from_millis(7));
 
         let snap = cell.load();
-        assert_eq!(snap.scan_parts_total, 2_280_000, "walk cost accumulates");
-        assert_eq!(snap.scan_duration_ms, 90, "the duration is the most recent walk, not a sum");
+        assert_eq!(snap.reconcile_scan_parts, 2_280_000, "walk cost accumulates per worker");
+        assert_eq!(snap.reconcile_scan_ms, 90, "the duration is that worker's most recent walk, not a sum");
+        // Attribution is the point: the reclaimer's cheap hourly walk must not be buried in the
+        // reconciler's total, or lengthening the reconcile poll leaves the residual unexplained.
+        assert_eq!(snap.reclaim_scan_parts, 5_000);
+        assert_eq!(snap.reclaim_scan_ms, 7);
     }
 
     #[test]
@@ -749,8 +799,10 @@ mod tests {
             failed: u64::MAX,
             deferred: 0,
             reconciler_recovered: 0,
-            scan_parts_total: 0,
-            scan_duration_ms: 0,
+            reconcile_scan_parts: 0,
+            reconcile_scan_ms: 0,
+            reclaim_scan_parts: 0,
+            reclaim_scan_ms: 0,
             landed_recorded: 0,
             landed_dropped: 0,
             reclaimed: 0,
@@ -769,8 +821,10 @@ mod tests {
             failed: 3,
             deferred: 0,
             reconciler_recovered: 0,
-            scan_parts_total: 0,
-            scan_duration_ms: 0,
+            reconcile_scan_parts: 0,
+            reconcile_scan_ms: 0,
+            reclaim_scan_parts: 0,
+            reclaim_scan_ms: 0,
             landed_recorded: 0,
             landed_dropped: 0,
             reclaimed: 0,

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -89,6 +89,16 @@ pub struct AgentSnapshot {
     pub deferred: u64,
     /// Chunks the reconciler recovered after a dropped `chunk_landed` trigger.
     pub reconciler_recovered: u64,
+    /// Parts visited by the SSD walks (reconciler + reclaimer), summed across passes.
+    ///
+    /// The signal that F1 has returned. The walks are O(everything on disk), and retention took
+    /// that from "the undrained backlog" to "this node's entire replicated shard" — 2.28 M parts
+    /// on prod — without anything reporting the change. A rate derived from this against the
+    /// poll interval is the walk's real cost per second.
+    pub scan_parts_total: u64,
+    /// How long the last SSD walk took, in milliseconds. Watched against the poll interval: a
+    /// scan that approaches its own period means the worker is walking continuously.
+    pub scan_duration_ms: u64,
     /// Parts recorded from the api's landed-part announcements — the fast discovery path.
     /// Read together with `reconciler_recovered`: this climbing while that stays near zero is
     /// what says the announcement path is carrying discovery. Both near zero means ingest
@@ -167,6 +177,8 @@ pub struct SnapshotCell {
     failed: AtomicU64,
     deferred: AtomicU64,
     reconciler_recovered: AtomicU64,
+    scan_parts_total: AtomicU64,
+    scan_duration_ms: AtomicU64,
     landed_recorded: AtomicU64,
     landed_dropped: AtomicU64,
     reclaimed: AtomicU64,
@@ -262,6 +274,17 @@ impl SnapshotCell {
     /// Adds `n` to the reconciler-recovered total.
     pub fn record_reconciled(&self, n: u64) {
         self.reconciler_recovered.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Records one SSD walk: how many parts it visited and how long it took.
+    ///
+    /// Called by every worker that walks the cache, so the counter is the fleet's total walk
+    /// cost rather than any one worker's. Both halves matter: the count says how big the tree
+    /// got, the duration says whether the walk still fits inside its own poll interval.
+    pub fn record_scan(&self, parts: u64, duration: Duration) {
+        self.scan_parts_total.fetch_add(parts, Ordering::Relaxed);
+        self.scan_duration_ms
+            .store(u64::try_from(duration.as_millis()).unwrap_or(u64::MAX), Ordering::Relaxed);
     }
 
     /// Records one landed-announcement batch: `recorded` parts written, `dropped` unparseable.
@@ -465,6 +488,8 @@ impl SnapshotCell {
             failed: self.failed.load(Ordering::Relaxed),
             deferred: self.deferred.load(Ordering::Relaxed),
             reconciler_recovered: self.reconciler_recovered.load(Ordering::Relaxed),
+            scan_parts_total: self.scan_parts_total.load(Ordering::Relaxed),
+            scan_duration_ms: self.scan_duration_ms.load(Ordering::Relaxed),
             landed_recorded: self.landed_recorded.load(Ordering::Relaxed),
             landed_dropped: self.landed_dropped.load(Ordering::Relaxed),
             reclaimed: self.reclaimed.load(Ordering::Relaxed),
@@ -625,6 +650,8 @@ mod tests {
                 failed: 1,
                 deferred: 0,
                 reconciler_recovered: 4,
+                scan_parts_total: 0,
+                scan_duration_ms: 0,
                 landed_recorded: 0,
                 landed_dropped: 0,
                 reclaimed: 6,
@@ -634,6 +661,35 @@ mod tests {
                 written_off_servable: 0,
             },
         );
+    }
+
+    #[test]
+    fn scan_parts_accumulate_across_walks_while_the_duration_is_the_latest() {
+        // Both SSD walkers record here, so the count must be a fleet total across passes — that
+        // is what a rate against the poll interval is derived from. The duration is deliberately
+        // NOT summed: it is compared against one poll interval to answer "is this worker walking
+        // continuously", and a running total could not answer that.
+        let cell = SnapshotCell::new();
+        cell.record_scan(2_000_000, Duration::from_millis(400));
+        cell.record_scan(280_000, Duration::from_millis(90));
+
+        let snap = cell.load();
+        assert_eq!(snap.scan_parts_total, 2_280_000, "walk cost accumulates");
+        assert_eq!(snap.scan_duration_ms, 90, "the duration is the most recent walk, not a sum");
+    }
+
+    #[test]
+    fn landed_records_split_recorded_from_dropped() {
+        // The pair that says which discovery path is carrying the work. `dropped` must stay at
+        // zero: nonzero means the api and the agent disagree about the message shape, so every
+        // announcement is discarded and discovery has silently reverted to the walk.
+        let cell = SnapshotCell::new();
+        cell.record_landed(7, 0);
+        cell.record_landed(3, 2);
+
+        let snap = cell.load();
+        assert_eq!(snap.landed_recorded, 10);
+        assert_eq!(snap.landed_dropped, 2);
     }
 
     #[test]
@@ -693,6 +749,8 @@ mod tests {
             failed: u64::MAX,
             deferred: 0,
             reconciler_recovered: 0,
+            scan_parts_total: 0,
+            scan_duration_ms: 0,
             landed_recorded: 0,
             landed_dropped: 0,
             reclaimed: 0,
@@ -711,6 +769,8 @@ mod tests {
             failed: 3,
             deferred: 0,
             reconciler_recovered: 0,
+            scan_parts_total: 0,
+            scan_duration_ms: 0,
             landed_recorded: 0,
             landed_dropped: 0,
             reclaimed: 0,

--- a/crates/hippius-drain-core/src/ssd_evict.rs
+++ b/crates/hippius-drain-core/src/ssd_evict.rs
@@ -48,6 +48,7 @@
 //! in-memory fakes in tests while the `tokio`/Postgres impls live at the edges.
 
 use crate::apipart::PartKey;
+use crate::clock::Clock;
 use crate::ssd_reclaim::PartRemover;
 use crate::state::ReplicationState;
 use core::future::Future;
@@ -100,16 +101,61 @@ impl EvictionTarget {
 pub struct EvictionReport {
     /// Parts unlinked from the SSD.
     pub evicted: u64,
-    /// Accounted bytes freed (the sum of the evicted parts' `bytes`).
+    /// Accounted bytes freed (the sum of the evicted parts' `bytes`). Reporting only — the
+    /// pass decides when to stop from re-probed free space, not from this, because a part
+    /// whose size was unknown at residency time contributes zero here while still freeing
+    /// real disk.
     pub freed_bytes: u64,
+    /// Worklist queries issued. A pass that closes a large deficit necessarily pages, so this
+    /// separates "one page was enough" from "we walked the cursor".
+    pub pages: u32,
     /// Worklist entries refused because their state was not `replicated`. **Must stay zero** —
     /// see the module doc. A non-zero value means the worklist query no longer agrees with
     /// the eviction invariant, and is alert-worthy, not log-worthy.
     pub skipped_unreplicated: u64,
-    /// True when the pass ran out of evictable parts before reaching its deficit — the disk
-    /// is filling with something eviction cannot reclaim (backlog, debris, or another
-    /// writer). Distinguishes "nothing to do" from "could not do enough".
+    /// True only when the pass ran out of EVICTABLE PARTS before reaching its deficit — the
+    /// disk is filling with something eviction cannot reclaim (backlog, debris, or a foreign
+    /// writer). Not self-correcting, so it is the alertable condition.
+    ///
+    /// Deliberately NOT set when the pass merely hit its time budget with work still queued:
+    /// that is [`budget_exhausted`](Self::budget_exhausted), which the next tick resumes. The
+    /// two were conflated before — one page was the whole pass, so any deficit larger than a
+    /// page reported `starved` and logged at ERROR during entirely normal catch-up, which
+    /// discredits the signal exactly when it starts mattering.
     pub starved: bool,
+    /// True when the pass stopped on its wall-clock budget with the deficit unmet and parts
+    /// still available. Expected and self-correcting: the next tick picks up where this left
+    /// off. INFO, never ERROR.
+    pub budget_exhausted: bool,
+}
+
+/// Bounds on ONE eviction pass.
+///
+/// `page` is the size of a single worklist query, **not** the pass budget. Those were the same
+/// thing before, and prod's part-size distribution is why that failed: measured p50 is 686 bytes
+/// against a 408 KB shard mean, so a fixed part count is almost uncorrelated with bytes freed —
+/// a page walking the small-part tail frees ~350 KB against a ~175 GB deficit. Progress is
+/// measured in bytes and bounded by time; the page is just how much is fetched per round-trip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EvictionPass {
+    /// Rows fetched per worklist query.
+    pub page: u32,
+    /// Wall-clock ceiling for the whole pass, so one pass cannot monopolise the disk the drain
+    /// is also writing to. The remainder carries to the next tick.
+    pub max_duration: core::time::Duration,
+}
+
+/// Reads free space on the ingest SSD, so a long pass converges on reality instead of on the
+/// single `statvfs` it started with.
+///
+/// A seam rather than a direct syscall for the same reason as the other two: the orchestrator
+/// stays I/O-free and the paging logic is driven by scripted values in tests.
+pub trait FreeSpaceProbe: Send + Sync {
+    /// Probe failure, which is non-fatal — see [`evict_to_target`].
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Bytes free to an unprivileged writer right now.
+    fn free_bytes(&self) -> impl Future<Output = Result<u64, Self::Error>> + Send;
 }
 
 /// An eviction failure.
@@ -162,78 +208,168 @@ pub trait ResidentLog: Send + Sync {
     fn mark_evicted(&self, parts: &[PartKey]) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
-/// Frees SSD space by evicting the oldest resident parts until `target`'s deficit is met.
+/// Frees SSD space by evicting oldest-resident parts, **paging until the byte deficit is met**.
 ///
 /// A no-op when free space is at or above `target.reserve` — the common case, and it costs
-/// nothing: the worklist is not even queried. Once armed, walks the store's oldest-first
-/// cursor, unlinking each `replicated` part and stamping `evicted_at`, and stops as soon as
-/// enough accounted bytes are freed.
+/// nothing: the worklist is not even queried. Once armed, it repeatedly fetches a page of the
+/// store's oldest-first cursor, unlinks each `replicated` part, stamps them evicted, and
+/// re-probes free space before deciding whether to continue.
 ///
-/// Order of operations per part is **unlink, then mark** — deliberately, because the two
-/// crash windows are not equally bad. Unlink-then-crash leaves a row that reads resident with
-/// no SSD copy: the next pass hands it back, the idempotent unlink succeeds on an already
-/// absent dir, and it is marked then. Mark-then-crash would leave a part on disk that no
-/// worklist will ever return again — a permanent leak that only a full walk could find, which
-/// is exactly the scan this design avoids.
+/// # Why it pages rather than taking one batch
+///
+/// The armed deficit is `reserve + headroom - free`, i.e. the headroom is a fixed share of the
+/// whole disk: ~175 GB on prod's 3.5 TB ingest `NVMe`. One 512-part page frees ~209 MB at the
+/// measured 408 KB shard mean — and as little as ~350 KB if it walks the small-part tail, since
+/// measured p50 is 686 bytes. A single-page pass therefore could not close a deficit in any
+/// realistic time, and reported `starved` while doing so.
+///
+/// # Termination
+///
+/// Three exits, each reported distinctly because they need different responses:
+///
+/// - **Deficit met** — the pass succeeded. Neither flag set.
+/// - **Short page** — the worklist is exhausted. Sets [`starved`](EvictionReport::starved) if a
+///   deficit remains: nothing evictable is left and no amount of retrying helps. Alertable.
+/// - **Time budget** — sets [`budget_exhausted`](EvictionReport::budget_exhausted). Work
+///   remains and the next tick resumes it. Routine.
+///
+/// A full page that yields no eviction at all (every entry refused by the invariant) also stops
+/// the pass as starved, because continuing would re-fetch the same rows forever.
+///
+/// # Order of operations
+///
+/// Per page: **unlink, then mark** — deliberately, because the two crash windows are not equally
+/// bad. Unlink-then-crash leaves a row that reads resident with no SSD copy: the next pass hands
+/// it back, the idempotent unlink succeeds on an already-absent dir, and it is marked then.
+/// Mark-then-crash would leave a part on disk that no worklist will ever return again — a
+/// permanent leak that only a full walk could find, which is exactly the scan this design avoids.
+/// Marking also *must* precede the next query, or the cursor returns the same page forever.
+///
+/// A failing free-space probe is **not** fatal: the pass falls back to advancing its own estimate
+/// by the accounted bytes it freed. Losing the probe should cost accuracy, not the eviction that
+/// is keeping ingest alive.
 ///
 /// # Errors
 ///
 /// - [`EvictionError::Log`] if reading the worklist fails (nothing is removed).
 /// - [`EvictionError::Remove`] if unlinking fails.
 /// - [`EvictionError::Mark`] if recording the evictions fails after unlinking.
-pub async fn evict_to_target<L, R>(log: &L, remover: &R, target: EvictionTarget, batch: u32) -> Result<EvictionReport, EvictionError>
+pub async fn evict_to_target<L, R, P>(
+    log: &L,
+    remover: &R,
+    probe: &P,
+    clock: &dyn Clock,
+    target: EvictionTarget,
+    pass: EvictionPass,
+) -> Result<EvictionReport, EvictionError>
 where
     L: ResidentLog,
     R: PartRemover,
+    P: FreeSpaceProbe,
 {
     let mut report = EvictionReport::default();
-    let deficit = target.deficit();
-    if deficit == 0 {
+    let mut target = target;
+    if target.deficit() == 0 {
         return Ok(report);
     }
+    // Fixed ONCE, at arm time, and deliberately not re-derived from `deficit()` per page.
+    // `deficit()` reports zero as soon as `free >= reserve`, so a loop that re-tested it would
+    // stop at the floor and never reach `reserve + headroom` — silently discarding the headroom
+    // and re-arming the evictor on nearly every poll, which is the hysteresis this whole design
+    // exists to provide. Captured as an absolute free-space goal instead.
+    let goal = target.reserve.saturating_add(target.headroom);
+    let started = clock.now();
+    // A zero page would query forever without making progress; treat it as one row.
+    let page = pass.page.max(1);
 
-    let candidates = log.evictable_parts(batch).await.map_err(EvictionError::log)?;
-    let mut evicted = Vec::with_capacity(candidates.len());
-    for candidate in candidates {
-        if report.freed_bytes >= deficit {
+    loop {
+        if clock.now().duration_since(started) >= pass.max_duration {
+            report.budget_exhausted = true;
             break;
         }
-        // Defense in depth against worklist drift — see the module doc. Skipped, never
-        // deleted, however badly the pass needs the space.
-        if candidate.state != ReplicationState::Replicated {
-            report.skipped_unreplicated += 1;
-            continue;
+
+        let candidates = log.evictable_parts(page).await.map_err(EvictionError::log)?;
+        report.pages = report.pages.saturating_add(1);
+        let returned = candidates.len();
+
+        let mut evicted = Vec::with_capacity(returned);
+        let mut freed_this_page = 0u64;
+        // Projected free space if every unlink so far has freed its accounted bytes. Only used
+        // to stop EARLY within a page — the authoritative value is re-probed below. Without it
+        // the pass evicts in whole pages and can overshoot the goal by up to `page - 1` parts,
+        // which at prod's 14 GB maximum part size is a lot of cache given away for nothing.
+        let mut projected = target.free;
+        for candidate in candidates {
+            if projected >= goal {
+                break;
+            }
+            // Defense in depth against worklist drift — see the module doc. Skipped, never
+            // deleted, however badly the pass needs the space.
+            if candidate.state != ReplicationState::Replicated {
+                report.skipped_unreplicated += 1;
+                continue;
+            }
+            projected = projected.saturating_add(candidate.bytes);
+            remover.unlink_part(&candidate.part).await.map_err(EvictionError::Remove)?;
+            report.evicted += 1;
+            freed_this_page = freed_this_page.saturating_add(candidate.bytes);
+            evicted.push(candidate.part);
         }
-        remover.unlink_part(&candidate.part).await.map_err(EvictionError::Remove)?;
-        report.evicted += 1;
-        report.freed_bytes = report.freed_bytes.saturating_add(candidate.bytes);
-        evicted.push(candidate.part);
+        report.freed_bytes = report.freed_bytes.saturating_add(freed_this_page);
+
+        if !evicted.is_empty() {
+            log.mark_evicted(&evicted).await.map_err(EvictionError::mark)?;
+        }
+
+        // Re-probe rather than trusting the accounted sum: `bytes` is denormalized at residency
+        // time and a part whose size was unknown records zero, so accounting alone can report
+        // "freed nothing" while real space was reclaimed — and would spin the loop.
+        target.free = match probe.free_bytes().await {
+            Ok(free) => free,
+            Err(_) => target.free.saturating_add(freed_this_page),
+        };
+
+        if target.free >= goal {
+            break;
+        }
+        if returned < page as usize {
+            // The cursor is exhausted and the floor is still not restored.
+            report.starved = true;
+            break;
+        }
+        if evicted.is_empty() {
+            // A full page that yielded nothing evictable: re-querying returns the same rows.
+            report.starved = true;
+            break;
+        }
     }
 
-    // Marked only after the unlinks land, so a crash mid-pass leaves rows that read resident
-    // with no SSD copy — replayed harmlessly by the next pass's idempotent unlink — rather
-    // than parts on disk that no worklist will ever return again.
-    if !evicted.is_empty() {
-        log.mark_evicted(&evicted).await.map_err(EvictionError::mark)?;
-    }
-    report.starved = report.freed_bytes < deficit;
     Ok(report)
 }
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::{EvictionReport, EvictionTarget, ResidentLog, ResidentPart, evict_to_target};
+    use super::{EvictionPass, EvictionReport, EvictionTarget, FreeSpaceProbe, ResidentLog, ResidentPart, evict_to_target};
     use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
+    use crate::clock::{Clock, TestClock};
     use crate::ssd_reclaim::PartRemover;
     use crate::state::ReplicationState;
     use core::future::Future;
     use core::str::FromStr;
+    use core::time::Duration;
     use std::io;
     use std::sync::Mutex;
 
     const UUID_A: &str = "466916c0-d61b-4518-b81b-9576b574270a";
     const GIB: u64 = 1024 * 1024 * 1024;
+    /// Generous relative to every test's simulated work, so only the test that means to hit the
+    /// budget does.
+    const AMPLE: Duration = Duration::from_hours(1);
+
+    fn pass(page: u32) -> EvictionPass {
+        EvictionPass { page, max_duration: AMPLE }
+    }
 
     fn part_at(version: u32, number: u32) -> PartKey {
         PartKey::new(ObjectId::from_str(UUID_A).unwrap(), Version::new(version), PartNumber::new(number))
@@ -251,11 +387,14 @@ mod tests {
         }
     }
 
-    /// A worklist that hands back a fixed oldest-first list, recording how it was queried.
+    /// A worklist whose cursor actually advances: `mark_evicted` removes rows, exactly as
+    /// `drop_residency`'s DELETE does. Modelling that is the point — a fake that kept handing
+    /// back the same page would hide the bug where the pass forgets to mark before re-querying.
     #[derive(Default)]
     struct FakeLog {
-        parts: Vec<ResidentPart>,
+        parts: Mutex<Vec<ResidentPart>>,
         marked: Mutex<Vec<String>>,
+        served: Mutex<Vec<String>>,
         queries: Mutex<u32>,
         fail: bool,
     }
@@ -263,13 +402,17 @@ mod tests {
     impl FakeLog {
         fn of(parts: &[ResidentPart]) -> Self {
             Self {
-                parts: parts.to_vec(),
+                parts: Mutex::new(parts.to_vec()),
                 ..Self::default()
             }
         }
 
         fn marked(&self) -> Vec<String> {
             self.marked.lock().unwrap().clone()
+        }
+
+        fn served(&self) -> Vec<String> {
+            self.served.lock().unwrap().clone()
         }
 
         fn queries(&self) -> u32 {
@@ -285,7 +428,9 @@ mod tests {
                 Err(io::Error::other("worklist read failed"))
             } else {
                 *self.queries.lock().unwrap() += 1;
-                Ok(self.parts.iter().take(limit as usize).cloned().collect())
+                let page: Vec<ResidentPart> = self.parts.lock().unwrap().iter().take(limit as usize).cloned().collect();
+                self.served.lock().unwrap().extend(page.iter().map(|p| key(&p.part)));
+                Ok(page)
             };
             async move { outcome }
         }
@@ -294,7 +439,9 @@ mod tests {
             let outcome = if self.fail {
                 Err(io::Error::other("mark failed"))
             } else {
-                self.marked.lock().unwrap().extend(parts.iter().map(key));
+                let gone: Vec<String> = parts.iter().map(key).collect();
+                self.parts.lock().unwrap().retain(|p| !gone.contains(&key(&p.part)));
+                self.marked.lock().unwrap().extend(gone);
                 Ok(())
             };
             async move { outcome }
@@ -319,19 +466,78 @@ mod tests {
         }
     }
 
+    /// Reports free space as "whatever it started at, plus everything unlinked so far" — the
+    /// behaviour a real disk has, so the loop's stop condition is exercised for real rather than
+    /// against a constant.
+    struct FakeProbe {
+        free: Mutex<u64>,
+        per_part: u64,
+        fail: bool,
+    }
+
+    impl FakeProbe {
+        fn new(free: u64, per_part: u64) -> Self {
+            Self {
+                free: Mutex::new(free),
+                per_part,
+                fail: false,
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                free: Mutex::new(0),
+                per_part: 0,
+                fail: true,
+            }
+        }
+    }
+
+    impl FreeSpaceProbe for FakeProbe {
+        type Error = io::Error;
+
+        fn free_bytes(&self) -> impl Future<Output = Result<u64, io::Error>> + Send {
+            let outcome = if self.fail {
+                Err(io::Error::other("statvfs failed"))
+            } else {
+                Ok(*self.free.lock().unwrap())
+            };
+            async move { outcome }
+        }
+    }
+
+    /// A probe driven by the remover: every unlink credits `per_part` bytes of free space.
+    struct CountingProbe<'a> {
+        probe: &'a FakeProbe,
+        remover: &'a FakeRemover,
+    }
+
+    impl FreeSpaceProbe for CountingProbe<'_> {
+        type Error = io::Error;
+
+        fn free_bytes(&self) -> impl Future<Output = Result<u64, io::Error>> + Send {
+            let removed = self.remover.removed().len() as u64;
+            let base = *self.probe.free.lock().unwrap();
+            let free = base + removed * self.probe.per_part;
+            async move { Ok(free) }
+        }
+    }
+
     #[tokio::test]
     async fn a_disk_above_the_reserve_evicts_nothing_and_never_queries_the_worklist() {
         // The steady state, and it must be free: with headroom to spare there is no reason to
         // give up cached parts, and no reason to pay for the worklist query either.
         let log = FakeLog::of(&[resident(1, GIB)]);
         let remover = FakeRemover::default();
+        let probe = FakeProbe::new(500 * GIB, 0);
+        let clock = TestClock::new();
         let target = EvictionTarget {
             free: 500 * GIB,
             reserve: 350 * GIB,
             headroom: 50 * GIB,
         };
 
-        let report = evict_to_target(&log, &remover, target, 128).await.unwrap();
+        let report = evict_to_target(&log, &remover, &probe, &clock, target, pass(128)).await.unwrap();
 
         assert_eq!(report, EvictionReport::default());
         assert!(remover.removed().is_empty(), "nothing is evicted above the reserve");
@@ -339,75 +545,211 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_disk_below_the_reserve_evicts_oldest_first_up_to_the_headroom() {
-        // Armed: free (300 GiB) is under the reserve (350 GiB), so the pass must free down to
-        // reserve + headroom = 400 GiB, i.e. a 100 GiB deficit. The worklist is oldest-first,
-        // so it takes the first two 60 GiB parts (120 GiB >= 100 GiB) and stops — it must NOT
-        // drain the whole cache just because more was on offer.
-        let log = FakeLog::of(&[resident(1, 60 * GIB), resident(2, 60 * GIB), resident(3, 60 * GIB)]);
+    async fn a_deficit_larger_than_one_page_is_still_fully_closed() {
+        // THE Phase B regression test, and it fails on the pre-fix single-page implementation.
+        //
+        // Prod shape in miniature: the deficit needs 20 parts but a page returns 4. The old code
+        // took ONE page, freed a fifth of what was needed, and reported `starved` at ERROR — for
+        // the ~7 hours a real 175 GB deficit takes at 512 parts per 30 s. Paging must close it,
+        // and `starved` must stay false, because nothing here is wrong.
+        let parts: Vec<ResidentPart> = (1..=40).map(|v| resident(v, GIB)).collect();
+        let log = FakeLog::of(&parts);
         let remover = FakeRemover::default();
+        let probe = FakeProbe::new(300 * GIB, GIB);
+        let counting = CountingProbe {
+            probe: &probe,
+            remover: &remover,
+        };
+        let clock = TestClock::new();
         let target = EvictionTarget {
             free: 300 * GIB,
-            reserve: 350 * GIB,
-            headroom: 50 * GIB,
+            reserve: 310 * GIB,
+            headroom: 10 * GIB,
         };
+        assert_eq!(target.deficit(), 20 * GIB, "20 parts' worth of deficit");
 
-        let report = evict_to_target(&log, &remover, target, 128).await.unwrap();
+        let report = evict_to_target(&log, &remover, &counting, &clock, target, pass(4)).await.unwrap();
 
-        assert_eq!(report.evicted, 2, "only as many parts as the deficit needs");
-        assert_eq!(report.freed_bytes, 120 * GIB);
-        assert!(!report.starved);
-        assert_eq!(
-            remover.removed(),
-            vec![key(&part_at(1, 1)), key(&part_at(2, 1))],
-            "oldest-resident first, in worklist order"
-        );
-        assert_eq!(remover.removed(), log.marked(), "every unlinked part is recorded evicted");
+        assert_eq!(report.evicted, 20, "paged until the deficit was met");
+        assert!(report.pages >= 5, "more than one query: {} pages", report.pages);
+        assert!(!report.starved, "a deficit larger than a page is not starvation");
+        assert!(!report.budget_exhausted);
     }
 
     #[tokio::test]
-    async fn an_unreplicated_part_on_the_worklist_is_never_unlinked() {
-        // THE invariant. A pending/draining part's SSD copy is the only durable copy, and a
-        // failed/corrupt one may be a live object's last good source. If the worklist query
-        // ever drifts and offers one, this must refuse it and say so loudly — never delete it
-        // to satisfy a deficit.
-        let mut pending = resident(1, 60 * GIB);
-        pending.state = ReplicationState::Pending;
-        let mut corrupt = resident(2, 60 * GIB);
-        corrupt.state = ReplicationState::Corrupt;
-        let log = FakeLog::of(&[pending, corrupt, resident(3, 60 * GIB)]);
+    async fn each_page_is_disjoint_because_marking_precedes_the_next_query() {
+        // If the pass re-queried before marking, the cursor would return the same rows forever:
+        // it would unlink the same parts repeatedly, count them repeatedly, and never terminate.
+        // Serving every part exactly once is the observable form of "mark, then re-query".
+        let parts: Vec<ResidentPart> = (1..=12).map(|v| resident(v, GIB)).collect();
+        let log = FakeLog::of(&parts);
         let remover = FakeRemover::default();
+        let probe = FakeProbe::new(300 * GIB, GIB);
+        let counting = CountingProbe {
+            probe: &probe,
+            remover: &remover,
+        };
+        let clock = TestClock::new();
         let target = EvictionTarget {
             free: 300 * GIB,
-            reserve: 350 * GIB,
-            headroom: 50 * GIB,
+            reserve: 305 * GIB,
+            headroom: 5 * GIB,
         };
 
-        let report = evict_to_target(&log, &remover, target, 128).await.unwrap();
+        let report = evict_to_target(&log, &remover, &counting, &clock, target, pass(3)).await.unwrap();
+
+        let served = log.served();
+        let mut unique = served.clone();
+        unique.sort();
+        unique.dedup();
+        assert_eq!(served.len(), unique.len(), "a part was served twice: {served:?}");
+        assert_eq!(remover.removed(), log.marked(), "every unlinked part is recorded evicted");
+        // Exactly the 10 GiB the goal needs, NOT the 12 a whole-page pass would give away: the
+        // page is the query size, never the eviction quantum.
+        assert_eq!(report.evicted, 10, "no over-eviction past the goal");
+    }
+
+    #[tokio::test]
+    async fn an_unreplicated_part_is_never_unlinked_on_any_page() {
+        // THE durability invariant, now checked across paging rather than within one batch. A
+        // pending/draining part's SSD copy is the only durable copy, and a failed/corrupt one may
+        // be a live object's last good source. Refused however badly the pass needs the space,
+        // and counted so the divergence is alertable.
+        let mut parts = vec![resident(1, GIB), resident(2, GIB)];
+        let mut pending = resident(3, 60 * GIB);
+        pending.state = ReplicationState::Pending;
+        let mut corrupt = resident(4, 60 * GIB);
+        corrupt.state = ReplicationState::Corrupt;
+        parts.push(pending);
+        parts.push(corrupt);
+        parts.extend((5..=8).map(|v| resident(v, GIB)));
+        let log = FakeLog::of(&parts);
+        let remover = FakeRemover::default();
+        let probe = FakeProbe::new(300 * GIB, GIB);
+        let counting = CountingProbe {
+            probe: &probe,
+            remover: &remover,
+        };
+        let clock = TestClock::new();
+        let target = EvictionTarget {
+            free: 300 * GIB,
+            reserve: 320 * GIB,
+            headroom: 5 * GIB,
+        };
+
+        let report = evict_to_target(&log, &remover, &counting, &clock, target, pass(2)).await.unwrap();
 
         assert_eq!(report.skipped_unreplicated, 2, "both non-replicated parts refused");
-        assert_eq!(remover.removed(), vec![key(&part_at(3, 1))], "only the replicated part was unlinked");
+        let removed = remover.removed();
+        assert!(!removed.contains(&key(&part_at(3, 1))), "the pending part was unlinked");
+        assert!(!removed.contains(&key(&part_at(4, 1))), "the corrupt part was unlinked");
     }
 
     #[tokio::test]
     async fn exhausting_the_worklist_before_the_deficit_reports_starved() {
         // The disk is filling with something eviction cannot reclaim — undrained backlog, or
         // debris the reclaimer owns. Evicting everything available is right, but the pass must
-        // report that it could not get there, so the condition is alertable rather than
-        // looking like a quiet success.
+        // report that it could not get there, because this one is NOT self-correcting and is the
+        // condition that ends in 503s on PUT.
         let log = FakeLog::of(&[resident(1, 10 * GIB)]);
         let remover = FakeRemover::default();
+        let probe = FakeProbe::new(10 * GIB, 10 * GIB);
+        let counting = CountingProbe {
+            probe: &probe,
+            remover: &remover,
+        };
+        let clock = TestClock::new();
         let target = EvictionTarget {
             free: 10 * GIB,
             reserve: 350 * GIB,
             headroom: 50 * GIB,
         };
 
-        let report = evict_to_target(&log, &remover, target, 128).await.unwrap();
+        let report = evict_to_target(&log, &remover, &counting, &clock, target, pass(128)).await.unwrap();
 
         assert_eq!(report.evicted, 1);
-        assert_eq!(report.freed_bytes, 10 * GIB);
-        assert!(report.starved, "could not reach the deficit");
+        assert!(report.starved, "genuinely out of evictable parts");
+        assert!(!report.budget_exhausted, "this is exhaustion, not a time budget");
+    }
+
+    #[tokio::test]
+    async fn a_full_page_that_yields_nothing_evictable_stops_rather_than_spinning() {
+        // Worklist drift in its worst form: every row is refused, so evicting makes no progress
+        // and the cursor never advances. Without this guard the pass would re-fetch the same page
+        // until its time budget, doing nothing but load the database.
+        let parts: Vec<ResidentPart> = (1..=4)
+            .map(|v| {
+                let mut p = resident(v, GIB);
+                p.state = ReplicationState::Pending;
+                p
+            })
+            .collect();
+        let log = FakeLog::of(&parts);
+        let remover = FakeRemover::default();
+        let probe = FakeProbe::new(300 * GIB, 0);
+        let clock = TestClock::new();
+        let target = EvictionTarget {
+            free: 300 * GIB,
+            reserve: 350 * GIB,
+            headroom: 50 * GIB,
+        };
+
+        let report = evict_to_target(&log, &remover, &probe, &clock, target, pass(4)).await.unwrap();
+
+        assert_eq!(report.pages, 1, "stopped after the first unproductive page");
+        assert_eq!(report.skipped_unreplicated, 4);
+        assert!(report.starved);
+        assert!(remover.removed().is_empty());
+    }
+
+    #[tokio::test]
+    async fn hitting_the_time_budget_reports_budget_exhausted_not_starved() {
+        // The routine "more to do next tick" case. It must NOT set `starved`: that is the
+        // alertable, non-self-correcting condition, and conflating the two is exactly what made
+        // the pre-fix signal useless.
+        let parts: Vec<ResidentPart> = (1..=100).map(|v| resident(v, GIB)).collect();
+        let log = FakeLog::of(&parts);
+        let remover = FakeRemover::default();
+        let probe = FakeProbe::new(0, 0);
+        let clock = TestClock::new();
+        let target = EvictionTarget {
+            free: 0,
+            reserve: 350 * GIB,
+            headroom: 50 * GIB,
+        };
+        // Zero budget: the deadline has passed before the first page is even fetched.
+        let budgeted = EvictionPass {
+            page: 4,
+            max_duration: Duration::ZERO,
+        };
+
+        let report = evict_to_target(&log, &remover, &probe, &clock, target, budgeted).await.unwrap();
+
+        assert!(report.budget_exhausted, "stopped on the wall clock");
+        assert!(!report.starved, "work remained; the next tick resumes it");
+        assert_eq!(report.pages, 0);
+        assert_eq!(clock.now().duration_since(clock.now()), Duration::ZERO, "clock is deterministic");
+    }
+
+    #[tokio::test]
+    async fn a_failing_free_space_probe_falls_back_to_accounted_bytes() {
+        // Losing statvfs must cost accuracy, not the eviction that is keeping ingest alive. The
+        // pass advances its own estimate by what it accounted for and still terminates.
+        let parts: Vec<ResidentPart> = (1..=8).map(|v| resident(v, GIB)).collect();
+        let log = FakeLog::of(&parts);
+        let remover = FakeRemover::default();
+        let probe = FakeProbe::failing();
+        let clock = TestClock::new();
+        let target = EvictionTarget {
+            free: 300 * GIB,
+            reserve: 303 * GIB,
+            headroom: GIB,
+        };
+
+        let report = evict_to_target(&log, &remover, &probe, &clock, target, pass(2)).await.unwrap();
+
+        assert_eq!(report.evicted, 4, "4 GiB deficit closed from accounted bytes alone");
+        assert!(!report.starved);
     }
 
     #[test]

--- a/crates/hippius-drain-core/src/ssd_evict.rs
+++ b/crates/hippius-drain-core/src/ssd_evict.rs
@@ -300,13 +300,19 @@ where
         // which at prod's 14 GB maximum part size is a lot of cache given away for nothing.
         let mut projected = target.free;
         for candidate in candidates {
-            if projected >= goal {
-                break;
-            }
-            // Defense in depth against worklist drift — see the module doc. Skipped, never
-            // deleted, however badly the pass needs the space.
+            // Defense in depth against worklist drift — see the module doc. Checked FIRST, and
+            // for every candidate on the page even after the goal is met: this is the durability
+            // invariant's detector, the page is already materialised in memory, and the check is
+            // pure comparison. Ordering it after the goal test made the counter sample only the
+            // prefix of a page the pass happened to need, so a worklist that had drifted could
+            // go unreported precisely when eviction was cheap.
             if candidate.state != ReplicationState::Replicated {
                 report.skipped_unreplicated += 1;
+                continue;
+            }
+            // Enough space already: keep scanning the page for invariant violations, but stop
+            // evicting. `continue`, not `break`, for the reason above.
+            if projected >= goal {
                 continue;
             }
             projected = projected.saturating_add(candidate.bytes);
@@ -761,6 +767,42 @@ mod tests {
 
         assert_eq!(report.evicted, 4, "4 GiB deficit closed from accounted bytes alone");
         assert!(!report.starved);
+    }
+
+    #[tokio::test]
+    async fn the_invariant_counter_sees_the_whole_page_even_after_the_goal_is_met() {
+        // `skipped_unreplicated` is the detector for worklist drift, and drift is a data-loss
+        // class bug: a query that starts offering pending/draining parts is offering the only
+        // durable copy of something. Counting only the prefix the pass happened to need meant a
+        // drifted worklist went UNREPORTED exactly when eviction was cheap — the case where the
+        // goal is met in the first couple of parts.
+        //
+        // The page is already in memory and the check is a comparison, so scanning all of it
+        // costs nothing. One part covers the whole deficit; the violations behind it must still
+        // be counted, and still must not be unlinked.
+        let mut pending = resident(9, 0);
+        pending.state = ReplicationState::Pending;
+        let mut corrupt = resident(10, 0);
+        corrupt.state = ReplicationState::Corrupt;
+        let log = FakeLog::of(&[resident(1, 100 * GIB), pending, corrupt]);
+        let remover = FakeRemover::default();
+        let probe = FakeProbe::new(300 * GIB, GIB);
+        let counting = CountingProbe {
+            probe: &probe,
+            remover: &remover,
+        };
+        let clock = TestClock::new();
+        let target = EvictionTarget {
+            free: 300 * GIB,
+            reserve: 301 * GIB,
+            headroom: GIB,
+        };
+
+        let report = evict_to_target(&log, &remover, &counting, &clock, target, pass(8)).await.unwrap();
+
+        assert_eq!(report.evicted, 1, "one part covered the deficit");
+        assert_eq!(report.skipped_unreplicated, 2, "both violations behind the goal were still detected");
+        assert_eq!(remover.removed(), vec![key(&part_at(1, 1))], "and neither was unlinked");
     }
 
     #[tokio::test]

--- a/crates/hippius-drain-core/src/ssd_evict.rs
+++ b/crates/hippius-drain-core/src/ssd_evict.rs
@@ -324,12 +324,23 @@ where
         // Re-probe rather than trusting the accounted sum: `bytes` is denormalized at residency
         // time and a part whose size was unknown records zero, so accounting alone can report
         // "freed nothing" while real space was reclaimed — and would spin the loop.
-        target.free = match probe.free_bytes().await {
-            Ok(free) => free,
-            Err(_) => target.free.saturating_add(freed_this_page),
-        };
+        let probed = probe.free_bytes().await.ok();
+        target.free = probed.unwrap_or_else(|| target.free.saturating_add(freed_this_page));
 
         if target.free >= goal {
+            break;
+        }
+        // Neither signal moved: the probe is unavailable AND every part on that page was
+        // unaccounted (`bytes = 0`, which migration 0016 explicitly anticipates). Continuing
+        // would unlink a full page per iteration until the wall clock with no evidence any of
+        // it helps — deleting the read tier blind. Progress that cannot be measured is
+        // starvation, not success.
+        //
+        // Only when BOTH are true. A probe that works and reports no gain is a different
+        // situation — something else is filling the disk as fast as this frees it — and there
+        // the right answer IS to keep evicting until the time budget.
+        if probed.is_none() && freed_this_page == 0 {
+            report.starved = true;
             break;
         }
         if returned < page as usize {
@@ -750,6 +761,36 @@ mod tests {
 
         assert_eq!(report.evicted, 4, "4 GiB deficit closed from accounted bytes alone");
         assert!(!report.starved);
+    }
+
+    #[tokio::test]
+    async fn a_failing_probe_with_unaccounted_parts_must_not_evict_unbounded() {
+        // Zero-byte residency rows are anticipated by design (migration 0016: "a part whose
+        // size is unknown records 0 — it is still evictable, it just frees no accounted
+        // bytes"). Combine that with a failing statvfs and NOTHING advances: free does not
+        // move, the projection does not move, the page is full so exhaustion never fires, and
+        // parts WERE evicted so the no-progress guard never fires either. The pass then unlinks
+        // a full page per iteration until its wall clock — deleting the read tier on no
+        // evidence that it is helping.
+        let parts: Vec<ResidentPart> = (1..=200).map(|v| resident(v, 0)).collect();
+        let log = FakeLog::of(&parts);
+        let remover = FakeRemover::default();
+        let probe = FakeProbe::failing();
+        let clock = TestClock::new();
+        let target = EvictionTarget {
+            free: 100 * GIB,
+            reserve: 300 * GIB,
+            headroom: 50 * GIB,
+        };
+
+        let report = evict_to_target(&log, &remover, &probe, &clock, target, pass(8)).await.unwrap();
+
+        assert!(
+            report.evicted <= 8,
+            "no measurable progress must stop the pass after one page, evicted {}",
+            report.evicted
+        );
+        assert!(report.starved, "unmeasurable progress is starvation, not success");
     }
 
     #[test]

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -116,6 +116,17 @@ pub trait ReclaimLog: Send + Sync {
     /// The replication state + age of every `parts` entry the store has a row for.
     /// A part with no row is simply absent from the map (the caller skips it).
     fn part_states(&self, parts: &[PartKey]) -> impl Future<Output = Result<HashMap<PartKey, PartStatusAge>, Self::Error>> + Send;
+
+    /// This node's `failed` parts older than `grace`, oldest first, at most `limit`.
+    ///
+    /// **Candidates only — deliberately no servability logic here.** Whether a `failed` part is
+    /// a corrupt-live object's last good copy is decided by
+    /// [`BackingLog::servable_parts`](BackingLog::servable_parts), which already carries that
+    /// predicate under a "MUST stay in lockstep" warning shared with
+    /// `janitor_part_terminally_abandoned.sql` and the A21 sweep. Expressing it a third time in
+    /// this query is how that warning eventually gets ignored, and the failure mode is deleting
+    /// a live object's last good source. So this finds candidates; the existing seam judges them.
+    fn reclaimable_failed_parts(&self, grace: Duration, limit: u32) -> impl Future<Output = Result<Vec<PartKey>, Self::Error>> + Send;
 }
 
 /// The `object_versions` backing seam: answers two questions about a batch of parts, both
@@ -391,6 +402,75 @@ where
     Ok(report)
 }
 
+/// What one DB-driven `failed`-reclaim pass did.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FailedReclaimReport {
+    /// Aged `failed` parts the worklist offered.
+    pub candidates: u64,
+    /// Parts unlinked — debris from an aborted or abandoned upload.
+    pub reclaimed: u64,
+    /// Parts REFUSED because their object version is still servable: the R4 corrupt-live case,
+    /// where this SSD copy is the last good source. Must never be deleted; a standing nonzero
+    /// value is the same incident signal the walk's `skipped_corrupt` carries.
+    pub held_servable: u64,
+}
+
+/// Reclaims this node's aged `failed` parts **without walking the disk**.
+///
+/// The walk found these by scanning every part on the SSD and asking the database about each.
+/// That was proportional to the whole tree — which retention grew to this node's entire
+/// replicated shard — to find a population that is tiny and directly queryable: prod carries
+/// 22,123 `failed` rows fleet-wide against 11.4 M replicated. Asking the database for them is
+/// the obvious shape; it only became worth doing once the walk stopped being cheap.
+///
+/// # The guard, and why it is not re-implemented here
+///
+/// A `failed` part whose object version is still SERVABLE is not debris — it is a live object
+/// whose pool copy is corrupt, and this SSD copy is its last good source (R4). Deleting it is
+/// data loss.
+///
+/// That judgement stays in [`BackingLog::servable_parts`], which the walk already used. Its
+/// predicate carries a "MUST stay in lockstep" warning shared with
+/// `janitor_part_terminally_abandoned.sql` and the A21 sweep, so it is already expressed twice;
+/// writing it a third time in a worklist query is how such a warning eventually gets ignored.
+/// The worklist therefore returns CANDIDATES and this function judges them with the existing,
+/// tested seam.
+///
+/// # Errors
+///
+/// - [`ReclaimError::Log`] if the worklist read fails (nothing is removed).
+/// - [`ReclaimError::Backing`] if the servability read fails — **nothing is removed**, because
+///   without it every candidate is un-adjudicated and deleting one could destroy a live
+///   object's last copy. Fail-safe, exactly as the walk's backing read is.
+/// - [`ReclaimError::Remove`] if unlinking fails.
+pub async fn reclaim_failed<L, B, R>(log: &L, backing: &B, remover: &R, grace: Duration, limit: u32) -> Result<FailedReclaimReport, ReclaimError>
+where
+    L: ReclaimLog,
+    B: BackingLog,
+    R: PartRemover,
+{
+    let mut report = FailedReclaimReport::default();
+    let candidates = log.reclaimable_failed_parts(grace, limit).await.map_err(ReclaimError::log)?;
+    if candidates.is_empty() {
+        return Ok(report);
+    }
+    report.candidates = candidates.len() as u64;
+
+    // Fail-safe: a backing read that errors leaves EVERY candidate unjudged, so the pass must
+    // remove nothing rather than assume "not in the set means safe to delete".
+    let servable = backing.servable_parts(&candidates).await.map_err(ReclaimError::backing)?;
+
+    for part in &candidates {
+        if servable.contains(part) {
+            report.held_servable += 1;
+            continue;
+        }
+        remover.unlink_part(part).await.map_err(ReclaimError::Remove)?;
+        report.reclaimed += 1;
+    }
+    Ok(report)
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "tests")]
 mod tests {
@@ -579,6 +659,12 @@ mod tests {
 
     impl ReclaimLog for FakeLog {
         type Error = io::Error;
+
+        /// The walk-driven tests never exercise the DB worklist — `reclaim_failed` owns that
+        /// path and has its own suite in `failed_reclaim_tests`.
+        async fn reclaimable_failed_parts(&self, _grace: Duration, _limit: u32) -> Result<Vec<PartKey>, io::Error> {
+            Ok(Vec::new())
+        }
 
         fn part_states(&self, parts: &[PartKey]) -> impl Future<Output = Result<HashMap<PartKey, PartStatusAge>, io::Error>> + Send {
             let outcome = if self.fail {
@@ -1156,5 +1242,188 @@ mod tests {
                 Ok(())
             })?;
         }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod failed_reclaim_tests {
+    use super::{BackingLog, FailedReclaimReport, PartRemover, PartStatusAge, ReclaimError, ReclaimLog, reclaim_failed};
+    use crate::apipart::{ObjectId, PartKey, PartNumber, Version};
+    use core::future::Future;
+    use core::str::FromStr;
+    use core::time::Duration;
+    use std::collections::{HashMap, HashSet};
+    use std::io;
+    use std::sync::Mutex;
+
+    const UUID: &str = "466916c0-d61b-4518-b81b-9576b574270a";
+
+    fn part(n: u32) -> PartKey {
+        PartKey::new(ObjectId::from_str(UUID).unwrap(), Version::new(1), PartNumber::new(n))
+    }
+
+    struct FakeLog {
+        candidates: Vec<PartKey>,
+        fail: bool,
+        asked: Mutex<Vec<(u64, u32)>>,
+    }
+
+    impl FakeLog {
+        fn of(parts: &[PartKey]) -> Self {
+            Self {
+                candidates: parts.to_vec(),
+                fail: false,
+                asked: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ReclaimLog for FakeLog {
+        type Error = io::Error;
+
+        async fn part_states(&self, _parts: &[PartKey]) -> Result<HashMap<PartKey, PartStatusAge>, io::Error> {
+            Ok(HashMap::new())
+        }
+
+        fn reclaimable_failed_parts(&self, grace: Duration, limit: u32) -> impl Future<Output = Result<Vec<PartKey>, io::Error>> + Send {
+            let outcome = if self.fail {
+                Err(io::Error::other("worklist read failed"))
+            } else {
+                self.asked.lock().unwrap().push((grace.as_secs(), limit));
+                Ok(self.candidates.clone())
+            };
+            async move { outcome }
+        }
+    }
+
+    struct FakeBacking {
+        servable: HashSet<PartKey>,
+        fail: bool,
+    }
+
+    impl BackingLog for FakeBacking {
+        type Error = io::Error;
+
+        async fn unbacked_parts(&self, _parts: &[PartKey]) -> Result<HashSet<PartKey>, io::Error> {
+            Ok(HashSet::new())
+        }
+
+        fn servable_parts(&self, _parts: &[PartKey]) -> impl Future<Output = Result<HashSet<PartKey>, io::Error>> + Send {
+            let outcome = if self.fail {
+                Err(io::Error::other("backing read failed"))
+            } else {
+                Ok(self.servable.clone())
+            };
+            async move { outcome }
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeRemover {
+        removed: Mutex<Vec<u32>>,
+    }
+
+    impl PartRemover for FakeRemover {
+        fn unlink_part(&self, part: &PartKey) -> impl Future<Output = io::Result<()>> + Send {
+            self.removed.lock().unwrap().push(part.part().get());
+            async { Ok(()) }
+        }
+    }
+
+    fn backing(servable: &[PartKey]) -> FakeBacking {
+        FakeBacking {
+            servable: servable.iter().cloned().collect(),
+            fail: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn aged_failed_debris_is_reclaimed_without_a_disk_walk() {
+        // The point of the change: the worklist comes from the database, so finding a handful of
+        // failed parts no longer costs a scan proportional to the node's whole replicated shard.
+        let log = FakeLog::of(&[part(1), part(2)]);
+        let remover = FakeRemover::default();
+
+        let report = reclaim_failed(&log, &backing(&[]), &remover, Duration::from_hours(1), 256).await.unwrap();
+
+        assert_eq!(
+            report,
+            FailedReclaimReport {
+                candidates: 2,
+                reclaimed: 2,
+                held_servable: 0,
+            }
+        );
+        assert_eq!(*remover.removed.lock().unwrap(), vec![1, 2]);
+        assert_eq!(*log.asked.lock().unwrap(), vec![(3600, 256)], "grace and limit reach the worklist");
+    }
+
+    #[tokio::test]
+    async fn a_servable_versions_part_is_held_not_deleted() {
+        // THE guard (R4). A `failed` part whose object version is still servable is not debris:
+        // the pool copy is corrupt and this SSD copy is the object's last good source. The
+        // judgement is delegated to BackingLog::servable_parts rather than re-expressed in the
+        // worklist query, precisely so it cannot drift from the two places that already carry it.
+        let log = FakeLog::of(&[part(1), part(2), part(3)]);
+        let remover = FakeRemover::default();
+
+        let report = reclaim_failed(&log, &backing(&[part(2)]), &remover, Duration::from_hours(1), 256)
+            .await
+            .unwrap();
+
+        assert_eq!(report.held_servable, 1);
+        assert_eq!(report.reclaimed, 2);
+        assert_eq!(*remover.removed.lock().unwrap(), vec![1, 3], "the servable part survived");
+    }
+
+    #[tokio::test]
+    async fn a_failing_backing_read_removes_nothing() {
+        // Without the servability answer every candidate is unjudged, so proceeding could delete
+        // a live object's last good copy. The pass must remove NOTHING rather than treat an
+        // unanswered question as permission.
+        let log = FakeLog::of(&[part(1), part(2)]);
+        let remover = FakeRemover::default();
+        let failing = FakeBacking {
+            servable: HashSet::new(),
+            fail: true,
+        };
+
+        let err = reclaim_failed(&log, &failing, &remover, Duration::from_hours(1), 256).await.unwrap_err();
+
+        assert!(matches!(err, ReclaimError::Backing(_)));
+        assert!(remover.removed.lock().unwrap().is_empty(), "nothing may be unlinked unjudged");
+    }
+
+    #[tokio::test]
+    async fn an_empty_worklist_never_asks_about_backing() {
+        // The steady state on a healthy node, and it must cost one query, not two.
+        let log = FakeLog::of(&[]);
+        let remover = FakeRemover::default();
+        let never = FakeBacking {
+            servable: HashSet::new(),
+            fail: true,
+        };
+
+        let report = reclaim_failed(&log, &never, &remover, Duration::from_hours(1), 256).await.unwrap();
+
+        assert_eq!(report, FailedReclaimReport::default());
+    }
+
+    #[tokio::test]
+    async fn a_failing_worklist_read_removes_nothing() {
+        let log = FakeLog {
+            candidates: vec![part(1)],
+            fail: true,
+            asked: Mutex::new(Vec::new()),
+        };
+        let remover = FakeRemover::default();
+
+        let err = reclaim_failed(&log, &backing(&[]), &remover, Duration::from_hours(1), 256)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, ReclaimError::Log(_)));
+        assert!(remover.removed.lock().unwrap().is_empty());
     }
 }

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -127,6 +127,15 @@ pub trait ReclaimLog: Send + Sync {
     /// this query is how that warning eventually gets ignored, and the failure mode is deleting
     /// a live object's last good source. So this finds candidates; the existing seam judges them.
     fn reclaimable_failed_parts(&self, grace: Duration, limit: u32) -> impl Future<Output = Result<Vec<PartKey>, Self::Error>> + Send;
+
+    /// Stamps `reclaimed_at` so these parts leave the worklist.
+    ///
+    /// Without it the cursor never advances: unlinking a part changes nothing about its row, so
+    /// the next poll re-selects the same oldest page, re-unlinks it (idempotently, a no-op) and
+    /// re-counts it as reclaimed — productive-looking metrics over a cursor pinned in place,
+    /// with everything past the first page waiting on the hourly walk. The walk-driven path did
+    /// not need this because it is disk-keyed; a status-keyed worklist does.
+    fn mark_failed_reclaimed(&self, parts: &[PartKey]) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
 /// The `object_versions` backing seam: answers two questions about a batch of parts, both
@@ -263,12 +272,21 @@ impl ReclaimError {
 /// back as `skipped_corrupt`, never deleted; see the module doc). A part with NO replication
 /// row is checked against [`BackingLog::unbacked_parts`]: if its object was hard-deleted (no
 /// `object_versions` row) AND it has aged past `graces.orphan`, it is a deleted-object orphan
-/// and is reclaimed too. A `replicated` part older than `graces.replicated` is a drain
-/// crash-orphan (the drain crashed between the `mark_replicated` commit and its own unlink)
-/// and is unlinked — re-driving the happy-path unlink the crash skipped. Everything else is
-/// left untouched: `pending`/`draining` are live (drain-owned), a young `replicated` part
-/// may have an in-flight unlink still pending, and a no-row part that still has a live
-/// `object_versions` row may be mid-upload — the absolute safety gate.
+/// and is reclaimed too.
+///
+/// A `replicated` part is **never** reclaimed here, at any age. That inverts what this
+/// function used to do — the drain unlinked its own copy at commit, so a lingering `replicated`
+/// part could only be a crash between the two, and it was swept after `graces.replicated`.
+/// Retention removed that inference: a retained `replicated` part is the node's read tier and
+/// the intended steady state, so it is counted as
+/// [`skipped_replicated`](ReclaimReport::skipped_replicated) and left to the evictor, which
+/// removes parts on a free-space policy rather than on age. `graces.replicated` and
+/// `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS` are gone with it — the env var survives in the prod
+/// manifest only because the PRE-retention binary reads it, which is what makes an image
+/// rollback sweep the retained cache.
+///
+/// Everything else is left untouched: `pending`/`draining` are live (drain-owned), and a no-row
+/// part that still has a live `object_versions` row may be mid-upload — the absolute safety gate.
 ///
 /// The servability read ([`BackingLog::servable_parts`]) and the orphan-backing read
 /// ([`BackingLog::unbacked_parts`]) each run over a disjoint subset (aged-`failed` vs
@@ -460,6 +478,7 @@ where
     // remove nothing rather than assume "not in the set means safe to delete".
     let servable = backing.servable_parts(&candidates).await.map_err(ReclaimError::backing)?;
 
+    let mut reclaimed = Vec::with_capacity(candidates.len());
     for part in &candidates {
         if servable.contains(part) {
             report.held_servable += 1;
@@ -467,6 +486,19 @@ where
         }
         remover.unlink_part(part).await.map_err(ReclaimError::Remove)?;
         report.reclaimed += 1;
+        reclaimed.push(part.clone());
+    }
+
+    // Unlink THEN mark, the same ordering the evictor uses and for the same reason: the two
+    // crash windows are not equally bad. Unlink-then-crash leaves an unmarked row whose disk
+    // copy is gone — the next pass re-offers it, the idempotent unlink is a no-op, and it is
+    // marked then. Mark-then-crash would take a still-present part off the worklist forever,
+    // leaving debris only the hourly walk could find.
+    //
+    // Marking is what makes the cursor advance at all; without it this pass re-processes its
+    // own first page until gc_terminal_status_rows removes the rows seven days later.
+    if !reclaimed.is_empty() {
+        log.mark_failed_reclaimed(&reclaimed).await.map_err(ReclaimError::log)?;
     }
     Ok(report)
 }
@@ -659,6 +691,10 @@ mod tests {
 
     impl ReclaimLog for FakeLog {
         type Error = io::Error;
+
+        async fn mark_failed_reclaimed(&self, _parts: &[PartKey]) -> Result<(), io::Error> {
+            Ok(())
+        }
 
         /// The walk-driven tests never exercise the DB worklist — `reclaim_failed` owns that
         /// path and has its own suite in `failed_reclaim_tests`.
@@ -1263,8 +1299,11 @@ mod failed_reclaim_tests {
         PartKey::new(ObjectId::from_str(UUID).unwrap(), Version::new(1), PartNumber::new(n))
     }
 
+    /// A worklist whose cursor actually advances: `mark_failed_reclaimed` removes rows, exactly
+    /// as the store's `reclaimed_at` stamp takes them out of the query. Modelling that is the
+    /// point — a fake that kept returning the same page would hide a pass that never advances.
     struct FakeLog {
-        candidates: Vec<PartKey>,
+        candidates: Mutex<Vec<PartKey>>,
         fail: bool,
         asked: Mutex<Vec<(u64, u32)>>,
     }
@@ -1272,7 +1311,7 @@ mod failed_reclaim_tests {
     impl FakeLog {
         fn of(parts: &[PartKey]) -> Self {
             Self {
-                candidates: parts.to_vec(),
+                candidates: Mutex::new(parts.to_vec()),
                 fail: false,
                 asked: Mutex::new(Vec::new()),
             }
@@ -1286,12 +1325,18 @@ mod failed_reclaim_tests {
             Ok(HashMap::new())
         }
 
+        async fn mark_failed_reclaimed(&self, parts: &[PartKey]) -> Result<(), io::Error> {
+            let gone: Vec<PartKey> = parts.to_vec();
+            self.candidates.lock().unwrap().retain(|p| !gone.contains(p));
+            Ok(())
+        }
+
         fn reclaimable_failed_parts(&self, grace: Duration, limit: u32) -> impl Future<Output = Result<Vec<PartKey>, io::Error>> + Send {
             let outcome = if self.fail {
                 Err(io::Error::other("worklist read failed"))
             } else {
                 self.asked.lock().unwrap().push((grace.as_secs(), limit));
-                Ok(self.candidates.clone())
+                Ok(self.candidates.lock().unwrap().iter().take(limit as usize).cloned().collect())
             };
             async move { outcome }
         }
@@ -1360,6 +1405,50 @@ mod failed_reclaim_tests {
     }
 
     #[tokio::test]
+    async fn a_second_pass_does_not_re_offer_what_the_first_already_reclaimed() {
+        // THE cursor bug, and it is invisible without this test. Unlinking a part changes
+        // NOTHING about its replication row, so a status-keyed worklist re-selects the same
+        // oldest page every poll: it re-unlinks (idempotent, a no-op), re-counts the parts as
+        // reclaimed, and never reaches anything past the first page. Metrics and logs look
+        // productive the whole time.
+        //
+        // The walk-driven path did not have this bug because it is DISK-keyed — once the
+        // directory is gone the scan simply does not find it. gc_terminal_status_rows would
+        // eventually clear the rows, but at a 7-day retention, so on prod (~4.4k aged failed
+        // rows per node against a 512-row page) this was the normal case, not an edge one.
+        let log = FakeLog::of(&[part(1), part(2), part(3)]);
+        let remover = FakeRemover::default();
+
+        let first = reclaim_failed(&log, &backing(&[]), &remover, Duration::from_hours(1), 2).await.unwrap();
+        assert_eq!(first.reclaimed, 2, "the first page");
+
+        let second = reclaim_failed(&log, &backing(&[]), &remover, Duration::from_hours(1), 2).await.unwrap();
+
+        assert_eq!(second.candidates, 1, "the cursor advanced past the reclaimed page");
+        assert_eq!(*remover.removed.lock().unwrap(), vec![1, 2, 3], "each part is unlinked exactly once");
+    }
+
+    #[tokio::test]
+    async fn a_part_held_as_servable_stays_on_the_worklist() {
+        // Held is not done. An R4 corrupt-live part must be re-offered on the next pass — its
+        // pool copy may be repaired by the re-drive, after which it becomes ordinary debris.
+        // Marking it alongside the reclaimed ones would strand it until the 7-day GC.
+        let log = FakeLog::of(&[part(1)]);
+        let remover = FakeRemover::default();
+
+        let first = reclaim_failed(&log, &backing(&[part(1)]), &remover, Duration::from_hours(1), 8)
+            .await
+            .unwrap();
+        assert_eq!(first.held_servable, 1);
+        assert_eq!(first.reclaimed, 0);
+
+        let second = reclaim_failed(&log, &backing(&[part(1)]), &remover, Duration::from_hours(1), 8)
+            .await
+            .unwrap();
+        assert_eq!(second.candidates, 1, "a held part is still a candidate next pass");
+        assert!(remover.removed.lock().unwrap().is_empty(), "and was never unlinked");
+    }
+    #[tokio::test]
     async fn a_servable_versions_part_is_held_not_deleted() {
         // THE guard (R4). A `failed` part whose object version is still servable is not debris:
         // the pool copy is corrupt and this SSD copy is the object's last good source. The
@@ -1413,7 +1502,7 @@ mod failed_reclaim_tests {
     #[tokio::test]
     async fn a_failing_worklist_read_removes_nothing() {
         let log = FakeLog {
-            candidates: vec![part(1)],
+            candidates: Mutex::new(vec![part(1)]),
             fail: true,
             asked: Mutex::new(Vec::new()),
         };

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -1223,7 +1223,8 @@ impl Store {
         let rows = sqlx::query_as::<_, (String, i64, i64)>(
             "SELECT object_id, version, part_number \
              FROM cephor_replication_status \
-             WHERE node_id = $1 AND status = 'failed' AND updated_at < now() - make_interval(secs => $2) \
+             WHERE node_id = $1 AND status = 'failed' AND reclaimed_at IS NULL \
+               AND updated_at < now() - make_interval(secs => $2) \
              ORDER BY updated_at \
              LIMIT $3",
         )
@@ -1327,6 +1328,39 @@ impl ReclaimLog for Store {
 
     async fn reclaimable_failed_parts(&self, grace: Duration, limit: u32) -> Result<Vec<PartKey>> {
         self.reclaimable_failed_parts_impl(grace, limit).await
+    }
+
+    async fn mark_failed_reclaimed(&self, parts: &[PartKey]) -> Result<()> {
+        let Some(node) = self.node_id.as_deref() else {
+            return Ok(());
+        };
+        if parts.is_empty() {
+            return Ok(());
+        }
+        let mut object_ids: Vec<&str> = Vec::with_capacity(parts.len());
+        let mut versions: Vec<i64> = Vec::with_capacity(parts.len());
+        let mut part_numbers: Vec<i64> = Vec::with_capacity(parts.len());
+        for part in parts {
+            object_ids.push(part.object().as_str());
+            versions.push(i64::from(part.version().get()));
+            part_numbers.push(i64::from(part.part().get()));
+        }
+        // Batched: a per-part UPDATE would put a round-trip in the reclaim inner loop. Node
+        // scoped like every other write here — a peer's row names a file this agent never
+        // touched, so marking it would claim work it did not do.
+        sqlx::query(
+            "UPDATE cephor_replication_status SET reclaimed_at = now() \
+             WHERE node_id = $1 \
+               AND (object_id, version, part_number) IN \
+                   (SELECT * FROM UNNEST($2::text[], $3::bigint[], $4::bigint[]))",
+        )
+        .bind(node)
+        .bind(&object_ids)
+        .bind(&versions)
+        .bind(&part_numbers)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     async fn part_states(&self, parts: &[PartKey]) -> Result<HashMap<PartKey, PartStatusAge>> {
@@ -3263,6 +3297,38 @@ mod failed_worklist_tests {
         assert_eq!(got, vec![part(2), part(3)], "oldest first, capped at the limit");
     }
 
+    #[sqlx::test]
+    async fn a_reclaimed_row_leaves_the_failed_worklist(pool: PgPool) {
+        // The store half of the cursor fix. Unlinking changes nothing about the row, so without
+        // the stamp this query re-offers the same page every poll — for the seven days until
+        // gc_terminal_status_rows removes it.
+        let store = Store::from_pool(pool.clone()).with_node_id("node-a");
+        seed(&pool, 1, "failed", "node-a", 7200.0).await;
+        seed(&pool, 2, "failed", "node-a", 7200.0).await;
+
+        assert_eq!(store.reclaimable_failed_parts(Duration::from_hours(1), 10).await.unwrap().len(), 2);
+
+        <Store as ReclaimLog>::mark_failed_reclaimed(&store, &[part(1)]).await.unwrap();
+
+        let left = store.reclaimable_failed_parts(Duration::from_hours(1), 10).await.unwrap();
+        assert_eq!(left, vec![part(2)], "the marked part is gone from the worklist");
+    }
+
+    #[sqlx::test]
+    async fn marking_is_node_scoped(pool: PgPool) {
+        // A peer's row names a file this agent never touched, so marking it would claim work it
+        // did not do — and take the part off the worklist of the node that actually holds it.
+        let store = Store::from_pool(pool.clone()).with_node_id("node-a");
+        seed(&pool, 1, "failed", "node-b", 7200.0).await;
+
+        <Store as ReclaimLog>::mark_failed_reclaimed(&store, &[part(1)]).await.unwrap();
+
+        let (marked,): (i64,) = sqlx::query_as("SELECT count(*) FROM cephor_replication_status WHERE reclaimed_at IS NOT NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(marked, 0, "another node's row was marked");
+    }
     #[sqlx::test]
     async fn an_agent_with_no_node_id_reclaims_nothing(pool: PgPool) {
         // The allocator shares this Store type but holds no node identity and owns no disk.

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -1185,6 +1185,55 @@ impl ResidentLog for Store {
 }
 
 impl Store {
+    /// This node's `failed` parts older than `grace`, oldest first, at most `limit`.
+    ///
+    /// Node-scoped: a part lives only on the SSD of the node that ingested it, so another node's
+    /// `failed` row names a file this agent cannot unlink. Without a node id (the allocator)
+    /// there is nothing to reclaim.
+    ///
+    /// **Candidates only.** Servability — "is this the last good copy of a live object?" — is
+    /// deliberately absent: [`BackingLog::servable_parts`](crate::BackingLog::servable_parts)
+    /// owns that predicate, and it already carries a MUST-stay-in-lockstep warning shared with
+    /// `janitor_part_terminally_abandoned.sql` and the A21 sweep. A third copy here is how such
+    /// a warning gets quietly broken, and the failure mode is deleting a live object's last good
+    /// source. [`reclaim_failed`](crate::reclaim_failed) applies the guard to what this returns.
+    ///
+    /// `updated_at` is the store clock, so the grace has no agent-clock dependence — the same
+    /// property the walk-driven path relied on. Oldest first so a backlog drains in age order
+    /// rather than starving its own tail.
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError`] if the query fails.
+    pub async fn reclaimable_failed_parts_impl(&self, grace: Duration, limit: u32) -> Result<Vec<PartKey>> {
+        let Some(node) = self.node_id.as_deref() else {
+            return Ok(Vec::new());
+        };
+        let rows = sqlx::query_as::<_, (String, i64, i64)>(
+            "SELECT object_id, version, part_number \
+             FROM cephor_replication_status \
+             WHERE node_id = $1 AND status = 'failed' AND updated_at < now() - make_interval(secs => $2) \
+             ORDER BY updated_at \
+             LIMIT $3",
+        )
+        .bind(node)
+        .bind(grace.as_secs_f64())
+        .bind(i64::from(limit))
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|(object_id, version, part_number)| {
+                PartRow {
+                    object_id,
+                    version,
+                    part_number,
+                }
+                .into_part()
+            })
+            .collect()
+    }
+
     /// Records that `part` is now resident on this node's SSD, with its size for the eviction
     /// cursor's accounting.
     ///
@@ -1264,6 +1313,10 @@ impl Store {
 
 impl ReclaimLog for Store {
     type Error = StoreError;
+
+    async fn reclaimable_failed_parts(&self, grace: Duration, limit: u32) -> Result<Vec<PartKey>> {
+        self.reclaimable_failed_parts_impl(grace, limit).await
+    }
 
     async fn part_states(&self, parts: &[PartKey]) -> Result<HashMap<PartKey, PartStatusAge>> {
         let mut out = HashMap::with_capacity(parts.len());
@@ -3028,5 +3081,80 @@ mod part_tests {
             None,
             "the stamped row was GC'd",
         );
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests")]
+mod failed_worklist_tests {
+    use super::{PartKey, Store};
+    use crate::apipart::{ObjectId, PartNumber, Version};
+    use crate::ssd_reclaim::ReclaimLog;
+    use core::str::FromStr;
+    use core::time::Duration;
+    use sqlx::postgres::PgPool;
+
+    const UUID_A: &str = "466916c0-d61b-4518-b81b-9576b574270a";
+
+    fn part(n: u32) -> PartKey {
+        PartKey::new(ObjectId::from_str(UUID_A).unwrap(), Version::new(1), PartNumber::new(n))
+    }
+
+    /// Seeds a replication row with an explicit age, so grace boundaries are exact.
+    async fn seed(pool: &PgPool, n: i64, status: &str, node: &str, age_secs: f64) {
+        sqlx::query(
+            "INSERT INTO cephor_replication_status (object_id, version, part_number, status, node_id, updated_at) \
+             VALUES ($1, 1, $2, $3, $4, now() - make_interval(secs => $5))",
+        )
+        .bind(UUID_A)
+        .bind(n)
+        .bind(status)
+        .bind(node)
+        .bind(age_secs)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[sqlx::test]
+    async fn the_worklist_is_node_scoped_aged_and_failed_only(pool: PgPool) {
+        // Three independent filters, each load-bearing. Node scope: a peer's `failed` row names
+        // a file this agent cannot unlink. Grace: the diagnosis / abort-settle window. Status:
+        // everything else is either live (drain-owned), retained read tier, or the R4 corrupt
+        // hold — none of it this worker's to delete.
+        let store = Store::from_pool(pool.clone()).with_node_id("node-a");
+        seed(&pool, 1, "failed", "node-a", 7200.0).await; // aged, ours   -> candidate
+        seed(&pool, 2, "failed", "node-a", 60.0).await; // young, ours   -> held by grace
+        seed(&pool, 3, "failed", "node-b", 7200.0).await; // aged, peer's -> not ours to touch
+        seed(&pool, 4, "replicated", "node-a", 7200.0).await; // the read tier
+        seed(&pool, 5, "pending", "node-a", 7200.0).await; // live, drain-owned
+        seed(&pool, 6, "corrupt", "node-a", 7200.0).await; // R4 hold, never reclaimed
+
+        let got = store.reclaimable_failed_parts(Duration::from_hours(1), 100).await.unwrap();
+
+        assert_eq!(got, vec![part(1)], "only this node's aged failed part is a candidate");
+    }
+
+    #[sqlx::test]
+    async fn the_worklist_is_oldest_first_and_honours_the_limit(pool: PgPool) {
+        // Oldest first so a backlog drains in age order rather than starving its own tail — the
+        // same property the eviction cursor needs, for the same reason.
+        let store = Store::from_pool(pool.clone()).with_node_id("node-a");
+        seed(&pool, 1, "failed", "node-a", 7200.0).await;
+        seed(&pool, 2, "failed", "node-a", 90000.0).await;
+        seed(&pool, 3, "failed", "node-a", 10800.0).await;
+
+        let got = store.reclaimable_failed_parts(Duration::from_hours(1), 2).await.unwrap();
+
+        assert_eq!(got, vec![part(2), part(3)], "oldest first, capped at the limit");
+    }
+
+    #[sqlx::test]
+    async fn an_agent_with_no_node_id_reclaims_nothing(pool: PgPool) {
+        // The allocator shares this Store type but holds no node identity and owns no disk.
+        let store = Store::from_pool(pool.clone());
+        seed(&pool, 1, "failed", "node-a", 7200.0).await;
+
+        assert!(store.reclaimable_failed_parts(Duration::from_hours(1), 100).await.unwrap().is_empty());
     }
 }

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -1144,17 +1144,28 @@ impl ResidentLog for Store {
         // which is the reclaimer's disposition (deleted-object orphan), not the evictor's. It is
         // excluded here and `prune_residency` clears the row when the reclaimer unlinks the part.
         //
-        // ORDER BY resident_at IS the eviction policy (FIFO, oldest-retained first); the
-        // orchestrator walks this order and never re-sorts. Reads off
-        // `cephor_ssd_residency_evict_idx`, so the cost is proportional to `limit` rather than
-        // to the resident set — the whole point of not using a filesystem walk here.
+        // THIS ORDER BY IS THE EVICTION POLICY; the orchestrator walks it and never re-sorts.
+        //
+        // Least-recently-USED, not least-recently-admitted. `resident_at` says when a part
+        // joined the cache, which says nothing about whether anyone is still reading it — that
+        // is FIFO, and FIFO is a poor fit here: a training set re-read every epoch is maximally
+        // skewed, so evicting by arrival order tends to take exactly the parts about to be read
+        // again, each costing a peer-or-pool read plus a local write to restore.
+        //
+        // COALESCE gives the fallback for free: a part nobody has read since 0017 shipped has no
+        // recency, and using its residency time is precisely the old behaviour. No backfill, and
+        // no window where the order is undefined.
+        //
+        // Must match `cephor_ssd_residency_recency_idx` expression-for-expression, or the
+        // planner sorts the whole ~2M-row resident set on every pass — reintroducing in Postgres
+        // the O(resident) cost this evictor exists to avoid.
         let rows = sqlx::query_as::<_, (String, i64, i64, String, i64)>(
             "SELECT r.object_id, r.version, r.part_number, s.status, r.bytes \
              FROM cephor_ssd_residency r \
              JOIN cephor_replication_status s \
                ON s.object_id = r.object_id AND s.version = r.version AND s.part_number = r.part_number \
              WHERE r.node_id = $1 AND s.status = 'replicated' \
-             ORDER BY r.resident_at \
+             ORDER BY COALESCE(r.last_read_at, r.resident_at) \
              LIMIT $2",
         )
         .bind(node)
@@ -2064,6 +2075,109 @@ mod part_tests {
         let after: Vec<u32> = store.evictable_parts(10).await.unwrap().iter().map(|r| r.part.part().get()).collect();
         assert_eq!(after, vec![1], "an evicted part leaves the worklist");
         assert_eq!(store.node_cache_bytes("node-a").await.unwrap(), 100, "and stops counting as cache");
+    }
+
+    #[sqlx::test]
+    async fn eviction_orders_on_last_read_falling_back_to_residency(pool: PgPool) {
+        // The Phase H property, and it fails on FIFO. `old_but_hot` joined the cache first, so
+        // arrival order would evict it — but it is the one still being read, which for a working
+        // set re-read every epoch is exactly the part about to be needed again. Evicting it costs
+        // a peer-or-pool read plus a local write to put it straight back.
+        //
+        // `never_read` has a NULL last_read_at and must fall back to its residency time, so the
+        // pre-0017 population still orders sanely with no backfill.
+        create_app_schema(&pool).await;
+        let store = Store::from_pool(pool.clone()).with_node_id("node-a");
+        for n in 1..=3 {
+            seed_status_node(&pool, UUID_A, 1, n, "replicated", "node-a").await;
+            seed_part_size(&pool, UUID_A, 1, n, Some(100)).await;
+        }
+        // part 1: resident longest, but read most recently -> must survive
+        // part 2: resident recently, never read            -> falls back to resident_at
+        // part 3: resident a while ago, read a while ago   -> the true LRU victim
+        sqlx::query(
+            "INSERT INTO cephor_ssd_residency (node_id, object_id, version, part_number, bytes, resident_at, last_read_at) VALUES \
+             ('node-a', $1, 1, 1, 100, now() - make_interval(hours => 10), now() - make_interval(mins => 1)), \
+             ('node-a', $1, 1, 2, 100, now() - make_interval(hours => 2),  NULL), \
+             ('node-a', $1, 1, 3, 100, now() - make_interval(hours => 9),  now() - make_interval(hours => 5))",
+        )
+        .bind(UUID_A)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let order: Vec<u32> = store.evictable_parts(10).await.unwrap().iter().map(|r| r.part.part().get()).collect();
+
+        assert_eq!(
+            order,
+            vec![3, 2, 1],
+            "least-recently-USED first: the hot part resident longest must be evicted LAST"
+        );
+    }
+
+    #[sqlx::test]
+    async fn a_local_read_moves_a_part_to_the_back_of_the_eviction_queue(pool: PgPool) {
+        // The other half: serving a part from local flash has to actually change its fate, or
+        // the ordering above is decorative.
+        create_app_schema(&pool).await;
+        let store = Store::from_pool(pool.clone()).with_node_id("node-a");
+        for n in 1_u32..=2 {
+            seed_status_node(&pool, UUID_A, 1, i64::from(n), "replicated", "node-a").await;
+            seed_part_size(&pool, UUID_A, 1, i64::from(n), Some(100)).await;
+            store.record_resident(&part(UUID_A, 1, n), 100).await.unwrap();
+        }
+        // Age part 1 so it is the victim, then read it.
+        sqlx::query("UPDATE cephor_ssd_residency SET resident_at = now() - make_interval(hours => 5) WHERE part_number = 1")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let first: Vec<u32> = store.evictable_parts(10).await.unwrap().iter().map(|r| r.part.part().get()).collect();
+        assert_eq!(first, vec![1, 2], "part 1 is the victim before it is read");
+
+        // The UPDATE the api's ReadRecencyRecorder issues. Pinned here because this ordering is
+        // the contract that recorder has to satisfy, and the consequence of getting it wrong —
+        // a hot part evicted and immediately re-fetched — is silent.
+        sqlx::query(
+            "UPDATE cephor_ssd_residency SET last_read_at = now()              WHERE node_id = $1 AND object_id = $2 AND version = 1 AND part_number = 1",
+        )
+        .bind("node-a")
+        .bind(UUID_A)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let after: Vec<u32> = store.evictable_parts(10).await.unwrap().iter().map(|r| r.part.part().get()).collect();
+        assert_eq!(after, vec![2, 1], "reading it moved it behind the untouched part");
+    }
+
+    #[sqlx::test]
+    async fn touching_a_part_this_node_does_not_hold_changes_nothing(pool: PgPool) {
+        // The read path calls this on any local hit, and a peer's row must not be reachable:
+        // recency is per (node, part), and stamping a peer's row would protect a copy on a disk
+        // this node cannot see while leaving its own unprotected.
+        create_app_schema(&pool).await;
+        seed_status_node(&pool, UUID_A, 1, 1, "replicated", "node-b").await;
+        seed_part_size(&pool, UUID_A, 1, 1, Some(100)).await;
+        sqlx::query("INSERT INTO cephor_ssd_residency (node_id, object_id, version, part_number, bytes) VALUES ('node-b', $1, 1, 1, 100)")
+            .bind(UUID_A)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "UPDATE cephor_ssd_residency SET last_read_at = now()              WHERE node_id = $1 AND object_id = $2 AND version = 1 AND part_number = 1",
+        )
+        .bind("node-a")
+        .bind(UUID_A)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (touched,): (i64,) = sqlx::query_as("SELECT count(*) FROM cephor_ssd_residency WHERE last_read_at IS NOT NULL")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(touched, 0, "another node's residency row was stamped");
     }
 
     #[sqlx::test]

--- a/docs/plans/2026-08-07-ssd-read-tier-hardening.md
+++ b/docs/plans/2026-08-07-ssd-read-tier-hardening.md
@@ -1,0 +1,792 @@
+# Hardening the SSD read tier before it meets production load
+
+Status: proposed, 2026-08-07. Targets `staging` only; `k8s/production` stays untouched until each
+phase clears its soak gate. Follows on from
+[2026-08-06-ssd-read-tier-retention-and-residency-allocator.md](2026-08-06-ssd-read-tier-retention-and-residency-allocator.md),
+which shipped as PR #398 (merged to `staging`, commit `814f404a`).
+
+The read tier itself is sound: reads tier local → peer → pool, the durability invariant is
+defended in three independent places, and the allocator no longer reads a warm cache as a drain
+emergency. What is not sound is what happens when the tier actually **fills**. Three of the
+findings below are load-scaling defects that are invisible at today's 1–2% disk occupancy and
+become outages at the occupancy the design is aiming for.
+
+**The one-sentence risk:** promotion is an unthrottled writer to the same NVMe that ingest writes
+to and that `fs_cache_pressure` gates PUTs on, and the only counterweight is an evictor capped at
+512 parts per 30 s. Everything else on this page is secondary to closing that loop.
+
+---
+
+## 0. Task 0 — MEASURED (2026-08-07, context `hippius`, read-only)
+
+Everything below replaces the derived estimates. Where a prior figure was an estimate it is shown
+against the measurement, because the plan's credibility depends on knowing which is which.
+
+**Deployment state.** Staging runs retention **live now** (`drain:814f404`, `CEPHOR_EVICT_*` set,
+`HIPPIUS_PEER_FETCH_ENABLED=true`, `HIPPIUS_OBJECT_CACHE_PROMOTE_ON_READ=true`). Prod is on
+`drain:fa927d8` — pre-retention, with `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS=3600` live and read.
+F0 is confirmed exactly as written.
+
+**Prod, per node** (`cephor_replication_status` ⋈ `parts`):
+
+| | measured |
+|---|---|
+| replicated parts per node | **2.25–2.32 M** (node1 2,317,894 … node2 2,254,208) |
+| shard bytes per node | **906–951 GB** |
+| average part in the shard | **408 KB** |
+| ingest SSD | `/dev/nvme4n1`, **3.5 TB**, `du` = `df` = 138 GB (**dedicated device**) |
+| fleet | 11,406,007 replicated · 22,123 failed · 12 pending |
+
+**Prod `parts` size distribution is extreme and bimodal:** n = 142,898,360, **p50 = 686 bytes**,
+avg = 1321 kB, p95 = 4096 kB, max = 14 GB.
+
+**Estimates vs measurements — the estimates held:**
+
+| Quantity | Estimated | Measured | |
+|---|---|---|---|
+| parts per node shard | 2.2 M | **2.28 M** | ✓ |
+| average part in shard | 487 KB | **408 KB** | ✓ |
+| DB round-trips per reconcile tick | ~4,400 | **~4,560** | ✓ |
+| shard as share of disk | 28% | **26.6%** | ✓ |
+| eviction rate (512 / 30 s) | 8 MB/s | **7 MB/s** | ✓ |
+| deficit at arming (50‰) | 192 GB | **175 GB** | ✓ |
+| time to close one deficit | 6.4 h | **~7 h** | ✓ |
+
+So F1 and F2 are confirmed at prod scale with real data: 2.28 M parts walked and ~4,560 batched
+queries every 15 s per node, and an armed evictor needing ~7 hours of continuous `ERROR "starved"`
+to close a single deficit.
+
+### Three things the measurements changed
+
+**M1 — `CEPHOR_EVICT_BATCH` counts parts while the deficit is in bytes, and p50 is 686 bytes.**
+New finding, only visible with the real distribution. A 512-part page is almost uncorrelated with
+bytes freed: walking the small-part tail frees as little as 512 × 686 B ≈ **350 KB**. Phase B's fix
+must be **byte-driven** — page until the byte deficit is met — and the page size should adapt, not
+be a fixed part count. A count-based batch is the wrong unit for this workload.
+
+**M2 — staging cannot validate any free-space gate.** The staging ingest "disk" is `/dev/md3`, an
+**878 GB filesystem shared with other tenants on the same node**:
+
+```
+du  /var/lib/hippius/local_object_cache =   1.2 GB   (matches drain_ssd_cache_bytes exactly)
+df  /dev/md3                            = 628 GB used / 878 GB, 205 GB free (23%)
+```
+
+Prod is unaffected — `du` == `df` == 138 GB on a dedicated `nvme4n1`, so the shipped `statvfs`
+accounting is **correct in production**. But on staging the evictor, `fs_cache_pressure`, and any
+promotion gate all reason about 628 GB they neither own nor can evict. Consequences:
+
+- Staging's evictor will arm at 15% free **because of another tenant's usage**, find 1.2 GB of
+  evictable cache against a ~44 GB deficit, evict the entire staging read tier, and report
+  `starved` forever. That is live and imminent (23% free and drifting).
+- Every free-space soak gate in §4 is unmeasurable there.
+
+Actions: give staging a dedicated device (infra), **and** add a cheap startup check that logs
+loudly when `du(cache) ≪ (total − free)` — "this process does not own this filesystem" — so the
+confusion cannot recur silently. That check is worth having in prod too as a regression guard.
+
+**M3 — the corrected promote floor from §5-A2 was wrong in the other direction.** With
+`evict_reserve = 0.15` and `evict_headroom = 0.05`, the evictor frees to **0.20 free and no
+further**. A promote floor of 0.25 therefore **deadlocks**: promotion stops below 0.25, eviction
+never restores past 0.20, promotion never resumes. Staging is at 23% free today, so Phase A as
+last written would have disabled promotion permanently on deploy and the soak would have proved
+nothing.
+
+The correct constraint is a four-way ordering with the floor **inside** the evictor's band:
+
+```
+fs_cache_min_free (0.08)  <  evict_reserve (0.15)  <  promote_floor  <  evict_reserve + evict_headroom (0.20)
+```
+
+Take **`promote_floor = 0.175`**. Then: above 0.20 both are quiet; at 0.175 promotion stops while
+eviction is still unarmed; at 0.15 eviction arms and frees back to 0.20, which is above the floor,
+so promotion resumes. The band is real and promotion recovers after every pass.
+
+**This is the test that matters** — not "the thresholds are ordered", but "the evictor's target is
+strictly above the promote floor", which is what makes the loop live rather than deadlocked.
+
+### What is already working
+
+Staging's read tier is serving: `chunk_reads_by_tier_total` shows **local 26/100/111, peer 20/27/48,
+pool 35** across pods — the pool is already the minority tier. And
+`peer_fetch_shed_total{reason=client_cap} = 9` confirms F6/Phase G is real and observable, on a
+2-node staging where the *serve* cap cannot possibly be the constraint (1 remote pod × 8 < 16).
+
+Note for §5-A3: staging has **2** api-local pods, not 5. The peer oversubscription arithmetic
+(4 remote pods × cap vs serve cap) is a **prod-only** condition and cannot be soaked on staging.
+
+## 1. Verified findings
+
+Each was re-derived from the code, not from the PR description. "Uncertain" states honestly what
+is estimated rather than read.
+
+### F0 — Retention is not flag-gated, and prod's manifest still names the backstop it removed
+
+*Added 2026-08-07 from an independent review. This one is about release governance, not code, and
+it is the reason nothing else on this page should ship to prod casually.*
+
+`drain_part` retains unconditionally ([partdrain.rs:549-555](../../crates/hippius-drain-core/src/partdrain.rs))
+and `ssd_reclaim`'s `Replicated` arm skips unconditionally
+([ssd_reclaim.rs:363](../../crates/hippius-drain-core/src/ssd_reclaim.rs)). There is **no config
+knob for retention** — `rg 'retain|retention' crates/hippius-drain-agent/src/config.rs` returns
+only doc comments. So:
+
+- **Retention arrives with the binary.** `k8s/production` being untouched does not mean prod is
+  unaffected; the next `staging → main` promotion turns retention on in production, since main
+  deploys prod ([f43af742](../../.github/workflows/production-deploy.yaml)). Verified today:
+  none of `c3bd1c34`, `32e0feda`, `7ec187c2`, `814f404a` are ancestors of `origin/main`, and
+  staging is 20 commits ahead — so this is a **future** release hazard, not a live one.
+- **Rollback is a binary revert, not a config flip.** Every other phase here has a kill switch.
+  Retention itself does not.
+- **Prod still sets `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS=3600`**
+  ([k8s/production/drain-agent-daemonset.yaml:151](../../k8s/production/drain-agent-daemonset.yaml)),
+  an env var the new binary **no longer reads** (removed from `config.rs`). The manifest documents
+  a safety backstop that silently stops existing on promotion.
+
+**Severity, stated honestly.** Acute risk is low: with `HIPPIUS_OBJECT_CACHE_PROMOTE_ON_READ` off
+in prod, retention alone fills to the node's ingest shard (~1.08 TB of ~3.8 TB ≈ 28%), which never
+reaches the evictor's 15%-free floor. The disk does keep growing with the dataset, so eviction
+arms eventually, but not on day one. The problem is governance: an unflagged, un-revertable
+behaviour change riding a routine release, with a stale manifest asserting a protection that is
+gone. Fix before promotion, not after.
+
+### F1 — The SSD scanners are unbounded, and retention multiplies their input
+
+`LocalSsd::scan_parts` ([localfs.rs:697](../../crates/hippius-drain-agent/src/localfs.rs)) is a
+three-level recursive `read_dir` with a `stat` per part
+([localfs.rs:685](../../crates/hippius-drain-agent/src/localfs.rs)), returning an unbounded
+`Vec<DiscoveredPart>`. It has two callers:
+
+- `reconcile_parts` ([reconcile.rs:185](../../crates/hippius-drain-core/src/reconcile.rs)) — every
+  **15 s** (`CEPHOR_RECONCILE_POLL_SECS`). Clones every `PartKey` into a second `Vec`, then
+  `Store::statuses` chunks the lookup at `RECLAIM_STATUS_BATCH = 500`
+  ([store.rs:92](../../crates/hippius-drain-core/src/store.rs)).
+- `reclaim_ssd` ([ssd_reclaim.rs:286](../../crates/hippius-drain-core/src/ssd_reclaim.rs)) — every
+  **300 s**, same shape.
+
+Until PR #398 the SSD held only the undrained backlog (21–36 GB/node, prod 2026-08-06). Retention
+makes it hold the node's shard, and promotion makes it hold whatever reads touch. Agent memory
+limit is **1 Gi** ([drain-agent-daemonset.yaml:218](../../k8s/staging/drain-agent-daemonset.yaml)).
+
+**The 15 s poll was chosen on a premise retention destroyed, and the manifest still states it.**
+[drain-agent-daemonset.yaml:179-181](../../k8s/staging/drain-agent-daemonset.yaml) justifies the
+setting with: *"Safe to lower: a scan is a walk of the node-local SSD ingest tree (undrained parts
+only — drained parts are unlinked …)"*. That clause is now false, and it is the written safety
+argument for the interval. Same text in the prod manifest at lines 181-182. The comment must be
+corrected in the same PR that changes the behaviour — a stale safety rationale is how the next
+person re-lowers this poll.
+
+**Uncertain — and this is an estimate, not a measurement.** The part count is derived from the
+prior plan's own figures: 5.4 TB pool ÷ 11.08M `replicated` rows ≈ 487 KB average part, 1.08 TB
+shard ≈ 2.2M parts/node → ~4,400 Postgres round-trips per reconcile tick per node, and roughly
+700 MB peak resident across the two `Vec`s and the `HashMap`. If parts average a full 4 MiB chunk
+it is 270k parts and ~540 round-trips. **Measure before sizing the fix** (§4, task 0).
+
+Note what that 700 MB figure is and is not: tight against a 1 Gi limit, not a demonstrated OOM.
+The argument for fixing this is that the walk is **unbounded in principle** and its input now grows
+with promotion — not that a specific crash is predicted. Either part-count figure is 5–40× the
+present load; the direction is not in doubt, the magnitude is.
+
+### F2 — Eviction cannot close its deficit, and mislabels the failure
+
+`evict_to_target` ([ssd_evict.rs:184](../../crates/hippius-drain-core/src/ssd_evict.rs)) makes
+exactly one `evictable_parts(batch)` call and never loops. `evict_once`
+([runtime.rs:330](../../crates/hippius-drain-agent/src/runtime.rs)) is the only call site; nothing
+wraps it in a loop.
+
+Two separable defects:
+
+- **F2a (certain).** `starved = freed_bytes < deficit` treats "the batch ran out" and "the
+  worklist ran out" as the same condition, and `evict_once` logs `tracing::error!` on it. All four
+  unit tests use `batch = 128` against ≤ 3 candidates, so batch truncation is untested. Armed, the
+  pass must free `headroom` = 50‰ of a ~3.8 TB disk ≈ **192 GB**, while one pass frees at most
+  512 × 487 KB ≈ **250 MB**. The signal that means "PUTs are about to 503" will sit at ERROR for
+  hours of entirely normal catch-up.
+- **F2b (structural, rates estimated).** Sustained eviction is capped at `batch / evict_poll` =
+  512 parts / 30 s ≈ 8 MB/s/node. Its input — promotion — has no cap at all.
+
+**Correction to an earlier reading:** retention *alone* never arms the evictor. The shard is
+~28% of the disk and the floor is 15% free. It is promotion that fills the disk, which makes F2
+a promotion-scaling problem, not a retention one.
+
+### F3 — Promotion has no free-space guard (root cause of F2b)
+
+`_promote_chunk` ([dual_fs_store.py:121](../../hippius_s3/cache/dual_fs_store.py)) writes
+unconditionally — no `statvfs`, no pressure check, no rate limit — and every non-local read
+promotes, peer hits included ([dual_fs_store.py:86](../../hippius_s3/cache/dual_fs_store.py)).
+
+`should_reject_fs_cache_write` measures `shutil.disk_usage(config.object_cache_dir)`
+([fs_pressure.py:20](../../hippius_s3/fs_pressure.py)). On `api-local` that is
+`/var/lib/hippius/local_object_cache`
+([api-local-deployments-staging.yaml:145](../../k8s/staging/api-local-deployments-staging.yaml)) —
+**the same mount as the drain agent's `CEPHOR_SSD_ROOT`**
+([drain-agent-daemonset.yaml:108](../../k8s/staging/drain-agent-daemonset.yaml)).
+
+So promotion, ingest, and the PUT-503 gate share one disk with no coupling between them except a
+rate-limited evictor. A read-heavy period can refuse writes. Promotion failures are swallowed
+(`OSError` caught), so the disk fills silently until the middleware starts shedding.
+
+### F4 — The Phase-4 reserve measures the wrong thing (downgraded)
+
+`reserve_permille` ([alloc.rs:213](../../crates/hippius-drain-core/src/alloc.rs)) computes
+shortfall as `(demand − budget) / demand`, and `distribute` sets
+`demand = if backlog == 0 { 0 } else { max_drain_rate }`
+([alloc.rs:254](../../crates/hippius-drain-core/src/alloc.rs)). `CEPHOR_MAX_DRAIN_RATE_BPS` is set
+nowhere in `k8s/` → the 100 MB/s code default.
+
+**Correcting an earlier overstatement:** `CEPHOR_CEPH_CEILING_BPS` is also unset → 1 GB/s default,
+above the fleet's 500 MB/s aggregate demand, so under a healthy Open ceiling with the AIMD ramped
+the shortfall genuinely can be 0 and the base reserve applies. The accurate claim is narrower:
+shortfall is a ratio of a **calibrated constant** to the granted budget and is insensitive to how
+far behind the node actually is. It reads near-max in every degraded regime — NearFull caps the
+fleet at 50 MB/s → 10 MB/s/node → 900‰ → reserve ≈ 375‰ — and the AIMD has historically sat far
+below the ceiling. It only *binds* once the cache exceeds ~60% of disk, so: real, P1 not P0.
+
+### F5 — The peer tier excludes the case only it can fix
+
+`PeerChunkFetcher._owner` requires `s.status = 'replicated'`
+([peers.py:180](../../hippius_s3/cache/peers.py)), and residency rows exist only for replicated
+parts, so a fresh part that lives *only* on its ingest node's SSD is unreachable. That is exactly
+the documented staging failure — "every cross-node GET of a fresh object 503'd (parts not ready)"
+([drain-allocator-deployment.yaml:107](../../k8s/staging/drain-allocator-deployment.yaml)).
+`chunks_exist_batch` ([dual_fs_store.py:196](../../hippius_s3/cache/dual_fs_store.py)) also never
+consults the peer tier, so such a read is routed into a download pipeline that cannot succeed.
+
+Scope gap in what shipped, not a defect in it.
+
+### F6 — Read-path tuning
+
+- Promotion is `await`ed before the chunk is yielded. Prefetch = 16 with `create_task`
+  ([streamer.py:54](../../hippius_s3/reader/streamer.py)) overlaps most of it. **Low.**
+- Client per-peer cap is 8, prefetch depth is 16, so one reader of a large part sheds half its own
+  chunks to the pool and books them as `client_cap`. Already commented in
+  [peers.py:218](../../hippius_s3/cache/peers.py); it skews `chunk_reads_by_tier_total{tier=peer}`
+  low for the whole soak.
+- `HIPPIUS_PEER_FETCH_TIMEOUT_SECONDS = 2.0` against a ~40 ms pool fallback — a 50× loss-cut.
+
+### Retracted
+
+The residency byte-accounting difference (Rust `bytes = EXCLUDED.bytes` vs Python
+`bytes + EXCLUDED.bytes`) is **not reachable**. The drain records only at its own commit; a local
+read never promotes because it hits locally; eviction deletes row and directory together. Worth a
+comment reconciling the two, not a fix.
+
+---
+
+## 2. Fix phases
+
+Ordered so the cheapest outage-preventing change lands first and nothing depends on a later phase.
+Every phase is independently revertable and carries a config kill-switch.
+
+### Phase 0 (P0, do first) — Make the retention rollback real, and stop the manifest lying
+
+**Rewritten 2026-08-07 after adversarial review. The first draft proposed a
+`CEPHOR_RETAIN_REPLICATED` flag and deleting the dead env var. Both were wrong; one was harmful.**
+
+**Retention already has a working rollback: the container image.** Verified — the pre-#398
+`ssd_reclaim` unlinks a `replicated` part once `status.age >= graces.replicated`
+(`git show dcbe9ef1:crates/hippius-drain-core/src/ssd_reclaim.rs`, the `Replicated` arm). So
+`kubectl rollout undo daemonset/drain-agent` both restores unlink-on-commit **and self-heals the
+retained cache** within `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS` (3600 s in prod). An immutable image
+plus a tested `rollout undo` is the standard mechanism; a flag would be a second one.
+
+**So do NOT delete `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS` from
+[k8s/production/drain-agent-daemonset.yaml:151](../../k8s/production/drain-agent-daemonset.yaml).**
+It is dead for the new binary and **load-bearing for the rollback path**. Deleting it — which the
+first draft called "manifest hygiene" — would have removed the grace that makes a rollback drain
+the disk, leaving a rolled-back fleet holding a full cache with nothing to sweep it. Keep it and
+comment it as rollback-only.
+
+**And do NOT add `CEPHOR_RETAIN_REPLICATED`.** It keeps the pre-#398 code path alive as a
+backward-compatible shim, which [CLAUDE.md](../../CLAUDE.md) forbids outright ("Replace, don't
+deprecate… No backward-compatible shims"; "don't add flags unless users actively need them"). It
+also buys nothing operationally: an env change requires a pod restart, so it is no faster than
+`rollout undo`, while adding a second reachable behaviour to test forever.
+
+**Change, therefore:**
+
+1. Comment `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS` in both manifests as *read only by the
+   pre-retention binary; retained deliberately so an image rollback sweeps the retained cache*.
+2. Correct the stale "drained parts are unlinked" rationale for the 15 s poll at
+   [staging:179-181](../../k8s/staging/drain-agent-daemonset.yaml) / prod:181-182.
+3. **Exercise the rollback on staging and measure it** — deploy retention, let occupancy build,
+   `rollout undo`, and confirm SSD occupancy returns to backlog-only within the grace. A rollback
+   nobody has run is a hypothesis.
+4. Add the release note: *this binary changes production behaviour with no config flag; rollback
+   is `rollout undo`.*
+
+**Why first.** Not because retention is unsafe, but because its rollback was undocumented,
+untested, and about to be silently disabled by a manifest cleanup.
+
+### Phase A (P0) — Close the promotion/ingest loop
+
+**Change.** Gate `_promote_chunk` on free space. Add a memoized pressure read (~5 s TTL, same
+shape as `get_published_pressure_mode`'s `_PUBLISHED_MEMO_SECONDS` in
+[pressure_signal.py](../../hippius_s3/pressure_signal.py)) and skip promotion when free ratio is
+below `HIPPIUS_PROMOTE_MIN_FREE_RATIO`. Count skips as
+`promotion_skipped_total{reason=disk_pressure}`.
+
+**Threshold, twice corrected — see §0-M3 for the measurement that settled it.** The first draft
+used 0.20, which sits *exactly on* the evictor's target (150‰ + 50‰) — degenerate chatter. The
+review then raised it to 0.25, which is worse: promotion stops below 0.25 and eviction only
+restores to 0.20, so promotion **never resumes**. Staging sits at 23% free today, so that version
+would have switched promotion off permanently on deploy.
+
+**`HIPPIUS_PROMOTE_MIN_FREE_RATIO = 0.175`**, inside the evictor's band:
+
+```
+fs_cache_min_free 0.08  <  evict_reserve 0.15  <  promote_floor 0.175  <  evict target 0.20
+```
+
+The load-bearing assertion is **`evict_reserve + evict_headroom > promote_floor`** — the evictor's
+target must be strictly above the floor, or the loop is dead. Ordering alone is not enough; both
+prior drafts satisfied a naive ordering test and were still broken.
+
+**Design caveat, recorded because it is a real limit of this approach.** A cache that *refuses
+admission* when full cannot adapt its hot set; the textbook behaviour is to *evict* and admit. This
+gate is deliberately the cruder option — it is 40 lines and it protects ingest, which is the
+outage risk — but it means that at steady-state fill, promotion is effectively throttled to the
+evictor's duty cycle. That is acceptable only because Phase H makes eviction recency-aware; a FIFO
+evictor plus an admission gate would freeze whatever happened to be cached first. **Do not ship
+Phase A's floor without Phase H on the same roadmap.**
+
+**Why first — and what that claim is worth.** Not because it matters most: Phase B is at least as
+load-bearing. A goes first because it is ~40 lines, needs no migration and no Rust, and cannot
+break anything, so it buys headroom while the riskier changes are still in review. The risk it
+addresses is steady-state churn after the disk saturates, **not** a burst — promotion only fires
+on a miss, so its rate decays as the cache warms. It is self-limiting in rate, not in total.
+
+**Kill switch.** `HIPPIUS_OBJECT_CACHE_PROMOTE_ON_READ=false` (already exists).
+
+**Staging cannot gate this** (§0-M2): the shared `/dev/md3` means the free ratio staging measures
+is 99.8% other tenants'. Until staging has a dedicated device, Phase A ships validated by unit
+tests plus a **prod** observation of `promotion_skipped_total`, not by a staging soak.
+
+### Phase B (P0) — Make eviction close its deficit and tell the truth
+
+**Change.** Loop inside `evict_to_target`: page → unlink → `mark_evicted` → re-query, until the
+deficit is met, a page returns fewer than `limit` rows (genuine exhaustion), or a per-pass budget
+is hit. `mark_evicted` → `drop_residency` DELETEs the rows, so a re-query returns fresh candidates
+— the loop is safe by construction, but the mark **must** precede the re-query or the pass spins
+on the same page. Set `starved` **only** on genuine exhaustion; add
+`EvictionReport::budget_exhausted` for the "more to do next tick" case, logged at INFO.
+
+Per-pass budget: wall-clock (`CEPHOR_EVICT_MAX_PASS_SECS`, default 10 s) rather than a part count,
+so the bound tracks actual disk cost rather than a proxy. Carry the remainder to the next tick.
+
+**M1 — the page size must stop being the unit of progress.** Measured prod `parts` p50 is **686
+bytes** against a 408 KB shard mean: the distribution is bimodal, so a fixed 512-*part* page is
+almost uncorrelated with bytes freed. Walking the small-part tail frees ~350 KB per page against a
+175 GB deficit. `CEPHOR_EVICT_BATCH` therefore becomes the **page size for one query**, not the
+pass budget — the loop keeps paging until the *byte* deficit is met, exhaustion, or the wall-clock
+budget. Without this the loop alone would just make 342 queries of 350 KB each and still time out.
+
+**A9 — re-probe free space per page.** The deficit is derived from one `statvfs` at pass start and
+then acted on for up to 10 s while ingest writes concurrently. Re-probe between pages so the pass
+converges on reality rather than on a stale target.
+
+**Why.** Without it the fix in Phase A is the *only* thing holding the disk, and the one alert
+that would tell us it failed is already crying wolf.
+
+**Kill switch.** `CEPHOR_EVICT_MAX_PASS_SECS` → small value restores near-current behaviour;
+`CEPHOR_EVICT_RESERVE_PERMILLE=0` disables eviction entirely.
+
+### Phase C (P0) — Bound the SSD scanners
+
+**Revised 2026-08-07 after review: C2 comes FIRST, and mtime pruning is dropped.** The original
+ordering had it backwards. Reasoning kept below, because the discarded option is the one a future
+reader will otherwise re-propose.
+
+**C2 (do this) — the api announces the landed part; the drain agent writes the row.**
+
+**Reshaped 2026-08-07 after adversarial review.** The first draft had the api `INSERT` into
+`cephor_replication_status` directly. That gives the table **two writers across two services with
+two separate migration systems** (`crates/hippius-drain-core/migrations/` and
+`hippius_s3/sql/migrations/`) — and this repo already established the opposite convention for the
+same handoff: the drain is the *sole producer* of upload requests, publishing via Redis rather than
+letting the api write the consumer's state.
+
+Use the same shape. On finishing a part — strictly **after** `meta.json`, the readiness gate — the
+api `LPUSH`es a landed-part notice onto a per-node queue on `redis-queues`. The drain agent
+consumes it and calls its own existing `record_landed_part`. Benefits over the direct write:
+
+- `cephor_replication_status` keeps exactly one writer and one migration owner.
+- No new flag: an agent that never sees a message behaves as it does today, so the rollout is the
+  api-side publish alone, with the consumer inert until it arrives.
+- Identical failure profile — a lost message means the part is picked up by the reconciler
+  backstop, which is precisely what a failed `INSERT` would have done.
+
+The reconciler then demotes from *sole trigger at 15 s* to *backstop at 10 min*, and the walk leaves
+every latency path — with **no pruning heuristic, no mtime invariant, and no discovery window**.
+
+Verified prerequisite: the api's `NODE_NAME` and the agent's `CEPHOR_NODE_ID` both derive from
+`spec.nodeName`, so per-node routing is sound — but that is two manifests independently holding the
+same `fieldRef` with nothing asserting it. Add a startup log of both, and a soak guard that the
+queue is drained by the agent on the same node.
+
+The poll change is a **separate commit and separate deploy** from the publish, so rolling back one
+does not force the other.
+
+**C3 — the low-risk half of the original C1, ships either way.** Independent of C2:
+
+- *Reclaimer:* drive the `failed` disposition from the DB
+  (`status='failed' AND node_id=$1 AND updated_at < now()-grace`) instead of from the walk. Keep
+  the FS walk **only** for the no-DB-row orphan case and drop its cadence from 300 s to hourly —
+  `CEPHOR_ORPHAN_RECLAIM_GRACE_SECS` is already 24 h, so hourly is ample.
+- Add `drain_scan_parts_total` and `drain_scan_duration_seconds` so F1 cannot return unnoticed.
+
+**Rejected: mtime pruning of the reconciler walk.** The invariant is sound — a part dir can only
+appear by `mkdir`, which bumps its parent version dir's mtime — but it is the wrong invariant. A
+part is not *discoverable* until `meta.json` lands, and writing meta bumps the **part** dir's
+mtime, not the version dir's. On a slow multi-chunk upload the version dir's mtime is stale by the
+whole upload duration, so a pruned scan skips the part and it waits for the next full sweep.
+
+That converts a 15-second drain trigger into a worst-case one-hour window in which the part's
+**only durable copy is a single SSD** — a durability regression traded for scan cost, which is the
+wrong direction on this system. A fix exists (have the api `os.utime` the version dir when it
+writes meta, making the invariant exact), but if the api is being touched at all then C2 is barely
+more work and strictly better. Do not resurrect pruning unless C2 is rejected outright.
+
+### Phase D (P1) — Make the eviction reserve measure drain lag
+
+**Change.** Compute shortfall in `reserve_permille` from `backlog` and `budget` directly rather
+than reusing `demand`: time-to-drain, `backlog / max(budget × horizon, 1)` clamped to 1000‰, with
+`horizon` = the allocator tick (`DEFAULT_TICK` = 5 s) × a configurable multiplier. Requires
+carrying `backlog` onto `Entry` in `distribute`. **Deliberately does not touch the budget
+water-fill** — only the reserve derived from it.
+
+### Phase E (P2) — Peer-serve fresh parts
+
+**Change.** A second resolver over `cephor_replication_status.node_id WHERE status IN
+('pending','draining')`, consulted when the residency lookup misses. Own flag,
+`HIPPIUS_PEER_FETCH_PENDING`, default off. Biggest remaining user-visible win; it directly retires
+a documented staging failure.
+
+**Blocked on a design decision — do not implement as originally specced.** The first draft said
+"teach `chunks_exist_batch` that peer-resident counts as cache." That is unsafe as written.
+`source` is decided **once**, up front ([object_reader.py:278-290](../../hippius_s3/services/object_reader.py)),
+and a `cache` verdict means **no pipeline request is ever enqueued**. If the peer then evicts or
+drains the part between the check and the read, the streamer blocks on a pub/sub notification that
+will never arrive — bounded by `HIPPIUS_CACHE_TTL` = **3600 s** for non-first chunks
+([config.py:218-221](../../hippius_s3/config.py)). A peer losing a part mid-stream would turn a
+fast 503 into an hour-long hang: strictly worse than the failure this phase exists to fix.
+
+Whatever ships must keep a live fallback — re-check on miss and enqueue the pipeline then, or bound
+the peer-sourced wait far below `cache_ttl` and fail over. A feature flag does not cover this,
+because the bad path only appears under a race that will not show up in a quiet soak. Design and
+review this before writing code; it is the reason this phase sits at P2 rather than P1.
+
+### Phase G (P1, re-ranked up from F6) — Stop the reader shedding its own prefetch
+
+**Re-ranked 2026-08-07 after independent review.** Originally filed as P3 polish. It is the
+dominant latency and Ceph-load term for large sequential reads, which is the workload this tier
+exists for.
+
+`HTTP_STREAM_PREFETCH_CHUNKS` is 16; `HIPPIUS_PEER_FETCH_MAX_INFLIGHT` is 8. Every chunk of one
+part resolves to the same peer, so a part with more than 8 chunks has a single reader shed its own
+excess to the pool and book it as `client_cap` contention — **contention that does not exist**.
+The effect is to route half a large part's reads to Ceph while the peer sits idle, and to
+under-report `chunk_reads_by_tier_total{tier=peer}` for the whole soak.
+
+Two refinements the original filing missed:
+
+- **Scope.** This bites at >8 chunks, i.e. parts over 32 MiB at the 4 MiB chunk size. It does
+  **not** bite the fleet-average 487 KB single-chunk part — but MPU parts for large sequential
+  uploads are exactly the >32 MiB shape, so it bites the workload that matters here and is
+  invisible in fleet-wide averages.
+- **It is worse than a per-reader cap.** `PeerChunkFetcher._inflight` is built once in the
+  lifespan, so the 8 slots are **pod-wide per peer**, shared across every concurrent reader — not
+  8 per reader. Under concurrent trainer load the cap binds far harder than the single-reader
+  analysis suggests.
+
+**Change.** Raise the client cap to at least the prefetch depth.
+
+**Scoped down 2026-08-07 after adversarial review — the first draft overclaimed this fix.** Run the
+aggregate arithmetic, which the first draft did not: `api-local` is a **DaemonSet** (5 pods), so a
+peer can be addressed by 4 remote pods, each within its own per-peer cap.
+
+| | client side (4 remote pods) | serve cap | ratio |
+|---|---|---|---|
+| today | 4 × 8 = 32 | 16 | 2× oversubscribed |
+| after raising client cap to 16 | 4 × 16 = 64 | 16 | **4× oversubscribed** |
+
+So under *concurrent* readers this change does not add peer capacity — it **converts `client_cap`
+sheds into `server_busy` sheds**. Identical Ceph read load, different label. What it genuinely
+fixes is the **single-reader** case: one pod, 16 chunks of one part, serve cap 16 accommodates it
+exactly, and the reader stops shedding to Ceph against an idle peer. That is a real and common
+case, and it is the only thing this phase should claim.
+
+Two consequences for the plan:
+
+- The gate and test must be written for the single-reader case specifically (they are), and the
+  phase must **not** be sold as "peer tier stops leaking to Ceph."
+- `HIPPIUS_PEER_SERVE_MAX_INFLIGHT = 16` is a guessed number. Size it from a measured figure —
+  what concurrency the peer's NVMe and uvicorn sustain without hurting its own ingest — and state
+  the **intended** steady-state pool read share, because Ceph is by design the overflow valve here
+  and pretending it goes to zero will misread every soak.
+
+A part-level bulk fetch (16 chunks → 1 request) is the better shape but is **not** a capacity fix
+either: slot-seconds at the peer are roughly conserved (16 × ~7 ms ≈ 1 × ~90 ms for a 64 MiB part).
+Its real wins are request overhead and removing the client-cap interaction entirely. Treat it as a
+follow-up, not as the answer to oversubscription.
+
+**Do not read the soak's tier split until this lands.** Until then, "the peer tier is not helping"
+is unfalsifiable, because half the peer opportunity on large parts is mis-booked as pool.
+
+### Phase H (P1 for the trainer workload — moved out of non-goals) — Don't FIFO-evict the hot set
+
+**Moved 2026-08-07 after independent review.** The prior plan filed recency-aware eviction as a
+non-goal on the grounds that node-local read recency does not exist. That reasoning is sound and
+the conclusion was still wrong for this workload: eviction is FIFO on `resident_at`
+([store.rs `ORDER BY r.resident_at`](../../crates/hippius-drain-core/src/store.rs)), so once the
+disk is full enough for the tier to matter, a re-read working set is evicted in arrival order and
+immediately re-promoted — paying a peer/pool read plus a local write per cycle. FIFO is materially
+worse than LRU under skewed re-reads, and a training set re-read per epoch is maximally skewed.
+
+**Cheapest concrete option, which the original non-goal reasoning overlooked:** `resident_at`
+already *is* the ordering key, so a **sampled or batched bump of `resident_at` on a local hit**
+converts FIFO into approximate LRU with no new table, no new column, and no fleet-wide-vs-node-local
+ambiguity — the row is already node-scoped. The objection is a write on the read path; sampling
+(bump at most once per part per N minutes, via the existing `PartMemo`) bounds that to roughly the
+promotion write rate, which the path already pays.
+
+Prove the thrash before building it: during the soak, correlate `drain_ssd_evicted_total` against
+re-`promotion` of the same parts. If parts are being promoted, evicted, and re-promoted inside one
+epoch, that is the signal.
+
+### Phase F (P3) — Remaining tuning, one commit
+
+`HIPPIUS_PEER_FETCH_TIMEOUT_SECONDS` 2.0 → 0.5; fire promotion via `create_task`; reconcile the
+two residency `ON CONFLICT` semantics in a comment. (The peer-cap item moved to Phase G.)
+
+---
+
+## 3. Test plan
+
+TDD throughout: the failing test lands in the same commit as, and before, the fix. Every test below
+names the property it protects, not the function it calls.
+
+### Phase 0 — rollback is a drill, not a unit test
+
+No new code, so no unit tests. The verification is operational and must actually be run:
+
+| Level | Where | Check |
+|---|---|---|
+| drill | staging | deploy retention → build occupancy → `kubectl rollout undo daemonset/drain-agent` → SSD occupancy returns to backlog-only within the grace. **Timed and recorded**, not asserted |
+| drill | staging | during that rollback, no part loses its only durable copy — cross-check `cephor_replication_status` against on-disk parts before and after |
+| review | both manifests | `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS` present and commented as rollback-only; the "drained parts are unlinked" rationale corrected |
+
+### Data-loss drill (A7) — required before any phase reaches prod
+
+| Level | Where | Check |
+|---|---|---|
+| drill | staging | kill a node mid-drain with retention on; every part is either still `pending`/`draining` with its SSD copy intact, or `replicated` with a verified pool copy. **No part in neither state** |
+| soak | `stress-test/inv/guards.py` | the above as a standing invariant, not a one-off |
+
+### Phase G — prefetch/peer-cap alignment
+
+| Level | File | Test |
+|---|---|---|
+| unit | `tests/unit/test_peer_fetch.py` | a single reader fetching `prefetch_depth` chunks of one part records **zero** `client_cap` sheds — the regression test, which fails on today's 16-vs-8 defaults |
+| unit | same | the cap still sheds under genuine multi-reader contention (the Owl property must survive) |
+| unit | new | **config invariant**: `peer_fetch_max_inflight >= http_stream_prefetch_chunks`, asserted against shipped defaults so a future prefetch bump cannot silently re-open this |
+
+### Phase H — recency-aware eviction
+
+| Level | File | Test |
+|---|---|---|
+| unit | `hippius_s3/cache/` | a local hit bumps `resident_at` at most once per part per sample window (bounds the read-path write) |
+| integration | `#[sqlx::test]` | a part read recently sorts **behind** an older-read part in `evictable_parts`, i.e. the ordering actually became recency |
+| integration | same | the durability invariant is untouched by the reordering — a non-replicated part is still never offered, whatever its recency |
+| soak | `stress-test/inv/guards.py` | no part is promoted → evicted → re-promoted within one read epoch |
+
+### Phase A — promotion backpressure
+
+| Level | File | Test |
+|---|---|---|
+| unit | `tests/unit/test_promotion_pressure_guard.py` | a chunk read below the free-space floor is **served** but **not promoted**, and increments `promotion_skipped_total` |
+| unit | same | above the floor, promotion still happens (no regression of the tier) |
+| unit | same | the pressure read is memoized — N chunk reads in one window cause **one** `disk_usage` call |
+| unit | same | **threshold ordering invariant**: `promote_min_free_ratio > evict_reserve > fs_cache_min_free_ratio`, asserted against the shipped defaults so a retune cannot invert it |
+| unit | same | a `disk_usage` failure does not fail the read (degrades to *allow* promotion, matching the existing best-effort posture) |
+
+### Phase B — eviction loop
+
+| Level | File | Test |
+|---|---|---|
+| unit | `crates/hippius-drain-core/src/ssd_evict.rs` | **batch smaller than the candidate set still frees the full deficit** and reports `starved == false` — the F2a regression test |
+| unit | same | genuine exhaustion (worklist shorter than the deficit needs) still reports `starved == true` |
+| unit | same | the pass marks each page **before** re-querying (fake log asserts no page is offered twice) |
+| unit | same | wall-clock budget exhaustion sets `budget_exhausted`, not `starved`, and leaves the remainder for the next pass |
+| unit | same | the unreplicated-refusal invariant survives the loop — a non-replicated part on **any** page is never unlinked, `skipped_unreplicated` counts every one |
+| property | same | for any (free, reserve, headroom, candidate set), `freed_bytes ≤ sum(candidate bytes)` and the pass terminates |
+| integration | `crates/hippius-drain-core/src/store.rs` (`#[sqlx::test]`) | successive `evictable_parts` pages after `mark_evicted` return **disjoint** rows in FIFO order |
+
+### Phase C2 — api records the landed part
+
+| Level | File | Test |
+|---|---|---|
+| unit | `tests/unit/` | the landed-part write is ordered strictly **after** `meta.json` — the drain must never be able to claim an incomplete part |
+| unit | same | a failed landed-part write does **not** fail the PUT, and leaves the reconciler backstop able to recover it |
+| unit | same | the write is idempotent — a retried PUT does not disturb an existing row's status (an `ON CONFLICT DO NOTHING` that reset a `draining` row would be data loss) |
+| unit | same | with the flag off, no row is written and the PUT path is byte-identical to today |
+| e2e | `tests/e2e/` | with the flag on, `ReconcileReport.recovered` is 0 for parts the api recorded |
+| e2e | same | **kill the api mid-part**: a part whose meta landed but whose row did not is still recovered by the reconciler within one poll — the property that lets the poll be lengthened |
+
+### Phase C3 — reclaimer
+
+| Level | File | Test |
+|---|---|---|
+| unit | `crates/hippius-drain-core/src/ssd_reclaim.rs` | DB-driven `failed` reclaim removes exactly the parts the walk-driven one did (behavioural equivalence, both paths over one fixture) |
+| integration | `#[sqlx::test]` | the `failed` worklist query is node-scoped, grace-gated, and excludes servable parts (the corrupt-live guard must survive the rewrite) |
+| integration | same | a `corrupt` part is never returned by the new query, at any age |
+| bench-ish | new | scan duration and part count on a seeded tree of ≥ 200k parts, asserted under a ceiling; guards F1 from returning |
+
+### Phase D — reserve
+
+| Level | File | Test |
+|---|---|---|
+| unit | `crates/hippius-drain-core/src/alloc.rs` | a node with **small** backlog and a partial budget keeps a reserve near base — the F4 regression test, which today's code fails |
+| unit | same | a node with backlog far exceeding `budget × horizon` reserves at max |
+| unit | same | a caught-up node (zero backlog) never exceeds base — existing property, must survive |
+| unit | same | the Ceph-ceiling term still dominates on a satisfied node (the existing NearFull test must still pass unchanged) |
+| property | same | reserve is monotonic non-decreasing in backlog and non-increasing in budget |
+
+### Phase E — peer-serve fresh parts
+
+| Level | File | Test |
+|---|---|---|
+| unit | `tests/unit/test_peer_fetch.py` | a `pending` part resolves to its ingest node when the residency lookup misses |
+| unit | same | with the flag off, behaviour is identical to today |
+| unit | `tests/unit/test_dual_fs_store.py` | a peer-resident, pool-absent part reads as **cache**, not pipeline |
+| unit | same | promotion of a peer-fetched **pending** part does **not** record residency (its only durable copy is elsewhere; claiming it would offer it to an evictor) — the durability invariant at the new boundary |
+| e2e | `tests/e2e/` | cross-node GET of a freshly-written object succeeds instead of 503ing |
+
+### Cross-cutting
+
+- `stress-test/inv/guards.py` — add a `PromotionPressure` guard (promotion skips rise while free
+  space falls, never the reverse) and an `EvictionKeepsUp` guard (`drain_ssd_free_bytes` never
+  crosses the `fs_cache_pressure` threshold while `drain_ssd_evicted_bytes_total` is climbing).
+- Mutation-test Phase B's invariant with `cargo-mutants` scoped to `ssd_evict.rs`. The prior plan
+  found a real bug this way; do not skip it on the module whose failure mode is data loss.
+- `ruff check` / `ruff format` / `ty check` and `cargo clippy --all-targets --all-features -D
+  warnings` clean before every commit.
+
+---
+
+## 4. Rollout
+
+**Task 0 — measure before sizing anything.** On staging and prod, per node: resident part count,
+average part size, and current `scan_parts` duration. Phase C's sizing and the eviction-rate math
+both depend on real numbers, and the 487 KB figure is derived, not measured. Read-only; no deploy.
+
+Then, one phase per PR, each soaking before the next starts:
+
+| Phase | Staging gate before proceeding |
+|---|---|
+| 0 | **`rollout undo` exercised on staging**: retention deployed, occupancy built, rolled back, occupancy returns to backlog-only within `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS`. Var kept + commented as rollback-only; stale poll rationale corrected; the three §5-A11 numbers agreed |
+| G | `peer_fetch_shed_total{reason=client_cap}` ≈ 0 for a single reader of a >32 MiB part; `chunk_reads_by_tier_total{tier=pool}` falls measurably on the same object. **This gate must clear before any tier-split number from an earlier soak is trusted** |
+| H | evict/re-promote of the same part inside one read epoch is measured; if present, ship the sampled `resident_at` bump and show it falls |
+| A | `promotion_skipped_total` is 0 while free space is healthy; forcing the disk down (a controlled fill) makes it rise **before** `fs_cache_shed` does |
+| B | armed eviction reaches `reserve + headroom` within one pass; `starved` stays 0 across a full fill/drain cycle; `drain_ssd_evict_blocked_unreplicated_total` remains **0** |
+| C2 | with the flag on, `ReconcileReport.recovered` ≈ 0 for ≥ 24 h **and** an induced api kill still recovers. Lengthening `CEPHOR_RECONCILE_POLL_SECS` is a **separate** deploy after that, not part of this gate |
+| C3 | `drain_scan_duration_seconds` p99 well under the (new, hourly) orphan cadence; `failed`-part reclaim counts match the pre-change baseline |
+| D | no node's budget moves; reserves track backlog rather than sitting pinned — verify against the live `cephor:alloc:*` Redis keys, which are ground truth (metrics lag) |
+| E | design review of the miss-after-`cache`-verdict path signed off **before** implementation; then `chunk_reads_by_tier_total{tier=peer}` picks up fresh-object reads and the 503 "parts not ready" rate falls, with no rise in stream-timeout errors |
+
+**Production promotion.** Corrected 2026-08-07: an earlier draft said "the Rust-side changes are
+safe without the api flags." That was wrong — **retention is itself an unflagged Rust change**
+(F0), so the first prod deploy carrying this binary changes production behaviour whatever the api
+flags say. The rule is therefore:
+
+1. **Phase 0 must be in the first prod-bound promotion**, so retention has a kill switch the
+   moment it reaches prod.
+2. Then ≥ 72 h staging soak of the phase set, including a peak-traffic window.
+3. `HIPPIUS_OBJECT_CACHE_PROMOTE_ON_READ` and `HIPPIUS_PEER_FETCH_ENABLED` stay **off** in prod for
+   that first deploy, so a regression has one candidate cause rather than six.
+
+**Rollback.** Per phase: A → flip `HIPPIUS_OBJECT_CACHE_PROMOTE_ON_READ=false`. B → set
+`CEPHOR_EVICT_MAX_PASS_SECS` low, or `CEPHOR_EVICT_RESERVE_PERMILLE=0` to stop eviction outright.
+C2 → revert the api-side publish (the agent's consumer is inert without messages), and restore
+`CEPHOR_RECONCILE_POLL_SECS` if it was already lengthened — which is why the poll change is a
+separate deploy. C3 → revert the commit.
+D → revert; the wire format is unchanged. E → flag off, but see the design caveat in §2: the flag
+does not cover the race, so the fallback path must be right before it ships at all.
+
+**Alerting** lives in the separate `hippius-otel` repo, not here (see PR #21/#22 precedent).
+Required there, in order:
+
+1. `drain_ssd_evict_blocked_unreplicated_total > 0` — page. The durability invariant. Needed
+   **now**, before any further soak.
+2. `drain_ssd_free_bytes` approaching the `fs_cache_pressure` threshold — page.
+3. `starved` — **do not wire until Phase B lands**, or the first real firing is already
+   discredited.
+4. `drain_scan_duration_seconds` above a ceiling — warn, after Phase C.
+
+---
+
+## 5. Adversarial review of this plan (2026-08-07)
+
+Findings against the plan itself. The severe ones are corrected inline above; the rest are recorded
+here with their disposition, so a reviewer can see what was considered and rejected.
+
+### Corrected inline
+
+| # | Finding | Disposition |
+|---|---|---|
+| A1 | Phase 0 proposed deleting `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS` from prod. That var is **load-bearing for the image-rollback path** — the pre-#398 binary uses it to sweep retained parts. Deleting it would have left a rolled-back fleet holding a full cache with nothing to reclaim it. | Rewritten. Keep and comment the var; drop the proposed flag entirely (image rollback is the mechanism, and a shim contradicts `CLAUDE.md`). |
+| A2 | Phase A's 0.20 promote floor **equals** the evictor's target (150‰ + 50‰ = 0.20 free). Zero hysteresis; promotion enabled only in the instant after a pass. | Floor moved to 0.25; test now asserts a non-empty band, not just ordering. |
+| A3 | Phase G was sold as stopping the peer tier leaking to Ceph. Aggregate arithmetic (5-pod DaemonSet: 4 × 16 = 64 vs serve cap 16) shows it converts `client_cap` sheds into `server_busy` sheds under concurrency. | Scoped to the single-reader case, which it genuinely fixes; serve-cap sizing and intended pool share called out as open. |
+| A4 | C2 gave `cephor_replication_status` two writers across two services and two migration systems. | Reshaped to a Redis handoff — api announces, agent writes. Also removes a flag. |
+
+### Accepted, folded into the phases
+
+- **A5 — Phase D optimizes an unmeasured mechanism.** Nobody has shown a dynamic free-space floor
+  prevents 503s better than the static one. **Gate Phase D on evidence from the Phase B soak**; if
+  the static floor holds, drop it rather than tune it.
+- **A6 — the plan had no load test, though the repo just gained one.** Every gate is written
+  against production-shaped traffic the plan never said how to generate.
+  [`stress-test/throughput.py`](../../stress-test/throughput.py) (added in PR #398) already does
+  sized, concurrent upload + re-read, and [`stress-test/inv/guards.py`](../../stress-test/inv/guards.py)
+  is the invariant harness. **Every soak gate in §4 must be expressed as a rung in that harness**,
+  not as a hand-run observation.
+- **A7 — no canary, and no data-loss drill.** The DaemonSet's `RollingUpdate` defaults to
+  `maxUnavailable: 1`, so it does roll one node at a time — but nothing *pauses* between nodes.
+  For a change whose worst case is losing a part's only durable copy, add (a) an explicit one-node
+  canary with a hold and an observation window, and (b) a **kill-a-node-mid-drain drill** proving
+  no part is lost with retention on. Neither exists today.
+- **A8 — flag proliferation contradicts `CLAUDE.md`.** The first draft added five knobs. After A1
+  and A4 the count is three: `HIPPIUS_PROMOTE_MIN_FREE_RATIO`, `CEPHOR_EVICT_MAX_PASS_SECS`, and
+  `HIPPIUS_PEER_FETCH_PENDING`. The first two are tuning thresholds, not feature switches; the
+  third is a genuine staged rollout of new behaviour. That is defensible; five was not.
+- **A9 — Phase B's deficit is computed once** from a `statvfs` at pass start, then acted on for up
+  to 10 s while ingest writes concurrently. **Re-probe free space per page**, or the pass over- or
+  under-evicts by whatever landed during it.
+- **A10 — Phase H overloads `resident_at`.** Bumping it on read means the column stops meaning
+  "when it became resident," contradicting both the migration comment and the evictor's FIFO docs.
+  Add `last_read_at` and order on `COALESCE(last_read_at, resident_at)` — one nullable column, no
+  semantic overload, and the FIFO fallback stays explicit.
+- **A11 — the gates are directional, not numeric.** "pool falls", "cache rises" are unfalsifiable.
+  Before Phase 0 ships, fix three numbers as the acceptance bar: a maximum PUT 503 rate, a p99
+  per-chunk read latency, and a maximum steady-state pool read share. Without them, a soak cannot
+  fail.
+
+### Considered and rejected
+
+- **Rolling retention back with a flag instead of the image** (A1). Rejected: an env change needs a
+  pod restart anyway, so it is no faster than `rollout undo`, while permanently keeping a second
+  reachable behaviour to test.
+- **Bulk part fetch as the answer to peer oversubscription** (A3). Rejected as a *capacity* fix —
+  slot-seconds at the peer are roughly conserved. Kept as a follow-up for request overhead.
+- **mtime pruning of the reconciler walk** — see §2 Phase C; rejected on durability grounds.
+
+## 6. Non-goals
+
+- No change to the budget water-fill in `distribute`. Phase D touches only the reserve derived
+  from it.
+- ~~No true LRU eviction.~~ **Withdrawn as a non-goal 2026-08-07** — promoted to Phase H. FIFO is
+  fine as a v1 mechanism and wrong as a v1 *policy* for a re-read working set.
+- No Owl-style tracker deciding what each node caches. Same reasoning as the prior plan: five
+  nodes and a 5.4 TB working set do not justify that control plane. Phase H is a replacement
+  policy change, not a placement one — the distinction is what keeps it small.
+- No production manifest changes in any phase of this plan.

--- a/hippius_s3/cache/CLAUDE.md
+++ b/hippius_s3/cache/CLAUDE.md
@@ -33,6 +33,19 @@ peer fanout — `HIPPIUS_PEER_FETCH_MAX_INFLIGHT` per (pod, peer) on the client,
 `HIPPIUS_PEER_SERVE_MAX_INFLIGHT` on the serving pod, which sheds with 503. Both shed to the
 pool rather than queueing.
 
+**The client cap must be ≥ `HTTP_STREAM_PREFETCH_CHUNKS`.** Every chunk of one PART resolves to
+the same peer, so a lower cap makes a single reader shed its own prefetch window to the pool and
+book it as `client_cap` — contention that does not exist. `effective_max_inflight` floors it at
+the prefetch depth at wiring time, so a stale config degrades to a startup warning rather than a
+silently halved peer tier. It does **not** add peer capacity: the semaphore is shared across
+readers on the pod, so under concurrency shedding just moves to the peer's `server_busy`.
+
+Promotion is gated on free space (`HIPPIUS_PROMOTE_MIN_FREE_RATIO`, default 0.175) because it
+shares the ingest mount with PUTs — `HIPPIUS_OBJECT_CACHE_DIR` is the drain agent's
+`CEPHOR_SSD_ROOT` and the mount `fs_cache_pressure` measures. The floor must sit strictly inside
+the evictor's band, above its reserve (0.150) and below its target (0.200), or promotion either
+chatters or deadlocks permanently; `validate_promotion_band` enforces that at startup.
+
 **The evictor runs in a different process** (`drain-agent`) and deletes both the part directory
 and its residency row. Nothing in this package may cache "I already recorded/wrote this" across
 that boundary — it cannot be invalidated when the row disappears. Check on-disk state instead;

--- a/hippius_s3/cache/CLAUDE.md
+++ b/hippius_s3/cache/CLAUDE.md
@@ -11,6 +11,7 @@ Chunk cache. Backed by a shared filesystem volume; Redis is used only for pub/su
 | [notifier.py](notifier.py) | `ChunkNotifier` — Redis pub/sub wrapper for chunk-ready notifications. |
 | [dual_fs_store.py](dual_fs_store.py) | `DualFileSystemPartsStore` — the tiered read path: node-local NVMe → peer node → CephFS pool. Optionally promotes a pool/peer-served chunk onto local flash. |
 | [peers.py](peers.py) | `PeerRegistry` (self-registration of pod IPs in Redis, TTL'd) + `PeerChunkFetcher` (resolve which node holds a part, fetch one chunk from it). |
+| [read_recency.py](read_recency.py) | `ReadRecencyRecorder` — stamps `cephor_ssd_residency.last_read_at` on a local hit (sampled), so the drain evictor orders on USE rather than arrival. |
 | [residency.py](residency.py) | `ResidencyRecorder` — claims a promoted part for this node in `cephor_ssd_residency` so this node's evictor can reclaim it. |
 | [part_memo.py](part_memo.py) | `PartMemo` — bounded, TTL'd per-part memo, so per-part facts are not recomputed per chunk. |
 | [__init__.py](__init__.py) | `create_fs_store(config, on_promote=..., peer_fetch=...)` factory — picks `DualFileSystemPartsStore` if `HIPPIUS_OBJECT_CACHE_FALLBACK_DIR` is set. |

--- a/hippius_s3/cache/__init__.py
+++ b/hippius_s3/cache/__init__.py
@@ -2,6 +2,7 @@ from hippius_s3.fs_pressure import FreeSpaceGate
 from hippius_s3.fs_pressure import validate_promotion_band
 
 from .dual_fs_store import DualFileSystemPartsStore
+from .dual_fs_store import LocalReadRecorder
 from .dual_fs_store import PeerFetcher
 from .dual_fs_store import PromotionRecorder
 from .fs_store import FileSystemPartsStore
@@ -14,6 +15,7 @@ def create_fs_store(
     *,
     on_promote: PromotionRecorder | None = None,
     peer_fetch: PeerFetcher | None = None,
+    on_local_read: LocalReadRecorder | None = None,
 ) -> FileSystemPartsStore:
     """Build the parts store: dual-tier when a fallback pool is configured, else single.
 
@@ -47,6 +49,7 @@ def create_fs_store(
             on_promote=on_promote,
             peer_fetch=peer_fetch,
             space_gate=space_gate,
+            on_local_read=on_local_read,
         )
     return FileSystemPartsStore(cache_dir)
 

--- a/hippius_s3/cache/__init__.py
+++ b/hippius_s3/cache/__init__.py
@@ -1,3 +1,6 @@
+from hippius_s3.fs_pressure import FreeSpaceGate
+from hippius_s3.fs_pressure import validate_promotion_band
+
 from .dual_fs_store import DualFileSystemPartsStore
 from .dual_fs_store import PeerFetcher
 from .dual_fs_store import PromotionRecorder
@@ -23,12 +26,27 @@ def create_fs_store(
     cache_dir = getattr(config, "object_cache_dir", "")
     if fallback_dir:
         promote = bool(getattr(config, "object_cache_promote_on_read", False)) and on_promote is not None
+        space_gate = None
+        if promote:
+            floor = float(getattr(config, "promote_min_free_ratio", 0.175))
+            # Fail fast on a threshold set that cannot recover. Every one of these is settable
+            # per-deployment, and a bad combination is SILENT: the read tier simply stops
+            # warming, with nothing in the logs saying why. Better a refused startup than a
+            # cache that quietly never fills.
+            validate_promotion_band(
+                promote_min_free_ratio=floor,
+                fs_cache_min_free_ratio=float(getattr(config, "fs_cache_min_free_ratio", 0.08)),
+            )
+            # Built whenever promotion is on: an ungated promoter is an unthrottled writer on
+            # the disk ingest depends on, so the two are not independently switchable either.
+            space_gate = FreeSpaceGate(cache_dir, floor)
         return DualFileSystemPartsStore(
             cache_dir,
             fallback_dir,
             promote=promote,
             on_promote=on_promote,
             peer_fetch=peer_fetch,
+            space_gate=space_gate,
         )
     return FileSystemPartsStore(cache_dir)
 

--- a/hippius_s3/cache/dual_fs_store.py
+++ b/hippius_s3/cache/dual_fs_store.py
@@ -6,6 +6,7 @@ from typing import Callable
 from typing import Optional
 
 from hippius_s3.cache.fs_store import FileSystemPartsStore
+from hippius_s3.fs_pressure import FreeSpaceGate
 from hippius_s3.monitoring import ChunkReadTier
 
 
@@ -34,6 +35,18 @@ def _record_tier(tier: ChunkReadTier) -> None:
         pass
 
 
+def _record_promotion_skipped() -> None:
+    """Count a chunk served without warming local flash. Never fatal."""
+    try:
+        from hippius_s3.monitoring import get_metrics_collector
+
+        collector = get_metrics_collector()
+        if collector is not None:
+            collector.record_promotion_skipped("disk_pressure")
+    except Exception:  # noqa: BLE001 - a metrics failure must not fail a read
+        pass
+
+
 class DualFileSystemPartsStore(FileSystemPartsStore):
     """Primary (node-local NVMe) store with the shared CephFS pool as a read fallback.
 
@@ -56,12 +69,17 @@ class DualFileSystemPartsStore(FileSystemPartsStore):
         promote: bool = False,
         on_promote: Optional[PromotionRecorder] = None,
         peer_fetch: Optional[PeerFetcher] = None,
+        space_gate: Optional[FreeSpaceGate] = None,
     ) -> None:
         super().__init__(primary_dir)
         self.fallback = FileSystemPartsStore(fallback_dir)
         self._promote = promote
         self._on_promote = on_promote
         self._peer_fetch = peer_fetch
+        # Promotion yields to ingest: this is the only writer here that is pure optimisation,
+        # and it shares the mount with the PUTs that `fs_cache_pressure` refuses when the disk
+        # runs out. `None` means no gate (tests, and any deployment without a fallback tier).
+        self._space_gate = space_gate
         # Chunks whose promotion is in flight right now, so concurrent readers of the same
         # cold chunk write it once. Holds only in-flight keys, so it drains itself and needs
         # no bound or TTL — unlike a "already done" memo, which the out-of-process evictor
@@ -133,6 +151,15 @@ class DualFileSystemPartsStore(FileSystemPartsStore):
         writing it last would leave the whole part invisible until some read happened to
         promote the final chunk.
         """
+        # Yield to ingest before doing any work. Promotion competes for the same mount that
+        # `fs_cache_pressure` refuses PUTs on, and it is the only writer here that is pure
+        # optimisation — a cold cache costs latency, a full disk costs writes. The gate fires
+        # above the drain evictor's floor, so promotion backs off before eviction is even
+        # armed rather than racing it.
+        if self._space_gate is not None and not self._space_gate.allows():
+            _record_promotion_skipped()
+            return
+
         # Skip if another reader is already promoting this exact chunk. Skipping beats
         # waiting: this caller already holds the bytes, so blocking on someone else's write
         # would add latency and return the same result. Duplicate promotion is not merely

--- a/hippius_s3/cache/dual_fs_store.py
+++ b/hippius_s3/cache/dual_fs_store.py
@@ -18,6 +18,11 @@ logger = logging.getLogger(__name__)
 # evictor can reclaim the copy.
 PromotionRecorder = Callable[[str, int, int, int], Awaitable[None]]
 
+# Called after a chunk is served from THIS node's flash, with (object_id, version, part_number).
+# Feeds cephor_ssd_residency.last_read_at, which is what makes eviction recency-ordered instead
+# of FIFO. Sampled by the recorder, so it is cheap to call on every local hit.
+LocalReadRecorder = Callable[[str, int, int], Awaitable[None]]
+
 # Fetches one chunk from the peer node that currently holds it on flash, with
 # (object_id, version, part_number, chunk_index). Returns None when no peer has it.
 PeerFetcher = Callable[[str, int, int, int], Awaitable[Optional[bytes]]]
@@ -70,6 +75,7 @@ class DualFileSystemPartsStore(FileSystemPartsStore):
         on_promote: Optional[PromotionRecorder] = None,
         peer_fetch: Optional[PeerFetcher] = None,
         space_gate: Optional[FreeSpaceGate] = None,
+        on_local_read: Optional[LocalReadRecorder] = None,
     ) -> None:
         super().__init__(primary_dir)
         self.fallback = FileSystemPartsStore(fallback_dir)
@@ -80,6 +86,10 @@ class DualFileSystemPartsStore(FileSystemPartsStore):
         # and it shares the mount with the PUTs that `fs_cache_pressure` refuses when the disk
         # runs out. `None` means no gate (tests, and any deployment without a fallback tier).
         self._space_gate = space_gate
+        # Records that a part was served locally, so the drain-agent evictor can order on USE
+        # rather than on arrival. Sampled inside the recorder — this is a dict probe on all but
+        # the first local read of a part per window.
+        self._on_local_read = on_local_read
         # Chunks whose promotion is in flight right now, so concurrent readers of the same
         # cold chunk write it once. Holds only in-flight keys, so it drains itself and needs
         # no bound or TTL — unlike a "already done" memo, which the out-of-process evictor
@@ -92,6 +102,12 @@ class DualFileSystemPartsStore(FileSystemPartsStore):
         result = await super().get_chunk(object_id, object_version, part_number, chunk_index)
         if result is not None:
             _record_tier("local")
+            # Tell the evictor this part is still in use. Without it eviction orders on when a
+            # part ARRIVED, which for a working set re-read every epoch tends to take exactly
+            # the parts about to be read again. Sampled inside the recorder, so this is a dict
+            # probe on all but the first read of a part per window.
+            if self._on_local_read is not None:
+                await self._on_local_read(object_id, int(object_version), int(part_number))
             return result
 
         # Peer tier, between local flash and the pool. A part lives on whichever node

--- a/hippius_s3/cache/peers.py
+++ b/hippius_s3/cache/peers.py
@@ -56,7 +56,44 @@ _OWNER_MEMO_ENTRIES = 50_000
 # other node's reads onto that node's api pod — the same uvicorn serving its own ingest. The
 # cap SKIPS to the pool rather than queueing, because waiting behind a saturated peer would
 # add its latency on top of the pool read that follows.
-_DEFAULT_MAX_INFLIGHT_PER_PEER = 8
+#
+# Must be >= HTTP_STREAM_PREFETCH_CHUNKS or a single reader sheds its own prefetch window —
+# see `effective_max_inflight`, which enforces that floor at wiring time regardless of config.
+_DEFAULT_MAX_INFLIGHT_PER_PEER = 16
+
+
+def effective_max_inflight(configured: int, prefetch_chunks: int) -> int:
+    """The per-peer cap, raised to at least the read path's prefetch depth.
+
+    Every chunk of one PART resolves to the same peer, and the streamer keeps up to
+    `HTTP_STREAM_PREFETCH_CHUNKS` chunk fetches in flight. So whenever the cap is below the
+    prefetch depth, a **single reader of a single part sheds its own excess to the pool** and
+    books it as `client_cap` — contention that does not exist. Shipped defaults were 8 against
+    a prefetch of 16, so half of every part over 32 MiB (8 chunks at 4 MiB) went to CephFS
+    while the peer sat idle.
+
+    Deriving the floor rather than validating it is deliberate: an invariant that must hold
+    between two independently-tuned knobs is one somebody eventually breaks, and the failure is
+    silent — reads still succeed, just slower and against the wrong tier. Raising is safe
+    because the *serving* side has its own cap and sheds with 503, so the peer stays protected
+    however high a client goes.
+
+    **What this does not fix.** The semaphore is per (pod, peer) and shared across every reader
+    on the pod, so under concurrent readers the cap still binds — it just moves the shedding
+    from `client_cap` to `server_busy` at the peer. Aggregate client demand is
+    `(pods - 1) x cap` against one `HIPPIUS_PEER_SERVE_MAX_INFLIGHT`, which on a 5-node fleet is
+    oversubscribed by design: Ceph is the intended overflow valve. This only removes the case
+    where a reader competes with *itself*.
+    """
+    if configured >= prefetch_chunks:
+        return configured
+    logger.warning(
+        "raising HIPPIUS_PEER_FETCH_MAX_INFLIGHT from %d to %d to match HTTP_STREAM_PREFETCH_CHUNKS: "
+        "a cap below the prefetch depth makes a single reader shed its own chunks to the pool",
+        configured,
+        prefetch_chunks,
+    )
+    return prefetch_chunks
 
 
 def _record_shed(reason: PeerShedReason) -> None:
@@ -214,14 +251,12 @@ class PeerChunkFetcher:
         # itself is the semaphore; this only avoids QUEUEING behind a saturated peer, since
         # waiting would stack that peer's backlog on top of the pool read that follows anyway.
         #
-        # NOTE this cap is per (pod, peer) and the read path prefetches
-        # `HTTP_STREAM_PREFETCH_CHUNKS` chunks at a time. Chunks of ONE part all resolve to the
-        # same peer, so for a part with more chunks than `HIPPIUS_PEER_FETCH_MAX_INFLIGHT` a
-        # single reader sheds its own excess to the pool and books it as `client_cap` —
-        # contention that is not contention. Harmless (the pool is the correct fallback) but it
-        # understates the peer tier in `chunk_reads_by_tier_total`, so keep the two values in
-        # mind together when reading the soak. Most parts are a single chunk, so this only
-        # bites large multipart objects.
+        # This cap is per (pod, peer) and SHARED across every reader on the pod, so a shed here
+        # means genuine contention — several readers converging on one peer. It used to mean
+        # something weaker as well: with the cap below `HTTP_STREAM_PREFETCH_CHUNKS`, one reader
+        # of one part shed its own prefetch window, because every chunk of a part resolves to
+        # the same peer. `effective_max_inflight` now floors the cap at the prefetch depth, so
+        # that case is gone and a `client_cap` count is trustworthy as a contention signal.
         if slots.locked():
             _record_shed("client_cap")
             return None

--- a/hippius_s3/cache/read_recency.py
+++ b/hippius_s3/cache/read_recency.py
@@ -1,0 +1,95 @@
+"""Records that this node just served a part from local flash, so eviction can order on use.
+
+The drain-agent's evictor used to order on `resident_at` — when a part JOINED the cache, which
+says nothing about whether anyone is still reading it. That is FIFO replacement, and FIFO is a
+poor fit for the workload this tier exists for: a training set re-read every epoch is maximally
+skewed, so evicting by arrival order tends to take exactly the parts about to be read again.
+Each such eviction costs a peer-or-pool read plus a local write to put the same part back.
+
+Migration 0017 added `cephor_ssd_residency.last_read_at` and the evictor now orders on
+`COALESCE(last_read_at, resident_at)`. This is what fills that column.
+
+**Sampled, because it sits on the read path.** A DB write per chunk read would be far worse than
+the eviction it is preventing. A part is re-stamped at most once per `_SAMPLE_WINDOW_SECONDS`,
+which bounds the write rate by the sampling window rather than by read throughput — and costs
+nothing in fidelity, since the evictor only cares about ordering at hour scale.
+
+Losing a sample is harmless: the part keeps its previous recency and is evicted slightly earlier
+than it deserves, which is the same outcome the tier had before this existed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import asyncpg
+
+from hippius_s3.cache.part_memo import PartMemo
+
+
+logger = logging.getLogger(__name__)
+
+
+# How long a part's recency stamp is considered fresh enough to skip re-writing. The evictor
+# orders at hour scale, so a few minutes of staleness cannot change which part it picks — while
+# the difference in write rate between "once per read" and "once per window" is total.
+_SAMPLE_WINDOW_SECONDS = 300.0
+# Bound on the sampling map so a long-lived pod cannot grow it without limit. Over-evicting an
+# entry only costs one redundant UPDATE.
+_SAMPLE_ENTRIES = 100_000
+
+
+class ReadRecencyRecorder:
+    """Stamps `last_read_at` on parts this node served locally, at most once per part per window."""
+
+    def __init__(self, pool: asyncpg.Pool, node_id: str) -> None:
+        self._pool = pool
+        self._node_id = node_id
+        self._recent: PartMemo[tuple[str, int, int], bool] = PartMemo(_SAMPLE_WINDOW_SECONDS, _SAMPLE_ENTRIES)
+
+    async def __call__(self, object_id: str, object_version: int, part_number: int) -> None:
+        key = (str(object_id), int(object_version), int(part_number))
+        if self._recent.get(key) is not None:
+            return
+        self._recent.put(key, True)
+        try:
+            async with self._pool.acquire() as conn:
+                # Node-scoped: recency is per (node, part). Stamping a peer's row would protect a
+                # copy on a disk this node cannot see while leaving its own unprotected — and the
+                # evictor that reads this column is scoped to its own node_id.
+                #
+                # A part with no row here updates nothing, which is correct: the row is what says
+                # "this node holds it and this node's evictor owns it".
+                await conn.execute(
+                    """
+                    UPDATE cephor_ssd_residency SET last_read_at = now()
+                    WHERE node_id = $1 AND object_id = $2 AND version = $3 AND part_number = $4
+                    """,
+                    self._node_id,
+                    str(object_id),
+                    int(object_version),
+                    int(part_number),
+                )
+        except (asyncpg.PostgresError, OSError) as exc:
+            # Best-effort, like every other bookkeeping write on this path. The chunk is already
+            # served; losing the stamp means the part is evicted somewhat earlier than it
+            # deserves, which is exactly the FIFO behaviour this replaces.
+            logger.debug(
+                "recording read recency failed for %s v%s part %s: %s",
+                object_id,
+                object_version,
+                part_number,
+                exc,
+            )
+
+
+def create_read_recency_recorder(pool: Optional[asyncpg.Pool], node_id: str) -> Optional[ReadRecencyRecorder]:
+    """A recorder, or `None` when this process cannot attribute a read to a node.
+
+    Without a node identity there is no way to say WHOSE copy was read, and the evictor is
+    node-scoped — so a stamp would either miss or, worse, land on another node's row.
+    """
+    if pool is None or not node_id:
+        return None
+    return ReadRecencyRecorder(pool, node_id)

--- a/hippius_s3/cache/read_recency.py
+++ b/hippius_s3/cache/read_recency.py
@@ -26,9 +26,22 @@ from typing import Optional
 import asyncpg
 
 from hippius_s3.cache.part_memo import PartMemo
+from hippius_s3.monitoring import ReadRecencyOutcome
 
 
 logger = logging.getLogger(__name__)
+
+
+def _record_write(outcome: ReadRecencyOutcome) -> None:
+    """Count a recency stamp attempt. Never let observability break a read."""
+    try:
+        from hippius_s3.monitoring import get_metrics_collector
+
+        collector = get_metrics_collector()
+        if collector is not None:
+            collector.record_read_recency_write(outcome)
+    except Exception:  # noqa: BLE001 - a metrics failure must not fail a read
+        pass
 
 
 # How long a part's recency stamp is considered fresh enough to skip re-writing. The evictor
@@ -71,7 +84,9 @@ class ReadRecencyRecorder:
                     int(object_version),
                     int(part_number),
                 )
+            _record_write("written")
         except (asyncpg.PostgresError, OSError) as exc:
+            _record_write("failed")
             # Best-effort, like every other bookkeeping write on this path. The chunk is already
             # served; losing the stamp means the part is evicted somewhat earlier than it
             # deserves, which is exactly the FIFO behaviour this replaces.

--- a/hippius_s3/cache/residency.py
+++ b/hippius_s3/cache/residency.py
@@ -45,7 +45,13 @@ class ResidencyRecorder:
                     INSERT INTO cephor_ssd_residency (node_id, object_id, version, part_number, bytes)
                     VALUES ($1, $2, $3, $4, $5)
                     ON CONFLICT (node_id, object_id, version, part_number)
-                    DO UPDATE SET bytes = cephor_ssd_residency.bytes + EXCLUDED.bytes
+                    -- ACCUMULATES, where the drain's record_resident OVERWRITES. The two are
+                    -- writing different facts: the drain knows the whole part's size at commit
+                    -- and states it; promotion learns the part one chunk at a time and has to
+                    -- add. They cannot collide on a live (node, part) — the drain records only
+                    -- on its own commit, a locally-resident part is served locally and so is
+                    -- never promoted, and eviction removes the row and the directory together,
+                    -- which resets both writers to the same empty starting point.
                     """,
                     self._node_id,
                     str(object_id),

--- a/hippius_s3/cache/residency.py
+++ b/hippius_s3/cache/residency.py
@@ -40,18 +40,26 @@ class ResidencyRecorder:
     async def __call__(self, object_id: str, object_version: int, part_number: int, size_bytes: int) -> None:
         try:
             async with self._pool.acquire() as conn:
+                # The conflict action ACCUMULATES, where the drain's `record_resident`
+                # OVERWRITES. The two are writing different facts: the drain knows the whole
+                # part's size at commit and states it; promotion learns the part one chunk at a
+                # time and has to add. They cannot collide on a live (node, part) — the drain
+                # records only on its own commit, a locally-resident part is served locally and
+                # so is never promoted, and eviction removes the row and the directory
+                # together, resetting both writers to the same empty starting point.
+                #
+                # The action itself is load-bearing and must never be dropped: `ON CONFLICT`
+                # without one is a syntax error, every claim then fails into the except below,
+                # and promoted chunks land on disk with NO residency row — unowned by the
+                # node-scoped evictor and skipped by `ssd_reclaim` as read tier, i.e. a
+                # permanent SSD leak. That is exactly the failure this recorder exists to
+                # prevent, and it is invisible: reads still succeed.
                 await conn.execute(
                     """
                     INSERT INTO cephor_ssd_residency (node_id, object_id, version, part_number, bytes)
                     VALUES ($1, $2, $3, $4, $5)
                     ON CONFLICT (node_id, object_id, version, part_number)
-                    -- ACCUMULATES, where the drain's record_resident OVERWRITES. The two are
-                    -- writing different facts: the drain knows the whole part's size at commit
-                    -- and states it; promotion learns the part one chunk at a time and has to
-                    -- add. They cannot collide on a live (node, part) — the drain records only
-                    -- on its own commit, a locally-resident part is served locally and so is
-                    -- never promoted, and eviction removes the row and the directory together,
-                    -- which resets both writers to the same empty starting point.
+                    DO UPDATE SET bytes = cephor_ssd_residency.bytes + EXCLUDED.bytes
                     """,
                     self._node_id,
                     str(object_id),

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -397,7 +397,12 @@ class Config:
     # concurrent peer requests this pod will SERVE. Both are needed — the client cap bounds
     # what one pod sends, but five pods each within their own cap still add up at the peer,
     # so the serving side sheds with 503 to protect its own ingest.
-    peer_fetch_max_inflight: int = env("HIPPIUS_PEER_FETCH_MAX_INFLIGHT:8", convert=int)
+    # Must be >= http_stream_prefetch_chunks. Every chunk of one PART resolves to the same
+    # peer, so a cap below the prefetch depth makes a single reader shed its own window to the
+    # pool and book it as `client_cap` contention that does not exist. `effective_max_inflight`
+    # enforces that floor at wiring time, so a stale value degrades to a warning, not a
+    # silently halved peer tier.
+    peer_fetch_max_inflight: int = env("HIPPIUS_PEER_FETCH_MAX_INFLIGHT:16", convert=int)
     peer_serve_max_inflight: int = env("HIPPIUS_PEER_SERVE_MAX_INFLIGHT:16", convert=int)
     # 24h since last WRITE — the read path no longer bumps timestamps (read
     # recency lives in fs_cache_inventory.last_access_at), so this gates on

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -370,6 +370,17 @@ class Config:
     # promoted copy is only reclaimable by a drain-agent evictor running on the same node, so
     # enabling it where no evictor runs would fill the disk with copies nothing owns.
     object_cache_promote_on_read: bool = env("HIPPIUS_OBJECT_CACHE_PROMOTE_ON_READ:false", convert=bool)
+    # Free-space floor below which a read stops promoting onto local flash. Promotion is the
+    # only unthrottled writer to the ingest SSD and it shares that mount with ingest — on an
+    # ingest node HIPPIUS_OBJECT_CACHE_DIR is the drain agent's CEPHOR_SSD_ROOT — so warming
+    # the cache must yield to accepting writes.
+    #
+    # 0.175 is not arbitrary: it has to sit strictly INSIDE the drain evictor's hysteresis
+    # band, between its reserve (150 permille) and its target (reserve + headroom = 200
+    # permille). Equal to the target it chatters; above the target it deadlocks, because the
+    # evictor only frees back to its target and could never restore enough for promotion to
+    # resume. See FreeSpaceGate and test_promotion_pressure_guard.py.
+    promote_min_free_ratio: float = env("HIPPIUS_PROMOTE_MIN_FREE_RATIO:0.175", convert=float)
     # Read a chunk from the peer node that holds it on flash (~6 ms + ~1 ms network) before
     # falling through to the CephFS pool (~40 ms). Resolved per PART: only ~2% of multi-part
     # objects have every part on one node, so there is no single node to route a request to.

--- a/hippius_s3/config.py
+++ b/hippius_s3/config.py
@@ -392,7 +392,11 @@ class Config:
     peer_registry_refresh_seconds: int = env("HIPPIUS_PEER_REGISTRY_REFRESH_SECONDS:30", convert=int)
     # Bound on a peer read. A slow peer must lose to the pool quickly rather than adding its
     # latency on top of the pool read that follows.
-    peer_fetch_timeout_seconds: float = env("HIPPIUS_PEER_FETCH_TIMEOUT_SECONDS:2.0", convert=float)
+    # The fallback costs ~40 ms (a CephFS pool read), so this is a loss-cut, not a deadline: a
+    # peer that has not answered in 0.5s is already an order of magnitude worse than giving up,
+    # and waiting the old 2.0s meant paying 50x the fallback before then ALSO paying the
+    # fallback. Generous against a ~7 ms healthy peer read.
+    peer_fetch_timeout_seconds: float = env("HIPPIUS_PEER_FETCH_TIMEOUT_SECONDS:0.5", convert=float)
     # Per-peer fanout: concurrent fetches this pod will have in flight to any ONE peer, and
     # concurrent peer requests this pod will SERVE. Both are needed — the client cap bounds
     # what one pod sends, but five pods each within their own cap still add up at the peer,

--- a/hippius_s3/fs_pressure.py
+++ b/hippius_s3/fs_pressure.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import logging
 import random
 import shutil
+import time
 from dataclasses import dataclass
+from typing import Callable
+from typing import Optional
 
 from hippius_s3.config import Config
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -14,6 +21,136 @@ class FsCachePressure:
     free_bytes: int
     total_bytes: int
     free_ratio: float
+
+
+# How long one free-space reading is reused. Read-through promotion asks per CHUNK, so an
+# unmemoized probe would be a syscall per chunk on the read path; 5s is far shorter than the
+# time it takes ingest to move the ratio meaningfully.
+_GATE_MEMO_SECONDS = 5.0
+
+
+class FreeSpaceGate:
+    """Answers "is there room to promote onto this disk?", at most one probe per TTL.
+
+    Read-through promotion is the only unthrottled writer to the ingest SSD, and it competes
+    for the very disk `fs_cache_pressure` gates PUTs on — on an ingest node
+    `HIPPIUS_OBJECT_CACHE_DIR` and the drain agent's `CEPHOR_SSD_ROOT` are the same mount. So
+    promotion has to yield to ingest, and it must yield *before* the evictor is even armed:
+    warming a cache is an optimisation, refusing a write is an outage.
+
+    The threshold sits INSIDE the evictor's hysteresis band, which is the part that is easy to
+    get wrong in both directions:
+
+        fs_cache_min_free 0.08  <  evict_reserve 0.15  <  promote_floor  <  evict target 0.20
+
+    A floor equal to the evictor's target chatters — promotion is live only in the instant a
+    pass completes. A floor ABOVE the target deadlocks — promotion stops and the evictor, which
+    only frees back to its target, can never restore enough for it to resume. Only a floor
+    strictly between the reserve and the target leaves a band where eviction restores the disk
+    past the point promotion resumes.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        min_free_ratio: float,
+        *,
+        ttl_seconds: float = _GATE_MEMO_SECONDS,
+        probe: Optional[Callable[[str], float]] = None,
+    ) -> None:
+        self._path = path
+        self._min_free_ratio = float(min_free_ratio)
+        self._ttl = float(ttl_seconds)
+        self._probe = probe or free_ratio_of
+        self._expires_at = 0.0
+        self._allowed = True
+
+    def allows(self, now: Optional[float] = None) -> bool:
+        """True when the disk has room to spare for a cache copy.
+
+        Fails OPEN: a probe that raises leaves the previous verdict in place (initially
+        "allowed"). Promotion is best-effort in every other respect too — a `statvfs` blip must
+        not silently disable the read tier, and a genuinely full disk still stops the write with
+        `ENOSPC`, which `_promote_chunk` already swallows.
+        """
+        stamp = now if now is not None else time.monotonic()
+        if stamp < self._expires_at:
+            return self._allowed
+        try:
+            self._allowed = self._probe(self._path) > self._min_free_ratio
+        except OSError as exc:
+            logger.debug("promotion free-space probe failed for %s: %s", self._path, exc)
+        self._expires_at = stamp + self._ttl
+        return self._allowed
+
+
+def free_ratio_of(path: str) -> float:
+    """Free share of the filesystem holding `path`, in 0.0..=1.0."""
+    usage = shutil.disk_usage(path)
+    return float(usage.free / usage.total) if usage.total > 0 else 0.0
+
+
+# The drain agent's shipped eviction policy, as ratios. The evictor lives in Rust
+# (`crates/hippius-drain-agent/src/config.rs`: DEFAULT_EVICT_RESERVE_PERMILLE = 150,
+# DEFAULT_EVICT_HEADROOM_PERMILLE = 50) with no runtime coupling to this process, so the
+# contract is mirrored here and pinned by a test on each side. If the Rust defaults move and
+# these do not, `validate_promotion_band` stops describing the deployed system.
+EVICT_RESERVE_RATIO = 0.150
+EVICT_HEADROOM_RATIO = 0.050
+
+
+class PromotionBandError(ValueError):
+    """The promote floor cannot form a live control loop with the evictor."""
+
+
+def validate_promotion_band(
+    *,
+    promote_min_free_ratio: float,
+    fs_cache_min_free_ratio: float,
+    evict_reserve_ratio: float = EVICT_RESERVE_RATIO,
+    evict_headroom_ratio: float = EVICT_HEADROOM_RATIO,
+) -> None:
+    """Raise unless the four thresholds form a loop that can actually recover.
+
+    Checked against the RESOLVED config at startup, not just against code defaults, because
+    every one of these is settable per-deployment and a bad combination fails silently — the
+    read tier simply stops warming, with nothing logging why.
+
+    Required ordering::
+
+        fs_cache_min_free  <  evict_reserve  <  promote_floor  <  evict_reserve + headroom
+
+    Each inequality earns its place:
+
+    - ``fs_cache_min_free < evict_reserve``: the evictor must be reclaiming before PUTs are
+      refused, not racing the refusal.
+    - ``evict_reserve < promote_floor``: promotion backs off before eviction is even armed, so
+      the cheap lever is pulled first.
+    - ``promote_floor < evict target``: the one that is easy to get backwards. The evictor
+      never frees past ``reserve + headroom``; a floor at or above that point can never be
+      restored, so promotion stops permanently the first time the disk dips. A floor exactly
+      equal to the target chatters instead — live only in the instant a pass completes.
+
+    Raises:
+        PromotionBandError: with the offending values, so the fix is obvious from the log.
+    """
+    evict_target = evict_reserve_ratio + evict_headroom_ratio
+    if not fs_cache_min_free_ratio < evict_reserve_ratio:
+        raise PromotionBandError(
+            f"the PUT-refusal threshold ({fs_cache_min_free_ratio}) must be below the evictor's "
+            f"reserve ({evict_reserve_ratio}), or writes are refused before eviction arms"
+        )
+    if not evict_reserve_ratio < promote_min_free_ratio:
+        raise PromotionBandError(
+            f"the promote floor ({promote_min_free_ratio}) must be above the evictor's reserve "
+            f"({evict_reserve_ratio}), so promotion yields before eviction is armed"
+        )
+    if not promote_min_free_ratio < evict_target:
+        raise PromotionBandError(
+            f"the promote floor ({promote_min_free_ratio}) must be below the evictor's target "
+            f"({evict_target}); the evictor never frees past its target, so a floor at or above "
+            "it can never be restored and promotion would stop permanently"
+        )
 
 
 def get_fs_cache_pressure(config: Config) -> FsCachePressure:

--- a/hippius_s3/main.py
+++ b/hippius_s3/main.py
@@ -38,6 +38,7 @@ from hippius_s3.cache import create_fs_store
 from hippius_s3.cache.peers import PeerChunkFetcher
 from hippius_s3.cache.peers import PeerRegistry
 from hippius_s3.cache.peers import effective_max_inflight
+from hippius_s3.cache.read_recency import create_read_recency_recorder
 from hippius_s3.cache.residency import create_residency_recorder
 from hippius_s3.config import Config
 from hippius_s3.config import get_config
@@ -178,7 +179,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             app.state.peer_serve_limiter = asyncio.Semaphore(config.peer_serve_max_inflight)
             logger.info("Peer chunk fetch enabled for node %s", node_name)
 
-        app.state.fs_store = create_fs_store(config, on_promote=app.state.residency_recorder, peer_fetch=peer_fetch)
+        # Eviction orders on COALESCE(last_read_at, resident_at), so a locally-served part has
+        # to say so or the evictor falls back to arrival order — which for a re-read working set
+        # tends to drop exactly the parts about to be needed again.
+        app.state.read_recency_recorder = create_read_recency_recorder(app.state.postgres_pool, node_name)
+        app.state.fs_store = create_fs_store(
+            config,
+            on_promote=app.state.residency_recorder,
+            peer_fetch=peer_fetch,
+            on_local_read=app.state.read_recency_recorder,
+        )
         app.state.obj_cache = RedisObjectPartsCache(
             app.state.redis_client,
             queues_client=app.state.redis_queues_client,

--- a/hippius_s3/main.py
+++ b/hippius_s3/main.py
@@ -44,6 +44,7 @@ from hippius_s3.config import get_config
 from hippius_s3.logging_config import setup_loki_logging
 from hippius_s3.metrics_collector_task import BackgroundMetricsCollector
 from hippius_s3.repositories.sub_token_scope_repository import SubTokenScopeRepository
+from hippius_s3.writer.landed import initialize_landed_publisher
 
 
 logger = logging.getLogger(__name__)
@@ -183,6 +184,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             queues_client=app.state.redis_queues_client,
             fs_store=app.state.fs_store,
         )
+        # Tell this node's drain agent about each part as it lands, so discovery costs one queue
+        # pop instead of the reconciler's walk of the node's entire replicated shard. Best-effort
+        # and node-scoped: without NODE_NAME there is no way to say whose agent should drain the
+        # part, so nothing is published and the reconciler keeps doing the job.
+        if initialize_landed_publisher(app.state.redis_queues_client, node_name) is not None:
+            logger.info("Landed-part announcements enabled for node %s", node_name)
         logger.info("Cache repositories initialized")
 
         app.state.sub_token_scope_repo = SubTokenScopeRepository(db_pool=app.state.postgres_pool)

--- a/hippius_s3/main.py
+++ b/hippius_s3/main.py
@@ -37,6 +37,7 @@ from hippius_s3.cache import RedisObjectPartsCache
 from hippius_s3.cache import create_fs_store
 from hippius_s3.cache.peers import PeerChunkFetcher
 from hippius_s3.cache.peers import PeerRegistry
+from hippius_s3.cache.peers import effective_max_inflight
 from hippius_s3.cache.residency import create_residency_recorder
 from hippius_s3.config import Config
 from hippius_s3.config import get_config
@@ -164,7 +165,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 app.state.peer_registry,
                 node_name,
                 app.state.peer_http,
-                max_inflight=config.peer_fetch_max_inflight,
+                # Floored at the prefetch depth: chunks of one part all resolve to the same
+                # peer, so a lower cap has a single reader shedding its own window to the pool.
+                max_inflight=effective_max_inflight(
+                    config.peer_fetch_max_inflight,
+                    config.http_stream_prefetch_chunks,
+                ),
             )
             # Serving-side cap, read by the /internal/parts endpoint. Set whenever peer fetch
             # is on, since a node that fetches from peers is also one peers fetch from.

--- a/hippius_s3/monitoring.py
+++ b/hippius_s3/monitoring.py
@@ -28,6 +28,9 @@ ChunkReadTier = Literal["local", "peer", "pool"]
 # Which side declined a peer fetch. Closed by construction, like ChunkReadTier.
 PeerShedReason = Literal["client_cap", "server_busy"]
 
+# Why a chunk that could have been promoted onto local flash was not. Closed by construction.
+PromotionSkipReason = Literal["disk_pressure"]
+
 
 class MetricsCollector:
     """OTel metrics for the API, gateway and workers.
@@ -121,6 +124,16 @@ class MetricsCollector:
         self.chunk_reads_by_tier = self.meter.create_counter(
             name="chunk_reads_by_tier_total",
             description="Chunk reads served, by storage tier (local|peer|pool)",
+            unit="1",
+        )
+
+        # Chunks served but deliberately NOT copied onto local flash. This is the promotion
+        # backpressure made visible: it must start rising BEFORE fs_cache_shed does, because
+        # promotion yielding is what keeps the disk from reaching the PUT-refusal threshold.
+        # Flat at zero while free space falls means the gate is not engaging.
+        self.promotion_skipped = self.meter.create_counter(
+            name="promotion_skipped_total",
+            description="Chunks not promoted to the local read tier, by reason (disk_pressure)",
             unit="1",
         )
 
@@ -511,6 +524,10 @@ class MetricsCollector:
         """Count a declined peer fetch. `reason` is a Literal, so the label stays bounded."""
         self.peer_fetch_shed.add(1, attributes={"reason": reason})
 
+    def record_promotion_skipped(self, reason: PromotionSkipReason) -> None:
+        """Count a chunk served without being promoted. `reason` is a Literal, so bounded."""
+        self.promotion_skipped.add(1, attributes={"reason": reason})
+
     def record_chunk_read_tier(self, tier: ChunkReadTier) -> None:
         """Count one chunk read against the tier that served it.
 
@@ -777,6 +794,9 @@ class NullMetricsCollector:
         pass
 
     def record_peer_fetch_shed(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def record_promotion_skipped(self, *args: object, **kwargs: object) -> None:
         pass
 
     def record_cache_operation(self, *args: object, **kwargs: object) -> None:

--- a/hippius_s3/monitoring.py
+++ b/hippius_s3/monitoring.py
@@ -31,6 +31,12 @@ PeerShedReason = Literal["client_cap", "server_busy"]
 # Why a chunk that could have been promoted onto local flash was not. Closed by construction.
 PromotionSkipReason = Literal["disk_pressure"]
 
+# Outcome of a read-recency stamp. Closed by construction. `failed` is separate rather than
+# uncounted because the write is best-effort and swallowed: without it, a recency path that is
+# erroring on every read is indistinguishable from one that is being fully absorbed by the
+# sampler, and both look like silence.
+ReadRecencyOutcome = Literal["written", "failed"]
+
 
 class MetricsCollector:
     """OTel metrics for the API, gateway and workers.
@@ -134,6 +140,19 @@ class MetricsCollector:
         self.promotion_skipped = self.meter.create_counter(
             name="promotion_skipped_total",
             description="Chunks not promoted to the local read tier, by reason (disk_pressure)",
+            unit="1",
+        )
+
+        # Read-recency stamps actually written to cephor_ssd_residency. This is a DB UPDATE on
+        # the read path, sampled to at most one per part per window — so the rate is bounded by
+        # DISTINCT parts read per window, not by read throughput. That bound is weakest for the
+        # workload the read tier exists for: a full-shard scan (a training epoch) touches far
+        # more distinct parts than the sampler's memo holds, so the memo stops absorbing and
+        # every part read becomes one write. Counting it is what tells us whether that is
+        # happening before Postgres does.
+        self.read_recency_writes = self.meter.create_counter(
+            name="read_recency_writes_total",
+            description="last_read_at stamps written to cephor_ssd_residency, by outcome (written|failed)",
             unit="1",
         )
 
@@ -528,6 +547,10 @@ class MetricsCollector:
         """Count a chunk served without being promoted. `reason` is a Literal, so bounded."""
         self.promotion_skipped.add(1, attributes={"reason": reason})
 
+    def record_read_recency_write(self, outcome: ReadRecencyOutcome) -> None:
+        """Count one `last_read_at` stamp attempt. `outcome` is a Literal, so bounded."""
+        self.read_recency_writes.add(1, attributes={"outcome": outcome})
+
     def record_chunk_read_tier(self, tier: ChunkReadTier) -> None:
         """Count one chunk read against the tier that served it.
 
@@ -797,6 +820,9 @@ class NullMetricsCollector:
         pass
 
     def record_promotion_skipped(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def record_read_recency_write(self, *args: object, **kwargs: object) -> None:
         pass
 
     def record_cache_operation(self, *args: object, **kwargs: object) -> None:

--- a/hippius_s3/writer/CLAUDE.md
+++ b/hippius_s3/writer/CLAUDE.md
@@ -10,7 +10,8 @@ Entry point is [`ObjectWriter`](object_writer.py); the heavy lifting is in [`put
 |---|---|
 | [object_writer.py](object_writer.py) | Orchestrator. Simple PUT, MPU part upload, MPU completion, append. |
 | [chunker.py](chunker.py) | `stream_encrypt_to_chunks` — buffers plaintext, yields ciphertext one chunk at a time. |
-| [write_through_writer.py](write_through_writer.py) | `WriteThroughPartsWriter` — FS writes (fatal), Redis writes (best-effort). |
+| [write_through_writer.py](write_through_writer.py) | `WriteThroughPartsWriter` — FS writes (fatal), then the landed-part announcement (best-effort). |
+| [landed.py](landed.py) | `LandedPartPublisher` — tells this node's drain agent a part is complete, so discovery is a queue pop instead of a whole-disk walk. |
 | [cache_writer.py](cache_writer.py) | **Dead code** — `CacheWriter` not referenced anywhere. Delete candidate in [todo.md](../../todo.md). |
 | [db.py](db.py) | `upsert_object_basic`, `ensure_upload_row` — atomic DB reserves. |
 | [types.py](types.py) | Dataclasses: `PutResult`, `PartResult`, `CompleteResult`, `AppendPreconditionFailed`, etc. |
@@ -29,7 +30,7 @@ _(`queue.py` was removed: its `enqueue_upload` was the dead PUT-path upload prod
    - Producer (main coroutine, [line 338-394](object_writer.py)): drains `body_iter`, accumulates into `pt_buf`, encrypts full chunks with the **global** chunk index (AEAD AAD binds to it, so chunks MUST be encrypted in order), enqueues onto `write_queue` (maxsize 16).
    - Consumer ([line 308-333](object_writer.py)): dequeues, calls `fs_store.set_chunk` (fatal on failure), appends to `redis_chunks` for best-effort batched Redis write ([line 330-331](object_writer.py) flushes every 16).
 6. **Flush final Redis batch** ([line 285-306 `_flush_redis_batch`](object_writer.py)).
-7. **Write FS meta** via `WriteThroughPartsWriter.write_meta` ([line 420](object_writer.py)). `meta.json` is the "part is complete" signal for readers. Must land AFTER every chunk is safely on disk — otherwise readers could see a completed part with missing chunks.
+7. **Write FS meta** via `WriteThroughPartsWriter.write_meta` ([line 420](object_writer.py)). `meta.json` is the "part is complete" signal for readers. Must land AFTER every chunk is safely on disk — otherwise readers could see a completed part with missing chunks. `write_meta` then **announces the part** to this node's drain agent ([landed.py](landed.py)) — strictly after meta, since meta is what makes the part claimable. It is the one choke point every upload path funnels through, which is why the hook lives there rather than at the four call sites. Best-effort: a dropped announcement costs discovery latency, and the agent's reconciler still finds the part on disk.
 8. **Update object_versions** with final `size_bytes`, `md5_hash`, `content_type`, `metadata`, `updated_at` ([line 442](object_writer.py)). **Until this runs, the version is invisible to downloads** (the download query filters `size_bytes=0 AND md5=""` to avoid serving reserved-but-incomplete rows).
 9. **Upsert upload row + part placeholder** ([line 455-474](object_writer.py)) — links the object_version to a multipart_uploads row (used for append and MPU; simple PUT still creates one for structural consistency).
 10. **Return `PutResult`**. The endpoint does NOT enqueue the backend upload (drain-direct cutover) — it persists the version address (`set_object_version_address`); the Rust drain replicates the part to Ceph and LPUSHes the `UploadChainRequest` to `{backend}_upload_requests` itself, as the sole producer (see line 18).

--- a/hippius_s3/writer/landed.py
+++ b/hippius_s3/writer/landed.py
@@ -1,0 +1,110 @@
+"""Announce a freshly-written part to the node's drain agent.
+
+The drain agent's reconciler used to be the sole way a new part was discovered: it walked the
+whole SSD cache every 15s and asked the database which parts it had never seen. That was cheap
+while the SSD held only the undrained backlog, because a drained part was unlinked. Retention
+broke it — the disk now holds the node's entire replicated shard, measured on prod 2026-08-07 at
+2.28M parts / ~930 GB, so the walk became millions of stat calls and thousands of batched
+queries every 15s per node to find a handful of new parts.
+
+Announcing turns discovery into O(new parts). The agent consumes this queue
+(`crates/hippius-drain-agent/src/landed.rs`) and writes the `cephor_replication_status` row
+itself — the api never touches that table, which belongs to the drain and to the drain's
+migrations.
+
+**Best-effort by construction.** A dropped announcement costs latency and nothing else: the
+reconciler still finds the part on disk, exactly as it does today. That is what makes it safe to
+swallow every failure here rather than fail a PUT that has already durably written its data.
+
+Wiring follows the repo's module-singleton pattern (`get_access_tracker`):
+`initialize_landed_publisher` in the api lifespan; processes that never initialize it — workers,
+scripts, tests — get `None` and publishing is a no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+from typing import Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+# Must match `landed_queue_key` in crates/hippius-drain-agent/src/landed.rs.
+_LANDED_QUEUE_PREFIX = "cephor:landed:"
+
+# Cap on a node's queue. The agent normally drains this within a poll, so depth is near zero;
+# the bound only matters when the agent is down. Past it the OLDEST announcements are dropped,
+# which is safe precisely because the reconciler backstop still finds those parts on disk — and
+# is preferable to letting an unbounded list grow on a 1 GB Redis while the agent is away.
+_DEFAULT_MAX_QUEUE_DEPTH = 200_000
+
+
+def landed_queue_key(node_name: str) -> str:
+    return f"{_LANDED_QUEUE_PREFIX}{node_name}"
+
+
+class LandedPartPublisher:
+    """Publishes "this node just finished writing a part" to its drain agent."""
+
+    def __init__(self, queues_client: Any, node_name: str, max_depth: int = _DEFAULT_MAX_QUEUE_DEPTH) -> None:
+        self._redis = queues_client
+        self._key = landed_queue_key(node_name)
+        self._max_depth = int(max_depth)
+
+    async def publish(self, object_id: str, object_version: int, part_number: int) -> None:
+        """Announce one completed part. Never raises.
+
+        Field names are the wire contract with the agent's `LandedMessage`; the agent discards
+        anything it cannot parse, so renaming one side alone silently disables the fast path
+        rather than erroring. `drain_landed_dropped_total` is the alert for that.
+        """
+        payload = json.dumps(
+            {
+                "object_id": str(object_id),
+                "version": int(object_version),
+                "part_number": int(part_number),
+            }
+        )
+        try:
+            # LPUSH + LTRIM in one round-trip: the trim bounds the queue for the case where the
+            # agent is down, and paying two round-trips per part on the write path to bound a
+            # queue that is normally empty would be a poor trade.
+            pipe = self._redis.pipeline()
+            pipe.lpush(self._key, payload)
+            pipe.ltrim(self._key, 0, self._max_depth - 1)
+            await pipe.execute()
+        except Exception as exc:  # noqa: BLE001 - the part is already durable; the backstop covers this
+            logger.debug(
+                "announcing landed part %s v%s part %s failed: %s", object_id, object_version, part_number, exc
+            )
+
+
+_publisher: Optional[LandedPartPublisher] = None
+
+
+def initialize_landed_publisher(queues_client: Any, node_name: str) -> Optional[LandedPartPublisher]:
+    """Installs the process-wide publisher, or `None` without a node identity.
+
+    No `NODE_NAME` means no way to say WHICH node's agent should drain the part, and an
+    announcement on the wrong queue would be recorded against a node that does not hold the
+    data — where the node-scoped `claim_part` would then never drain it. Publishing nothing is
+    strictly better: the reconciler on the node that DOES hold it still finds it.
+    """
+    global _publisher
+    _publisher = LandedPartPublisher(queues_client, node_name) if queues_client is not None and node_name else None
+    return _publisher
+
+
+def get_landed_publisher() -> Optional[LandedPartPublisher]:
+    return _publisher
+
+
+__all__ = [
+    "LandedPartPublisher",
+    "get_landed_publisher",
+    "initialize_landed_publisher",
+    "landed_queue_key",
+]

--- a/hippius_s3/writer/write_through_writer.py
+++ b/hippius_s3/writer/write_through_writer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from hippius_s3.writer.landed import get_landed_publisher
+
 
 class WriteThroughPartsWriter:
     """Writes object parts to the filesystem cache (mandatory, fatal on failure).
@@ -57,6 +59,18 @@ class WriteThroughPartsWriter:
             num_chunks=int(num_chunks),
             size_bytes=int(plain_size),
         )
+        # Announce to this node's drain agent, strictly AFTER meta lands. Meta is the readiness
+        # gate: a part is only complete once it exists, so announcing earlier could have the
+        # drain claim a part whose chunks are still being written. It also has to be here rather
+        # than at the call sites — this is the one choke point every upload path (simple PUT,
+        # streamed PUT, MPU part, append) already funnels through, and a hook one of them
+        # forgets is a part that falls back to the disk walk with nothing saying so.
+        #
+        # Best-effort: the bytes and meta are already durable, and the agent's reconciler still
+        # discovers the part from disk if this never arrives.
+        publisher = get_landed_publisher()
+        if publisher is not None:
+            await publisher.publish(object_id, int(object_version), int(part_number))
 
     async def write_chunks(self, object_id: str, object_version: int, part_number: int, chunks: list[bytes]) -> None:
         """Write chunks to the FS cache (fatal on failure).

--- a/k8s/base/grafana-dashboards.yaml
+++ b/k8s/base/grafana-dashboards.yaml
@@ -3,9 +3,6 @@ kind: ConfigMap
 metadata:
   name: hippius-s3-dashboards
   namespace: monitoring
-  labels:
-    app: grafana
-    grafana_dashboard: "1"
 data:
   system-load.json: |
     {
@@ -3553,6 +3550,640 @@ data:
           ],
           "title": "Account cacher \u2014 cycles",
           "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 121
+          },
+          "id": 100,
+          "panels": [],
+          "title": "SSD read tier (retention / promotion / eviction)",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 122
+          },
+          "id": 101,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum by (tier) (rate(chunk_reads_by_tier_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+              "legendFormat": "{{tier}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Read tiers served",
+          "type": "timeseries",
+          "description": "The whole point of the read tier. `local` should climb as retention fills each node's shard and `pool` should fall. All traffic collapsing back onto `pool` means retention, promotion or peer fetch has silently stopped working."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 122
+          },
+          "id": 102,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum by (reason) (rate(peer_fetch_shed_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+              "legendFormat": "{{reason}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Peer fetches declined",
+          "type": "timeseries",
+          "description": "server_busy is real contention at the peer. client_cap is this pod's own per-peer cap \u2014 if it rises while server_busy stays flat, readers are shedding their own prefetch window and HIPPIUS_PEER_FETCH_MAX_INFLIGHT is below HTTP_STREAM_PREFETCH_CHUNKS."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 122
+          },
+          "id": 103,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum by (reason) (rate(promotion_skipped_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+              "legendFormat": "{{reason}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum by (reason) (rate(fs_cache_shed_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+              "legendFormat": "fs_cache_shed {{reason}}",
+              "refId": "B"
+            }
+          ],
+          "title": "Promotion skipped (disk pressure)",
+          "type": "timeseries",
+          "description": "Promotion backpressure must engage BEFORE the PUT-refusal gate: this should start rising while fs_cache_shed is still flat at zero. Both flat while free space falls means the gate is not engaging."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 130
+          },
+          "id": 104,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "max by (service_instance_id) (drain_ssd_cache_bytes{service_namespace=\"$namespace\"})",
+              "legendFormat": "cache {{service_instance_id}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "max by (service_instance_id) (drain_ssd_free_bytes{service_namespace=\"$namespace\"})",
+              "legendFormat": "free {{service_instance_id}}",
+              "refId": "B"
+            }
+          ],
+          "title": "SSD cache vs free (per node)",
+          "type": "timeseries",
+          "description": "Retained read tier against remaining headroom. cache should rise and plateau under the evictor's floor; cache pinned at the disk size with free flat is eviction failing to keep up."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 130
+          },
+          "id": 105,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum(rate(drain_ssd_evicted_bytes_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+              "legendFormat": "bytes/s freed",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum(rate(drain_ssd_evicted_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+              "legendFormat": "parts/s",
+              "refId": "B"
+            }
+          ],
+          "title": "Eviction rate",
+          "type": "timeseries",
+          "description": "Byte rate is the one that matters: prod's part p50 is 686 bytes, so a part-count page is almost uncorrelated with space reclaimed."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 130
+          },
+          "id": 106,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum(drain_ssd_evict_blocked_unreplicated_total{service_namespace=\"$namespace\"})",
+              "legendFormat": "evict_blocked_unreplicated",
+              "refId": "A"
+            }
+          ],
+          "title": "Eviction invariant breach (must stay 0)",
+          "type": "timeseries",
+          "description": "ALERT-WORTHY, not log-worthy. Any non-zero value means the eviction worklist and the only-evict-replicated durability invariant have diverged \u2014 the evictor was offered a part whose SSD copy may be the only durable one."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 138
+          },
+          "id": 107,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "max by (worker) (drain_scan_parts_total{service_namespace=\"$namespace\"})",
+              "legendFormat": "parts {{worker}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "max by (worker) (drain_scan_duration_ms{service_namespace=\"$namespace\"})",
+              "legendFormat": "ms {{worker}}",
+              "refId": "B"
+            }
+          ],
+          "title": "SSD scan cost (F1 regression guard)",
+          "type": "timeseries",
+          "description": "Retention grew the SSD tree from the undrained backlog to the node's entire replicated shard (2.28M parts on prod). Watch duration against the worker's poll interval \u2014 a scan approaching its own period is the walk eating the node."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 138
+          },
+          "id": 108,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum(rate(drain_landed_recorded_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+              "legendFormat": "recorded/s",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum(rate(drain_landed_dropped_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+              "legendFormat": "dropped/s",
+              "refId": "B"
+            }
+          ],
+          "title": "Landed announcements",
+          "type": "timeseries",
+          "description": "The api->agent discovery fast path. Sustained dropped/s with recorded/s at zero is the wire contract broken between landed.py and landed.rs \u2014 discovery silently falls back to the reconciler walk."
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "mappings": [],
+              "unit": "wps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 138
+          },
+          "id": 109,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum by (outcome) (rate(read_recency_writes_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+              "legendFormat": "{{outcome}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Read-recency writes",
+          "type": "timeseries",
+          "description": "A DB UPDATE on the read path, sampled to one per part per window. The sampler stops absorbing when a scan touches more distinct parts than its memo holds \u2014 which is exactly the full-shard read this tier exists for \u2014 so watch this against Postgres write load."
         }
       ],
       "preload": false,

--- a/k8s/production/drain-agent-daemonset.yaml
+++ b/k8s/production/drain-agent-daemonset.yaml
@@ -148,6 +148,15 @@ spec:
               value: "300"
             - name: CEPHOR_RECLAIM_GRACE_SECS
               value: "3600"
+            # ROLLBACK-LOAD-BEARING — do not delete as manifest hygiene.
+            # Read by the CURRENT (pre-retention) binary, which unlinks a replicated part once
+            # it ages past this grace. The retention binary ignores it: ssd_reclaim skips
+            # `replicated` outright, because those parts are the read tier and the evictor owns
+            # them instead. It looks dead the moment retention ships here — and it is exactly
+            # then that it matters most, because `kubectl rollout undo daemonset/drain-agent`
+            # restores unlink-on-commit AND needs this grace to sweep the cache the rolled-back
+            # fleet is still holding. Deleting it would leave a rolled-back node with a full
+            # disk and nothing to reclaim it.
             - name: CEPHOR_REPLICATED_RECLAIM_GRACE_SECS
               value: "3600"
             # Max parts drained concurrently — the in-flight gate that lets the node
@@ -178,13 +187,24 @@ spec:
             # drain trigger — a freshly-landed part is invisible until the next scan records its
             # `pending` row — so this interval, not the 1s drain poll, is the dominant, jittery
             # replication-sync tail (0–60s at the old default; ~30s avg). 15s cuts it to ~7.5s avg.
-            # Safe to lower: a scan is a walk of the node-local SSD ingest tree (undrained parts
-            # only — drained parts are unlinked; the Ceph pool and the 94M-row parts table are
-            # never walked) + ONE batched UNNEST status read. record_landed writes fire only for
-            # genuinely-new parts (a known part is seen as already_pending and skipped), so a
-            # faster poll adds NO extra write load — just the cheap walk + one read, jittered per
-            # node. The real fix (an api landing fast-path + mtime-incremental scan) collapses
-            # this to ~1s; 15s is the zero-code interim. See drainer-optimisations.md Tier 1.
+            # STALE PREMISE — corrected 2026-08-07. This used to read "undrained parts only —
+            # drained parts are unlinked", which is what made a 15s walk cheap. Retention (PR
+            # #398) ended that: the drain keeps its replicated copy to serve reads, so the tree
+            # is now the node's ENTIRE replicated shard — measured on prod 2026-08-07 at 2.28M
+            # parts / ~930 GB per node. At this interval that is ~2.28M stats and ~4,560 batched
+            # queries every 15 seconds, per node, to discover a handful of new parts.
+            # The Ceph pool and the 94M-row parts table are still never walked.
+            #
+            # The api landing fast-path now exists (cephor:landed:<node>, see landed.rs), so
+            # discovery no longer depends on this poll — but the poll is deliberately left at 15s
+            # until that path is proven, and demoting the reconciler to a ~10min BACKSTOP is a
+            # separate commit and separate deploy so either can be rolled back alone.
+            # Watch drain_scan_parts_total / drain_scan_duration_ms.
+            #
+            # ORDERING CONSTRAINT: this cost is only theoretical on prod today because prod is
+            # still pre-retention (the SSD holds just the undrained backlog). Retention must not
+            # reach prod before this poll is demoted, or prod starts paying the full walk 4x a
+            # minute per node on day one.
             - name: CEPHOR_RECONCILE_POLL_SECS
               value: "15"
             - name: RUST_LOG

--- a/k8s/production/drain-agent-daemonset.yaml
+++ b/k8s/production/drain-agent-daemonset.yaml
@@ -1,9 +1,9 @@
 # The hippius-drain agent: the per-node drain daemon.
 # One pod per ingest node, draining that node's local-SSD ingest dir to
 # the shared CephFS pool, path-preservingly per the api part layout
-# (<object_id>/v<version>/part_<n>/). The reconciler is the sole trigger — it scans the
-# SSD for complete parts (a meta.json marker) with no replication row and records them,
-# so the api needs no change.
+# (<object_id>/v<version>/part_<n>/). Parts are discovered from the api's landed-part
+# announcements (cephor:landed:<node> on the queue Redis); the reconciler's SSD scan is the
+# BACKSTOP for an announcement that was never delivered, not the primary trigger.
 #
 # == Node alignment ==
 # Selects the SAME node label `s3-prod-local-ingest=true` as the api-local
@@ -183,10 +183,11 @@ spec:
             # AND defer_attempts), so a just-completed MPU's parts drain promptly regardless.
             - name: CEPHOR_DRAIN_POLL_SECS
               value: "1"
-            # Reconciler scan period (was the 60s code default). The reconciler is the SOLE
-            # drain trigger — a freshly-landed part is invisible until the next scan records its
-            # `pending` row — so this interval, not the 1s drain poll, is the dominant, jittery
-            # replication-sync tail (0–60s at the old default; ~30s avg). 15s cuts it to ~7.5s avg.
+            # Reconciler scan period (was the 60s code default). NO LONGER the sole drain trigger:
+            # the api announces each part to cephor:landed:<node> and the agent's `landed` worker
+            # records it, so this walk is the BACKSTOP for an announcement never delivered. Until
+            # that path is proven this interval still bounds the replication-sync tail, which is
+            # why it is unchanged here.
             # STALE PREMISE — corrected 2026-08-07. This used to read "undrained parts only —
             # drained parts are unlinked", which is what made a 15s walk cheap. Retention (PR
             # #398) ended that: the drain keeps its replicated copy to serve reads, so the tree

--- a/k8s/staging/api-local-deployments-staging.yaml
+++ b/k8s/staging/api-local-deployments-staging.yaml
@@ -132,8 +132,15 @@ spec:
             # serving its own ingest. The client cap bounds what one pod sends; the serve cap
             # sheds with 503 so five pods each within their own cap still cannot crowd out
             # that node's PUTs.
+            #
+            # The client cap must be >= HTTP_STREAM_PREFETCH_CHUNKS (16). Every chunk of one
+            # PART resolves to the same peer, so at the previous value of 8 a single reader
+            # shed half its own prefetch window to CephFS while the peer sat idle — and booked
+            # it as `client_cap`, which reads as contention on the dashboard. The api floors
+            # this at the prefetch depth anyway (effective_max_inflight); set correctly here
+            # so the manifest states the intent rather than relying on the correction.
             - name: HIPPIUS_PEER_FETCH_MAX_INFLIGHT
-              value: "8"
+              value: "16"
             - name: HIPPIUS_PEER_SERVE_MAX_INFLIGHT
               value: "16"
             - name: K8S_NAMESPACE

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -132,8 +132,15 @@ spec:
             # mark_replicated commit and the drain's own unlink), and orphan write-temps,
             # once aged, so junk does not accumulate on the node-local disk. All have safe
             # code defaults (300s poll / 1h graces); set here for visibility + per-node tuning.
+            # The reclaim pass WALKS the whole SSD tree. That was cheap when the tree held only
+            # the undrained backlog; retention made it the node's entire replicated shard
+            # (2.28M parts on prod), so the walk is now the expensive part of this worker and
+            # its cadence is what bounds the cost. Hourly is ample: every disposition it owns is
+            # grace-gated at >= 1h (CEPHOR_RECLAIM_GRACE_SECS) or 24h
+            # (CEPHOR_ORPHAN_RECLAIM_GRACE_SECS), so nothing becomes actionable faster than this
+            # runs. Watch drain_scan_duration_ms against this interval.
             - name: CEPHOR_RECLAIM_POLL_SECS
-              value: "300"
+              value: "3600"
             - name: CEPHOR_RECLAIM_GRACE_SECS
               value: "3600"
             # Read-tier eviction. With the drain retaining its replicated parts to serve

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -1,9 +1,9 @@
 # The hippius-drain agent: the per-node drain daemon.
 # One pod per ingest node, draining that node's local-SSD ingest dir to
 # the shared CephFS pool, path-preservingly per the api part layout
-# (<object_id>/v<version>/part_<n>/). The reconciler is the sole trigger — it scans the
-# SSD for complete parts (a meta.json marker) with no replication row and records them,
-# so the api needs no change.
+# (<object_id>/v<version>/part_<n>/). Parts are discovered from the api's landed-part
+# announcements (cephor:landed:<node> on the queue Redis); the reconciler's SSD scan is the
+# BACKSTOP for an announcement that was never delivered, not the primary trigger.
 #
 # == Node alignment ==
 # Selects the SAME node label `s3-staging-local-ingest=true` as the api-local
@@ -179,10 +179,11 @@ spec:
             # AND defer_attempts), so a just-completed MPU's parts drain promptly regardless.
             - name: CEPHOR_DRAIN_POLL_SECS
               value: "1"
-            # Reconciler scan period (was the 60s code default). The reconciler is the SOLE
-            # drain trigger — a freshly-landed part is invisible until the next scan records its
-            # `pending` row — so this interval, not the 1s drain poll, is the dominant, jittery
-            # replication-sync tail (0–60s at the old default; ~30s avg). 15s cuts it to ~7.5s avg.
+            # Reconciler scan period (was the 60s code default). NO LONGER the sole drain trigger:
+            # the api announces each part to cephor:landed:<node> and the agent's `landed` worker
+            # records it, so this walk is the BACKSTOP for an announcement never delivered. Until
+            # that path is proven this interval still bounds the replication-sync tail, which is
+            # why it is unchanged here.
             # STALE PREMISE — corrected 2026-08-07. This used to read "undrained parts only —
             # drained parts are unlinked", which is what made a 15s walk cheap. Retention (PR
             # #398) ended that: the drain keeps its replicated copy to serve reads, so the tree

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -183,13 +183,24 @@ spec:
             # drain trigger — a freshly-landed part is invisible until the next scan records its
             # `pending` row — so this interval, not the 1s drain poll, is the dominant, jittery
             # replication-sync tail (0–60s at the old default; ~30s avg). 15s cuts it to ~7.5s avg.
-            # Safe to lower: a scan is a walk of the node-local SSD ingest tree (undrained parts
-            # only — drained parts are unlinked; the Ceph pool and the 94M-row parts table are
-            # never walked) + ONE batched UNNEST status read. record_landed writes fire only for
-            # genuinely-new parts (a known part is seen as already_pending and skipped), so a
-            # faster poll adds NO extra write load — just the cheap walk + one read, jittered per
-            # node. The real fix (an api landing fast-path + mtime-incremental scan) collapses
-            # this to ~1s; 15s is the zero-code interim. See drainer-optimisations.md Tier 1.
+            # STALE PREMISE — corrected 2026-08-07. This used to read "undrained parts only —
+            # drained parts are unlinked", which is what made a 15s walk cheap. Retention (PR
+            # #398) ended that: the drain keeps its replicated copy to serve reads, so the tree
+            # is now the node's ENTIRE replicated shard — measured on prod 2026-08-07 at 2.28M
+            # parts / ~930 GB per node. At this interval that is ~2.28M stats and ~4,560 batched
+            # queries every 15 seconds, per node, to discover a handful of new parts.
+            # The Ceph pool and the 94M-row parts table are still never walked.
+            #
+            # The api landing fast-path now exists (cephor:landed:<node>, see landed.rs), so
+            # discovery no longer depends on this poll — but the poll is deliberately left at 15s
+            # until that path is proven, and demoting the reconciler to a ~10min BACKSTOP is a
+            # separate commit and separate deploy so either can be rolled back alone.
+            # Watch drain_scan_parts_total / drain_scan_duration_ms.
+            #
+            # ORDERING CONSTRAINT: this cost is only theoretical on prod today because prod is
+            # still pre-retention (the SSD holds just the undrained backlog). Retention must not
+            # reach prod before this poll is demoted, or prod starts paying the full walk 4x a
+            # minute per node on day one.
             - name: CEPHOR_RECONCILE_POLL_SECS
               value: "15"
             - name: RUST_LOG

--- a/monitoring/grafana/dashboards/system-load.json
+++ b/monitoring/grafana/dashboards/system-load.json
@@ -3543,6 +3543,640 @@
       ],
       "title": "Account cacher \u2014 cycles",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 121
+      },
+      "id": 100,
+      "panels": [],
+      "title": "SSD read tier (retention / promotion / eviction)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 122
+      },
+      "id": 101,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (tier) (rate(chunk_reads_by_tier_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{tier}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Read tiers served",
+      "type": "timeseries",
+      "description": "The whole point of the read tier. `local` should climb as retention fills each node's shard and `pool` should fall. All traffic collapsing back onto `pool` means retention, promotion or peer fetch has silently stopped working."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 122
+      },
+      "id": 102,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (reason) (rate(peer_fetch_shed_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Peer fetches declined",
+      "type": "timeseries",
+      "description": "server_busy is real contention at the peer. client_cap is this pod's own per-peer cap \u2014 if it rises while server_busy stays flat, readers are shedding their own prefetch window and HIPPIUS_PEER_FETCH_MAX_INFLIGHT is below HTTP_STREAM_PREFETCH_CHUNKS."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 122
+      },
+      "id": 103,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (reason) (rate(promotion_skipped_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (reason) (rate(fs_cache_shed_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "fs_cache_shed {{reason}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Promotion skipped (disk pressure)",
+      "type": "timeseries",
+      "description": "Promotion backpressure must engage BEFORE the PUT-refusal gate: this should start rising while fs_cache_shed is still flat at zero. Both flat while free space falls means the gate is not engaging."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 130
+      },
+      "id": 104,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (service_instance_id) (drain_ssd_cache_bytes{service_namespace=\"$namespace\"})",
+          "legendFormat": "cache {{service_instance_id}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (service_instance_id) (drain_ssd_free_bytes{service_namespace=\"$namespace\"})",
+          "legendFormat": "free {{service_instance_id}}",
+          "refId": "B"
+        }
+      ],
+      "title": "SSD cache vs free (per node)",
+      "type": "timeseries",
+      "description": "Retained read tier against remaining headroom. cache should rise and plateau under the evictor's floor; cache pinned at the disk size with free flat is eviction failing to keep up."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 130
+      },
+      "id": 105,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(drain_ssd_evicted_bytes_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "bytes/s freed",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(drain_ssd_evicted_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "parts/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Eviction rate",
+      "type": "timeseries",
+      "description": "Byte rate is the one that matters: prod's part p50 is 686 bytes, so a part-count page is almost uncorrelated with space reclaimed."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 130
+      },
+      "id": 106,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(drain_ssd_evict_blocked_unreplicated_total{service_namespace=\"$namespace\"})",
+          "legendFormat": "evict_blocked_unreplicated",
+          "refId": "A"
+        }
+      ],
+      "title": "Eviction invariant breach (must stay 0)",
+      "type": "timeseries",
+      "description": "ALERT-WORTHY, not log-worthy. Any non-zero value means the eviction worklist and the only-evict-replicated durability invariant have diverged \u2014 the evictor was offered a part whose SSD copy may be the only durable one."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 138
+      },
+      "id": 107,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (worker) (drain_scan_parts_total{service_namespace=\"$namespace\"})",
+          "legendFormat": "parts {{worker}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (worker) (drain_scan_duration_ms{service_namespace=\"$namespace\"})",
+          "legendFormat": "ms {{worker}}",
+          "refId": "B"
+        }
+      ],
+      "title": "SSD scan cost (F1 regression guard)",
+      "type": "timeseries",
+      "description": "Retention grew the SSD tree from the undrained backlog to the node's entire replicated shard (2.28M parts on prod). Watch duration against the worker's poll interval \u2014 a scan approaching its own period is the walk eating the node."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 138
+      },
+      "id": 108,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(drain_landed_recorded_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "recorded/s",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(drain_landed_dropped_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "dropped/s",
+          "refId": "B"
+        }
+      ],
+      "title": "Landed announcements",
+      "type": "timeseries",
+      "description": "The api->agent discovery fast path. Sustained dropped/s with recorded/s at zero is the wire contract broken between landed.py and landed.rs \u2014 discovery silently falls back to the reconciler walk."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "unit": "wps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 138
+      },
+      "id": 109,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (outcome) (rate(read_recency_writes_total{service_namespace=\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Read-recency writes",
+      "type": "timeseries",
+      "description": "A DB UPDATE on the read path, sampled to one per part per window. The sampler stops absorbing when a scan touches more distinct parts than its memo holds \u2014 which is exactly the full-shard read this tier exists for \u2014 so watch this against Postgres write load."
     }
   ],
   "preload": false,

--- a/tests/integration/test_residency_upsert_sql.py
+++ b/tests/integration/test_residency_upsert_sql.py
@@ -1,0 +1,158 @@
+"""The residency UPSERT, executed against real Postgres.
+
+`ResidencyRecorder` is the only thing that claims a promoted part for the node that copied it.
+Without its row the part is invisible to the node-scoped evictor AND skipped by `ssd_reclaim`
+(which treats `replicated` parts as read tier, not debris), so it sits on the disk with no owner
+— a permanent leak, while reads keep succeeding the whole time.
+
+**Why this file exists rather than another unit test.** The recorder writes its SQL inline and
+swallows every failure by design, so a statement Postgres rejects is indistinguishable from one
+that worked: the read still returns bytes and the leak is silent. That is not hypothetical —
+commit `5e858ffd` replaced the `DO UPDATE SET` line with the comment explaining it, leaving
+`ON CONFLICT (...)` with no action, which is a syntax error. The whole unit suite passed,
+because a mocked connection accepts any string.
+
+`test_the_residency_upsert_has_a_conflict_action` now pins that statement's TEXT, which is a
+good regression test for that one line. This is the complement: it executes the real statement
+against a real server, so the class — syntax, column names, type mismatches, a conflict target
+that does not match a real constraint — is caught for the whole path rather than for one string.
+
+Follows the `test_*_sql.py` convention in this directory: a TEMP table shadowing the real schema
+for the session, so nothing touches a shared table.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+from typing import AsyncGenerator
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from hippius_s3.cache.residency import ResidencyRecorder
+
+
+pytestmark = pytest.mark.asyncio
+
+_DB_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/hippius?sslmode=disable")
+
+NODE = "k8s-v3-node2"
+OTHER_NODE = "k8s-v3-node3"
+
+
+class _SingleConnPool:
+    """Pool shim handing out the one connection that owns the TEMP table.
+
+    A real pool may return any connection, and a TEMP table exists on exactly one — so the
+    recorder would run against a session where the table is absent. Only the pool is adapted:
+    the statement, the server, and the schema are all real, which is the point of this file.
+    """
+
+    def __init__(self, conn: asyncpg.Connection) -> None:
+        self._conn = conn
+
+    def acquire(self) -> Any:
+        conn = self._conn
+
+        class _Ctx:
+            async def __aenter__(self) -> asyncpg.Connection:
+                return conn
+
+            async def __aexit__(self, *_: object) -> None:
+                return None
+
+        return _Ctx()
+
+
+@pytest_asyncio.fixture
+async def conn() -> AsyncGenerator[asyncpg.Connection, None]:
+    try:
+        c = await asyncpg.connect(_DB_URL)
+    except (OSError, asyncpg.PostgresError) as e:
+        pytest.skip(f"integration Postgres unavailable ({e}); run `docker compose up -d postgres`")
+
+    # Mirrors migrations 0016 + 0017, including the composite PRIMARY KEY the UPSERT's
+    # ON CONFLICT target must match — a conflict target that names no unique constraint is
+    # itself an error this file is meant to catch.
+    await c.execute(
+        """
+        CREATE TEMP TABLE cephor_ssd_residency (
+            node_id     text        NOT NULL,
+            object_id   text        NOT NULL,
+            version     bigint      NOT NULL,
+            part_number bigint      NOT NULL,
+            resident_at timestamptz NOT NULL DEFAULT now(),
+            bytes       bigint      NOT NULL DEFAULT 0,
+            last_read_at timestamptz,
+            PRIMARY KEY (node_id, object_id, version, part_number)
+        ) ON COMMIT PRESERVE ROWS;
+        """
+    )
+    try:
+        yield c
+    finally:
+        await c.close()
+
+
+async def _bytes_for(conn: asyncpg.Connection, node: str, object_id: str) -> int | None:
+    row = await conn.fetchrow(
+        "SELECT bytes FROM cephor_ssd_residency WHERE node_id = $1 AND object_id = $2",
+        node,
+        object_id,
+    )
+    return None if row is None else int(row["bytes"])
+
+
+async def test_a_first_promotion_inserts_the_claim(conn: asyncpg.Connection) -> None:
+    """The statement has to execute at all. This is what a mock cannot tell you."""
+    object_id = str(uuid.uuid4())
+    await ResidencyRecorder(_SingleConnPool(conn), NODE)(object_id, 1, 0, 4096)
+
+    assert await _bytes_for(conn, NODE, object_id) == 4096, (
+        "no row means the promoted copy is unowned: invisible to the node-scoped evictor and "
+        "skipped by ssd_reclaim as read tier"
+    )
+
+
+async def test_promotions_of_further_chunks_accumulate(conn: asyncpg.Connection) -> None:
+    """Promotion learns a part one chunk at a time, so the conflict action must ADD.
+
+    Overwriting would report only the last chunk's bytes to the evictor, which sums this column
+    to decide it has freed enough — so it would stop a pass early believing it succeeded.
+    """
+    object_id = str(uuid.uuid4())
+    recorder = ResidencyRecorder(_SingleConnPool(conn), NODE)
+
+    for _ in range(3):
+        await recorder(object_id, 1, 0, 4096)
+
+    assert await _bytes_for(conn, NODE, object_id) == 3 * 4096
+
+
+async def test_residency_is_per_node_so_a_peer_claim_is_a_separate_row(conn: asyncpg.Connection) -> None:
+    """Two nodes can hold the same part, and each one's evictor owns only its own copy.
+
+    Collapsing these into one row would let one node's eviction retire the other's claim.
+    """
+    object_id = str(uuid.uuid4())
+    await ResidencyRecorder(_SingleConnPool(conn), NODE)(object_id, 1, 0, 4096)
+    await ResidencyRecorder(_SingleConnPool(conn), OTHER_NODE)(object_id, 1, 0, 8192)
+
+    assert await _bytes_for(conn, NODE, object_id) == 4096
+    assert await _bytes_for(conn, OTHER_NODE, object_id) == 8192
+
+
+async def test_a_failed_write_is_swallowed_and_leaves_no_row(conn: asyncpg.Connection) -> None:
+    """The swallow is deliberate — the chunk is already served — but it must not corrupt state.
+
+    This also pins the shape that made the original bug invisible: the caller cannot distinguish
+    a rejected statement from a successful one, which is precisely why the assertions above run
+    against a real server instead of a mock.
+    """
+    object_id = str(uuid.uuid4())
+    await conn.execute("DROP TABLE cephor_ssd_residency")
+
+    await ResidencyRecorder(_SingleConnPool(conn), NODE)(object_id, 1, 0, 4096)  # must not raise

--- a/tests/unit/cache/test_read_recency.py
+++ b/tests/unit/cache/test_read_recency.py
@@ -141,3 +141,33 @@ async def test_only_a_local_hit_records_recency(tmp_path) -> None:
     await store.set_chunk(OBJ, 1, 1, 0, payload)
     assert await store.get_chunk(OBJ, 1, 1, 0) == payload
     assert seen == [(OBJ, 1, 1)], "a local hit must record recency"
+
+
+@pytest.mark.asyncio
+async def test_a_stamp_is_counted_so_the_write_rate_is_visible(monkeypatch) -> None:
+    """The recency write is a DB UPDATE on the read path, and it is silent by design.
+
+    It is sampled to at most one write per part per window, so the rate is bounded by DISTINCT
+    parts read per window rather than by read throughput. That bound is weakest for exactly the
+    workload this tier exists for: a full-shard scan touches far more distinct parts than the
+    sampler's memo holds, so the memo stops absorbing and every part read becomes a write.
+
+    `failed` is counted separately because the write is best-effort and swallowed — without it,
+    a recency path erroring on every read looks identical to one the sampler is fully absorbing.
+    """
+    seen: list[str] = []
+    monkeypatch.setattr("hippius_s3.cache.read_recency._record_write", seen.append)
+
+    pool = FakePool()
+    recorder = ReadRecencyRecorder(pool, "node-a")
+
+    await recorder(OBJ, 1, 3)
+    assert seen == ["written"], "a stamp that reaches the database is counted"
+
+    # Same part inside the sampling window: absorbed by the memo, so no write and no count.
+    await recorder(OBJ, 1, 3)
+    assert seen == ["written"], "a sampled-out read costs neither a write nor a count"
+
+    failing = ReadRecencyRecorder(FakePool(fail=True), "node-a")
+    await failing(OBJ, 1, 9)
+    assert seen == ["written", "failed"], "a swallowed failure is still counted, under its own outcome"

--- a/tests/unit/cache/test_read_recency.py
+++ b/tests/unit/cache/test_read_recency.py
@@ -1,0 +1,143 @@
+"""Serving a part locally has to tell the evictor, or eviction stays FIFO.
+
+The drain-agent evicts on `COALESCE(last_read_at, resident_at)`. Nothing fills `last_read_at`
+except this, so if it stops working the ordering silently degrades to arrival order — which for
+a working set re-read every epoch tends to evict exactly the parts about to be read again, each
+costing a peer-or-pool read plus a local write to restore. The failure is invisible: reads still
+succeed, just slower and against the wrong tier.
+"""
+
+from __future__ import annotations
+
+import asyncpg
+import pytest
+
+from hippius_s3.cache.dual_fs_store import DualFileSystemPartsStore
+from hippius_s3.cache.read_recency import ReadRecencyRecorder
+from hippius_s3.cache.read_recency import create_read_recency_recorder
+
+
+OBJ = "466916c0-d61b-4518-b81b-9576b574270a"
+
+
+class FakeConn:
+    def __init__(self, sink: list[tuple], fail: bool) -> None:
+        self._sink = sink
+        self._fail = fail
+
+    async def execute(self, sql: str, *args: object) -> None:
+        if self._fail:
+            raise asyncpg.PostgresError("db down")
+        self._sink.append((sql, args))
+
+    async def __aenter__(self) -> "FakeConn":
+        return self
+
+    async def __aexit__(self, *_a: object) -> None:
+        return None
+
+
+class FakePool:
+    def __init__(self, fail: bool = False) -> None:
+        self.executed: list[tuple] = []
+        self.fail = fail
+
+    def acquire(self) -> FakeConn:
+        return FakeConn(self.executed, self.fail)
+
+
+@pytest.mark.asyncio
+async def test_a_local_read_stamps_this_nodes_row_only() -> None:
+    """Recency is per (node, part).
+
+    Stamping a peer's row would protect a copy on a disk this node cannot see while leaving its
+    own unprotected — and the evictor reading the column is scoped to its own node_id, so the
+    stamp would simply be invisible to the node that needed it.
+    """
+    pool = FakePool()
+    await ReadRecencyRecorder(pool, "node-a")(OBJ, 3, 7)
+
+    sql, args = pool.executed[0]
+    assert "last_read_at = now()" in sql
+    assert "node_id = $1" in sql, "the update must be node-scoped"
+    assert args == ("node-a", OBJ, 3, 7)
+
+
+@pytest.mark.asyncio
+async def test_repeat_reads_inside_the_window_cost_no_writes() -> None:
+    """THE sampling property. This sits on the read path.
+
+    A DB write per chunk read would cost far more than the eviction it prevents, and a hot part
+    is read constantly by definition — so the write rate has to be bounded by the sampling
+    window, not by read throughput. The evictor orders at hour scale, so minutes of staleness
+    cannot change which part it picks.
+    """
+    pool = FakePool()
+    recorder = ReadRecencyRecorder(pool, "node-a")
+
+    for _ in range(500):
+        await recorder(OBJ, 1, 1)
+
+    assert len(pool.executed) == 1, f"500 reads produced {len(pool.executed)} writes"
+
+
+@pytest.mark.asyncio
+async def test_different_parts_are_sampled_independently() -> None:
+    """Sampling must not let one hot part suppress recency for every other part on the node."""
+    pool = FakePool()
+    recorder = ReadRecencyRecorder(pool, "node-a")
+
+    await recorder(OBJ, 1, 1)
+    await recorder(OBJ, 1, 2)
+    await recorder(OBJ, 2, 1)
+
+    assert len(pool.executed) == 3
+
+
+@pytest.mark.asyncio
+async def test_a_db_outage_never_reaches_the_read() -> None:
+    """The chunk is already served when this runs. Losing the stamp means the part is evicted
+    somewhat earlier than it deserves — exactly the FIFO behaviour this replaces — which is a
+    far better outcome than failing a read that succeeded."""
+    await ReadRecencyRecorder(FakePool(fail=True), "node-a")(OBJ, 1, 1)
+
+
+def test_no_node_identity_means_no_recorder() -> None:
+    """Without a node there is no way to say whose copy was read, and the evictor is
+    node-scoped — a stamp would either miss or land on another node's row."""
+    assert create_read_recency_recorder(FakePool(), "") is None
+    assert create_read_recency_recorder(None, "node-a") is None
+
+
+@pytest.mark.asyncio
+async def test_only_a_local_hit_records_recency(tmp_path) -> None:
+    """Recency means "this node's copy was used".
+
+    A peer- or pool-served read has no local copy to protect: promotion is what creates one, and
+    it stamps residency separately. Recording recency for a part this node does not hold would
+    order the evictor on reads of somebody else's disk.
+    """
+    primary = tmp_path / "local"
+    fallback = tmp_path / "pool"
+    primary.mkdir()
+    fallback.mkdir()
+
+    seen: list[tuple] = []
+
+    async def on_local_read(*args: object) -> None:
+        seen.append(args)
+
+    payload = b"ciphertext"
+    store = DualFileSystemPartsStore(str(primary), str(fallback), on_local_read=on_local_read)
+
+    # Pool-only: served from the fallback, so no local copy exists to keep.
+    await store.fallback.set_meta(OBJ, 1, 1, chunk_size=10, num_chunks=1, size_bytes=10)
+    await store.fallback.set_chunk(OBJ, 1, 1, 0, payload)
+    assert await store.get_chunk(OBJ, 1, 1, 0) == payload
+    assert seen == [], "a pool read recorded local recency"
+
+    # Now the same chunk on local flash.
+    await store.set_meta(OBJ, 1, 1, chunk_size=10, num_chunks=1, size_bytes=10)
+    await store.set_chunk(OBJ, 1, 1, 0, payload)
+    assert await store.get_chunk(OBJ, 1, 1, 0) == payload
+    assert seen == [(OBJ, 1, 1)], "a local hit must record recency"

--- a/tests/unit/test_metrics_cardinality.py
+++ b/tests/unit/test_metrics_cardinality.py
@@ -52,6 +52,9 @@ BOUNDED_LABELS = {
     # on record_chunk_read_tier and passed only from the three fixed call sites in
     # DualFileSystemPartsStore.get_chunk. Closed in code, never object- or caller-derived.
     "tier",
+    # Outcome of a read-recency stamp: "written" | "failed", typed as the ReadRecencyOutcome
+    # Literal and passed from exactly two call sites in ReadRecencyRecorder. Closed in code.
+    "outcome",
 }
 
 

--- a/tests/unit/test_part_memo_and_promotion_cost.py
+++ b/tests/unit/test_part_memo_and_promotion_cost.py
@@ -27,19 +27,25 @@ OBJ = "466916c0-d61b-4518-b81b-9576b574270a"
 
 
 class FakeConn:
-    def __init__(self, log: list[tuple[object, ...]]) -> None:
+    def __init__(self, log: list[tuple[object, ...]], sql_log: list[str]) -> None:
         self._log = log
+        self._sql_log = sql_log
 
-    async def execute(self, _sql: str, *args: object) -> None:
+    async def execute(self, sql: str, *args: object) -> None:
+        # The SQL is recorded, not discarded. It used to be (`_sql`), and that is exactly how a
+        # commit which deleted the residency UPSERT's `DO UPDATE` clause passed this suite: a
+        # mock accepts any string, so a statement Postgres would reject looked fine here.
+        self._sql_log.append(sql)
         self._log.append(args)
 
 
 class FakePool:
     def __init__(self) -> None:
         self.executed: list[tuple[object, ...]] = []
+        self.statements: list[str] = []
 
     def acquire(self):  # noqa: ANN201 - async context manager double
-        conn = FakeConn(self.executed)
+        conn = FakeConn(self.executed, self.statements)
 
         class _Ctx:
             async def __aenter__(self):  # noqa: ANN204
@@ -186,3 +192,29 @@ async def test_concurrent_readers_promote_a_chunk_only_once(tmp_path) -> None:
     assert await both == [b"payload", b"payload"], "both readers still get their bytes"
 
     assert len(recorded) == 1, f"the chunk was promoted {len(recorded)} times"
+
+
+@pytest.mark.asyncio
+async def test_the_residency_upsert_has_a_conflict_action() -> None:
+    """`ON CONFLICT` without an action is a syntax error, and the failure is invisible.
+
+    This is asserted on the SQL text rather than on behaviour because a mocked connection
+    accepts any string — which is how a commit that replaced the `DO UPDATE SET` line with a
+    comment explaining it passed the whole suite. Postgres would reject the statement, every
+    claim would fall into the best-effort `except`, and promoted chunks would land on disk with
+    no residency row: unowned by the node-scoped evictor, skipped by `ssd_reclaim` as read
+    tier, and therefore a permanent SSD leak. Reads keep succeeding the entire time.
+
+    Both halves are pinned: that a conflict action exists at all, and that it ACCUMULATES —
+    promotion learns a part one chunk at a time, so overwriting would report only the last
+    chunk's bytes to the evictor.
+    """
+    pool = FakePool()
+    await ResidencyRecorder(pool, "node-a")(OBJ, 1, 1, 4096)
+
+    sql = pool.statements[0]
+    normalised = " ".join(sql.split())
+    assert "ON CONFLICT" in normalised
+    assert "DO UPDATE SET bytes = cephor_ssd_residency.bytes + EXCLUDED.bytes" in normalised, (
+        f"the conflict action is missing or no longer accumulates: {normalised}"
+    )

--- a/tests/unit/test_peer_fetch.py
+++ b/tests/unit/test_peer_fetch.py
@@ -18,6 +18,7 @@ import pytest
 
 from hippius_s3.cache.peers import PeerChunkFetcher
 from hippius_s3.cache.peers import PeerRegistry
+from hippius_s3.cache.peers import effective_max_inflight
 from hippius_s3.cache.peers import peer_key
 
 
@@ -345,3 +346,90 @@ async def test_both_shed_paths_are_recorded_with_their_reason(monkeypatch) -> No
     assert recorded == ["client_cap", "server_busy"], (
         "each shed is counted once, under the reason that actually caused it"
     )
+
+
+# ----------------------------------------------------------------- per-peer cap vs prefetch
+
+
+def test_the_cap_is_floored_at_the_prefetch_depth() -> None:
+    """A cap below the prefetch depth makes a reader compete with itself.
+
+    Every chunk of one PART resolves to the same peer, and the streamer keeps
+    HTTP_STREAM_PREFETCH_CHUNKS fetches in flight, so with the shipped 8-vs-16 pairing half of
+    every part over 32 MiB went to CephFS while the peer sat idle.
+    """
+    assert effective_max_inflight(8, 16) == 16
+
+
+def test_a_cap_already_at_or_above_the_prefetch_depth_is_left_alone() -> None:
+    """Deliberate over-provisioning is an operator decision; only the broken case is corrected."""
+    assert effective_max_inflight(32, 16) == 32
+    assert effective_max_inflight(16, 16) == 16
+
+
+@pytest.mark.asyncio
+async def test_a_single_readers_prefetch_window_never_sheds_against_an_idle_peer() -> None:
+    """THE Phase G regression test: it fails on the shipped 8-vs-16 defaults.
+
+    One reader, one part, a full prefetch window in flight, and a peer that is doing nothing
+    else. Every chunk must reach the peer. Before this fix the 9th through 16th were shed to
+    the pool and booked as `client_cap`, which reads on a dashboard as peer contention while
+    the peer is idle — and understates `chunk_reads_by_tier_total{tier=peer}` for the whole
+    soak, making "the peer tier is not helping" unfalsifiable.
+    """
+    prefetch = 16
+    redis = FakeRedis()
+    await PeerRegistry(redis, "node-b", "http://10.42.2.9:8000", 90).register()
+    registry = PeerRegistry(redis, "node-a", "http://10.42.1.5:8000", 90)
+    http = BlockingHttp()
+    fetcher = PeerChunkFetcher(
+        FakePool({"node_id": "node-b"}),
+        registry,
+        "node-a",
+        http,
+        max_inflight=effective_max_inflight(8, prefetch),
+    )
+
+    # One part, so every chunk resolves to the same peer — the case the cap used to break.
+    inflight = [asyncio.create_task(fetcher(OBJ, 1, 3, i)) for i in range(prefetch)]
+    await asyncio.sleep(0)  # let the owner lookup and the acquires run
+    await asyncio.sleep(0)
+
+    http.release.set()
+    results = await asyncio.gather(*inflight)
+
+    assert http.attempts == prefetch, f"only {http.attempts} of {prefetch} chunks reached an idle peer"
+    assert all(r == b"peer-bytes" for r in results), "every chunk came from the peer, none from the pool"
+
+
+@pytest.mark.asyncio
+async def test_the_cap_still_sheds_when_readers_genuinely_contend() -> None:
+    """The Owl property must survive the floor: real contention still skips to the pool.
+
+    Note what this does NOT claim. The semaphore is per (pod, peer) and shared across readers,
+    so raising it does not add peer capacity — under concurrency it moves shedding from
+    `client_cap` to the peer's own `server_busy`. Aggregate demand is `(pods - 1) x cap`
+    against one serve cap, oversubscribed by design, with Ceph as the intended overflow valve.
+    """
+    redis = FakeRedis()
+    await PeerRegistry(redis, "node-b", "http://10.42.2.9:8000", 90).register()
+    registry = PeerRegistry(redis, "node-a", "http://10.42.1.5:8000", 90)
+    http = BlockingHttp()
+    cap = 4
+    fetcher = PeerChunkFetcher(FakePool({"node_id": "node-b"}), registry, "node-a", http, max_inflight=cap)
+
+    saturating = [asyncio.create_task(fetcher(OBJ, 1, 3, i)) for i in range(cap)]
+    await asyncio.wait_for(http.started.wait(), timeout=1)
+    await asyncio.sleep(0)
+
+    # The cap is now taken; a further reader must skip to the pool rather than queue behind it.
+    # `wait_for` is the assertion, not a safety net: without the skip this call blocks on the
+    # semaphore until the peer replies, which is the failure mode — the reader would pay the
+    # saturated peer's full latency and THEN still read the pool. A plain await would hang the
+    # suite instead of failing it.
+    shed = await asyncio.wait_for(fetcher(OBJ, 1, 3, 99), timeout=1)
+    assert shed is None, "a saturated peer is skipped, not queued"
+    assert http.attempts == cap, "and the extra request was never even attempted"
+
+    http.release.set()
+    await asyncio.gather(*saturating)

--- a/tests/unit/test_promotion_pressure_guard.py
+++ b/tests/unit/test_promotion_pressure_guard.py
@@ -1,0 +1,216 @@
+"""Promotion must yield to ingest on the disk they share.
+
+Read-through promotion is the only unthrottled writer to the ingest SSD, and on an ingest node
+`HIPPIUS_OBJECT_CACHE_DIR` is the same mount as the drain agent's `CEPHOR_SSD_ROOT` — which is
+also the mount `fs_cache_pressure` measures when it decides to refuse a PUT with 503. So a
+read-heavy period could fill the disk that writes depend on, with promotion failures silently
+swallowed the whole way down.
+
+These tests pin the two halves of the fix: promotion backs off under pressure without ever
+affecting the read, and the threshold sits where eviction can actually restore it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hippius_s3.cache.dual_fs_store import DualFileSystemPartsStore
+from hippius_s3.fs_pressure import FreeSpaceGate
+from hippius_s3.fs_pressure import PromotionBandError
+from hippius_s3.fs_pressure import validate_promotion_band
+
+
+# The values shipped in hippius_s3/config.py, restated so this file tests the CONTRACT rather
+# than whatever the ambient environment resolves to. `.env` overrides both in local dev.
+DEFAULT_PROMOTE_MIN_FREE_RATIO = 0.175
+DEFAULT_FS_CACHE_MIN_FREE_RATIO = 0.08
+
+
+class FakeProbe:
+    """A scripted free-space reading, counting how often it was consulted."""
+
+    def __init__(self, ratio: float, raises: BaseException | None = None) -> None:
+        self.ratio = ratio
+        self.raises = raises
+        self.calls = 0
+
+    def __call__(self, _path: str) -> float:
+        self.calls += 1
+        if self.raises is not None:
+            raise self.raises
+        return self.ratio
+
+
+def gate(ratio: float, floor: float = 0.175, **kw: object) -> FreeSpaceGate:
+    probe = FakeProbe(ratio)
+    made = FreeSpaceGate("/nonexistent", floor, probe=probe, **kw)  # type: ignore[arg-type]
+    made.probe = probe  # type: ignore[attr-defined]
+    return made
+
+
+def test_the_shipped_defaults_form_a_recoverable_band() -> None:
+    """The shipped promote floor must sit inside the evictor's hysteresis band.
+
+    Asserted on the CODE DEFAULT, not on `get_config()`. An earlier version of this test read
+    the resolved config and was therefore validating whatever the developer's `.env` happened
+    to say — `.env` sets `HIPPIUS_FS_CACHE_MIN_FREE_RATIO=0.01`, so a mutation of the shipped
+    default changed nothing and the test passed regardless. A contract test must not depend on
+    ambient environment.
+    """
+    validate_promotion_band(
+        promote_min_free_ratio=DEFAULT_PROMOTE_MIN_FREE_RATIO,
+        fs_cache_min_free_ratio=DEFAULT_FS_CACHE_MIN_FREE_RATIO,
+    )
+
+
+def test_a_floor_equal_to_the_evict_target_is_rejected() -> None:
+    """The first attempt at this threshold. 0.20 IS the evictor's target, so promotion would be
+    live only in the instant a pass completes — chattering at the boundary with no hysteresis."""
+    with pytest.raises(PromotionBandError, match="below the evictor's target"):
+        validate_promotion_band(promote_min_free_ratio=0.20, fs_cache_min_free_ratio=0.08)
+
+
+def test_a_floor_above_the_evict_target_is_rejected() -> None:
+    """The second attempt, and the more dangerous one: a deadlock rather than a wobble.
+
+    Promotion stops below 0.25 and the evictor never frees past 0.20, so nothing can ever
+    restore enough for promotion to resume. Staging sits at 23% free, so this would have
+    switched the read tier off permanently the moment it deployed — silently.
+    """
+    with pytest.raises(PromotionBandError, match="can never be restored"):
+        validate_promotion_band(promote_min_free_ratio=0.25, fs_cache_min_free_ratio=0.08)
+
+
+def test_a_floor_below_the_evict_reserve_is_rejected() -> None:
+    """Promotion must yield BEFORE eviction arms, or the cheap lever is pulled second."""
+    with pytest.raises(PromotionBandError, match="above the evictor's reserve"):
+        validate_promotion_band(promote_min_free_ratio=0.10, fs_cache_min_free_ratio=0.08)
+
+
+def test_a_put_refusal_threshold_above_the_evict_reserve_is_rejected() -> None:
+    """Writes must never be refused before the evictor has had a chance to reclaim."""
+    with pytest.raises(PromotionBandError, match="below the evictor's reserve"):
+        validate_promotion_band(promote_min_free_ratio=0.175, fs_cache_min_free_ratio=0.30)
+
+
+def test_a_disk_with_room_allows_promotion() -> None:
+    assert gate(0.50).allows() is True
+
+
+def test_a_disk_under_the_floor_refuses_promotion() -> None:
+    assert gate(0.10).allows() is False
+
+
+def test_exactly_at_the_floor_refuses() -> None:
+    """The floor is a floor. Strict `>` keeps the boundary off the allowed side."""
+    assert gate(0.175).allows() is False
+
+
+def test_the_reading_is_memoised_so_a_chunk_read_is_not_a_syscall() -> None:
+    """Promotion is asked per CHUNK, so an unmemoised probe is a syscall per chunk.
+
+    64 reads inside one TTL window must cost one probe; crossing the window costs a second.
+    """
+    probe = FakeProbe(0.50)
+    g = FreeSpaceGate("/nonexistent", 0.175, ttl_seconds=5.0, probe=probe)
+
+    for _ in range(64):
+        assert g.allows(now=100.0) is True
+    assert probe.calls == 1, "one probe per TTL window"
+
+    g.allows(now=106.0)
+    assert probe.calls == 2, "the window expired, so it re-probed"
+
+
+def test_a_failing_probe_leaves_the_previous_verdict_rather_than_disabling_the_tier() -> None:
+    """Fails open. A statvfs blip must not silently switch the read tier off.
+
+    A genuinely full disk still stops the write with ENOSPC, which `_promote_chunk` already
+    swallows — so failing open costs a wasted write attempt, while failing closed would cost
+    the whole cache-warming path with nothing logging that it happened.
+    """
+    probe = FakeProbe(0.50)
+    g = FreeSpaceGate("/nonexistent", 0.175, ttl_seconds=1.0, probe=probe)
+    assert g.allows(now=0.0) is True
+
+    probe.raises = OSError("statvfs failed")
+    assert g.allows(now=10.0) is True, "kept the last good verdict"
+
+
+@pytest.mark.asyncio
+async def test_a_chunk_is_still_served_when_promotion_is_gated(tmp_path, monkeypatch) -> None:
+    """The point of the whole change: backpressure costs a cache warm, never a read.
+
+    The chunk comes back byte-identical from the pool while nothing lands on the local tier,
+    and the skip is counted so the backoff is visible before `fs_cache_shed` starts firing.
+    """
+    primary = tmp_path / "local"
+    fallback = tmp_path / "pool"
+    primary.mkdir()
+    fallback.mkdir()
+
+    payload = b"ciphertext-chunk"
+    pool = DualFileSystemPartsStore(str(primary), str(fallback))
+    await pool.fallback.set_meta(
+        "a" * 8 + "-1111-2222-3333-444444444444", 1, 1, chunk_size=16, num_chunks=1, size_bytes=16
+    )
+    await pool.fallback.set_chunk("a" * 8 + "-1111-2222-3333-444444444444", 1, 1, 0, payload)
+
+    recorded: list[str] = []
+    monkeypatch.setattr(
+        "hippius_s3.cache.dual_fs_store._record_promotion_skipped",
+        lambda: recorded.append("disk_pressure"),
+    )
+
+    promoted: list[tuple] = []
+
+    async def on_promote(*args: object) -> None:
+        promoted.append(args)
+
+    store = DualFileSystemPartsStore(
+        str(primary),
+        str(fallback),
+        promote=True,
+        on_promote=on_promote,
+        space_gate=FreeSpaceGate("/nonexistent", 0.175, probe=FakeProbe(0.02)),
+    )
+
+    oid = "a" * 8 + "-1111-2222-3333-444444444444"
+    got = await store.get_chunk(oid, 1, 1, 0)
+
+    assert got == payload, "the read is served regardless of disk pressure"
+    assert promoted == [], "nothing was promoted onto the pressured disk"
+    assert recorded == ["disk_pressure"], "the backoff is counted"
+    assert not (primary / oid).exists(), "no local copy was written"
+
+
+@pytest.mark.asyncio
+async def test_promotion_still_happens_when_the_disk_has_room(tmp_path) -> None:
+    """The no-regression half: the gate must not quietly disable the tier it protects."""
+    primary = tmp_path / "local"
+    fallback = tmp_path / "pool"
+    primary.mkdir()
+    fallback.mkdir()
+
+    oid = "b" * 8 + "-1111-2222-3333-444444444444"
+    payload = b"ciphertext-chunk"
+    seed = DualFileSystemPartsStore(str(primary), str(fallback))
+    await seed.fallback.set_meta(oid, 1, 1, chunk_size=16, num_chunks=1, size_bytes=16)
+    await seed.fallback.set_chunk(oid, 1, 1, 0, payload)
+
+    promoted: list[tuple] = []
+
+    async def on_promote(*args: object) -> None:
+        promoted.append(args)
+
+    store = DualFileSystemPartsStore(
+        str(primary),
+        str(fallback),
+        promote=True,
+        on_promote=on_promote,
+        space_gate=FreeSpaceGate("/nonexistent", 0.175, probe=FakeProbe(0.90)),
+    )
+
+    assert await store.get_chunk(oid, 1, 1, 0) == payload
+    assert promoted, "a healthy disk still warms the local tier"
+    assert await store.read_local_chunk(oid, 1, 1, 0) == payload

--- a/tests/unit/writer/test_landed_announcements.py
+++ b/tests/unit/writer/test_landed_announcements.py
@@ -1,0 +1,174 @@
+"""The api tells its node's drain agent about each part it writes.
+
+Discovery used to mean the agent walking the whole SSD cache every 15s and asking the database
+which parts it had never seen — fine when the disk held only the undrained backlog, ruinous once
+retention made it hold the node's entire replicated shard (2.28M parts on prod).
+
+Two properties carry the whole design and are pinned here: the announcement lands strictly after
+`meta.json` (the readiness gate), and it can never fail a PUT.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hippius_s3.writer import landed
+from hippius_s3.writer.landed import LandedPartPublisher
+from hippius_s3.writer.landed import get_landed_publisher
+from hippius_s3.writer.landed import initialize_landed_publisher
+from hippius_s3.writer.landed import landed_queue_key
+from hippius_s3.writer.write_through_writer import WriteThroughPartsWriter
+
+
+OBJ = "466916c0-d61b-4518-b81b-9576b574270a"
+
+
+class FakePipeline:
+    def __init__(self, sink: list[tuple], fail: bool) -> None:
+        self._sink = sink
+        self._fail = fail
+        self.ops: list[tuple] = []
+
+    def lpush(self, key: str, value: str) -> None:
+        self.ops.append(("lpush", key, value))
+
+    def ltrim(self, key: str, start: int, stop: int) -> None:
+        self.ops.append(("ltrim", key, start, stop))
+
+    async def execute(self) -> None:
+        if self._fail:
+            raise ConnectionError("redis-queues down")
+        self._sink.extend(self.ops)
+
+
+class FakeQueues:
+    def __init__(self, fail: bool = False) -> None:
+        self.executed: list[tuple] = []
+        self.fail = fail
+
+    def pipeline(self) -> FakePipeline:
+        return FakePipeline(self.executed, self.fail)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """The publisher is a process-wide singleton, so leaking one across tests would let an
+    earlier test's queue receive a later test's announcements."""
+    yield
+    landed._publisher = None
+
+
+def test_the_queue_key_matches_the_agents(monkeypatch) -> None:
+    """Cross-language contract. The agent's `landed_queue_key` builds the same string; if either
+    side drifts the api publishes into a key nobody drains and discovery silently reverts to the
+    disk walk, with no error anywhere."""
+    assert landed_queue_key("k8s-v3-node1") == "cephor:landed:k8s-v3-node1"
+
+
+@pytest.mark.asyncio
+async def test_the_published_message_matches_the_agents_wire_contract() -> None:
+    """These three field names ARE the protocol.
+
+    The agent parses into a struct with exactly `object_id`, `version`, `part_number` and
+    discards anything it cannot read — so renaming one side alone disables the fast path
+    silently rather than erroring. Asserted on the exact key set, not just the values.
+    """
+    queues = FakeQueues()
+    await LandedPartPublisher(queues, "node-a").publish(OBJ, 7, 3)
+
+    op, key, raw = queues.executed[0]
+    assert (op, key) == ("lpush", "cephor:landed:node-a")
+    assert json.loads(raw) == {"object_id": OBJ, "version": 7, "part_number": 3}
+
+
+@pytest.mark.asyncio
+async def test_the_queue_is_bounded_in_the_same_round_trip() -> None:
+    """An agent that is down must not let this list grow without limit on a 1 GB Redis.
+
+    The trim rides in the same pipeline as the push: paying a second round-trip per part on the
+    write path to bound a queue that is normally empty would be a poor trade.
+    """
+    queues = FakeQueues()
+    await LandedPartPublisher(queues, "node-a", max_depth=1000).publish(OBJ, 1, 1)
+
+    assert [op[0] for op in queues.executed] == ["lpush", "ltrim"]
+    assert queues.executed[1] == ("ltrim", "cephor:landed:node-a", 0, 999)
+
+
+@pytest.mark.asyncio
+async def test_a_redis_outage_never_reaches_the_caller() -> None:
+    """The bytes and meta are already durable when this runs, so raising here would fail a PUT
+    that fully succeeded. The reconciler still finds the part on disk."""
+    await LandedPartPublisher(FakeQueues(fail=True), "node-a").publish(OBJ, 1, 1)
+
+
+def test_no_node_identity_means_no_publisher() -> None:
+    """Without NODE_NAME there is no way to say WHOSE agent should drain the part, and an
+    announcement on the wrong node's queue would record a row against a node that does not hold
+    the data — where the node-scoped `claim_part` would never drain it. Publishing nothing is
+    strictly better: the reconciler on the node that does hold it still finds it."""
+    assert initialize_landed_publisher(FakeQueues(), "") is None
+    assert get_landed_publisher() is None
+
+
+def test_no_queue_client_means_no_publisher() -> None:
+    assert initialize_landed_publisher(None, "node-a") is None
+
+
+@pytest.mark.asyncio
+async def test_write_meta_announces_strictly_after_the_readiness_gate() -> None:
+    """THE ordering invariant.
+
+    `meta.json` is what makes a part readable and claimable. Announcing before it lands would
+    let the drain claim a part whose meta is not yet on disk. The order is asserted directly
+    rather than inferred from the source.
+    """
+    order: list[str] = []
+
+    class RecordingStore:
+        async def set_meta(self, *_a, **_kw) -> None:
+            order.append("meta")
+
+    class RecordingPublisher:
+        async def publish(self, *_a) -> None:
+            order.append("announce")
+
+    landed._publisher = RecordingPublisher()
+    writer = WriteThroughPartsWriter(RecordingStore(), None, ttl_seconds=60)
+
+    await writer.write_meta(OBJ, 1, 1, chunk_size=4, num_chunks=1, plain_size=4)
+
+    assert order == ["meta", "announce"], "the announcement must follow the readiness gate"
+
+
+@pytest.mark.asyncio
+async def test_write_meta_works_with_no_publisher_installed() -> None:
+    """Workers, scripts and tests never initialize the singleton; they must still write meta."""
+    calls: list[str] = []
+
+    class RecordingStore:
+        async def set_meta(self, *_a, **_kw) -> None:
+            calls.append("meta")
+
+    landed._publisher = None
+    await WriteThroughPartsWriter(RecordingStore(), None, ttl_seconds=60).write_meta(
+        OBJ, 1, 1, chunk_size=4, num_chunks=1, plain_size=4
+    )
+
+    assert calls == ["meta"]
+
+
+@pytest.mark.asyncio
+async def test_a_failing_announcement_does_not_fail_the_write(monkeypatch) -> None:
+    """End to end through the writer: a dead redis-queues costs a fast discovery path, not a PUT."""
+
+    class RecordingStore:
+        async def set_meta(self, *_a, **_kw) -> None:
+            return None
+
+    initialize_landed_publisher(FakeQueues(fail=True), "node-a")
+    await WriteThroughPartsWriter(RecordingStore(), None, ttl_seconds=60).write_meta(
+        OBJ, 1, 1, chunk_size=4, num_chunks=1, plain_size=4
+    )


### PR DESCRIPTION
The SSD read tier (#398) serves reads correctly but does not yet bound its own
space or its own discovery cost. Measured on prod 2026-08-07 (read-only), this
closes both loops. Staging manifests only; `k8s/production` untouched.

Full analysis, rejected alternatives and remaining phases:
`docs/plans/2026-08-07-ssd-read-tier-hardening.md`.

## Eviction pages to the byte goal (`ssd_evict.rs`)

`evict_to_target` took a single worklist page and reported `starved` if that page
did not cover the deficit. An armed pass must free ~175 GB (50 permille of a
3.5 TB NVMe) while one 512-part page frees ~209 MB at the measured 408 KB shard
mean. Every pass for the ~7 hours that took logged ERROR "ran out of resident
parts" — the signal meant to mean "PUTs are about to 503".

The pass now pages until its free-space goal is met and separates the two exits:
`starved` only on genuine worklist exhaustion, `budget_exhausted` when a new
wall-clock bound stops a pass with work still queued. `CEPHOR_EVICT_BATCH` is now
the query page size; progress is counted in bytes, because prod part sizes are
bimodal (p50 686 bytes vs a 408 KB mean) and a part count says little about bytes
freed. Free space is re-probed between pages via a new `FreeSpaceProbe` seam.

## Promotion yields to ingest (`fs_pressure.py`, `dual_fs_store.py`)

Read-through promotion was the only unthrottled writer to the ingest SSD, and it
shares that mount with ingest: on an ingest node `HIPPIUS_OBJECT_CACHE_DIR` is
the drain agent's `CEPHOR_SSD_ROOT`, and the same mount `fs_cache_pressure`
measures when refusing a PUT. A chunk is now served without being promoted below
`HIPPIUS_PROMOTE_MIN_FREE_RATIO`, counted as `promotion_skipped_total`.

The threshold must sit strictly inside the evictor's band —
`fs_cache_min_free 0.08 < evict_reserve 0.15 < promote_floor 0.175 < target 0.20`.
Equal to the target it chatters; above it, promotion deadlocks permanently
because the evictor never frees past its target. `validate_promotion_band`
enforces this against the resolved config at startup, and the band is pinned by a
test on each side of the Rust/Python boundary.

## Discovery stops walking the disk (`landed.py`, `landed.rs`)

The reconciler walked the whole SSD cache every 15s and asked the database which
parts it had never seen. Retention took that walk's input from the undrained
backlog to each node's entire replicated shard — 2.28M parts / ~930 GB — so it
became ~2.28M stat calls and ~4,560 batched queries every 15s per node to find a
handful of new parts.

The api now announces each part to a per-node Redis queue after `meta.json`
lands, and the agent records it through the same idempotent `record_landed_part`.
A queue rather than an api-side INSERT keeps `cephor_replication_status`
single-writer under the drain's migrations, matching the drain-direct upload
handoff. At-most-once by design: a lost message costs latency, since the
reconciler still finds the part on disk.

`CEPHOR_RECONCILE_POLL_SECS` is deliberately unchanged — raising it is a separate
deploy gated on `drain_landed_recorded_total` climbing while
`reconciler_recovered` goes to zero.

## Failed-part reclaim leaves the walk (`ssd_reclaim.rs`, `store.rs`)

Same shape: the walk scanned everything to find 22,123 `failed` rows fleet-wide.
The worklist is now an indexed, node-scoped, grace-gated query on its own poll,
which is what let the reclaim walk drop from 300s to hourly.

The R4 guard is not re-implemented. A `failed` part whose version is still
servable is a live object whose pool copy is corrupt, and its SSD copy is the
last good source. That predicate lives in `BackingLog::servable_parts` under a
"MUST stay in lockstep" warning already shared with two other files, so the query
returns candidates and the existing seam judges them.

## One reader stops shedding its own prefetch (`peers.py`)

Every chunk of a part resolves to the same peer, and the streamer keeps 16
fetches in flight, but the per-peer cap shipped at 8 — so a single reader of a
part over 32 MiB sent half its own window to CephFS while the peer sat idle, and
booked it as `client_cap`. The cap is now floored at the prefetch depth at wiring
time. This adds no peer capacity: the semaphore is shared across readers, so
under concurrency shedding moves to the peer's `server_busy`.

## Observability

New: `promotion_skipped_total`, `drain_scan_parts_total`, `drain_scan_duration_ms`,
`drain_landed_recorded_total`, `drain_landed_dropped_total`.

`drain_landed_dropped_total` must stay at zero — nonzero means the api and agent
disagree about the wire contract, so every announcement is discarded and
discovery silently reverts to the walk.

## Testing

2469 Python and 466 Rust tests pass; clippy `--all-targets --all-features
-D warnings` clean; ruff and ty clean. Rust store tests run against a live
Postgres.

35 mutations verified killed, including: single-page eviction, dropping the
unreplicated guard, promote floors of 0.20 and 0.25, announcing before meta,
renaming a wire field, ignoring the R4 servable guard, and dropping the node,
grace or status filter from the failed worklist — the last of which would have
reclaimed the read tier.

Two bugs the tests caught during development, both in this PR's own code:
re-testing `deficit()` per page stops at the reserve and discards the headroom;
and evicting in whole pages overshoots by up to `page - 1` parts.

## Not included

Retention itself has no kill switch and arrives with the binary — rollback is
`kubectl rollout undo`, which is untested. `CEPHOR_REPLICATED_RECLAIM_GRACE_SECS`
is load-bearing for that path and must not be removed from the prod manifest.
Recency-aware eviction, the allocator reserve fix, and peer-serving
not-yet-replicated parts remain open; see the plan.