### PR TITLE
fix(alloc): pin the blind-probe floor and bound the AIMD estimate

### DIFF
--- a/crates/hippius-drain-allocator/src/config.rs
+++ b/crates/hippius-drain-allocator/src/config.rs
@@ -246,6 +246,17 @@ impl AllocatorConfig {
                 limit: max_total,
             });
         }
+        // The starting estimate lives in the same band as the estimate itself: above
+        // `max_total` the first ticks would allocate a rate the AIMD is not allowed to
+        // hold, and the back-off only walks it down geometrically.
+        let initial_total = positive_u64(&get, "CEPHOR_ALLOC_INITIAL_TOTAL_BPS", min_total)?;
+        if initial_total > max_total {
+            return Err(ConfigError::OutOfRange {
+                var: "CEPHOR_ALLOC_INITIAL_TOTAL_BPS",
+                value: initial_total,
+                limit: max_total,
+            });
+        }
         let alloc = AllocConfig {
             min_total: ByteRate::new(min_total),
             max_total: ByteRate::new(max_total),
@@ -279,7 +290,7 @@ impl AllocatorConfig {
             ceph_ceiling: ByteRate::new(ceph_ceiling),
             // The first tick starts from the AIMD floor unless overridden, so a
             // fresh leader ramps up from a safe rate rather than a guess.
-            initial_total: ByteRate::new(u64_or(&get, "CEPHOR_ALLOC_INITIAL_TOTAL_BPS", min_total)?),
+            initial_total: ByteRate::new(initial_total),
             alloc,
             ceph_mgr_metrics_url: optional(&get, "CEPHOR_CEPH_MGR_METRICS_URL"),
             ceph_thresholds: ceph_thresholds(&get)?,
@@ -589,6 +600,54 @@ mod tests {
                 limit: 1_000_000_000,
             }
         ));
+    }
+
+    #[test]
+    fn an_initial_total_above_the_max_total_is_out_of_range() {
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_ALLOC_MAX_TOTAL_BPS", "1000000000"));
+        pairs.push(("CEPHOR_ALLOC_INITIAL_TOTAL_BPS", "2000000000"));
+        let err = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::OutOfRange {
+                var: "CEPHOR_ALLOC_INITIAL_TOTAL_BPS",
+                value: 2_000_000_000,
+                limit: 1_000_000_000,
+            }
+        ));
+    }
+
+    #[test]
+    fn a_zero_initial_total_is_rejected() {
+        // A zero start allocates nothing on the first tick and only reaches a useful
+        // rate additively, so a fat-fingered zero must fail startup like any other rate.
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_ALLOC_INITIAL_TOTAL_BPS", "0"));
+        let err = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::NonPositive {
+                var: "CEPHOR_ALLOC_INITIAL_TOTAL_BPS"
+            }
+        ));
+    }
+
+    #[test]
+    fn the_alloc_tuning_vars_are_read_from_the_environment() {
+        // The four AIMD knobs deployed together, asserted together: each is otherwise
+        // silently defaulted, so a variable-name typo in the k8s manifest is
+        // indistinguishable from "the operator did not set it".
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_ALLOC_MIN_TOTAL_BPS", "250000000"));
+        pairs.push(("CEPHOR_ALLOC_INITIAL_TOTAL_BPS", "500000000"));
+        pairs.push(("CEPHOR_ALLOC_DECREASE_PERMILLE", "950"));
+        pairs.push(("CEPHOR_ALLOC_ADDITIVE_INCREASE_BPS", "50000000"));
+        let config = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap();
+        assert_eq!(config.alloc.min_total, ByteRate::new(250_000_000));
+        assert_eq!(config.initial_total, ByteRate::new(500_000_000));
+        assert_eq!(config.alloc.decrease_permille, 950);
+        assert_eq!(config.alloc.additive_increase, ByteRate::new(50_000_000));
     }
 
     #[test]

--- a/crates/hippius-drain-allocator/src/config.rs
+++ b/crates/hippius-drain-allocator/src/config.rs
@@ -209,6 +209,31 @@ impl AllocatorConfig {
         StaticCeiling(CephCeiling::Open(self.ceph_ceiling))
     }
 
