### PR TITLE
ci: smoke-test prod with prod's own test code

### DIFF
--- a/.github/workflows/production-smoke-tests.yml
+++ b/.github/workflows/production-smoke-tests.yml
@@ -19,8 +19,12 @@ jobs:
       cancel-in-progress: false
 
     steps:
+      # Scheduled runs read this file from the default branch (staging), so without an
+      # explicit ref they would smoke-test prod using staging's unreleased test code.
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

Pins `production-smoke-tests.yml`'s checkout to `main`, so production is smoke-tested with the code that is actually deployed to it.

## The problem

Scheduled workflows read their definition from the **default branch**, which the branch-model swap (#395) moved to `staging`. Since the cutover, every hourly prod smoke run has been checking out `staging`'s tree and running `tests/smoke/` against `s3.hippius.com`:

```
[staging] schedule success 2026-08-08T17:08:28Z
[staging] schedule success 2026-08-08T16:07:10Z
...
```

Today that's harmless — `git diff origin/main origin/staging -- tests/smoke/` is empty. But `staging` currently carries 35 unreleased commits, and the first smoke test written for an unreleased feature will fail against prod and page someone for a test-code mismatch rather than a real outage.

## The fix

```yaml
      - name: Checkout code
        uses: actions/checkout@v4
        with:
          ref: main
```

## What this does and doesn't change

- **Does**: `tests/smoke/`, `scripts/extract_failure_details.py`, and `tests/smoke/requirements.txt` now come from `main`.
- **Doesn't**: the cron schedule and the step definitions still come from the default branch's copy of this file — that's how GitHub resolves scheduled workflows and can't be changed from here. Only the workspace contents are affected, which is the part that matters.
- `workflow_dispatch` runs will also now always use `main`'s tests, regardless of the branch you dispatch from. That's intended for prod smoke.

Because scheduled runs resolve this file from the default branch, **the fix takes effect as soon as this lands on `staging`** — it does not need to reach `main` first.

## Conclusion

Three lines, closes the one place where the default-branch setting has real operational teeth.
