### PR TITLE
fix: let G6 allow the B-2 content-change re-drive

### DIFF
--- a/stress-test/inv/guards.py
+++ b/stress-test/inv/guards.py
@@ -44,6 +44,12 @@ class _Guard(Protocol):
     def check(self, probe: Probe) -> GuardResult: ...
 
 
+def _pg_bool(cell: str) -> bool:
+    """Read a boolean column out of a `probe.pg` row. `psql -tA` renders booleans as `t`/`f`, so
+    anything else — including the empty cell a NULL would give — is False."""
+    return cell.strip().lower() in ("t", "true")
+
+
 class SingleLeaderEpoch:
     """G1: at most one allocator leads, and the leadership epoch never decreases.
 
@@ -143,6 +149,15 @@ class SoleProducer:
         return GuardResult(self.name, "ok", "no duplicate (chunk_id, backend)")
 
 
+@dataclasses.dataclass(frozen=True)
+class _StatusSample:
+    """One `cephor_replication_status` row as G6 samples it: its status plus whether the row
+    carries a fresh B-2 re-landing stamp (see `TerminalMonotonicity`)."""
+
+    status: str
+    recently_relanded: bool
+
+
 class TerminalMonotonicity:
     """G6: a terminal replication state (`replicated`/`failed`) is never left.
 
@@ -160,28 +175,82 @@ class TerminalMonotonicity:
     NOTE: `corrupt` (R4) is deliberately NOT terminal — the bounded re-drive worker legitimately
     resets `corrupt->pending` to re-copy a live object's intact SSD source over its corrupt pool
     copy. Only `replicated`/`failed` are inert sinks, so `corrupt->pending` must not be flagged.
