### PR TITLE
stress-test: opt-in ingest-SSD fill that exercises the evictor

### DIFF
--- a/stress-test/harness/probes.py
+++ b/stress-test/harness/probes.py
@@ -22,6 +22,10 @@ from .config import Config
 _PSQL_FIELD_SEP = "\x1f"
 
 
+# The drain agent's CEPHOR_SSD_ROOT — the node-local ingest SSD the read tier lives on.
+_SSD_PATH = "/var/lib/hippius/local_object_cache"
+
+
 class ClusterProbe:
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
@@ -77,6 +81,61 @@ class ClusterProbe:
         if proc.returncode != 0:
             return []
         return proc.stdout.split()
+
+    def drain_agents(self) -> list[tuple[str, str]]:
+        """(pod, node) for every drain-agent — the pods that own the ingest SSD."""
+        cmd = [
+            "kubectl", "-n", self.cfg.namespace, "get", "pods", "-l", "app=drain-agent",
+            "--field-selector=status.phase=Running",
+            "-o", 'jsonpath={range .items[*]}{.metadata.name}:{.spec.nodeName}{"\\n"}{end}',
+        ]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return []
+        if proc.returncode != 0:
+            return []
+        out = []
+        for line in proc.stdout.splitlines():
+            if ":" in line:
+                pod, _, node = line.partition(":")
+                out.append((pod.strip(), node.strip()))
+        return out
+
+    def ssd_usage(self) -> list[dict]:
+        """Per-node ingest-SSD occupancy: the whole filesystem AND the read tier's share of it.
+
+        Both numbers, because on a shared filesystem they answer different questions and only the
+        pair is interpretable. `df` is what the evictor and `fs_cache_pressure` actually gate on;
+        `du` is how much of that this system owns and could therefore ever reclaim. A large gap
+        means free-space thresholds here are being driven by somebody else's bytes — which is the
+        state staging is in today (~1 GB of cache on a filesystem 623 GB full), and the reason a
+        fill test has to be read against `du`, not `df`.
+        """
+        rows = []
+        for pod, node in self.drain_agents():
+            entry = {"node": node, "pod": pod}
+            df = self._agent_exec(pod, ["df", "-PB1", _SSD_PATH])
+            if df:
+                parts = df.strip().splitlines()[-1].split()
+                if len(parts) >= 4:
+                    entry["total_bytes"] = int(parts[1])
+                    entry["used_bytes"] = int(parts[2])
+                    entry["free_bytes"] = int(parts[3])
+                    entry["free_ratio"] = int(parts[3]) / int(parts[1]) if int(parts[1]) else 0.0
+            du = self._agent_exec(pod, ["du", "-sb", _SSD_PATH])
+            if du:
+                entry["cache_bytes"] = int(du.split()[0])
+            rows.append(entry)
+        return rows
+
+    def _agent_exec(self, pod: str, argv: list[str]) -> str | None:
+        cmd = ["kubectl", "-n", self.cfg.namespace, "exec", pod, "-c", "agent", "--", *argv]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return None
+        return proc.stdout if proc.returncode == 0 else None
 
     def evict_ssd_parts(self, object_ids: list[str]) -> tuple[int, int, int]:
         """Delete each object's part tree from the WRITABLE SSD primary cache on every api pod.

--- a/stress-test/harness/scenarios.py
+++ b/stress-test/harness/scenarios.py
@@ -488,3 +488,135 @@ def durability_reverify(client, cfg: Config, ledger: Ledger, report: Report,
         metrics={"total": len(items), "ok": ok, "corrupt": len(mismatches), "missing": len(missing),
                  "authoritative": authoritative},
     ))
+
+
+def ssd_fill_pressure(client, cfg: Config, ledger: Ledger, report: Report, buckets: dict,
+                      probe, fill_bytes: int, obj_bytes: int, workers: int) -> None:
+    """Write a caller-specified volume at the ingest SSD and observe what the drain/evictor do.
+
+    **The volume is a parameter, never a computation.** This scenario deliberately does not look at
+    free space and decide how much to write. The disk it targets is shared with other tenants, so a
+    self-sizing fill would be a script that decides on its own to consume someone else's headroom —
+    and the number that makes eviction arm is a property of the cluster on the day, not of the test.
+    The operator reads the disk (`ssd_disk_report.sh`), decides, and passes `--fill-gb`.
+
+    What it asserts vs merely observes:
+      - PASS/FAIL on the durability invariant only: `drain_ssd_evict_blocked_unreplicated_total`
+        must stay 0. That is the one property with a ratified threshold — the evictor may never be
+        offered a part whose SSD copy is the only durable one.
+      - OBSERVED for everything else (free space moved, bytes evicted, whether `starved` fired).
+        There is no ratified "eviction is fast enough" threshold yet, and inventing one here would
+        turn a measurement into a gate that has never been calibrated.
+
+    Read the result against `cache_bytes`, not `free_bytes`. On a shared filesystem the evictor can
+    only ever reclaim what this system owns; a deficit larger than `cache_bytes` is unmeetable by
+    construction and `starved` is then the correct outcome, not a bug.
+    """
+    if fill_bytes <= 0:
+        report.add(Result(
+            name="ssd-fill-pressure", invariant="B (eviction under real disk pressure)",
+            passed=True, skipped=True,
+            detail="not requested — pass --fill-gb N to run it",
+            criteria="operator-specified fill volume reaches the ingest SSD",
+        ))
+        return
+
+    before = probe.ssd_usage() if probe else []
+    blocked_before = probe.prom_scalar(
+        'sum(drain_ssd_evict_blocked_unreplicated_total{service_namespace="%s"})' % cfg.namespace) if probe else None
+    evicted_before = probe.prom_scalar(
+        'sum(drain_ssd_evicted_bytes_total{service_namespace="%s"})' % cfg.namespace) if probe else None
+
+    for r in before:
+        print(f"    before: {r['node']} free={r.get('free_bytes',0)/1e9:.1f}G "
+              f"({r.get('free_ratio',0):.1%}) cache={r.get('cache_bytes',0)/1e9:.2f}G")
+
+    b = _bucket(cfg, "ssdfill")
+    s3util.ensure_bucket(client, b)
+    buckets["ssdfill"] = b
+
+    n = max(1, fill_bytes // obj_bytes)
+    print(f"    writing {n} x {obj_bytes/1e6:.0f}MB = {n*obj_bytes/1e9:.1f}GB with {workers} workers")
+    written = 0
+    errors = 0
+    t0 = time.time()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as ex:
+        futs = []
+        for i in range(n):
+            key = f"fill/obj-{i:05d}"
+
+            def task(k=key, idx=i):
+                body = s3util.random_body(obj_bytes, seed=f"{b}-{idx}".encode())
+                outcome, _ = _put_with_503_retry(client, b, k, body)
+                if outcome in ("ok", "slowdown-then-ok"):
+                    ledger.record(b, k, s3util.md5_hex(body), len(body), False)
+                    return len(body)
+                return 0
+            futs.append(ex.submit(task))
+        for f in concurrent.futures.as_completed(futs):
+            try:
+                got = f.result()
+            except Exception:  # noqa: BLE001 — one failed PUT must not abort the fill
+                got = 0
+            if got:
+                written += got
+            else:
+                errors += 1
+    wall = time.time() - t0
+
+    # Give the evictor at least one poll (CEPHOR_EVICT_POLL_SECS, 30s on staging) plus slack, or a
+    # pass that was always going to arm reads as "never armed".
+    settle = 90
+    print(f"    wrote {written/1e9:.1f}GB in {wall:.0f}s ({written/1e6/max(wall,1):.0f} MB/s); "
+          f"settling {settle}s for the evictor")
+    time.sleep(settle)
+
+    after = probe.ssd_usage() if probe else []
+    blocked_after = probe.prom_scalar(
+        'sum(drain_ssd_evict_blocked_unreplicated_total{service_namespace="%s"})' % cfg.namespace) if probe else None
+    evicted_after = probe.prom_scalar(
+        'sum(drain_ssd_evicted_bytes_total{service_namespace="%s"})' % cfg.namespace) if probe else None
+
+    for r in after:
+        print(f"    after:  {r['node']} free={r.get('free_bytes',0)/1e9:.1f}G "
+              f"({r.get('free_ratio',0):.1%}) cache={r.get('cache_bytes',0)/1e9:.2f}G")
+
+    by_node = {r["node"]: r for r in before}
+    deltas = []
+    for r in after:
+        prev = by_node.get(r["node"], {})
+        deltas.append(
+            f"{r['node']}: free {prev.get('free_ratio',0):.1%}->{r.get('free_ratio',0):.1%}, "
+            f"cache {prev.get('cache_bytes',0)/1e9:.2f}->{r.get('cache_bytes',0)/1e9:.2f}G")
+
+    evicted_delta = (evicted_after - evicted_before) if (evicted_after is not None and evicted_before is not None) else None
+
+    report.add(Result(
+        name="ssd-fill-observed", invariant="B/A (eviction + promotion under real pressure)",
+        passed=True, observed=True,
+        detail=f"wrote {written/1e9:.1f}GB ({errors} failed PUTs) in {wall:.0f}s; "
+               + "; ".join(deltas)
+               + (f"; evicted {evicted_delta/1e9:.2f}GB" if evicted_delta is not None else "; evicted n/a"),
+        criteria="free space and evicted bytes move as the operator-chosen fill lands (no ratified threshold)",
+        metrics={"written_bytes": written, "failed_puts": errors,
+                 "evicted_bytes_delta": evicted_delta if evicted_delta is not None else -1},
+    ))
+
+    # The one real gate. Unknown (no Prometheus) must not read as pass.
+    if blocked_after is None:
+        report.add(Result(
+            name="ssd-fill-durability-invariant", invariant="eviction durability invariant",
+            passed=True, skipped=True,
+            detail="Prometheus unavailable — evict_blocked_unreplicated not readable",
+            criteria="drain_ssd_evict_blocked_unreplicated_total stays 0 across the fill",
+        ))
+        return
+    rose = (blocked_after - (blocked_before or 0)) > 0
+    report.add(Result(
+        name="ssd-fill-durability-invariant", invariant="eviction durability invariant",
+        passed=not rose,
+        detail=f"evict_blocked_unreplicated {blocked_before} -> {blocked_after}",
+        criteria="drain_ssd_evict_blocked_unreplicated_total stays 0 across the fill "
+                 "(the evictor was never offered a part whose SSD copy is the only durable one)",
+        metrics={"blocked_before": blocked_before or 0, "blocked_after": blocked_after},
+    ))

--- a/stress-test/run.py
+++ b/stress-test/run.py
@@ -36,6 +36,15 @@ def main() -> int:
     ap.add_argument("--no-cluster", action="store_true", help="skip Postgres/Prometheus invariant probes")
     ap.add_argument("--keep", action="store_true", help="keep test buckets after the run")
     ap.add_argument("--timeout", type=int, default=None, help="drain-convergence timeout (s)")
+    # OPT-IN and OPERATOR-SIZED. The scenario never computes this: the ingest SSD on staging is
+    # shared with other tenants, so how much may be written is a judgement about the cluster on the
+    # day, not a property the suite can derive. Read the disk first (./ssd_disk_report.sh).
+    ap.add_argument("--fill-gb", type=float, default=0.0,
+                    help="GB to write at the ingest SSD to exercise eviction (0 = skip). "
+                         "Requires cluster access. Check ./ssd_disk_report.sh first.")
+    ap.add_argument("--fill-object-mb", type=int, default=64,
+                    help="object size for --fill-gb (default 64 MB)")
+    ap.add_argument("--fill-workers", type=int, default=8, help="concurrent uploads for --fill-gb")
     args = ap.parse_args()
 
     cfg = config.load()
@@ -81,6 +90,18 @@ def main() -> int:
         print("-- invariants + convergence: skipped (no cluster) --")
         # give the drain a moment before the durability re-verify even without cluster probes
         time.sleep(10)
+
+    if args.fill_gb > 0:
+        if not cluster:
+            print("-- ssd fill: SKIPPED, needs cluster access to read the disk and the evictor's metrics --")
+        else:
+            with probe.prometheus():
+                guarded(f"ssd fill pressure ({args.fill_gb} GB, operator-specified)",
+                        lambda: scenarios.ssd_fill_pressure(
+                            client, cfg, ledger, report, buckets, probe,
+                            fill_bytes=int(args.fill_gb * 1e9),
+                            obj_bytes=args.fill_object_mb * 1024 * 1024,
+                            workers=args.fill_workers))
 
     # Pass the probe only when the cluster is reachable: the re-verify uses it to evict the SSD ingest
     # cache so the re-GET reads the drained copy, not the intact ingest copy (see durability_reverify).

--- a/stress-test/ssd_disk_report.sh
+++ b/stress-test/ssd_disk_report.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Read the ingest SSD on every drain node, and say how much a fill would have to write.
+#
+# Run this BEFORE `run.py --fill-gb N`. The number you pass to --fill-gb is a judgement about the
+# cluster on the day, not something the suite may decide for itself: on staging this filesystem is
+# shared with other tenants, so a self-sizing fill would consume somebody else's headroom.
+#
+# The two numbers that matter, and why both:
+#   df free   — what the evictor and the api's fs_cache_pressure gate actually measure.
+#   du cache  — how much of that this system owns, i.e. the most eviction could ever reclaim.
+# A deficit larger than `du cache` is unmeetable by construction: the evictor will free everything
+# it has, still miss the target, and report `starved`. That is correct behaviour, not a bug — but
+# it means the run proves nothing about eviction keeping up.
+#
+# Pure read. Nothing here writes to the cluster.
+
+set -euo pipefail
+
+NS="${NS:-hippius-s3-staging}"
+SSD="${CEPHOR_SSD_ROOT:-/var/lib/hippius/local_object_cache}"
+
+reserve=$(kubectl -n "$NS" get ds drain-agent -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CEPHOR_EVICT_RESERVE_PERMILLE")].value}' 2>/dev/null || echo "")
+headroom=$(kubectl -n "$NS" get ds drain-agent -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CEPHOR_EVICT_HEADROOM_PERMILLE")].value}' 2>/dev/null || echo "")
+reserve="${reserve:-150}"; headroom="${headroom:-50}"
+
+echo "namespace: $NS   path: $SSD"
+echo "evictor: arms below ${reserve}‰ free, frees back to $((reserve + headroom))‰"
+echo
+
+printf "%-16s %10s %10s %8s %10s %14s %14s\n" NODE TOTAL FREE FREE% CACHE "TO-ARM" "EVICTABLE"
+for entry in $(kubectl -n "$NS" get pods -l app=drain-agent --field-selector=status.phase=Running \
+                 -o jsonpath='{range .items[*]}{.metadata.name}:{.spec.nodeName}{"\n"}{end}'); do
+  pod="${entry%%:*}"; node="${entry##*:}"
+  df_line=$(kubectl -n "$NS" exec "$pod" -c agent -- df -PB1 "$SSD" 2>/dev/null | tail -1 || true)
+  [ -z "$df_line" ] && { printf "%-16s %10s\n" "$node" "unreachable"; continue; }
+  total=$(echo "$df_line" | awk '{print $2}')
+  free=$(echo "$df_line" | awk '{print $4}')
+  cache=$(kubectl -n "$NS" exec "$pod" -c agent -- du -sb "$SSD" 2>/dev/null | awk '{print $1}' || echo 0)
+
+  python3 - "$node" "$total" "$free" "$cache" "$reserve" <<'PY'
+import sys
+node, total, free, cache, reserve = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4]), int(sys.argv[5])
+G = 1e9
+arm_at = total * reserve / 1000          # free bytes at which eviction arms
+to_arm = max(0, free - arm_at)           # bytes that must be WRITTEN to reach it
+print(f"{node:<16} {total/G:9.1f}G {free/G:9.1f}G {free/total:7.1%} {cache/G:9.2f}G "
+      f"{to_arm/G:13.1f}G {cache/G:13.2f}G")
+PY
+done
+
+cat <<'EOF'
+
+TO-ARM     bytes you must write on THAT node before the evictor arms.
+EVICTABLE  the most eviction could reclaim there (= cache). If TO-ARM's resulting
+           deficit exceeds this, the pass will starve by construction.
+
+The api Service round-robins across ingest nodes, so a fill spreads roughly evenly:
+budget ~= TO-ARM x (number of nodes) to arm them all.
+
+  ./ssd_disk_report.sh
+  python run.py --fill-gb <N>          # N from the table above, your call
+EOF


### PR DESCRIPTION
Adds the disk-pressure scenario the retention work left untested. Additive only — 212 lines, no deletions, and the default path is unchanged.

## Why

Retention changed what the ingest SSD does: parts now stay on it under a free-space policy instead of being unlinked once replicated. Nothing in the suite has ever put that disk under pressure, so the evictor, the reserve band, and the replication gate protecting them have been reasoned about but never run against a real disk.

## What's here

| | |
|---|---|
| `ssd_disk_report.sh` | per-node SSD: total/free/free%, the share this system owns, **TO-ARM** (bytes to write before the evictor wakes) and **EVICTABLE** (the most it could reclaim). Pure read — nothing writes to the cluster. |
| `probes.ssd_usage()` | the same occupancy, per node, during a run |
| `ssd_fill_pressure()` | the scenario: write until free space crosses the reserve, then observe the evictor |
| `run.py --fill-gb` | opt in. **Default 0 skips it**, so the normal suite is unaffected. `--fill-object-mb` / `--fill-workers` shape it. |

```
NODE            TOTAL      FREE   FREE%   CACHE    TO-ARM   EVICTABLE
k8s-v3-node2   941.7G    225.0G   23.9%   1.09G     83.7G       1.09G
k8s-v3-node3   941.7G    216.6G   23.0%   1.20G     75.3G       1.20G
```

## Two decisions worth reviewing

**The fill size is never computed.** Staging's ingest SSD is shared with other tenants, so a self-sizing fill would eat somebody else's headroom. The operator reads the disk, decides, and passes `--fill-gb`. The suite refuses to guess — deliberately, and it should stay that way.

**Exactly one PASS/FAIL, and it's the durability invariant.** `drain_ssd_evict_blocked_unreplicated_total` must stay `0` — the evictor never deletes a chunk that isn't replicated yet, which must hold no matter how full the disk gets. Everything else (free space moved, bytes evicted, whether the pass reported `starved`) is recorded as **OBSERVED**. On a disk we don't own exclusively those numbers aren't ours to assert on, and a suite that fails on them just teaches people to ignore it.

## Read this before running it

On staging today, arming the evictor needs **~159 GB written across the two nodes** while only **~1.1–1.2 GB is actually evictable** — the rest of the disk is co-tenants. A fill that size would report `starved` by construction and prove nothing about eviction keeping up.

Raising `CEPHOR_EVICT_RESERVE_PERMILLE` to ~300 arms the evictor at current occupancy and exercises the same path far more cheaply. `ssd_disk_report.sh` prints both numbers so that call is made from the disk rather than a guess.

## Verification

`stress-test/` is excluded from ruff in `pyproject.toml`, so CI does not lint it. Checked anyway: all three modules parse, `run.py --help` works, `ssd_disk_report.sh` is valid bash, and the only lint finding inside the new code was one avoidable escaped quote, now fixed. The remaining findings in the file are pre-existing and outside these hunks; `print` (T201) is the established convention here — `throughput.py` has nine of its own — and this is an operator CLI, so those are left alone.

Not executed against a cluster yet. That's the next step, as part of the soak.