+    /// The settings the live Ceph-mgr probe scrapes `url` with.
+    ///
+    /// The blind-decay floor is the near-full rate, *not* `alloc.min_total`: while the
+    /// probe cannot read the mgr it cannot tell an open pool from a full one, so the
+    /// rate the fleet keeps must be no looser than the one a KNOWN near-full pool
+    /// carries. `min_total` is an operator latency knob tuned to keep the drain out of
+    /// its collapse threshold and may sit far above any safe blind rate — and the
+    /// 2026-07-24 incident shape (a renamed/missing target pool) reaches exactly this
+    /// path, because a pool the scrape does not mention is a parse failure and so a
+    /// decay. Sharing one variable for both made a floor raise silently loosen the
+    /// fail-safe.
+    #[cfg(feature = "http")]
+    #[must_use]
+    pub fn probe_settings(&self, url: String) -> crate::probe::ProbeSettings {
+        crate::probe::ProbeSettings {
+            url,
+            ceiling_rate: self.ceph_ceiling,
+            nearfull_rate: self.ceph_nearfull_rate,
+            floor: self.ceph_nearfull_rate,
+            thresholds: self.ceph_thresholds,
+            timeout: self.ceph_probe_timeout,
+            pools: self.ceph_pools.clone(),
+        }
+    }
+
     /// Parsing core: resolves each key through `get`. Separated from
     /// [`from_env`](Self::from_env) so tests drive it with a fixture map.
     fn from_lookup(get: impl Fn(&str) -> Option<String>) -> Result<Self, ConfigError> {
@@ -396,6 +421,8 @@ mod tests {
         AllocatorConfig, ConfigError, DEFAULT_ALLOCATION_TTL, DEFAULT_CRITICAL_PRESSURE_BPS, DEFAULT_DECREASE_PERMILLE, DEFAULT_MAX_TOTAL_BPS,
         DEFAULT_MIN_TOTAL_BPS, DEFAULT_STATUS_RETENTION, DEFAULT_TICK,
     };
+    #[cfg(feature = "http")]
+    use hippius_drain_core::decay;
     use hippius_drain_core::{ByteRate, CephCeiling, DiskPressure};
 
     /// A `get` closure backed by an owned fixture list (no process env touched).
@@ -642,6 +669,27 @@ mod tests {
                 limit: 1_000_000_000,
             }
         ));
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn the_blind_probe_floor_is_never_looser_than_the_nearfull_rate() {
+        // A blind probe cannot tell an open pool from a full one, so the rate it bottoms
+        // out at must be the rate a KNOWN near-full pool carries — whatever the AIMD
+        // floor happens to be tuned to. While the two shared
+        // CEPHOR_ALLOC_MIN_TOTAL_BPS, prod's 250 MB/s latency floor let the fleet keep
+        // writing 5x the near-full rate for as long as the mgr stayed unreachable.
+        let mut pairs = required_only();
+        pairs.push(("CEPHOR_ALLOC_MIN_TOTAL_BPS", "250000000"));
+        pairs.push(("CEPHOR_CEPH_NEARFULL_RATE_BPS", "50000000"));
+        let config = AllocatorConfig::from_lookup(lookup(&pairs)).unwrap();
+        let settings = config.probe_settings("http://rook-ceph-mgr.rook-ceph.svc:9283/metrics".to_owned());
+        assert_eq!(settings.floor, config.ceph_nearfull_rate, "the decay floor tracks the near-full rate");
+        assert_eq!(
+            decay(CephCeiling::Open(ByteRate::new(1_000_000_000)), u32::MAX, settings.floor),
+            CephCeiling::Open(ByteRate::new(50_000_000)),
+            "an indefinitely blind probe bottoms out at the near-full rate, not the AIMD floor",
+        );
     }
 
     #[test]