+
+    CARVE-OUT (B-2 content-change re-drive): `Store::redrive_diverged_part` legitimately returns a
+    `replicated` part to `pending` when a re-landed part's `content_sha256` no longer matches what
+    was committed — the pool holds superseded bytes and must be re-copied. That is a real exit from
+    a terminal state, so it is permitted, but only under the predicate that makes it recognisable:
+    the re-drive is causally DOWNSTREAM of a re-landing, and `record_landed_part` stamps
+    `relanded_at` in the same statement that reads the prior `replicated` status — strictly before
+    the divergence check can flip the row. So a legitimate `replicated->pending` ALWAYS carries a
+    fresh `relanded_at`, and the guard permits the transition only when the current sample says so
+    (`_RELAND_RECENCY`, sized as the drain's 10-minute reland eviction grace plus slack, since the
+    stamp is never cleared and only its recency is meaningful). A `replicated->pending` with a NULL
+    or stale stamp is the silent-data-loss shape G6 exists to catch and still breaches, as does
+    every other terminal exit — `replicated->failed`, `replicated->draining`, `failed->*`. On a
+    cluster predating the B-2 migration the carve-out cannot apply at all; see `_sample`.
     """
 
     name = "G6"
     _TERMINAL = frozenset({"replicated", "failed"})
+    _KEY_COLUMNS = "object_id, version, part_number, status"
+    # Evaluated in the sample SQL rather than against a fetched timestamp: `now()` is then
+    # Postgres' clock, so the predicate never depends on the asserter host's clock skew.
+    _RECENCY = "(relanded_at IS NOT NULL AND relanded_at > now() - interval '15 minutes')"
 
     def __init__(self) -> None:
-        self._prev: dict[tuple[str, str, str], str] = {}
+        self._prev: dict[tuple[str, str, str], _StatusSample] = {}
+        self._samples_recency = True
 
     def check(self, probe: Probe) -> GuardResult:
-        rows = probe.pg("SELECT object_id, version, part_number, status FROM cephor_replication_status")
+        rows, columns = self._sample(probe)
         if rows is None:
             return GuardResult(self.name, "skip", "postgres unreachable")
-        current = {(r[0], r[1], r[2]): r[3] for r in rows if len(r) >= 4}
+        current = {
+            (r[0], r[1], r[2]): _StatusSample(r[3], columns == 5 and _pg_bool(r[4])) for r in rows if len(r) >= columns
+        }
+        if rows and not current:
+            # Every sampled row was too short to read, i.e. the sample query and this parser have
+            # diverged. Dropping them silently would leave the guard tracking nothing and reporting
+            # `ok` forever — a silent pass on the invariant, which is worse than an explicit skip.
+            return GuardResult(
+                self.name, "skip", f"unreadable sample rows (got {len(rows[0])} columns, want {columns})"
+            )
         breaches = [
-            f"{key}: {prev}->{current[key]}"
+            f"{key}: {prev.status}->{current[key].status}"
             for key, prev in self._prev.items()
-            if prev in self._TERMINAL and key in current and current[key] != prev
+            if key in current and self._is_regression(prev.status, current[key])
         ]
         self._prev = current
         if breaches:
             return GuardResult(self.name, "breach", f"terminal-state regression: {breaches[:3]}")
         return GuardResult(self.name, "ok", f"{len(current)} rows tracked, no terminal regression")
+
+    def _sample(self, probe: Probe) -> tuple[list[list[str]] | None, int]:
+        """Sample every row's status, with the reland-recency column when the cluster has it.
+
+        A cluster older than the B-2 migration (0019) has no `relanded_at`, and psql fails that
+        query indistinguishably from an unreachable pg. So the absent-column case falls back to the
+        plain sample ONCE and latches: with no column no re-drive can have happened, making the
+        pre-B-2 rule (every terminal exit breaches) the correct one — far better than mislabelling
+        the whole run's G6 as `postgres unreachable` and asserting nothing. Both queries failing is
+        the genuinely-unreachable case and does NOT latch, so the recency sample resumes on recovery.
+        """
+        if self._samples_recency:
+            rows = probe.pg(f"SELECT {self._KEY_COLUMNS}, {self._RECENCY} FROM cephor_replication_status")
+            if rows is not None:
+                return (rows, 5)
+            rows = probe.pg(f"SELECT {self._KEY_COLUMNS} FROM cephor_replication_status")
+            if rows is None:
+                return (None, 5)
+            self._samples_recency = False
+            return (rows, 4)
+        return (probe.pg(f"SELECT {self._KEY_COLUMNS} FROM cephor_replication_status"), 4)
+
+    def _is_regression(self, prev: str, now: _StatusSample) -> bool:
+        if prev not in self._TERMINAL or now.status == prev:
+            return False
+        return not (prev == "replicated" and now.status == "pending" and now.recently_relanded)
 
 
 class AgedPendingOrphanBacklog:

--- a/tests/unit/test_inv_guard.py
+++ b/tests/unit/test_inv_guard.py
@@ -115,8 +115,11 @@ def test_g4_skip_when_pg_unreachable():
 
 
 # ----------------------------------------------------------------- G6 terminal monotonicity
-def _crs_rows(status_by_part: dict[int, str]) -> list[list[str]]:
-    return [["obj-a", "1", str(pn), st] for pn, st in status_by_part.items()]
+def _crs_rows(status_by_part: dict[int, str], recently_relanded: bool = False) -> list[list[str]]:
+    """G6's sampled row shape. The 5th column is the SQL-evaluated reland-recency boolean, rendered
+    by `psql -tA` as 't'/'f' — 'f' also stands in for a NULL `relanded_at` (never re-landed)."""
+    relanded = "t" if recently_relanded else "f"
+    return [["obj-a", "1", str(pn), st, relanded] for pn, st in status_by_part.items()]
 
 
 def test_g6_seeds_then_ok_on_forward_progress():
@@ -130,7 +133,7 @@ def test_g6_seeds_then_ok_on_forward_progress():
 def test_g6_breach_on_terminal_regression():
     g = guards.TerminalMonotonicity()
     g.check(FakeProbe(rows=_crs_rows({0: "replicated"})))  # seed a terminal row
-    # replicated -> pending is a terminal-state regression
+    # replicated -> pending with no reland stamp is a terminal-state regression
     r = g.check(FakeProbe(rows=_crs_rows({0: "pending"})))
     assert r.status == "breach" and "regression" in r.detail
 
@@ -144,6 +147,96 @@ def test_g6_breach_on_failed_leaving_terminal():
 
 def test_g6_skip_when_pg_unreachable():
     assert guards.TerminalMonotonicity().check(FakeProbe(rows=None)).status == "skip"
+
+
+def test_g6_ok_on_b2_redrive_after_recent_reland():
+    # The B-2 content-change re-drive: record_landed_part stamps relanded_at BEFORE
+    # redrive_diverged_part flips the row, so the pending sample always carries a fresh stamp.
+    g = guards.TerminalMonotonicity()
+    g.check(FakeProbe(rows=_crs_rows({0: "replicated"})))
+    r = g.check(FakeProbe(rows=_crs_rows({0: "pending"}, recently_relanded=True)))
+    assert r.status == "ok", "a re-drive downstream of a fresh re-landing is legitimate"
+
+
+def test_g6_breach_on_replicated_to_pending_with_stale_reland():
+    # relanded_at older than the recency window (or NULL) means no re-drive caused this exit — the
+    # silent-data-loss shape the guard exists for. The SQL predicate renders both cases as 'f'.
+    g = guards.TerminalMonotonicity()
+    g.check(FakeProbe(rows=_crs_rows({0: "replicated"}, recently_relanded=True)))
+    r = g.check(FakeProbe(rows=_crs_rows({0: "pending"}, recently_relanded=False)))
+    assert r.status == "breach", "the carve-out reads the CURRENT sample's recency, not the previous one"
+
+
+def test_g6_breach_on_replicated_to_failed_despite_recent_reland():
+    # The carve-out is scoped to the one transition the re-drive makes; a fresh stamp does not
+    # license any other terminal exit.
+    g = guards.TerminalMonotonicity()
+    g.check(FakeProbe(rows=_crs_rows({0: "replicated"}, recently_relanded=True)))
+    r = g.check(FakeProbe(rows=_crs_rows({0: "failed"}, recently_relanded=True)))
+    assert r.status == "breach"
+
+
+def test_g6_skip_when_sample_rows_are_short():
+    # If the sample query loses the reland column, every row is unreadable — that must read as skip,
+    # not as an `ok` over zero tracked rows.
+    g = guards.TerminalMonotonicity()
+    r = g.check(FakeProbe(rows=[["obj-a", "1", "0", "replicated"]]))
+    assert r.status == "skip" and "columns" in r.detail
+
+
+def test_g6_ok_on_corrupt_to_pending():
+    # R4's bounded re-drive worker: `corrupt` is not in _TERMINAL, so leaving it needs no carve-out.
+    g = guards.TerminalMonotonicity()
+    g.check(FakeProbe(rows=_crs_rows({0: "corrupt"})))
+    assert g.check(FakeProbe(rows=_crs_rows({0: "pending"}))).status == "ok"
+
+
+class NoRelandColumnProbe:
+    """A cluster predating the B-2 migration: any query naming `relanded_at` fails (psql error ->
+    None), the plain 4-column sample answers."""
+
+    def __init__(self, status: str):
+        self._status = status
+        self.reland_queries = 0
+
+    def pg(self, sql: str) -> list[list[str]] | None:
+        if "relanded_at" in sql:
+            self.reland_queries += 1
+            return None
+        return [["obj-a", "1", "0", self._status]]
+
+    def pg_scalar(self, sql: str) -> str | None:
+        return None
+
+    def prom_scalar(self, promql: str) -> float | None:
+        return None
+
+
+def test_g6_falls_back_to_strict_when_reland_column_absent():
+    # No relanded_at means no re-drive can have happened, so every terminal exit still breaches —
+    # and the guard must keep asserting rather than reading `postgres unreachable` all run.
+    g = guards.TerminalMonotonicity()
+    assert g.check(NoRelandColumnProbe("replicated")).status == "ok"
+    r = g.check(NoRelandColumnProbe("pending"))
+    assert r.status == "breach"
+
+
+def test_g6_stops_probing_the_absent_column_after_the_first_fallback():
+    g = guards.TerminalMonotonicity()
+    probe = NoRelandColumnProbe("replicated")
+    for _ in range(3):
+        g.check(probe)
+    assert probe.reland_queries == 1, "the absent-column verdict must latch, not re-probe every poll"
+
+
+def test_g6_unreachable_pg_does_not_latch_the_fallback():
+    # Both queries failing is the genuinely-unreachable case; the recency sample must resume once pg
+    # is back, or a transient outage would permanently downgrade the guard and re-arm the false breach.
+    g = guards.TerminalMonotonicity()
+    assert g.check(FakeProbe(rows=None)).status == "skip"
+    g.check(FakeProbe(rows=_crs_rows({0: "replicated"})))
+    r = g.check(FakeProbe(rows=_crs_rows({0: "pending"}, recently_relanded=True)))
+    assert r.status == "ok"
 
 
 # ----------------------------------------------------------------- G9 aged-pending-orphan backlog


### PR DESCRIPTION
## The conflict

`stress-test/inv/guards.py` guard G6 (`TerminalMonotonicity`) reports a breach on any
transition out of `replicated` or `failed`. Its docstring carved out exactly one legitimate
exit: `corrupt -> pending` (the R4 re-drive worker), which needs no code because `corrupt`
was never in `_TERMINAL`.

PR #403 adds a second legitimate exit. `Store::redrive_diverged_part` runs
`UPDATE cephor_replication_status SET status='pending' ... WHERE status='replicated' AND
content_sha256 IS DISTINCT FROM $5` when a re-landed part's SSD content no longer matches
what the drain committed — the pool holds superseded bytes and has to be re-copied. Nothing
on that branch touches `stress-test/`, so the first soak run after it merges would report a
terminal-state regression on correct behaviour, and G6 becomes a known false alarm nobody
reads.

## The predicate

The re-drive is causally downstream of a re-landing: `record_landed_part` stamps
`relanded_at` in the same statement that reads the prior `replicated` status, and
`check_reland` only flips the row afterwards. A legitimate `replicated -> pending`
therefore always carries a fresh `relanded_at`, and `redrive_diverged_part` never clears it.

So G6's sample now selects a per-row boolean —
`relanded_at IS NOT NULL AND relanded_at > now() - interval '15 minutes'`, evaluated in SQL
so the window is measured on Postgres' clock rather than the asserter host's — and permits
`replicated -> pending` only when the CURRENT sample has it true. 15 minutes is the drain's
10-minute `RELAND_EVICTION_GRACE` plus slack; only recency is meaningful because the stamp is
never cleared.

Everything else still breaches:

- `replicated -> pending` with a NULL or stale stamp — the silent-data-loss shape the guard
  exists for.
- `replicated -> failed`, `replicated -> draining`, and every `failed -> *`, fresh stamp or not.
- `corrupt -> pending` remains permitted, unchanged, by not being terminal.

The poll-sampling caveat is unchanged: a `replicated -> pending -> replicated` round trip
inside one interval is still invisible.

## Compatibility of the sample

A cluster older than the migration that adds `relanded_at` fails the recency query exactly as
an unreachable pg does (psql exits non-zero, the probe returns `None`). Rather than report
`postgres unreachable` and assert nothing for a whole run, `_sample` falls back to the plain
four columns once and latches — with no column no re-drive can have happened, so the pre-B-2
rule is the correct one there. Both queries failing is the genuinely-unreachable case and does
not latch, so the recency sample resumes after an outage.

A sample whose every row is shorter than the guard parses now reports `skip` instead of `ok`
over zero tracked rows, so a future divergence between the query and the parser cannot read green.

## Tests

`tests/unit/test_inv_guard.py`, fixture rows against the existing `FakeProbe` — no Postgres.
Covers the re-drive being allowed, a NULL/stale stamp breaching, `replicated -> failed`
breaching despite a fresh stamp, `corrupt -> pending` staying ok, the short-row skip, and the
three fallback behaviours (strict verdicts, the latch, and no latch on an outage). 40 pass.
Each new assertion was mutation-checked: reverting the carve-out, dropping the recency term,
removing the short-row skip, latching on an outage, never latching, and counting fallback rows
as re-landed each turn the relevant test red.