### PR TITLE
Demote prod reconcile poll to a 600s backstop

### DIFF
--- a/k8s/production/api-local-deployments-production.yaml
+++ b/k8s/production/api-local-deployments-production.yaml
@@ -114,6 +114,17 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            # The landed-announcement fast path this PR's 600s poll demotes itself to a BACKSTOP
+            # for. `initialize_landed_publisher` returns None without a node identity, because an
+            # announcement on the wrong node's queue would be claimed by an agent that does not
+            # hold the bytes — so with NODE_NAME unset the api publishes nothing at all and the
+            # reconcile walk becomes 100% of discovery. Demoting the poll without this would put
+            # up to 600s between a part landing and anything knowing, i.e. single-copy exposure
+            # and cross-node read-after-write 503s for that whole window. Staging already sets it.
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/k8s/production/drain-agent-daemonset.yaml
+++ b/k8s/production/drain-agent-daemonset.yaml
@@ -183,31 +183,30 @@ spec:
             # AND defer_attempts), so a just-completed MPU's parts drain promptly regardless.
             - name: CEPHOR_DRAIN_POLL_SECS
               value: "1"
-            # Reconciler scan period (was the 60s code default). NO LONGER the sole drain trigger:
-            # the api announces each part to cephor:landed:<node> and the agent's `landed` worker
-            # records it, so this walk is the BACKSTOP for an announcement never delivered. Until
-            # that path is proven this interval still bounds the replication-sync tail, which is
-            # why it is unchanged here.
-            # STALE PREMISE — corrected 2026-08-07. This used to read "undrained parts only —
-            # drained parts are unlinked", which is what made a 15s walk cheap. Retention (PR
-            # #398) ended that: the drain keeps its replicated copy to serve reads, so the tree
-            # is now the node's ENTIRE replicated shard — measured on prod 2026-08-07 at 2.28M
-            # parts / ~930 GB per node. At this interval that is ~2.28M stats and ~4,560 batched
-            # queries every 15 seconds, per node, to discover a handful of new parts.
-            # The Ceph pool and the 94M-row parts table are still never walked.
+            # Reconciler scan period — the BACKSTOP for a lost landed announcement, not the
+            # drain trigger. Primary discovery is the api's cephor:landed:<node> announcement,
+            # drained every 1s (landed.rs); this walk only recovers a part whose announcement
+            # was never delivered, so its interval bounds nothing but that recovery lag. An
+            # unrecovered part waits safely on SSD in the meantime: with no DB row the evictor
+            # never selects it, and the orphan reclaim grace is 24h.
             #
-            # The api landing fast-path now exists (cephor:landed:<node>, see landed.rs), so
-            # discovery no longer depends on this poll — but the poll is deliberately left at 15s
-            # until that path is proven, and demoting the reconciler to a ~10min BACKSTOP is a
-            # separate commit and separate deploy so either can be rolled back alone.
-            # Watch drain_scan_parts_total / drain_scan_duration_ms.
+            # 600 (was 15): retention (PR #398) turns the walked tree from the small undrained
+            # backlog into the node's ENTIRE replicated shard — measured 2026-08-07 at 2.28M
+            # parts / ~930 GB per node, i.e. ~2.28M stats + ~4,560 batched status queries per
+            # cycle. At 15s that walk would run 4x a minute per node from the moment retention
+            # lands; at 600s it runs 6x an hour (a 40x reduction) while a dropped announcement
+            # still recovers within the ~10min backstop the 2026-08-07 note planned. 600s also
+            # matches the code's own backstop scale (CEPHOR_DEFER_BACKOFF_CAP defaults to 600s)
+            # and is 10x the 60s code default set back when this walk was the sole — and cheap —
+            # trigger. Watch drain_scan_parts_total / drain_scan_duration_ms.
             #
-            # ORDERING CONSTRAINT: this cost is only theoretical on prod today because prod is
-            # still pre-retention (the SSD holds just the undrained backlog). Retention must not
-            # reach prod before this poll is demoted, or prod starts paying the full walk 4x a
-            # minute per node on day one.
+            # ORDERING CONSTRAINT (closed): PR #400's review gated promoting retention to prod
+            # on this demotion landing first. Done here, on the staging branch, ahead of the
+            # retention stack's promotion — so it rides the same staging->main train as
+            # retention and prod can never receive retention without it. Staging deliberately
+            # keeps 15s (see k8s/staging/drain-agent-daemonset.yaml for why).
             - name: CEPHOR_RECONCILE_POLL_SECS
-              value: "15"
+              value: "600"
             - name: RUST_LOG
               value: "info"
             # OTLP metrics -> otel-collector -> Prometheus -> Grafana (feature `otel`, on by

--- a/k8s/staging/drain-agent-daemonset.yaml
+++ b/k8s/staging/drain-agent-daemonset.yaml
@@ -179,29 +179,21 @@ spec:
             # AND defer_attempts), so a just-completed MPU's parts drain promptly regardless.
             - name: CEPHOR_DRAIN_POLL_SECS
               value: "1"