--- a/crates/hippius-drain-allocator/src/main.rs
+++ b/crates/hippius-drain-allocator/src/main.rs
@@ -99,17 +99,7 @@ async fn main() -> Result<(), StartupError> {
 async fn run_with_ceiling_source(coord: &Coordinator, config: &AllocatorConfig, metrics: &AllocatorMetrics) -> Result<(), StartupError> {
     #[cfg(feature = "http")]
     if let Some(url) = config.ceph_mgr_metrics_url.clone() {
-        // The decay floor is the AIMD floor: while the probe is blind, the fleet
-        // backs off toward the same conservative rate the allocator never drops below.
-        let probe = hippius_drain_allocator::probe::CephProbe::new(hippius_drain_allocator::probe::ProbeSettings {
-            url: url.clone(),
-            ceiling_rate: config.ceph_ceiling,
-            nearfull_rate: config.ceph_nearfull_rate,
-            floor: config.alloc.min_total,
-            thresholds: config.ceph_thresholds,
-            timeout: config.ceph_probe_timeout,
-            pools: config.ceph_pools.clone(),
-        })?;
+        let probe = hippius_drain_allocator::probe::CephProbe::new(config.probe_settings(url.clone()))?;
         tracing::info!(
             mgr_url = %url,
             pools = config.ceph_pools.join(","),

--- a/crates/hippius-drain-core/src/alloc.rs
+++ b/crates/hippius-drain-core/src/alloc.rs
@@ -369,12 +369,16 @@ fn next_capacity(fleet: &FleetView, ceiling: CephCeiling, prev: BudgetController
     let back_off = latency_saturated || !matches!(ceiling, CephCeiling::Open(_));
 
     let prev_total = prev.total.get();
-    let new_total = if back_off {
-        let decreased = u64::try_from(u128::from(prev_total) * u128::from(config.decrease_permille) / 1000).unwrap_or(prev_total);
-        decreased.max(config.min_total.get())
+    let evolved = if back_off {
+        u64::try_from(u128::from(prev_total) * u128::from(config.decrease_permille) / 1000).unwrap_or(prev_total)
     } else {
-        prev_total.saturating_add(config.additive_increase.get()).min(config.max_total.get())
+        prev_total.saturating_add(config.additive_increase.get())
     };
+    // Both arms land in the same band. Clamping only the arm that moves toward each
+    // bound leaves a carried estimate that started outside the band stuck there: a
+    // `prev` above `max_total` (an operator lowering the ceiling between ticks) would
+    // back off only geometrically instead of being capped on the first tick.
+    let new_total = evolved.max(config.min_total.get()).min(config.max_total.get());
 
     let capacity = new_total.min(ceiling.budget().get());
     (BudgetController::new(ByteRate::new(new_total)), ByteRate::new(capacity))
@@ -594,6 +598,50 @@ mod tests {
             plan.controller.total().get() >= min_total.get(),
             "the carried AIMD estimate keeps its floor so the fleet resumes promptly when the ceiling reopens",
         );
+    }
+
+    #[test]
+    fn the_first_tick_starts_from_initial_total_not_the_floor() {
+        // A fresh leader carries `initial_total` into its first tick, so a deployment that
+        // starts high (500 MB/s over a 250 MB/s floor) must ramp from there. Reading the
+        // start as "the floor" would cost the whole ramp — at 50 MB/s per tick, ~5 ticks —
+        // every time leadership moves.
+        let cfg = AllocConfig {
+            min_total: ByteRate::new(250_000_000),
+            additive_increase: ByteRate::new(50_000_000),
+            ..config()
+        };
+        let fleet = fleet_of(&[node("a", 5_000, 10_000_000_000, 1_000_000_000)]);
+        let plan = allocate(
+            &fleet,
+            CephCeiling::Open(ByteRate::new(1_000_000_000)),
+            BudgetController::new(ByteRate::new(500_000_000)),
+            &cfg,
+        );
+        assert_eq!(
+            plan.controller.total().get(),
+            550_000_000,
+            "a healthy first tick increases the initial estimate, it does not snap to the floor",
+        );
+    }
+
+    #[test]
+    fn a_critical_ceiling_zeroes_capacity_even_with_a_floor_far_above_it() {
+        // The floor bounds the ESTIMATE, never the distributed capacity: a pool that
+        // accepts no writes must hand out nothing however high the AIMD floor is tuned.
+        // The estimate still keeps its floor so the fleet resumes at rate — not from
+        // scratch — the moment the ceiling reopens.
+        let min_total = ByteRate::new(250_000_000);
+        let cfg = AllocConfig { min_total, ..config() };
+        let fleet = fleet_of(&[
+            node("a", 9_500, 10_000_000_000, 1_000_000_000),
+            node("b", 9_500, 10_000_000_000, 1_000_000_000),
+        ]);
+        let plan = allocate(&fleet, CephCeiling::Critical, BudgetController::new(ByteRate::new(1_000_000_000)), &cfg);
+        for allocation in &plan.allocations {
+            assert_eq!(allocation.budget.get(), 0, "node {} must get nothing", allocation.node);
+        }
+        assert!(plan.controller.total().get() >= min_total.get(), "the carried estimate keeps its floor");
     }
 
     #[test]
@@ -844,6 +892,91 @@ mod tests {
             // No node is rationed above its reservation floor.
             for alloc in &plan.allocations {
                 prop_assert!(alloc.budget.get() <= 50_000, "rationing must not exceed the reservation floor");
+            }
+        }
+
+        /// The carried estimate never leaves `[min_total, max_total]`, on either arm.
+        ///
+        /// The back-off arm clamped only the floor, so an estimate that entered the tick
+        /// above `max_total` stayed above it and decayed geometrically instead of being
+        /// capped at once.
+        #[test]
+        fn the_carried_estimate_always_stays_within_its_bounds(
+            prev in 1u64..u64::MAX,
+            specs in prop::collection::vec((0u64..20_000_000, 0u16..=10_000), 1..6),
+            p99_ms in 0u64..5_000,
+            band in 0u8..3,
+        ) {
+            let cfg = config();
+            let nodes: Vec<_> = specs.iter().enumerate()
+                .map(|(i, &(backlog, pressure))| {
+                    let (id, mut obs) = node(&format!("n{i}"), pressure, backlog, 5_000_000);
+                    obs.observed_p99 = Duration::from_millis(p99_ms);
+                    (id, obs)
+                }).collect();
+            let ceiling = match band {
+                0 => CephCeiling::Open(ByteRate::new(1_000_000_000)),
+                1 => CephCeiling::NearFull(ByteRate::new(10_000_000)),
+                _ => CephCeiling::Critical,
+            };
+            let plan = allocate(&fleet_of(&nodes), ceiling, BudgetController::new(ByteRate::new(prev)), &cfg);
+            let total = plan.controller.total().get();
+            prop_assert!(total >= cfg.min_total.get(), "estimate {total} below the floor {}", cfg.min_total.get());
+            prop_assert!(total <= cfg.max_total.get(), "estimate {total} above the ceiling {}", cfg.max_total.get());
+        }
+
+        /// The ceiling bounds the distributed total whatever the AIMD floor is tuned to.
+        ///
+        /// Generalizes the 2026-07-24 regression above (which pins one floor/rate pair) over
+        /// arbitrary floors and bands: the floor is a property of the ESTIMATE, and must never
+        /// leak into the capacity a near-full or critical pool allows.
+        #[test]
+        fn a_ceiling_always_bounds_the_distributed_total_whatever_the_floor(
+            floor in 1u64..=1_000_000_000,
+            prev in 1u64..2_000_000_000,
+            rate in 1u64..1_000_000_000,
+            backlogs in prop::collection::vec(0u64..20_000_000_000, 1..6),
+            band in 0u8..3,
+        ) {
+            let cfg = AllocConfig { min_total: ByteRate::new(floor), max_total: ByteRate::new(1_000_000_000), ..config() };
+            let nodes: Vec<_> = backlogs.iter().enumerate()
+                .map(|(i, &backlog)| node(&format!("n{i}"), 5_000, backlog, 1_000_000_000)).collect();
+            let ceiling = match band {
+                0 => CephCeiling::Open(ByteRate::new(rate)),
+                1 => CephCeiling::NearFull(ByteRate::new(rate)),
+                _ => CephCeiling::Critical,
+            };
+            let plan = allocate(&fleet_of(&nodes), ceiling, BudgetController::new(ByteRate::new(prev)), &cfg);
+            let distributed: u64 = plan.allocations.iter().map(|a| a.budget.get()).sum();
+            prop_assert!(
+                distributed <= ceiling.budget().get(),
+                "distributed {distributed} exceeds the ceiling {} (floor {floor})", ceiling.budget().get(),
+            );
+        }
+
+        /// A fleet saturated on every tick converges to exactly `min_total` and stays there.
+        ///
+        /// Documents the absorbing state: multiplicative decrease has no lower stop but the
+        /// floor, so a permanently-saturated fleet ends up writing `min_total` forever. That
+        /// makes the floor the operating rate under sustained saturation — the reason it is
+        /// tuned above the drain's collapse threshold rather than left at a safe-looking
+        /// small value.
+        #[test]
+        fn a_fleet_saturated_on_every_tick_converges_to_the_floor_and_stays(
+            prev in 1u64..1_000_000_000,
+        ) {
+            let cfg = AllocConfig { min_total: ByteRate::new(50_000_000), ..config() };
+            let fleet = fleet_of(&[node_p99("a", Duration::from_secs(30), 10_000_000_000)]);
+            let mut controller = BudgetController::new(ByteRate::new(prev));
+            let mut totals = Vec::new();
+            for _ in 0..50 {
+                controller = allocate(&fleet, CephCeiling::Open(ByteRate::new(1_000_000_000)), controller, &cfg).controller;
+                totals.push(controller.total().get());
+            }
+            // 20% off per tick closes a <=20x gap to the floor in ~14 ticks, so the tail of a
+            // 50-tick run must be pinned — not merely trending down.
+            for total in &totals[40..] {
+                prop_assert_eq!(*total, cfg.min_total.get(), "saturated ticks must settle at the floor exactly");
             }
         }
 

--- a/k8s/production/drain-allocator-deployment.yaml
+++ b/k8s/production/drain-allocator-deployment.yaml
@@ -110,6 +110,9 @@ spec:
             # is the actual pool protection, and the janitor's pool-gated eviction has
             # outpaced a 50 MB/s drain all day. Must stay <= CEPHOR_CEPH_CEILING_BPS
             # (config-enforced) and should move WITH the ceph watermarks if retuned.
+            # This is ALSO the rate the fleet decays to while the mgr scrape is failing:
+            # a blind probe cannot tell an open pool from a full one, so raising this
+            # loosens the blind fail-safe as well as the known-near-full cap.
             - name: CEPHOR_CEPH_NEARFULL_RATE_BPS
               value: "50000000"
           resources:

--- a/k8s/staging/drain-allocator-deployment.yaml
+++ b/k8s/staging/drain-allocator-deployment.yaml
@@ -110,6 +110,9 @@ spec:
             # is the actual pool protection, and the janitor's pool-gated eviction has
             # outpaced a 50 MB/s drain all day. Must stay <= CEPHOR_CEPH_CEILING_BPS
             # (config-enforced) and should move WITH the ceph watermarks if retuned.
+            # This is ALSO the rate the fleet decays to while the mgr scrape is failing:
+            # a blind probe cannot tell an open pool from a full one, so raising this
+            # loosens the blind fail-safe as well as the known-near-full cap.
             - name: CEPHOR_CEPH_NEARFULL_RATE_BPS
               value: "50000000"
           resources:


### PR DESCRIPTION
Two allocator defects, both about a bound that is not applied where it should be.

## The blind ceph probe decayed to the AIMD floor

`main.rs` passed `config.alloc.min_total` as the mgr probe's blind-decay floor. While a scrape keeps failing, `decay`/`halve_to_floor` halves the last successful ceiling once per failure but never below that floor, and an `Open` band stays `Open` — so `next_capacity` does not force a back-off and a healthy-latency fleet ramps to the floor and holds it while blind to pool fullness.

`CEPHOR_ALLOC_MIN_TOTAL_BPS` is a latency knob (raised to keep the drain out of its collapse threshold); it is not a fullness brake. Sharing it with the probe floor meant every floor raise silently loosened the fail-safe. In prod the two were equal at 50 MB/s, so the blind rate was exactly as conservative as a *known* near-full pool.

The floor is now `config.ceph_nearfull_rate`. No new environment variable: a blind probe cannot tell an open pool from a full one, so it must be no looser than the known-near-full case. `halve_to_floor` already clamps at `base`, so a floor above a `NearFull` rate cannot raise it, and the allocator config already rejects a near-full rate above the ceiling.

The probe wiring moved out of `main.rs` (which has no tests) into `AllocatorConfig::probe_settings`, so `the_blind_probe_floor_is_never_looser_than_the_nearfull_rate` can pin the coupling end to end: min_total 250 MB/s, near-full rate 50 MB/s, an indefinitely blind probe bottoms out at 50 MB/s.

The 2026-07-24 incident shape reaches this path: a renamed or missing target pool is a parse failure, and a parse failure is a decay (`a_scrape_missing_the_configured_pool_decays_rather_than_reading_healthy`).

## The AIMD estimate was bounded on one side per arm

`alloc.rs::next_capacity` clamped the back-off arm to `min_total` and the ramp arm to `max_total`. An estimate that entered a tick outside the band therefore stayed outside it — a `prev` above `max_total` decayed only geometrically instead of being capped on the first tick. Both arms now land in `[min_total, max_total]`.

`CEPHOR_ALLOC_INITIAL_TOTAL_BPS` was also the one rate parsed with `u64_or`, so `0` (allocates nothing on the first tick) and values above `max_total` were accepted. It now uses `positive_u64` and is rejected above `max_total`, next to the existing min<=max check.

## Tests

- `the_blind_probe_floor_is_never_looser_than_the_nearfull_rate` (config)
- `an_initial_total_above_the_max_total_is_out_of_range`, `a_zero_initial_total_is_rejected` (config)
- `the_alloc_tuning_vars_are_read_from_the_environment` — one fixture with the four AIMD knobs a deployment sets together, asserting all four land. Each is otherwise silently defaulted, so a variable-name typo in a manifest reads exactly like "the operator did not set it".
- `the_carried_estimate_always_stays_within_its_bounds` (proptest) — verified to fail on the pre-fix clamp: `prev = 1250000002` leaves the estimate at 1000000001 against a 1000000000 ceiling.
- `a_ceiling_always_bounds_the_distributed_total_whatever_the_floor` (proptest) — generalizes the single 2026-07-24 regression case over arbitrary floors and bands.
- `a_fleet_saturated_on_every_tick_converges_to_the_floor_and_stays` (proptest) — documents the absorbing state: multiplicative decrease has no stop but the floor, so under sustained saturation the floor *is* the operating rate. That is what a floor raise is tuning.
- `the_first_tick_starts_from_initial_total_not_the_floor`, `a_critical_ceiling_zeroes_capacity_even_with_a_floor_far_above_it` (unit)

Every new invariant test was mutation-checked: the fix was reverted, the test observed red, then the fix re-applied.

## Merge order

**PR #399 should land after this PR.** #399 raises `CEPHOR_ALLOC_MIN_TOTAL_BPS` from 50 MB/s to 250 MB/s. On `staging` today that also raises the probe's blind-decay floor to 250 MB/s — five times the 50 MB/s `CEPHOR_CEPH_NEARFULL_RATE_BPS` — so the fleet would keep writing 250 MB/s into a pool it cannot see for as long as the mgr is unreachable. With this PR merged first, the blind floor is pinned to the near-full rate and #399 becomes a pure latency retune. #399 also sets `CEPHOR_ALLOC_INITIAL_TOTAL_BPS=500000000`, which this PR is the first to validate.

## Verification

`cargo fmt --all --check`; `cargo clippy --all-targets --all-features -p hippius-drain-core -p hippius-drain-allocator -- -D warnings` clean, and clean again with `--no-default-features` (the probe and its config method are `http`-gated); `cargo test -p hippius-drain-core` 230 lib + 6 integration; `cargo test -p hippius-drain-allocator` 40. The pg-feature store tests need a database and were not run.
