### PR TITLE
docs: correct drain-core comments that describe a superseded design

### DIFF
--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -466,7 +466,7 @@ impl PromoteFloorPublisher {
 }
 
 /// One eviction pass: probe the ingest disk and, if free space is under the reserve, evict
-/// oldest-resident parts until it is back over the floor.
+/// least-recently-used resident parts until it is back over the floor.
 ///
 /// With retention on, this is the ONLY thing that frees the ingest SSD, so a persistent
 /// failure here ends in `fs_cache_pressure` 503ing PUTs. Errors are logged and retried on the

--- a/crates/hippius-drain-core/src/partdrain.rs
+++ b/crates/hippius-drain-core/src/partdrain.rs
@@ -228,10 +228,12 @@ pub trait PartReplicationStore: Send + Sync {
     ///
     /// Called just BEFORE the commit, not after, and the order matters. The part is already on
     /// the disk, so recording residency first means a crash between the two leaves a residency
-    /// row for a still-`draining` part — which the eviction worklist's status guard refuses,
-    /// and which the reclaimer clears if the part never commits. The reverse order could commit
-    /// a part whose residency was never recorded: a copy on the disk that no evictor can see
-    /// and no `cache_bytes` sum counts, leaking space until the node fills.
+    /// row for a still-`draining` part — which the eviction worklist's status guard refuses, and
+    /// which the next successful commit simply overwrites. (Nothing DELETES it if the part never
+    /// commits: the reclaimer touches only the disk, never `cephor_ssd_residency` — see
+    /// `Store::drop_residency` for why that dead row is inert.) The reverse order could commit a
+    /// part whose residency was never recorded: a copy on the disk that no evictor can see and no
+    /// `cache_bytes` sum counts, leaking space until the node fills.
     fn mark_resident(&self, part: &PartKey, bytes: u64) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
     /// Stamp that this part's backend `UploadChainRequest` has been published (sets

--- a/crates/hippius-drain-core/src/ssd_evict.rs
+++ b/crates/hippius-drain-core/src/ssd_evict.rs
@@ -296,10 +296,12 @@ pub trait ResidentLog: Send + Sync {
 /// is keeping ingest alive.
 ///
 /// A failing UNLINK is likewise not fatal, and for a sharper reason: aborting the pass returned
-/// before `mark_evicted`, which is the only thing that advances the cursor. Since the worklist is
-/// oldest-first and stable, a part that persistently refuses to be unlinked — EIO, EACCES, EROFS,
-/// or an `ENOTEMPTY` from the api renaming a promoted chunk into the directory being removed —
-/// pinned the head and every later pass died on the same row having freed nothing. The candidate
+/// before `mark_evicted`, which is the only thing that advances the cursor. The worklist is
+/// coldest-first by `COALESCE(last_read_at, resident_at)`, and a part nobody reads keeps its
+/// rank — the pinning holds under any stable order, LRU or the old FIFO alike. A part that
+/// persistently refuses to be unlinked — EIO, EACCES, EROFS, or an `ENOTEMPTY` from the api
+/// renaming a promoted chunk into the directory being removed — pinned the head and every later
+/// pass died on the same row having freed nothing. The candidate
 /// is counted in [`remove_failed`](EvictionReport::remove_failed) and skipped; a page on which
 /// EVERY candidate fails still terminates the pass via the existing `starved` guard.
 ///
@@ -385,8 +387,9 @@ where
             if let Err(err) = remover.unlink_part(&candidate.part).await {
                 // Counted and skipped rather than propagated. Returning here landed BEFORE
                 // `mark_evicted`, and `mark_evicted` -> `drop_residency` is the only thing that
-                // advances the cursor — so on a stable oldest-first worklist one un-unlinkable
-                // part pinned the head and halted ALL eviction, with no report to carry `starved`.
+                // advances the cursor — the worklist is coldest-first by read recency and an
+                // unread part keeps its rank, so one un-unlinkable part pinned the head and
+                // halted ALL eviction, with no report to carry `starved`.
                 report.remove_failed = report.remove_failed.saturating_add(1);
                 // Ranked by what needs a human, NOT by arrival order. `get_or_insert` here would
                 // keep whichever fault the worklist happened to order first, and the worklist is
@@ -836,7 +839,8 @@ mod tests {
 
     #[tokio::test]
     async fn a_persistently_failing_head_does_not_starve_later_passes() {
-        // The operational regression. The worklist is ordered oldest-first and stable, so a part
+        // The operational regression. The worklist is ordered coldest-first by
+        // COALESCE(last_read_at, resident_at), and a part nobody reads keeps its rank — so a part
         // that fails to unlink stays at the head; propagating that failure meant every subsequent
         // pass died on the same row having freed nothing, indefinitely and silently — the report
         // that carries `starved` was never produced, so neither eviction alert could fire.

--- a/crates/hippius-drain-core/src/ssd_evict.rs
+++ b/crates/hippius-drain-core/src/ssd_evict.rs
@@ -1,5 +1,6 @@
 //! The SSD read-tier evictor: keeps a free-space floor on the ingest `NVMe` by reclaiming the
-//! oldest RESIDENT parts — the ones the drain deliberately kept after replicating them.
+//! least-recently-used RESIDENT parts — the ones the drain deliberately kept after replicating
+//! them.
 //!
 //! This worker exists because the drain no longer unlinks on replicate. Retaining replicated
 //! parts is what makes a local GET read at ~705 MB/s off `NVMe` instead of ~94 MB/s off the
@@ -233,7 +234,7 @@ impl EvictionError {
 /// The eviction worklist seam: which resident parts to reclaim, and recording that they were.
 ///
 /// Implemented by [`crate::Store`] (under `pg`) against the
-/// `cephor_replication_resident_idx` partial index; faked in tests.
+/// `cephor_ssd_residency_recency_idx` expression index (migration 0017); faked in tests.
 pub trait ResidentLog: Send + Sync {
     /// Store-specific failure, boxed into [`EvictionError`].
     type Error: std::error::Error + Send + Sync + 'static;
@@ -244,9 +245,11 @@ pub trait ResidentLog: Send + Sync {
     /// whatever order it is handed and never re-sorts.
     fn evictable_parts(&self, limit: u32) -> impl Future<Output = Result<Vec<ResidentPart>, Self::Error>> + Send;
 
-    /// Stamps `evicted_at` on each part, so it leaves the resident set and the next pass's
-    /// worklist. Batched: a per-part UPDATE would put a round-trip in the eviction inner
-    /// loop, which runs under disk pressure.
+    /// Records that each part is no longer resident, so it leaves the next pass's worklist. In
+    /// the Postgres impl that is a DELETE of the residency row, not a tombstone stamp — the table
+    /// is meant to stay bounded by what is actually on disk (migration 0016) — and it is the ONLY
+    /// thing that advances the cursor, since the worklist query has no OFFSET. Batched: a per-part
+    /// statement would put a round-trip in the eviction inner loop, which runs under disk pressure.
     fn mark_evicted(&self, parts: &[PartKey]) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -10,7 +10,7 @@
 //! It is emphatically NOT the owner of `replicated` parts. Those are RETAINED on purpose —
 //! they are the node's read tier, served from local `NVMe` at ~705 MB/s / ~6 ms per chunk
 //! against the pool's ~94 MB/s / ~40 ms — and they are reclaimed by
-//! [`evict_to_target`](crate::evict_to_target) on a free-space policy, oldest-resident first
+//! [`evict_to_target`](crate::evict_to_target) on a free-space policy, least-recently-used first
 //! and only as much as the disk needs. This module handles DEBRIS; the evictor handles CACHE.
 //! Before retention the drain unlinked its own copy at commit, so anything `replicated` left
 //! on disk could only be a crash between the commit and that unlink, and this worker
@@ -385,8 +385,8 @@ where
             // two; retention removed that inference entirely.
             //
             // Reclaiming these is now the EVICTOR's job (`crate::evict_to_target`), and the
-            // distinction is not cosmetic: the evictor deletes on a free-space policy, oldest
-            // resident first, only as much as the disk needs. An age-based sweep here would
+            // distinction is not cosmetic: the evictor deletes on a free-space policy,
+            // least-recently-USED first, only as much as the disk needs. An age-based sweep here would
             // throw away hot cache on a disk with terabytes free, quietly undoing retention —
             // which is exactly what shipping the retention change without this arm would do.
             ReplicationState::Replicated => report.skipped_replicated += 1,

--- a/crates/hippius-drain-core/src/store.rs
+++ b/crates/hippius-drain-core/src/store.rs
@@ -376,8 +376,9 @@ impl Store {
     /// headroom rather than against it, so a disk full of warm cache does not read to the
     /// allocator as a node critically behind on draining.
     ///
-    /// Served by `cephor_ssd_residency_evict_idx`, reading the denormalized `bytes` rather
-    /// than joining the ~140M-row `parts` table. A part whose size was unknown at residency
+    /// The `node_id` equality is served by the leading column of `cephor_ssd_residency_recency_idx`
+    /// (migration 0017, which DROPPED the older `cephor_ssd_residency_evict_idx`), and `bytes` is
+    /// read denormalized rather than joined off the ~140M-row `parts` table. A part whose size was unknown at residency
     /// time contributes zero, which under-reports cache — the fail-safe direction, since
     /// understating evictable space overstates drain urgency rather than hiding it.
     ///
@@ -1240,8 +1241,10 @@ impl ResidentLog for Store {
         // it regardless, but a worklist that never emits it is the real guard.
         //
         // INNER JOIN: a residency row with no replication row means the object was hard-deleted,
-        // which is the reclaimer's disposition (deleted-object orphan), not the evictor's. It is
-        // excluded here and `prune_residency` clears the row when the reclaimer unlinks the part.
+        // which is the reclaimer's disposition (deleted-object orphan), not the evictor's. Note
+        // the reclaimer unlinks the part and leaves the row — it never touches this table — so
+        // this join is not merely a filter, it is the whole reason that row is inert. See
+        // `drop_residency` for why leaving it is safe and for the assumption that makes it so.
         //
         // THIS ORDER BY IS THE EVICTION POLICY; the orchestrator walks it and never re-sorts.
         //
@@ -1401,14 +1404,38 @@ impl Store {
     /// Drops this node's residency rows for `parts` — the counterpart to
     /// [`record_resident`](Self::record_resident), called by the evictor after it unlinks.
     ///
-    /// The reclaim worker deliberately does NOT call this, because the parts it removes never
-    /// had a residency row: residency is recorded only at the drain's commit, and everything
-    /// the reclaimer removes is either terminal (`failed`) or has no replication row at all
-    /// (a deleted-object orphan). The one loose end is a part that was resident and then had
-    /// its object hard-deleted: its replication row goes, the reclaimer frees the disk space,
-    /// and the residency row is left behind — but both `evictable_parts` and `node_cache_bytes`
-    /// INNER JOIN the replication row, so it is invisible to each and drifts no signal. It is a
-    /// dead row bounded by the hard-delete rate, not a leak of disk or of accounting.
+    /// # Why the reclaim worker deliberately does NOT call this
+    ///
+    /// Not because the parts it removes never had a residency row — that argument is false twice
+    /// over. Residency is not recorded only at the drain's commit: the api records it on
+    /// read-through promotion too (see [`record_resident`](Self::record_resident)), so a part can
+    /// be resident on a node that never drained it, and `reclaim_ssd`'s walk adjudicates such a
+    /// copy against the INGESTING node's row (`part_states` has no node predicate). And a part the
+    /// drain itself made resident can still reach terminal `failed` afterwards:
+    /// [`redrive_diverged_part`](Self::redrive_diverged_part) and
+    /// [`redrive_corrupt_parts`](Self::redrive_corrupt_parts) both return a committed part to
+    /// `pending` while deliberately leaving residency alone, and the retry can then escalate via
+    /// [`defer_part_missing_source`](Self::defer_part_missing_source) or `mark_failed`. Both
+    /// reclaim dispositions — terminal `failed` and deleted-object orphan — therefore unlink parts
+    /// that leave a residency row behind.
+    ///
+    /// What makes the leftover row harmless is the STATUS FILTER, not its absence. The only two
+    /// readers of `cephor_ssd_residency` here — [`ResidentLog::evictable_parts`](crate::ResidentLog::evictable_parts)
+    /// and [`node_cache_bytes`](Self::node_cache_bytes) — INNER JOIN `cephor_replication_status`
+    /// and require `status = 'replicated'`, and every reclaim disposition is by construction the
+    /// opposite: `failed` on both `failed` paths, no replication row at all on the orphan path. So
+    /// the row is invisible to the eviction worklist and to the heartbeat's `cache_bytes`, and it
+    /// stays invisible — `failed` is terminal (every writer back to `pending` is guarded on
+    /// `draining`, `corrupt`, or `replicated`, none of which a `failed` row matches) and nothing
+    /// recreates a replication row for a part the reclaimer just unlinked. The cost is a dead row
+    /// per reclaimed resident part, bounded by the reclaim rate — not disk, and not accounting.
+    ///
+    /// **Nothing enforces that.** There is no foreign key and no cascade between the two tables;
+    /// the safety is the `status = 'replicated'` predicate, written out twice. Dropping it from
+    /// either query — or adding a third consumer that reads this table by `node_id` alone — turns
+    /// every one of those dead rows into live over-accounting, compounded by the api's
+    /// `ResidencyRecorder`, which ACCUMULATES `bytes` and so would add to a stale row rather than
+    /// replace it. Such a change must also add the `drop_residency` call this doc calls needless.
     ///
     /// # Errors
     ///
@@ -2338,7 +2365,8 @@ mod part_tests {
 
     #[sqlx::test]
     async fn the_eviction_worklist_is_oldest_first_scoped_to_this_node_and_excludes_evicted(pool: PgPool) {
-        // Three properties the evictor's correctness rests on: FIFO order (the policy),
+        // Three properties the evictor's correctness rests on: order (here the `resident_at`
+        // FALLBACK, since nothing has been read — the LRU policy itself has its own test below),
         // node-scoping (a node must never evict a peer's part — it does not even hold it),
         // and that a marked part leaves the worklist (or the next pass would re-offer it
         // forever and never make progress).

--- a/hippius_s3/cache/peers.py
+++ b/hippius_s3/cache/peers.py
@@ -383,12 +383,18 @@ class PeerChunkFetcher:
         expected = sizes.get(int(chunk_index))
         if expected is None:
             # No recorded size means no way to tell a correct body from a truncated one, and an
-            # unverified body that gets promoted onto local flash is a PERMANENT read failure
-            # for that chunk: nothing on the read path invalidates a cached chunk on AEAD
-            # failure, so it wins the local tier and fails every subsequent read until the
-            # evictor happens to unlink the part. The pool copy is authoritative, so declining
-            # costs one pool read. Counted rather than silent because it should never happen —
-            # `part_chunks` rows are written for every chunk index when the part is created.
+            # unverified body gets promoted onto local flash, where it wins the read tier.
+            # `invalidate_local_chunk` now clears such a chunk on AEAD failure, so this is no
+            # longer permanent — but it is not a substitute for the size check either. That
+            # invalidation is gated on the POOL already holding the chunk, which a peer-served
+            # part need not be (the owner is resolved from residency alone, not from
+            # `status='replicated'`); the retry after it re-enters this same peer tier and
+            # re-promotes, so a deterministically wrong peer fails the retry too; and the retry
+            # fires exactly once per request, spending a budget that exists for genuine DEK
+            # faults and reporting on `chunk_aead_failures_total`, the metric that says the keys
+            # are wrong. The pool copy is authoritative, so declining costs one pool read.
+            # Counted rather than silent because it should never happen — `part_chunks` rows are
+            # written for every chunk index when the part is created.
             _record_shed("unknown_size")
             return None
 

--- a/hippius_s3/cache/peers.py
+++ b/hippius_s3/cache/peers.py
@@ -386,9 +386,12 @@ class PeerChunkFetcher:
             # unverified body gets promoted onto local flash, where it wins the read tier.
             # `invalidate_local_chunk` now clears such a chunk on AEAD failure, so this is no
             # longer permanent — but it is not a substitute for the size check either. That
-            # invalidation is gated on the POOL already holding the chunk, which a peer-served
-            # part need not be (the owner is resolved from residency alone, not from
-            # `status='replicated'`); the retry after it re-enters this same peer tier and
+            # invalidation is gated on the POOL holding the chunk, and `_resolve_part` checks the
+            # `status='replicated'` guarantee behind that only ONCE, at resolve time: the memo
+            # then holds the owner for its TTL while a redrive (`redrive_diverged_part`,
+            # `redrive_corrupt_parts`) can flip the part back to `pending` without touching
+            # residency, so by the time a promoted body fails AEAD the pool copy may be stale or
+            # mid-rewrite; the retry after it re-enters this same peer tier and
             # re-promotes, so a deterministically wrong peer fails the retry too; and the retry
             # fires exactly once per request, spending a budget that exists for genuine DEK
             # faults and reporting on `chunk_aead_failures_total`, the metric that says the keys


### PR DESCRIPTION
Stacked on #403. **Comments only** — every test count is unchanged (243 core / 246 coord / 117 agent / 2604 python), verified by diffing for non-comment added lines.

This codebase's review value is that the reasoning is written at the point of use, so engineers trust these comments instead of re-deriving invariants. That makes a **wrong** comment worse than none. The review named three; a prior pass found five more restatements of the same two facts. This finishes the sweep and answers the one open question.

## The open question: `drop_residency`'s premise

Its doc said *"residency is recorded only at the drain's commit"* — false since read-through promotion also records it. The question was whether the **conclusion** (the reclaimer need not call `drop_residency`) survives.

**It does, but not for the reason previously given**, and the previously-given reason does not hold:

- `Store::part_states` has **no node predicate**, and `CEPHOR_SSD_ROOT` == the api's `HIPPIUS_OBJECT_CACHE_DIR`. So `reclaim_ssd`'s walk on node B finds B's promoted copy and adjudicates it against node **A**'s replication row. Only `reclaimable_failed_parts_impl` is node-scoped — that defence covers `reclaim_failed`, not `reclaim_ssd`.
- A replicated-then-promoted part **can** reach `failed`: `redrive_diverged_part` and `redrive_corrupt_parts` both return a committed part to `pending` while deliberately leaving residency alone, and the retry can then escalate to terminal `failed`.

**The real safety is the status filter.** The only two readers of the table in drain-core — `evictable_parts` and `node_cache_bytes` — both INNER JOIN `cephor_replication_status` and require `status = 'replicated'`. Every reclaim disposition is the opposite by construction, and `failed` is terminal.

**The assumption, which nothing enforces:** no foreign key, no cascade. The safety is `status = 'replicated'` written out **twice**. Drop it from either query, or add a third consumer reading by `node_id` alone, and every dead row becomes live over-accounting — compounded because the Python `ResidencyRecorder` *accumulates* `bytes`. That is now in the doc.

## The sweep — 9 further hits

**"FIFO by `resident_at`"** (5): the `ssd_evict.rs` module *summary line* rustdoc shows in the crate index, `ssd_reclaim.rs` ×2, `runtime.rs`'s `evict_once` doc, and a `store.rs` test comment.

**"`mark_replicated` stamps `resident_at`"**: **0 further hits** — confirmed exhausted. The surviving "same statement" mentions are about `content_sha256`, which genuinely is.

**Two families the brief did not anticipate — names that do not exist:**
- `prune_residency` — credited with cleanup; exists nowhere in the tree, and contradicted `drop_residency`'s own text 160 lines later
- `evicted_at` — a column that has never existed; `mark_evicted` is a DELETE
- two index names, one that never existed and one that migration 0017 explicitly **dropped**

## Coverage and honesty

`coordination.rs` swept under `--features coord` (clean). All 20 `CLAUDE.md` files swept with `rg --no-ignore` — a bare `CLAUDE.md` in `.gitignore:83` means plain `rg` skips every one of them.

Migration `0016`'s FIFO index description is **left alone**: migrations are applied history, and `0017` supersedes it in the same directory with an explicit note.

**Is the drift exhausted?** For the two named facts in `crates/`, yes. But this produced two *new* families, found only by chasing the `drop_residency` question — the whole tree has not been swept for dead names.

Follow-up: corrected three remaining stale "oldest-first" comments in `ssd_evict.rs` (the worklist is coldest-first by `COALESCE(last_read_at, resident_at)`) and the `peers.py` unknown_size comment that wrongly claimed the peer owner is resolved from residency alone — `_resolve_part` requires `status='replicated'`; the real caveat is that the guarantee is resolve-time only and a redrive can lapse it while the owner memo lives.