-            # Reconciler scan period (was the 60s code default). NO LONGER the sole drain trigger:
-            # the api announces each part to cephor:landed:<node> and the agent's `landed` worker
-            # records it, so this walk is the BACKSTOP for an announcement never delivered. Until
-            # that path is proven this interval still bounds the replication-sync tail, which is
-            # why it is unchanged here.
-            # STALE PREMISE — corrected 2026-08-07. This used to read "undrained parts only —
-            # drained parts are unlinked", which is what made a 15s walk cheap. Retention (PR
-            # #398) ended that: the drain keeps its replicated copy to serve reads, so the tree
-            # is now the node's ENTIRE replicated shard — measured on prod 2026-08-07 at 2.28M
-            # parts / ~930 GB per node. At this interval that is ~2.28M stats and ~4,560 batched
-            # queries every 15 seconds, per node, to discover a handful of new parts.
-            # The Ceph pool and the 94M-row parts table are still never walked.
+            # Reconciler scan period — the BACKSTOP for a lost landed announcement, not the
+            # drain trigger. Primary discovery is the api's cephor:landed:<node> announcement,
+            # drained every 1s (landed.rs); this walk only recovers a part whose announcement
+            # was never delivered.
             #
-            # The api landing fast-path now exists (cephor:landed:<node>, see landed.rs), so
-            # discovery no longer depends on this poll — but the poll is deliberately left at 15s
-            # until that path is proven, and demoting the reconciler to a ~10min BACKSTOP is a
-            # separate commit and separate deploy so either can be rolled back alone.
-            # Watch drain_scan_parts_total / drain_scan_duration_ms.
-            #
-            # ORDERING CONSTRAINT: this cost is only theoretical on prod today because prod is
-            # still pre-retention (the SSD holds just the undrained backlog). Retention must not
-            # reach prod before this poll is demoted, or prod starts paying the full walk 4x a
-            # minute per node on day one.
+            # Staging DELIBERATELY stays at 15s where production runs 600s. Retention is
+            # already live here, but the walked shard is just the two staging ingest nodes'
+            # staging-only cache (the disjoint local_ingest_staging dir on node2/node3) —
+            # nowhere near prod's 2.28M-part / ~930 GB shards, so the fast walk stays cheap.
+            # And staging is where the announcement fast-path is being proven: a 15s cycle
+            # surfaces a dropped announcement (a nonzero `recovered` tally, see
+            # drain_scan_parts_total) within seconds instead of hiding it for ten minutes,
+            # and keeps the replication-lag tail tight while that path is validated. Demote
+            # this toward prod's 600s only once staging's cache grows enough for
+            # drain_scan_duration_ms to matter.
             - name: CEPHOR_RECONCILE_POLL_SECS
               value: "15"
             - name: RUST_LOG


### PR DESCRIPTION
## What changed

- `k8s/production/drain-agent-daemonset.yaml`: `CEPHOR_RECONCILE_POLL_SECS` 15 -> **600**, and the ORDERING CONSTRAINT comment rewritten to record that the demotion is done and why 600 is the value.
- `k8s/staging/drain-agent-daemonset.yaml`: value unchanged (still 15); comment rewritten to state why staging deliberately stays fast.

## Why 600

The reconciler is the **backstop** for a lost `cephor:landed:<node>` announcement — primary discovery drains that queue every 1s (`landed.rs`, `DEFAULT_LANDED_POLL`). Its poll interval therefore bounds only the recovery lag of a dropped announcement; nothing on the primary path waits on it, and an unrecovered part waits safely on SSD (no DB row means the evictor never selects it; the orphan reclaim grace is 24h).

Post-retention (PR #398) the walk covers the node's entire replicated shard — measured 2026-08-07 at ~2.28M parts / ~930 GB per node, i.e. ~2.28M stats + ~4,560 batched status queries per cycle. At 15s that runs 4x/minute per node; at 600s it runs 6x/hour — a 40x reduction — while a dropped announcement still recovers within the ~10min backstop the manifest comment itself planned. 600s also matches the code's own backstop scale (`CEPHOR_DEFER_BACKOFF_CAP` defaults to 600s) and is 10x the 60s `DEFAULT_RECONCILE_POLL` code default set when this walk was the sole, cheap trigger.

Staging stays at 15s: retention is already live there but the walked shard is just the two staging ingest nodes' small staging-only cache, and the fast cycle is what proves the announcement fast-path (a dropped announcement shows as a nonzero `recovered` tally within seconds).

## No prod effect until promotion

This edits `k8s/production/` but production deploys only from `main`. Nothing changes in prod until staging is promoted — and that is the point: the demotion rides the **same** staging->main promotion train as the retention stack (PRs #401-#407), so prod can never receive retention without the demoted poll.

## Closes the PR #400 gate

The reviewer on PR #400 gated prod promotion of retention on this demotion landing first. With this merged to staging, that ordering constraint is satisfied structurally rather than procedurally.