### PR TITLE
fix: close the four release-review blockers before staging goes to main

### DIFF
--- a/crates/hippius-drain-agent/src/config.rs
+++ b/crates/hippius-drain-agent/src/config.rs
@@ -67,6 +67,12 @@ const DEFAULT_HEARTBEAT_TTL: Duration = Duration::from_secs(30);
 /// Reclaim scan period when `CEPHOR_RECLAIM_POLL_SECS` is unset: the SSD-ingest GC
 /// runs less often than the drain — eviction is a backstop, not a hot path.
 const DEFAULT_RECLAIM_POLL: Duration = Duration::from_mins(5);
+/// R4 corrupt re-drive cadence. Deliberately its OWN knob rather than riding `reclaim_poll`:
+/// a `corrupt` part is a LIVE object whose pool copy is bad and whose SSD copy is the last good
+/// source, and unlike everything else that worker owns it is not grace-gated — so it is the one
+/// disposition where the poll interval IS the exposure window. Keeping it at the historical
+/// 5 minutes means raising the walk's interval for cost reasons cannot silently widen it.
+const DEFAULT_REDRIVE_POLL: Duration = Duration::from_mins(5);
 /// Orphan-reclaim grace when `CEPHOR_ORPHAN_RECLAIM_GRACE_SECS` is unset: how long a
 /// no-DB-backing part (its object hard-deleted) is kept on SSD before eviction. Longer
 /// than the `failed` grace because this age is the FS `meta.json` mtime (a deleted object
@@ -202,6 +208,10 @@ pub struct Config {
     /// Max times an R4 `corrupt` part is re-driven before it is held and paged. Bounds the
     /// re-drive so a persistently-bad pool copy cannot loop forever.
     pub redrive_max_attempts: u32,
+    /// How often bounded `corrupt` parts are re-driven. Separate from `reclaim_poll` because a
+    /// corrupt part is a live object running on its SSD copy alone: this interval is a
+    /// single-copy exposure window, not a debris-collection cadence.
+    pub redrive_poll: Duration,
     /// How often the read-tier evictor probes the ingest disk's free space.
     pub evict_poll: Duration,
     /// The evictor's fallback free-space floor, in permille of the ingest disk, used when the
@@ -299,6 +309,7 @@ impl Config {
             grace: self.grace,
             drain_concurrency: self.drain_concurrency,
             redrive_max_attempts: self.redrive_max_attempts,
+            redrive_poll: self.redrive_poll,
             failed_reclaim_poll: self.failed_reclaim_poll,
             landed_poll: self.landed_poll,
             evict_poll: self.evict_poll,
@@ -382,6 +393,7 @@ impl Config {
             orphan_reclaim_grace: duration_secs(&get, "CEPHOR_ORPHAN_RECLAIM_GRACE_SECS", DEFAULT_ORPHAN_RECLAIM_GRACE)?,
             drain_concurrency: positive_u32_or(&get, "CEPHOR_DRAIN_CONCURRENCY", DEFAULT_DRAIN_CONCURRENCY)?,
             redrive_max_attempts: positive_u32_or(&get, "CEPHOR_REDRIVE_MAX_ATTEMPTS", DEFAULT_REDRIVE_MAX_ATTEMPTS)?,
+            redrive_poll: duration_secs(&get, "CEPHOR_REDRIVE_POLL_SECS", DEFAULT_REDRIVE_POLL)?,
             evict_poll: duration_secs(&get, "CEPHOR_EVICT_POLL_SECS", DEFAULT_EVICT_POLL)?,
             evict_reserve_permille: permille_or(&get, "CEPHOR_EVICT_RESERVE_PERMILLE", DEFAULT_EVICT_RESERVE_PERMILLE)?,
             evict_headroom_permille: permille_or(&get, "CEPHOR_EVICT_HEADROOM_PERMILLE", DEFAULT_EVICT_HEADROOM_PERMILLE)?,

--- a/crates/hippius-drain-agent/src/metrics.rs
+++ b/crates/hippius-drain-agent/src/metrics.rs
@@ -135,6 +135,20 @@ fn register_ssd_tier_instruments(meter: &opentelemetry::metrics::Meter, snapshot
             .build(),
     ));
 
+    // The same discriminator for the `failed`-part reclaim, which needs it MORE than the evictor
+    // does. The evictor's worklist re-offers a skipped part next pass and the existing starvation
+    // alert covers a whole page failing; this worklist is `WHERE reclaimed_at IS NULL` with no
+    // offset, so a part that never unlinks is never marked and pins the head of every later page.
+    // Rising while the reclaim's removals stay flat means this node's failed debris is not being
+    // collected at all — and since the residency guard, those rows also stop being GC-able.
+    let snap = Arc::clone(snapshot);
+    instruments.push(Box::new(
+        meter
+            .u64_observable_counter("drain_ssd_reclaim_remove_failed_total")
+            .with_callback(move |observer| observer.observe(snap.reclaim_remove_failed(), &[]))
+            .build(),
+    ));
+
     // Whether this node's ingest disk is shared with a writer the drain cannot account for (1)
     // or is its own (0). The precondition for reading ANY of the three gauges above as a
     // statement about the drain: on a shared mount the eviction reserve, the promote floor and

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -792,6 +792,7 @@ async fn failed_reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotC
             // near `candidates` with `reclaimed` flat across cycles: the worklist has no offset,
             // so the same page is being re-offered and this node's failed debris — which the
             // residency guard also keeps un-GC-able — is not being reclaimed at all.
+            snapshot.record_reclaim_remove_failed(report.remove_failed);
             if report.remove_failed > 0 {
                 tracing::warn!(
                     remove_failed = report.remove_failed,

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -89,6 +89,9 @@ pub struct RuntimeConfig {
     pub reconcile_poll: Duration,
     /// How often the reclaim worker scans the SSD for `failed` (abandoned-upload) parts.
     pub reclaim_poll: Duration,
+    /// R4 corrupt re-drive cadence. Separate from `reclaim_poll` because it is the only
+    /// disposition on that path with no grace: the interval is a single-copy exposure window.
+    pub redrive_poll: Duration,
     /// How often the DB-driven `failed`-part reclaim runs. Independent of the reclaim WALK:
     /// decoupling debris cleanup from the walk is the point, so the walk can be rare.
     pub failed_reclaim_poll: Duration,
@@ -1252,15 +1255,36 @@ impl<E: UploadEnqueuer + 'static> AgentRuntime<E> {
             failed: FailedGrace(self.config.reclaim_grace),
             orphan: OrphanGrace(self.config.orphan_reclaim_grace),
         };
-        let redrive_max_attempts = self.config.redrive_max_attempts;
         supervisor.spawn(WorkerName::new("ssd_reclaim"), move |token| {
             run_periodic(token, reclaim_poll, move || {
                 let (ssd, store, snapshot) = (Arc::clone(&ssd), Arc::clone(&store), Arc::clone(&snapshot));
                 async move {
                     reclaim_once(&ssd, &store, &snapshot, reclaim_graces).await;
-                    // R4 re-drive: reset bounded `corrupt` parts to `pending` for a fresh copy,
-                    // then publish the held-corrupt gauge. Same cadence as reclaim (both are the
-                    // node-local SSD lifecycle); errors log and retry next poll (fail-safe).
+                }
+            })
+        });
+
+        // R4 re-drive on its OWN poll, no longer folded into the reclaim walk above.
+        //
+        // It was sharing that loop on the reasoning that both are "the node-local SSD lifecycle",
+        // which is true but hides the thing that matters: every other disposition the reclaim
+        // worker owns is grace-gated at an hour or more, so its poll interval is a cost knob. A
+        // `corrupt` part is not. It is a LIVE object whose pool copy is bad and whose SSD copy is
+        // the last good source, and the re-drive is what gets a fresh pool copy made — so for
+        // this one call the poll interval IS the single-copy exposure window.
+        //
+        // Retention made the reclaim walk proportional to the node's whole replicated shard,
+        // which is a good reason to run it hourly and NOT a reason to leave an R4 part on one
+        // copy for an hour. Splitting them lets each answer to its own clock; it also keeps the
+        // `drain-corrupt-live-parts` alert's `for:` window calibrated against a cadence that no
+        // longer moves when the walk's does.
+        let (store, snapshot) = (Arc::clone(&self.store), Arc::clone(&self.snapshot));
+        let redrive_poll = self.config.redrive_poll;
+        let redrive_max_attempts = self.config.redrive_max_attempts;
+        supervisor.spawn(WorkerName::new("redrive_corrupt"), move |token| {
+            run_periodic(token, redrive_poll, move || {
+                let (store, snapshot) = (Arc::clone(&store), Arc::clone(&snapshot));
+                async move {
                     redrive_corrupt_once(&store, &snapshot, redrive_max_attempts).await;
                 }
             })
@@ -2030,6 +2054,7 @@ mod tests {
                 reconcile_poll: Duration::from_mins(1),
                 enqueue_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
+                redrive_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
@@ -2124,6 +2149,7 @@ mod tests {
                 reconcile_poll: Duration::from_mins(1),
                 enqueue_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
+                redrive_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
@@ -2252,6 +2278,7 @@ mod tests {
                 reconcile_poll: Duration::from_mins(1),
                 enqueue_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
+                redrive_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
@@ -2326,6 +2353,7 @@ mod tests {
                 reconcile_poll: Duration::from_millis(20),
                 enqueue_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
+                redrive_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),
@@ -2383,6 +2411,7 @@ mod tests {
                 reconcile_poll: Duration::from_millis(50),
                 enqueue_poll: Duration::from_mins(1),
                 reclaim_poll: Duration::from_mins(1),
+                redrive_poll: Duration::from_mins(1),
                 reclaim_grace: Duration::from_hours(1),
                 orphan_reclaim_grace: Duration::from_hours(24),
                 grace: Duration::from_secs(5),

--- a/crates/hippius-drain-agent/src/runtime.rs
+++ b/crates/hippius-drain-agent/src/runtime.rs
@@ -784,6 +784,20 @@ async fn failed_reclaim_once(ssd: &LocalSsd, store: &Store, snapshot: &SnapshotC
                     "corrupt-live SSD parts held (pool copy corrupt) — last good source preserved (R4)"
                 );
             }
+            // A skipped removal is no longer fatal to the pass, so it has to be visible here or
+            // it is invisible everywhere. The shape that needs a human is `remove_failed` at or
+            // near `candidates` with `reclaimed` flat across cycles: the worklist has no offset,
+            // so the same page is being re-offered and this node's failed debris — which the
+            // residency guard also keeps un-GC-able — is not being reclaimed at all.
+            if report.remove_failed > 0 {
+                tracing::warn!(
+                    remove_failed = report.remove_failed,
+                    candidates = report.candidates,
+                    reclaimed = report.reclaimed,
+                    kind = ?report.remove_failed_kind,
+                    "failed-part reclaim skipped un-removable parts; cursor is pinned if this persists with reclaimed=0"
+                );
+            }
         }
         // A backing-read abort leaves every candidate unjudged, so the pass removed nothing and
         // this GC is DISABLED rather than merely slow — the same distinction the walk draws.

--- a/crates/hippius-drain-core/src/snapshot.rs
+++ b/crates/hippius-drain-core/src/snapshot.rs
@@ -277,6 +277,7 @@ pub struct SnapshotCell {
     /// starved-because-removals-are-failing (a disk, permissions, or racing-promotion fault) from
     /// starved-because-the-cursor-is-empty (genuine backlog). The two need opposite responses.
     evict_remove_failed: AtomicU64,
+    reclaim_remove_failed: AtomicU64,
     /// Aborted-reclaim counter mirroring `reclaimed`: bumped once per reclaim cycle that failed
     /// its object-backing read (`ReclaimError::Backing`). Monotonic, `Relaxed` — a stat counter
     /// with no cross-counter ordering dependency (axiom `rust_quality_92`). See
@@ -462,6 +463,25 @@ impl SnapshotCell {
     #[must_use]
     pub fn evict_remove_failed(&self) -> u64 {
         self.evict_remove_failed.load(Ordering::Relaxed)
+    }
+
+    /// Records `failed`-part reclaim candidates skipped because their unlink failed.
+    ///
+    /// Separate from the evictor's counter because the two answer different questions: the
+    /// evictor's worklist re-offers a skipped part on the next pass with no lasting consequence,
+    /// while this worklist is `WHERE reclaimed_at IS NULL` with no offset — a part that never
+    /// unlinks is never marked, so it sits at the head of every later page. `remove_failed` at or
+    /// near the candidate count with `reclaimed` flat is a pinned cursor, and since the residency
+    /// guard those rows also stop being GC-able.
+    pub fn record_reclaim_remove_failed(&self, n: u64) {
+        self.reclaim_remove_failed.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Cumulative reclaim skipped-on-unlink-failure count
+    /// (`drain_ssd_reclaim_remove_failed_total`).
+    #[must_use]
+    pub fn reclaim_remove_failed(&self) -> u64 {
+        self.reclaim_remove_failed.load(Ordering::Relaxed)
     }
 
     /// Records free bytes on the ingest SSD. A gauge: `store`, not add.

--- a/crates/hippius-drain-core/src/ssd_evict.rs
+++ b/crates/hippius-drain-core/src/ssd_evict.rs
@@ -391,13 +391,16 @@ where
                 // unread part keeps its rank, so one un-unlinkable part pinned the head and
                 // halted ALL eviction, with no report to carry `starved`.
                 report.remove_failed = report.remove_failed.saturating_add(1);
-                // Ranked by what needs a human, NOT by arrival order. `get_or_insert` here would
-                // keep whichever fault the worklist happened to order first, and the worklist is
-                // ordered by read recency — which has no relationship to severity. One transient
-                // `DirectoryNotEmpty` on the oldest part would then mask 511 EROFS behind it and
-                // report a promotion race for a read-only mount.
+                // Ranked by what needs a human, NOT by arrival order — the worklist's order has no
+                // relationship to severity, so first-wins would let one routine race mask a mount
+                // fault behind it. Two kinds are routine and both must be demoted:
+                // `DirectoryNotEmpty` (the api winning a rename into a directory being removed)
+                // and `WouldBlock` (the api holding the part-publish flock, which
+                // `remove_part_dir_exclusive` reports as an ordinary removal failure by design).
+                // Everything else — EACCES, EIO, EROFS — means the mount needs intervention and
+                // must survive.
                 report.remove_failed_kind = match (report.remove_failed_kind, err.kind()) {
-                    (None | Some(std::io::ErrorKind::DirectoryNotEmpty), kind) => Some(kind),
+                    (None | Some(std::io::ErrorKind::DirectoryNotEmpty | std::io::ErrorKind::WouldBlock), kind) => Some(kind),
                     (existing, _) => existing,
                 };
                 failed.insert(candidate.part);

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -546,8 +546,16 @@ where
             // metrics over a cursor that never moves" that migration 0018 exists to end. And
             // since #407's residency guard, an unreclaimed row is also un-GC-able.
             report.remove_failed = report.remove_failed.saturating_add(1);
+            // Ranked by what needs a human, NOT by arrival order — the worklist's order has no
+            // relationship to severity, so first-wins would let one routine race mask a mount
+            // fault behind it. Two kinds are routine and both must be demoted:
+            // `DirectoryNotEmpty` (the api winning a rename into a directory being removed)
+            // and `WouldBlock` (the api holding the part-publish flock, which
+            // `remove_part_dir_exclusive` reports as an ordinary removal failure by design).
+            // Everything else — EACCES, EIO, EROFS — means the mount needs intervention and
+            // must survive.
             report.remove_failed_kind = match (report.remove_failed_kind, err.kind()) {
-                (None | Some(std::io::ErrorKind::DirectoryNotEmpty), kind) => Some(kind),
+                (None | Some(std::io::ErrorKind::DirectoryNotEmpty | std::io::ErrorKind::WouldBlock), kind) => Some(kind),
                 (existing, _) => existing,
             };
             continue;
@@ -1686,5 +1694,32 @@ mod failed_reclaim_tests {
             .unwrap();
 
         assert_eq!((report.held_servable, report.remove_failed, report.reclaimed), (1, 1, 0));
+    }
+
+    #[tokio::test]
+    async fn a_flock_contention_does_not_mask_a_mount_fault() {
+        // WouldBlock is the api holding the part-publish flock — routine, and by design reported
+        // as an ordinary removal failure. Before this it was NOT demoted, so one publish race on
+        // the oldest part hid an EROFS behind it and the operator saw a promotion race where the
+        // mount had gone read-only.
+        let log = FakeLog::of(&[part(1), part(2)]);
+        let remover = FakeRemover::refusing(&[(1, io::ErrorKind::WouldBlock), (2, io::ErrorKind::ReadOnlyFilesystem)]);
+
+        let report = reclaim_failed(&log, &backing(&[]), &remover, Duration::from_hours(1), 256).await.unwrap();
+
+        assert_eq!(report.remove_failed_kind, Some(io::ErrorKind::ReadOnlyFilesystem));
+    }
+
+    #[tokio::test]
+    async fn a_pass_of_only_routine_races_still_reports_one() {
+        // Demoting must not mean discarding: with nothing worse to promote, the transient is
+        // still what happened and still the reason nothing was reclaimed.
+        let log = FakeLog::of(&[part(1), part(2)]);
+        let remover = FakeRemover::refusing(&[(1, io::ErrorKind::WouldBlock), (2, io::ErrorKind::DirectoryNotEmpty)]);
+
+        let report = reclaim_failed(&log, &backing(&[]), &remover, Duration::from_hours(1), 256).await.unwrap();
+
+        assert!(report.remove_failed_kind.is_some(), "a transient-only pass must still name a kind");
+        assert_eq!(report.remove_failed, 2);
     }
 }

--- a/crates/hippius-drain-core/src/ssd_reclaim.rs
+++ b/crates/hippius-drain-core/src/ssd_reclaim.rs
@@ -467,6 +467,15 @@ pub struct FailedReclaimReport {
     /// where this SSD copy is the last good source. Must never be deleted; a standing nonzero
     /// value is the same incident signal the walk's `skipped_corrupt` carries.
     pub held_servable: u64,
+    /// Parts whose unlink FAILED and were skipped so the pass could continue. Distinct parts
+    /// within a pass, never attempts — see [`reclaim_failed`] for why aborting instead was the
+    /// bug this counts. A value at or near `candidates` every pass means the cursor is pinned
+    /// and this node's `failed` debris is not being reclaimed at all.
+    pub remove_failed: u64,
+    /// The errno class of the skipped removals, ranked by what needs a human rather than by
+    /// arrival order: a transient `DirectoryNotEmpty` (the api renaming a promoted chunk into a
+    /// directory being removed) must not mask an `EROFS` behind it.
+    pub remove_failed_kind: Option<std::io::ErrorKind>,
 }
 
 /// Reclaims this node's aged `failed` parts **without walking the disk**.
@@ -496,7 +505,12 @@ pub struct FailedReclaimReport {
 /// - [`ReclaimError::Backing`] if the servability read fails — **nothing is removed**, because
 ///   without it every candidate is un-adjudicated and deleting one could destroy a live
 ///   object's last copy. Fail-safe, exactly as the walk's backing read is.
-/// - [`ReclaimError::Remove`] if unlinking fails.
+///
+/// A failing UNLINK is deliberately **not** an error: it is counted in
+/// [`remove_failed`](FailedReclaimReport::remove_failed) and the part is skipped. The distinction
+/// is between an *adjudication* failure — the worklist or backing read, where the pass does not
+/// know what is safe to delete and must stop — and an *I/O* failure on one inode, where every
+/// candidate is already adjudicated and the other 511 can proceed.
 pub async fn reclaim_failed<L, B, R>(log: &L, backing: &B, remover: &R, grace: Duration, limit: u32) -> Result<FailedReclaimReport, ReclaimError>
 where
     L: ReclaimLog,
@@ -520,7 +534,24 @@ where
             report.held_servable += 1;
             continue;
         }
-        remover.unlink_part(part).await.map_err(ReclaimError::Remove)?;
+        if let Err(err) = remover.unlink_part(part).await {
+            // Counted and skipped, NOT propagated — the same fix `evict_to_target` carries, for
+            // the same reason. Returning here landed before `mark_failed_reclaimed`, which is the
+            // only thing that advances this cursor: the worklist is `ORDER BY updated_at WHERE
+            // reclaimed_at IS NULL` with no offset, so one part refusing to be unlinked (EIO,
+            // EACCES, EROFS, or an ENOTEMPTY from the api publishing into the directory being
+            // removed) pinned the head of every later page. Worse than the evictor's version of
+            // this bug, because parts unlinked EARLIER in the same page were then never marked
+            // either, so the pass re-unlinked them every poll forever — the exact "productive
+            // metrics over a cursor that never moves" that migration 0018 exists to end. And
+            // since #407's residency guard, an unreclaimed row is also un-GC-able.
+            report.remove_failed = report.remove_failed.saturating_add(1);
+            report.remove_failed_kind = match (report.remove_failed_kind, err.kind()) {
+                (None | Some(std::io::ErrorKind::DirectoryNotEmpty), kind) => Some(kind),
+                (existing, _) => existing,
+            };
+            continue;
+        }
         report.reclaimed += 1;
         reclaimed.push(part.clone());
     }
@@ -1344,6 +1375,7 @@ mod failed_reclaim_tests {
         candidates: Mutex<Vec<PartKey>>,
         fail: bool,
         asked: Mutex<Vec<(u64, u32)>>,
+        marked: Mutex<Vec<u32>>,
     }
 
     impl FakeLog {
@@ -1352,7 +1384,15 @@ mod failed_reclaim_tests {
                 candidates: Mutex::new(parts.to_vec()),
                 fail: false,
                 asked: Mutex::new(Vec::new()),
+                marked: Mutex::new(Vec::new()),
             }
+        }
+
+        /// What actually reached `mark_failed_reclaimed` — the cursor's only advance.
+        fn marked(&self) -> Vec<u32> {
+            let mut out = self.marked.lock().unwrap().clone();
+            out.sort_unstable();
+            out
         }
     }
 
@@ -1365,6 +1405,7 @@ mod failed_reclaim_tests {
 
         async fn mark_failed_reclaimed(&self, parts: &[PartKey]) -> Result<(), io::Error> {
             let gone: Vec<PartKey> = parts.to_vec();
+            self.marked.lock().unwrap().extend(gone.iter().map(|p| p.part().get()));
             self.candidates.lock().unwrap().retain(|p| !gone.contains(p));
             Ok(())
         }
@@ -1405,12 +1446,30 @@ mod failed_reclaim_tests {
     #[derive(Default)]
     struct FakeRemover {
         removed: Mutex<Vec<u32>>,
+        /// Part numbers whose unlink fails, and with which errno. The old fake could only
+        /// succeed, which is precisely why a pass aborting on the first failure went unnoticed.
+        refuse: HashMap<u32, io::ErrorKind>,
+    }
+
+    impl FakeRemover {
+        fn refusing(refuse: &[(u32, io::ErrorKind)]) -> Self {
+            Self {
+                removed: Mutex::new(Vec::new()),
+                refuse: refuse.iter().copied().collect(),
+            }
+        }
     }
 
     impl PartRemover for FakeRemover {
         fn unlink_part(&self, part: &PartKey) -> impl Future<Output = io::Result<()>> + Send {
-            self.removed.lock().unwrap().push(part.part().get());
-            async { Ok(()) }
+            let n = part.part().get();
+            let outcome = if let Some(kind) = self.refuse.get(&n) {
+                Err(io::Error::from(*kind))
+            } else {
+                self.removed.lock().unwrap().push(n);
+                Ok(())
+            };
+            async move { outcome }
         }
     }
 
@@ -1436,6 +1495,8 @@ mod failed_reclaim_tests {
                 candidates: 2,
                 reclaimed: 2,
                 held_servable: 0,
+                remove_failed: 0,
+                remove_failed_kind: None,
             }
         );
         assert_eq!(*remover.removed.lock().unwrap(), vec![1, 2]);
@@ -1543,6 +1604,7 @@ mod failed_reclaim_tests {
             candidates: Mutex::new(vec![part(1)]),
             fail: true,
             asked: Mutex::new(Vec::new()),
+            marked: Mutex::new(Vec::new()),
         };
         let remover = FakeRemover::default();
 
@@ -1552,5 +1614,77 @@ mod failed_reclaim_tests {
 
         assert!(matches!(err, ReclaimError::Log(_)));
         assert!(remover.removed.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn one_unremovable_part_does_not_stop_the_rest_of_the_page() {
+        // The bug: `?` on the unlink returned BEFORE `mark_failed_reclaimed`, which is the only
+        // thing that advances this cursor. One bad inode pinned the head of every later page, so
+        // the node's failed debris was never reclaimed — and since the residency guard, never
+        // GC'd either. Worse than the evictor's version, because parts unlinked earlier in the
+        // same page were left unmarked and re-unlinked on every subsequent poll.
+        let log = FakeLog::of(&[part(1), part(2), part(3)]);
+        let remover = FakeRemover::refusing(&[(2, io::ErrorKind::PermissionDenied)]);
+
+        // Must not be an Err: an unlink failure is a skip, not a pass failure.
+        let report = reclaim_failed(&log, &backing(&[]), &remover, Duration::from_hours(1), 256).await.unwrap();
+
+        assert_eq!(report.candidates, 3);
+        assert_eq!(report.reclaimed, 2, "the two removable parts still go");
+        assert_eq!(report.remove_failed, 1);
+        assert_eq!(report.remove_failed_kind, Some(io::ErrorKind::PermissionDenied));
+        assert_eq!(remover.removed.lock().unwrap().clone(), vec![1, 3]);
+    }
+
+    #[tokio::test]
+    async fn the_parts_that_were_unlinked_are_still_marked_when_another_fails() {
+        // The cursor half, which is the part that made this permanent: marking is what takes a
+        // row off `WHERE reclaimed_at IS NULL`. Aborting the pass left parts 1 and 3 unlinked but
+        // unmarked, so the next poll re-offered and re-unlinked them, forever.
+        let log = FakeLog::of(&[part(1), part(2), part(3)]);
+        let remover = FakeRemover::refusing(&[(2, io::ErrorKind::PermissionDenied)]);
+
+        reclaim_failed(&log, &backing(&[]), &remover, Duration::from_hours(1), 256).await.unwrap();
+
+        assert_eq!(log.marked(), vec![1, 3], "unlinked parts must be marked so the cursor moves");
+    }
+
+    #[tokio::test]
+    async fn a_page_where_every_unlink_fails_marks_nothing_and_reports_it() {
+        // Terminates rather than looping, and says why: `remove_failed == candidates` with
+        // nothing reclaimed is the signature of a pinned cursor.
+        let log = FakeLog::of(&[part(1), part(2)]);
+        let remover = FakeRemover::refusing(&[(1, io::ErrorKind::ReadOnlyFilesystem), (2, io::ErrorKind::ReadOnlyFilesystem)]);
+
+        let report = reclaim_failed(&log, &backing(&[]), &remover, Duration::from_hours(1), 256).await.unwrap();
+
+        assert_eq!((report.candidates, report.reclaimed, report.remove_failed), (2, 0, 2));
+        assert!(log.marked().is_empty(), "nothing was removed, so nothing may be marked");
+    }
+
+    #[tokio::test]
+    async fn the_reported_errno_ranks_by_what_needs_a_human() {
+        // A transient DirectoryNotEmpty (the api publishing into a directory being removed) must
+        // not mask an EROFS behind it just because the worklist ordered it first.
+        let log = FakeLog::of(&[part(1), part(2)]);
+        let remover = FakeRemover::refusing(&[(1, io::ErrorKind::DirectoryNotEmpty), (2, io::ErrorKind::ReadOnlyFilesystem)]);
+
+        let report = reclaim_failed(&log, &backing(&[]), &remover, Duration::from_hours(1), 256).await.unwrap();
+
+        assert_eq!(report.remove_failed_kind, Some(io::ErrorKind::ReadOnlyFilesystem));
+    }
+
+    #[tokio::test]
+    async fn a_servable_part_is_still_held_and_is_not_counted_as_a_failure() {
+        // The R4 guard and the new skip must stay distinguishable: held_servable is a durability
+        // signal, remove_failed is an I/O one, and conflating them would hide either.
+        let log = FakeLog::of(&[part(1), part(2)]);
+        let remover = FakeRemover::refusing(&[(2, io::ErrorKind::PermissionDenied)]);
+
+        let report = reclaim_failed(&log, &backing(&[part(1)]), &remover, Duration::from_hours(1), 256)
+            .await
+            .unwrap();
+
+        assert_eq!((report.held_servable, report.remove_failed, report.reclaimed), (1, 1, 0));
     }
 }

--- a/docs/runbooks/2026-08-10-release-prod-migration-presteps.md
+++ b/docs/runbooks/2026-08-10-release-prod-migration-presteps.md
@@ -1,0 +1,116 @@
+# Prod pre-steps for the SSD read-tier release
+
+Run these **before** merging `staging → main`. Everything here is designed so the automatic
+migration that follows is a no-op on prod, while staying the source of truth for staging, CI and
+dev — where the tables are small and the in-transaction path is the safer one.
+
+## Why by hand at all
+
+Migration `0018_replication_reclaimed_marker` adds a column and then builds a partial index on
+`cephor_replication_status` (~11.4M rows on prod). sqlx wraps a migration file without
+`-- no-transaction` in **one transaction**, so the `ACCESS EXCLUSIVE` lock taken by
+`ALTER TABLE ... ADD COLUMN` is held until COMMIT — through the whole index build, which is a
+full heap scan. `ACCESS EXCLUSIVE` blocks readers, not just writers.
+
+Blocked for that window: the entire drain fleet (`claim_part`, `release_part`, `mark_replicated`,
+`record_landed_part`) and — on a **client** path — `CompleteMultipartUpload`, which runs
+`wake_version_replication` against the same table. `lock_timeout` bounds acquisition, not the
+build, so it does not bound this.
+
+**Do not "fix" this by editing the migration.** `sqlx` checksums the entire file with SHA-384,
+comments included, and `Migrator::DEFAULT` validates applied migrations — so changing so much as a
+comment in an already-applied file gives `MigrateError::VersionMismatch(18)` and CrashLoops the
+allocator on every environment that already ran it. The file is correct as written for a small
+table; prod is the exception, and the exception is handled here.
+
+## Steps
+
+Run against the prod app DB (`postgres-nvme-rw`), before the deploy.
+
+### 1. Add the column
+
+Metadata-only (nullable, no default), so it is sub-millisecond once it holds the lock. Keep the
+timeout short and just retry if it can't get in — that is the same trade the migration makes.
+
+```sql
+SET lock_timeout = '5s';
+ALTER TABLE cephor_replication_status ADD COLUMN IF NOT EXISTS reclaimed_at TIMESTAMPTZ;
+```
+
+### 2. Build the index without blocking
+
+`CONCURRENTLY` cannot run inside a transaction — run it on its own, not in a `psql -c` batch with
+other statements.
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS cephor_replication_status_failed_reclaimable
+    ON cephor_replication_status (node_id, updated_at)
+    WHERE status = 'failed' AND reclaimed_at IS NULL;
+```
+
+### 3. Verify the index is VALID — do not skip this
+
+`CREATE INDEX CONCURRENTLY` can fail and leave an **INVALID** index behind. If that happens, the
+`IF NOT EXISTS` in migration 0018 will silently decline to rebuild it, and you are left with a
+non-functional index while the failed-reclaim worklist quietly seq-scans an 11.4M-row table every
+poll, per node.
+
+```sql
+SELECT indisvalid
+FROM pg_index
+WHERE indexrelid = 'cephor_replication_status_failed_reclaimable'::regclass;
+```
+
+Anything other than `t`: drop it and repeat step 2.
+
+```sql
+DROP INDEX CONCURRENTLY cephor_replication_status_failed_reclaimable;
+```
+
+### 4. Confirm the agent's schema gate now passes
+
+This is the exact predicate `drain-agent`'s `wait-for-cephor-schema` initContainer runs. It must
+return `t` before the DaemonSet rolls, or every pod sits in init.
+
+```sql
+SELECT to_regclass('public.cephor_ssd_residency') IS NOT NULL
+   AND EXISTS (SELECT 1 FROM information_schema.columns
+               WHERE table_name = 'cephor_replication_status'
+                 AND column_name IN ('content_sha256', 'relanded_at', 'reclaimed_at')
+               HAVING count(*) = 3);
+```
+
+Note this also requires migrations 0016 (`cephor_ssd_residency`) and 0019 (`content_sha256`,
+`relanded_at`). Those are cheap — 0016 creates an empty table, 0019 is two metadata-only
+`ADD COLUMN`s — so letting the allocator apply them normally is fine. Only 0018's index build
+needs the treatment above.
+
+## Deploy order
+
+The manifests do not enforce this; `kubectl apply -k` starts everything rolling at once.
+
+1. Steps 1–4 above, out of band.
+2. **api-local** — picks up `NODE_NAME` and starts publishing `cephor:landed:<node>`. The old
+   agent ignores the queue harmlessly, so this is safe to do first and wants to be: it means
+   announcements are already flowing before anything depends on them.
+3. **drain-allocator** — applies 0016/0019 (0018 is now a no-op) and starts publishing the
+   per-node eviction reserve.
+4. **drain-agent** — last. This is the binary that stops unlinking on commit, so retention begins
+   here.
+
+## After
+
+Watch, in this order:
+
+- `drain_landed_dropped_total` — **must stay 0.** Nonzero means the api and agent disagree about
+  the announcement wire contract, every announcement is being discarded, and discovery has
+  silently reverted to the walk.
+- `drain_ssd_cache_bytes` — should rise and then plateau under the evictor's floor. Rising without
+  plateau means eviction is not keeping up.
+- `drain_ssd_evict_blocked_unreplicated_total` — **must stay 0.** This is the durability invariant:
+  the evictor never removes a chunk that is not yet replicated.
+- `drain_reland_vanished_total` — alert on any increase; it is the lost-race signature for a
+  rewritten part.
+- `fs_cache_pressure` 503s on PUT — retention deliberately runs the ingest SSD at 15–20% free
+  against a 10%-free 503 threshold. That five-point margin is defended only by the evictor
+  continuing to run.

--- a/hippius_s3/cache/fs_store.py
+++ b/hippius_s3/cache/fs_store.py
@@ -452,13 +452,21 @@ class FileSystemPartsStore:
                 for src, dst in zip(staged, targets, strict=False):
                     src.replace(dst)
                     renamed += 1
+                # Inside the same guard as the renames, not after it. meta.json is the readiness
+                # gate, so the window this un-publish exists to close does not end at the last
+                # rename — it ends when the NEW meta lands. An OSError from the trim or the meta
+                # write left the PREVIOUS attempt's meta.json standing over a chunk set that is
+                # now this attempt's and a different length: the part still reads as published,
+                # with a wrong declared size and holes, and the drain's completeness gate strands
+                # it as IncompleteSource. ENOSPC is the obvious way in, and a disk that retention
+                # deliberately runs at 15-20% free is where it happens.
+                _trim_chunk_tail(part_dir, int(num_chunks), label)
+                _write_meta_file(meta_path, payload)
             except OSError:
                 if renamed:
                     with contextlib.suppress(OSError):
                         meta_path.unlink(missing_ok=True)
                 raise
-            _trim_chunk_tail(part_dir, int(num_chunks), label)
-            _write_meta_file(meta_path, payload)
 
         async with _publish_locks.acquire(str(part_dir)):
             await asyncio.to_thread(_publish)

--- a/hippius_s3/monitoring.py
+++ b/hippius_s3/monitoring.py
@@ -62,6 +62,10 @@ PromoteFloorDivergence = Literal["stricter", "looser"]
 # erroring on every read is indistinguishable from one that is being fully absorbed by the
 # sampler, and both look like silence.
 ReadRecencyOutcome = Literal["written", "failed"]
+# Why an announcement did not reach redis-queues. `timeout` is deliberately its own value:
+# it is the outcome a slow (rather than broken) queue produces, and the one the bound on
+# the publish introduces, so it has to be distinguishable from an outright error.
+LandedAnnounceOutcome = Literal["timeout", "error"]
 
 # Where the bytes that failed a chunk's AEAD check were found, and what came of it. Closed by
 # construction. `local` means a copy on this node's flash was removed and the read retried from
@@ -189,6 +193,20 @@ class MetricsCollector:
         self.residency_release_failures = self.meter.create_counter(
             name="residency_release_failures_total",
             description="Residency claims left in place because the compensating decrement failed",
+            unit="1",
+        )
+
+        # A landed-part announcement the api could not hand to redis-queues. This MUST be
+        # alertable rather than a log line, because the announcement is the only trigger for the
+        # B-2 divergence check: the reconciler tallies an already-`replicated` part as an orphan
+        # and deliberately does not content-check it, so a lost announcement for a RE-uploaded
+        # part means the pool keeps the previous attempt's ciphertext and serves it under the new
+        # ETag, decrypting cleanly, permanently. `drain_landed_dropped_total` on the agent counts
+        # only messages it could not PARSE, so it cannot see a message that never arrived.
+        # `outcome` is a Literal, so cardinality is bounded.
+        self.landed_announce_failures = self.meter.create_counter(
+            name="landed_announce_failures_total",
+            description="Landed-part announcements the api failed to enqueue, by outcome",
             unit="1",
         )
 
@@ -626,6 +644,10 @@ class MetricsCollector:
         """Count a claim whose compensating decrement failed, leaving phantom bytes accounted."""
         self.residency_release_failures.add(1)
 
+    def record_landed_announce_failure(self, outcome: LandedAnnounceOutcome) -> None:
+        """Count one announcement that did not reach the queue. `outcome` is a Literal."""
+        self.landed_announce_failures.add(1, attributes={"outcome": outcome})
+
     def record_read_recency_write(self, outcome: ReadRecencyOutcome) -> None:
         """Count one `last_read_at` stamp attempt. `outcome` is a Literal, so bounded."""
         self.read_recency_writes.add(1, attributes={"outcome": outcome})
@@ -912,6 +934,9 @@ class NullMetricsCollector:
         pass
 
     def record_residency_release_failure(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def record_landed_announce_failure(self, *args: object, **kwargs: object) -> None:
         pass
 
     def record_read_recency_write(self, *args: object, **kwargs: object) -> None:

--- a/hippius_s3/writer/landed.py
+++ b/hippius_s3/writer/landed.py
@@ -26,8 +26,13 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Optional
+
+
+if TYPE_CHECKING:
+    from hippius_s3.monitoring import LandedAnnounceOutcome
 
 
 logger = logging.getLogger(__name__)
@@ -36,10 +41,19 @@ logger = logging.getLogger(__name__)
 # Must match `landed_queue_key` in crates/hippius-drain-agent/src/landed.rs.
 _LANDED_QUEUE_PREFIX = "cephor:landed:"
 
-# Bounds the one await this puts on the client PUT path. Generous next to a healthy LPUSH
-# (sub-millisecond) and short next to a client timeout: the announcement is an optimisation
-# over the reconcile walk, so waiting on it is never worth a slow PUT.
-_PUBLISH_TIMEOUT_SECONDS = 1.0
+# Bounds the one await this puts on the client PUT path.
+#
+# Sized to cover a TCP CONNECT plus a round trip, not just a round trip. redis-py drops the
+# pooled connection when a command is cancelled, so the publish after a timeout has to reconnect
+# inside this same budget — at 1s that was self-reinforcing, and because redis latency is a
+# shared property every api pod crossed the threshold at the same moment, losing 100% of
+# announcements fleet-wide rather than a sampled fraction. 5s keeps the bound (an unbounded await
+# on a client with no socket_timeout was the actual defect) while putting it far outside the
+# range a merely-loaded queue reaches.
+#
+# A timeout is NOT free, which is why it is counted rather than only logged: see
+# `landed_announce_failures_total` and the note on the counter in monitoring.py.
+_PUBLISH_TIMEOUT_SECONDS = 5.0
 
 # Cap on a node's queue. The agent normally drains this within a poll, so depth is near zero;
 # the bound only matters when the agent is down. Past it the OLDEST announcements are dropped,
@@ -50,6 +64,18 @@ _DEFAULT_MAX_QUEUE_DEPTH = 200_000
 
 def landed_queue_key(node_name: str) -> str:
     return f"{_LANDED_QUEUE_PREFIX}{node_name}"
+
+
+def _record_announce_failure(outcome: "LandedAnnounceOutcome") -> None:
+    """Best-effort counter bump; metrics must never be the reason a PUT fails."""
+    try:
+        from hippius_s3.monitoring import get_metrics_collector
+
+        collector = get_metrics_collector()
+        if collector is not None:
+            collector.record_landed_announce_failure(outcome)
+    except Exception:  # noqa: BLE001 - a metrics fault must not surface on the write path
+        logger.debug("recording a landed-announce failure failed", exc_info=True)
 
 
 class LandedPartPublisher:
@@ -89,8 +115,26 @@ class LandedPartPublisher:
             # reason; the write path is the one that needed it more. On timeout the part is
             # already durable and the agent's reconcile walk still finds it.
             await asyncio.wait_for(pipe.execute(), timeout=_PUBLISH_TIMEOUT_SECONDS)
+        except TimeoutError:
+            # WARNING and counted, not DEBUG. The module docstring's "a dropped announcement costs
+            # latency and nothing else" is true only for DISCOVERY of a new part — the reconciler
+            # does find that on disk. It is false for a RE-uploaded one: the reconciler tallies an
+            # already-`replicated` part as an orphan and deliberately does not content-check it, so
+            # the announcement is the only thing that triggers the divergence check. Losing one for
+            # a rewritten part leaves the pool serving the previous attempt's ciphertext under the
+            # new ETag, decrypting cleanly, with nothing else to notice.
+            _record_announce_failure("timeout")
+            logger.warning(
+                "announcing landed part %s v%s part %s timed out after %ss; a rewrite of an already-"
+                "replicated part would not be re-driven",
+                object_id,
+                object_version,
+                part_number,
+                _PUBLISH_TIMEOUT_SECONDS,
+            )
         except Exception as exc:  # noqa: BLE001 - the part is already durable; the backstop covers this
-            logger.debug(
+            _record_announce_failure("error")
+            logger.warning(
                 "announcing landed part %s v%s part %s failed: %s", object_id, object_version, part_number, exc
             )
 

--- a/hippius_s3/writer/landed.py
+++ b/hippius_s3/writer/landed.py
@@ -23,6 +23,7 @@ scripts, tests — get `None` and publishing is a no-op.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from typing import Any
@@ -34,6 +35,11 @@ logger = logging.getLogger(__name__)
 
 # Must match `landed_queue_key` in crates/hippius-drain-agent/src/landed.rs.
 _LANDED_QUEUE_PREFIX = "cephor:landed:"
+
+# Bounds the one await this puts on the client PUT path. Generous next to a healthy LPUSH
+# (sub-millisecond) and short next to a client timeout: the announcement is an optimisation
+# over the reconcile walk, so waiting on it is never worth a slow PUT.
+_PUBLISH_TIMEOUT_SECONDS = 1.0
 
 # Cap on a node's queue. The agent normally drains this within a poll, so depth is near zero;
 # the bound only matters when the agent is down. Past it the OLDEST announcements are dropped,
@@ -75,7 +81,14 @@ class LandedPartPublisher:
             pipe = self._redis.pipeline()
             pipe.lpush(self._key, payload)
             pipe.ltrim(self._key, 0, self._max_depth - 1)
-            await pipe.execute()
+            # Bounded, because this await is on the CLIENT PUT PATH and the api's queues client is
+            # built with no socket_timeout — so `except` below catches a redis-queues that ERRORS
+            # and does nothing at all for one that merely goes SLOW. That is not hypothetical on
+            # this queue: a 1.29M-entry list once made redis-queues slow enough to surface as
+            # prod GET IncompleteRead. `promote_floor` bounds its own queues read for exactly this
+            # reason; the write path is the one that needed it more. On timeout the part is
+            # already durable and the agent's reconcile walk still finds it.
+            await asyncio.wait_for(pipe.execute(), timeout=_PUBLISH_TIMEOUT_SECONDS)
         except Exception as exc:  # noqa: BLE001 - the part is already durable; the backstop covers this
             logger.debug(
                 "announcing landed part %s v%s part %s failed: %s", object_id, object_version, part_number, exc

--- a/k8s/production/drain-agent-daemonset.yaml
+++ b/k8s/production/drain-agent-daemonset.yaml
@@ -96,12 +96,20 @@ spec:
               # needs 0016's cephor_ssd_residency. Started against a pre-migration schema the
               # agent cannot commit or record ANY part while the api keeps accepting PUTs onto
               # the same SSD, and it does not self-heal until the allocator's migration lands.
+              # table_schema is load-bearing, and count(DISTINCT ...) with it. Without both,
+              # information_schema.columns spans EVERY schema the role can see, so the check
+              # answers the wrong question twice over: a same-named table in another schema
+              # (an archive, a restore staging area) can supply the missing columns and pass the
+              # gate against an un-migrated `public` — the exact outage it exists to prevent —
+              # and a duplicate of a CORRECTLY migrated table makes the count 6, so `= 3` is
+              # false and the initContainer spins forever on a healthy database.
               until [ "$(psql "$CEPHOR_DATABASE_URL" -tAc "
                 SELECT to_regclass('public.cephor_ssd_residency') IS NOT NULL
                    AND EXISTS (SELECT 1 FROM information_schema.columns
-                               WHERE table_name = 'cephor_replication_status'
+                               WHERE table_schema = 'public'
+                                 AND table_name = 'cephor_replication_status'
                                  AND column_name IN ('content_sha256', 'relanded_at', 'reclaimed_at')
-                               HAVING count(*) = 3)")" = "t" ]; do
+                               HAVING count(DISTINCT column_name) = 3)")" = "t" ]; do
                 echo "waiting for the cephor schema (allocator migrations 0016-0019)"; sleep 3
               done
           env:
@@ -165,11 +173,25 @@ spec:
             # and reads, i.e. twice the frequency of the reconcile walk this release just demoted
             # 40x for being too expensive. `ssd_reclaim.rs` already reasons about an hourly walk.
             #
-            # Nothing is delayed by the change: every disposition this worker owns is grace-gated
-            # at >= 1h (CEPHOR_RECLAIM_GRACE_SECS below), so no part becomes actionable faster
-            # than hourly and a 300s poll can only re-ask the same question twelve times.
+            # Every disposition this worker owns is grace-gated at >= 1h
+            # (CEPHOR_RECLAIM_GRACE_SECS below), so no part becomes actionable faster than hourly
+            # and a 300s poll could only re-ask the same question twelve times.
+            #
+            # That was NOT true while the R4 corrupt re-drive shared this loop. A `corrupt` part
+            # is a live object whose pool copy is bad and whose SSD copy is the last good source,
+            # and it has no grace — so for that one call the poll interval was the single-copy
+            # exposure window, and raising this to 3600 would have widened it 12x. The re-drive
+            # now runs on its own worker and its own CEPHOR_REDRIVE_POLL_SECS below; the two must
+            # stay separate, and this value must not be assumed to bound anything R4.
             - name: CEPHOR_RECLAIM_POLL_SECS
               value: "3600"
+            # Pinned at the historical 5 minutes, and pinned EXPLICITLY rather than left to the
+            # code default so that this window is visible next to the walk interval it used to be
+            # accidentally coupled to. `drain-corrupt-live-parts` (severity critical, for: 15m) is
+            # calibrated against this cadence — 15m is three cycles here, which is what lets a
+            # transient corruption clear itself before paging. Raising it breaks that calibration.
+            - name: CEPHOR_REDRIVE_POLL_SECS
+              value: "300"
             - name: CEPHOR_RECLAIM_GRACE_SECS
               value: "3600"
             # ROLLBACK-LOAD-BEARING — do not delete as manifest hygiene.

--- a/k8s/production/drain-agent-daemonset.yaml
+++ b/k8s/production/drain-agent-daemonset.yaml
@@ -88,8 +88,21 @@ spec:
             - -c
             - |
               until pg_isready -h postgres-nvme-rw -p 5432; do echo "waiting for postgres"; sleep 3; done
-              until [ "$(psql "$CEPHOR_DATABASE_URL" -tAc "SELECT to_regclass('public.cephor_replication_status') IS NOT NULL")" = "t" ]; do
-                echo "waiting for the cephor schema (allocator migration)"; sleep 3
+              # Gate on the columns THIS binary needs, not on the table existing. The table has
+              # been there since migration 0005, so the old check passed instantly and guarded
+              # nothing — while `record_landed_part` (the only record path, so the landed queue
+              # AND the reconciler backstop fail together) needs 0019's content_sha256 and
+              # relanded_at, `mark_replicated` needs content_sha256, and the evictor's worklist
+              # needs 0016's cephor_ssd_residency. Started against a pre-migration schema the
+              # agent cannot commit or record ANY part while the api keeps accepting PUTs onto
+              # the same SSD, and it does not self-heal until the allocator's migration lands.
+              until [ "$(psql "$CEPHOR_DATABASE_URL" -tAc "
+                SELECT to_regclass('public.cephor_ssd_residency') IS NOT NULL
+                   AND EXISTS (SELECT 1 FROM information_schema.columns
+                               WHERE table_name = 'cephor_replication_status'
+                                 AND column_name IN ('content_sha256', 'relanded_at', 'reclaimed_at')
+                               HAVING count(*) = 3)")" = "t" ]; do
+                echo "waiting for the cephor schema (allocator migrations 0016-0019)"; sleep 3
               done
           env:
             - name: CEPHOR_DATABASE_URL
@@ -142,10 +155,21 @@ spec:
             # SSD-ingest reclaim worker: clean up broken/abandoned uploads (failed parts
             # the drain skips forever), replicated crash-orphans (a crash between the
             # mark_replicated commit and the drain's own unlink), and orphan write-temps,
-            # once aged, so junk does not accumulate on the node-local disk. All have safe
-            # code defaults (300s poll / 1h graces); set here for visibility + per-node tuning.
+            # once aged, so junk does not accumulate on the node-local disk.
+            #
+            # 3600, not the 300s code default, for the SAME reason the reconcile poll above is
+            # 600: this worker still runs the full SSD tree walk (`reclaim_ssd` ->
+            # `scanner.scan_parts()`), and retention grew that tree from the undrained backlog to
+            # this node's ENTIRE replicated shard — the 2.28M parts / ~930 GB measured on prod
+            # 2026-08-07. At 300s that is 12 walks/hour per node, on the same NVMe serving ingest
+            # and reads, i.e. twice the frequency of the reconcile walk this release just demoted
+            # 40x for being too expensive. `ssd_reclaim.rs` already reasons about an hourly walk.
+            #
+            # Nothing is delayed by the change: every disposition this worker owns is grace-gated
+            # at >= 1h (CEPHOR_RECLAIM_GRACE_SECS below), so no part becomes actionable faster
+            # than hourly and a 300s poll can only re-ask the same question twelve times.
             - name: CEPHOR_RECLAIM_POLL_SECS
-              value: "300"
+              value: "3600"
             - name: CEPHOR_RECLAIM_GRACE_SECS
               value: "3600"
             # ROLLBACK-LOAD-BEARING — do not delete as manifest hygiene.

--- a/monitoring/grafana/provisioning/alerting/alert-rules.yml
+++ b/monitoring/grafana/provisioning/alerting/alert-rules.yml
@@ -891,25 +891,36 @@ groups:
       # aborted on an object-backing read (ReclaimError::Backing: the object_versions table missing
       # on a deploy, or a transient PG error). On this path the failed-part SSD GC reads nothing and
       # removes NOTHING — it is silently DISABLED while failing safe, so SSD debris accrues invisibly
-      # until drain_ssd_pressure trips the critical PUT-shedding alert downstream. increase()>0 held
-      # for 15m means the failure is STANDING across the 1m reclaim cycles, not a single transient PG
-      # blip (whose lone increment ages out of the window). Warning, not critical: the reclaim fails
-      # safe (no data loss) and drain-ssd-pressure-high is the downstream hard page.
+      # until drain_ssd_pressure trips the critical PUT-shedding alert downstream. Warning, not
+      # critical: the reclaim fails safe (no data loss) and drain-ssd-pressure-high is the
+      # downstream hard page.
+      #
+      # THE WINDOW TRACKS THE POLL, and the poll has moved twice. This was written for 1m cycles,
+      # ran at 300s, and CEPHOR_RECLAIM_POLL_SECS is now 3600 on prod (retention made the walk
+      # proportional to the node's whole replicated shard). A counter that can increment at most
+      # once an hour is invisible to increase()[15m] for 45 of every 60 minutes, and `for: 15m`
+      # could then never hold — the alarm for "reclaim is silently disabled" was itself silently
+      # disabled. 3h spans three poll intervals, so a STANDING failure is still distinguished from
+      # a single transient blip (one increment ages out), which is the property the short window
+      # was chosen for. `for` drops to 0 because the window now does that work: holding a 3h
+      # increase for a further 15m would only delay the page by a quarter-hour.
+      #
+      # If the poll changes again, change this with it. The rule is: window >= 3 x poll.
       - uid: drain-reclaim-backing-errors
         title: Drain Reclaim Disabled - Object-Backing Read Failing
         condition: C
         data:
           - refId: A
             relativeTimeRange:
-              from: 900
+              from: 10800
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
-              expr: 'sum(increase(drain_reclaim_backing_errors_total{job="otel-collector"}[15m]))'
+              expr: 'sum(increase(drain_reclaim_backing_errors_total{job="otel-collector"}[3h]))'
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 900
+              from: 10800
               to: 0
             datasourceUid: __expr__
             model:
@@ -919,7 +930,7 @@ groups:
               refId: B
           - refId: C
             relativeTimeRange:
-              from: 900
+              from: 10800
               to: 0
             datasourceUid: __expr__
             model:
@@ -934,9 +945,9 @@ groups:
               refId: C
         noDataState: OK
         execErrState: Error
-        for: 15m
+        for: 0m
         annotations:
-          description: '{{ if $values.B }}{{ printf "%.0f" $values.B.Value }}{{ else }}N/A{{ end }} reclaim cycle(s) in 15m aborted on an object-backing read — the failed-part SSD GC is disabled and removing nothing. Check for a missing object_versions table on the drain deploy or a PG error; SSD debris will accrue until the disk-pressure alert fires.'
+          description: '{{ if $values.B }}{{ printf "%.0f" $values.B.Value }}{{ else }}N/A{{ end }} reclaim cycle(s) in 3h aborted on an object-backing read — the failed-part SSD GC is disabled and removing nothing. Check for a missing object_versions table on the drain deploy or a PG error; SSD debris will accrue until the disk-pressure alert fires.'
           summary: The drain failed-part SSD reclaim is disabled (object-backing read failing)
         labels:
           severity: warning

--- a/tests/unit/cache/test_fs_store_trim_and_unpublish.py
+++ b/tests/unit/cache/test_fs_store_trim_and_unpublish.py
@@ -198,20 +198,35 @@ async def test_a_failed_meta_write_unpublishes_rather_than_leaving_a_holed_part(
 
 
 @pytest.mark.asyncio
-async def test_a_failed_trim_also_unpublishes(store, monkeypatch):
-    """Same window, one step earlier — the trim runs between the renames and the meta write."""
+async def test_the_trim_cannot_be_what_triggers_the_unpublish(store, caplog):
+    """Pins the reachability claim itself, because an earlier version of this test got it wrong.
+
+    That version monkeypatched `_trim_chunk_tail` to raise and asserted the un-publish ran — which
+    passed, but tested a state the code cannot reach and left a docstring implying a risk that
+    does not exist. `_trim_chunk_tail` swallows every `OSError`: the `iterdir` returns 0 and each
+    per-file `unlink` logs at ERROR and continues, deliberately, because a surviving tail is a
+    stranded part and not a reason to fail an upload whose bytes are already durable.
+
+    So `_write_meta_file` is the only thing in that block that can trigger the un-publish. This
+    asserts the property the other test depends on: an untrimmable tail leaves the part PUBLISHED
+    and merely logs, rather than unwinding it.
+    """
     object_id = str(uuid.uuid4())
     part_dir = await _seed_part(store, object_id, indices=[0, 1, 2], with_meta=True)
     await _stage(store, object_id, 1)
 
-    from hippius_s3.cache import fs_store as fs_store_mod
+    real_unlink = Path.unlink
 
-    def _boom(*_a, **_kw):
-        raise OSError(5, "I/O error")
+    def _refuse_tail(self, *args, **kwargs):
+        if self.name.startswith("chunk_") and self.name.endswith(".bin"):
+            raise OSError(13, "Permission denied")
+        return real_unlink(self, *args, **kwargs)
 
-    monkeypatch.setattr(fs_store_mod, "_trim_chunk_tail", _boom)
+    with caplog.at_level(logging.ERROR):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(Path, "unlink", _refuse_tail)
+            await _publish(store, object_id, 1)
 
-    with pytest.raises(OSError):
-        await _publish(store, object_id, 1)
-
-    assert not (part_dir / "meta.json").exists()
+    meta = json.loads((part_dir / "meta.json").read_text())
+    assert int(meta["num_chunks"]) == 1, "the publish must still have completed"
+    assert any("trim failed" in r.message for r in caplog.records), "and must have said so loudly"

--- a/tests/unit/cache/test_fs_store_trim_and_unpublish.py
+++ b/tests/unit/cache/test_fs_store_trim_and_unpublish.py
@@ -161,3 +161,57 @@ async def test_delete_meta_idempotent_on_missing(store):
     await store.delete_meta(object_id, 1, 1)  # no dir at all — must not raise
     await _seed_part(store, object_id, indices=[0], with_meta=False)
     await store.delete_meta(object_id, 1, 1)  # dir without meta — must not raise
+
+
+@pytest.mark.asyncio
+async def test_a_failed_meta_write_unpublishes_rather_than_leaving_a_holed_part(store, monkeypatch):
+    """The un-publish window ends when the NEW meta lands, not at the last rename.
+
+    meta.json is the readiness gate. If the meta write fails after the renames — ENOSPC is the
+    way in, and a disk retention deliberately runs at 15-20% free is where it happens — the
+    PREVIOUS attempt's meta.json is left standing over a chunk set that is now this attempt's and
+    a different length. The part still reads as published, with a wrong declared size and holes,
+    and the drain's completeness gate then strands it as IncompleteSource: never replicated,
+    never evicted. Un-publishing instead makes it invisible, which is recoverable.
+    """
+    object_id = str(uuid.uuid4())
+    part_dir = await _seed_part(store, object_id, indices=[0, 1, 2], with_meta=True)
+    before = json.loads((part_dir / "meta.json").read_text())
+    assert int(before["num_chunks"]) == 3
+
+    await _stage(store, object_id, 1)
+
+    from hippius_s3.cache import fs_store as fs_store_mod
+
+    def _enospc(*_a, **_kw):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(fs_store_mod, "_write_meta_file", _enospc)
+
+    with pytest.raises(OSError):
+        await _publish(store, object_id, 1)
+
+    assert not (part_dir / "meta.json").exists(), (
+        "the previous attempt's meta survived over the new chunk set: the part reads as published "
+        "with a wrong num_chunks and holes"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_failed_trim_also_unpublishes(store, monkeypatch):
+    """Same window, one step earlier — the trim runs between the renames and the meta write."""
+    object_id = str(uuid.uuid4())
+    part_dir = await _seed_part(store, object_id, indices=[0, 1, 2], with_meta=True)
+    await _stage(store, object_id, 1)
+
+    from hippius_s3.cache import fs_store as fs_store_mod
+
+    def _boom(*_a, **_kw):
+        raise OSError(5, "I/O error")
+
+    monkeypatch.setattr(fs_store_mod, "_trim_chunk_tail", _boom)
+
+    with pytest.raises(OSError):
+        await _publish(store, object_id, 1)
+
+    assert not (part_dir / "meta.json").exists()

--- a/tests/unit/test_metric_wrappers_hit_real_collector.py
+++ b/tests/unit/test_metric_wrappers_hit_real_collector.py
@@ -36,6 +36,7 @@ from hippius_s3.cache import dual_fs_store
 from hippius_s3.cache import peers
 from hippius_s3.cache import read_recency
 from hippius_s3.cache import residency
+from hippius_s3.writer import landed
 from hippius_s3.monitoring import MetricsCollector
 from hippius_s3.reader import streamer
 
@@ -105,6 +106,13 @@ WRAPPERS: list[tuple[str, Callable[..., None], tuple[Any, ...], str, dict[str, s
         (),
         "residency_release_failures_total",
         {},
+    ),
+    (
+        "hippius_s3/writer/landed.py::_record_announce_failure",
+        landed._record_announce_failure,
+        ("timeout",),
+        "landed_announce_failures_total",
+        {"outcome": "timeout"},
     ),
     (
         "hippius_s3/cache/peers.py::_record_shed",

--- a/tests/unit/writer/test_landed_announcements.py
+++ b/tests/unit/writer/test_landed_announcements.py
@@ -26,6 +26,26 @@ from hippius_s3.writer.write_through_writer import WriteThroughPartsWriter
 OBJ = "466916c0-d61b-4518-b81b-9576b574270a"
 
 
+class _HangingPipe:
+    def lpush(self, *_a: object) -> None:
+        return None
+
+    def ltrim(self, *_a: object) -> None:
+        return None
+
+    async def execute(self) -> None:
+        import asyncio as _asyncio
+
+        await _asyncio.sleep(300)
+
+
+class _HangingRedis:
+    """A queues client that accepts the pipeline and then never answers."""
+
+    def pipeline(self) -> _HangingPipe:
+        return _HangingPipe()
+
+
 class FakePipeline:
     def __init__(self, sink: list[tuple], fail: bool) -> None:
         self._sink = sink
@@ -412,7 +432,7 @@ async def test_a_failed_publish_stamps_no_recency() -> None:
 
 @pytest.mark.asyncio
 async def test_a_hanging_redis_does_not_hang_the_put() -> None:
-    """The swallow below catches a redis-queues that ERRORS. It does nothing for a slow one.
+    """The swallow catches a redis-queues that ERRORS. It does nothing for a slow one.
 
     This await is on the client PUT path and the api's queues client is built with no
     socket_timeout, so without a bound a slow redis-queues stalls every PUT — the shape of a real
@@ -420,46 +440,54 @@ async def test_a_hanging_redis_does_not_hang_the_put() -> None:
     """
     import asyncio as _asyncio
 
-    class HangingPipe:
-        def lpush(self, *_a: object) -> None:
-            return None
-
-        def ltrim(self, *_a: object) -> None:
-            return None
-
-        async def execute(self) -> None:
-            await _asyncio.sleep(30)
-
-    class HangingRedis:
-        def pipeline(self) -> HangingPipe:
-            return HangingPipe()
-
-    publisher = landed.LandedPartPublisher(HangingRedis(), "node-a")
+    publisher = landed.LandedPartPublisher(_HangingRedis(), "node-a")
 
     started = _asyncio.get_running_loop().time()
-    await _asyncio.wait_for(publisher.publish(OBJ, 1, 1), timeout=5)
+    await _asyncio.wait_for(publisher.publish(OBJ, 1, 1), timeout=landed._PUBLISH_TIMEOUT_SECONDS + 5)
     elapsed = _asyncio.get_running_loop().time() - started
 
-    assert elapsed < 3, f"publish waited {elapsed:.1f}s on a hanging redis; it must give up quickly"
+    assert elapsed < landed._PUBLISH_TIMEOUT_SECONDS + 2, (
+        f"publish waited {elapsed:.1f}s on a hanging redis; it must give up at its own bound"
+    )
 
 
 @pytest.mark.asyncio
-async def test_a_timed_out_announcement_still_never_reaches_the_caller() -> None:
-    """Timing out is the same contract as erroring: the bytes are durable, the walk still finds it."""
+async def test_a_timed_out_announcement_never_reaches_the_caller_and_is_bounded() -> None:
+    """Timing out is the same contract as erroring — but it must also actually STOP.
+
+    The elapsed assertion is the point: without it this test passes against an unbounded await,
+    just slowly, so it would pin nothing.
+    """
     import asyncio as _asyncio
 
-    class HangingPipe:
-        def lpush(self, *_a: object) -> None:
-            return None
+    started = _asyncio.get_running_loop().time()
+    await landed.LandedPartPublisher(_HangingRedis(), "node-a").publish(OBJ, 1, 1)
+    elapsed = _asyncio.get_running_loop().time() - started
 
-        def ltrim(self, *_a: object) -> None:
-            return None
+    assert elapsed < landed._PUBLISH_TIMEOUT_SECONDS + 2
 
-        async def execute(self) -> None:
-            await _asyncio.sleep(30)
 
-    class HangingRedis:
-        def pipeline(self) -> HangingPipe:
-            return HangingPipe()
+@pytest.mark.asyncio
+async def test_a_dropped_announcement_is_counted_not_just_logged(monkeypatch) -> None:
+    """A drop has to be alertable.
 
-    await landed.LandedPartPublisher(HangingRedis(), "node-a").publish(OBJ, 1, 1)
+    The announcement is the only trigger for the B-2 divergence check — the reconciler tallies an
+    already-`replicated` part as an orphan and does not content-check it — so losing one for a
+    RE-uploaded part leaves the pool serving the previous attempt's bytes under the new ETag.
+    The agent's `drain_landed_dropped_total` counts only messages it could not PARSE, so it
+    cannot see one that never arrived. If this is only a log line, nothing can page on it.
+    """
+    recorded: list[str] = []
+    monkeypatch.setattr(landed, "_record_announce_failure", lambda outcome: recorded.append(outcome))
+
+    await landed.LandedPartPublisher(_HangingRedis(), "node-a").publish(OBJ, 1, 1)
+    assert recorded == ["timeout"]
+
+    recorded.clear()
+
+    class _BrokenRedis:
+        def pipeline(self) -> object:
+            raise ConnectionError("redis-queues is down")
+
+    await landed.LandedPartPublisher(_BrokenRedis(), "node-a").publish(OBJ, 1, 1)
+    assert recorded == ["error"], "an outright failure must be distinguishable from a timeout"

--- a/tests/unit/writer/test_landed_announcements.py
+++ b/tests/unit/writer/test_landed_announcements.py
@@ -408,3 +408,58 @@ async def test_a_failed_publish_stamps_no_recency() -> None:
         )
 
     assert stamped == []
+
+
+@pytest.mark.asyncio
+async def test_a_hanging_redis_does_not_hang_the_put() -> None:
+    """The swallow below catches a redis-queues that ERRORS. It does nothing for a slow one.
+
+    This await is on the client PUT path and the api's queues client is built with no
+    socket_timeout, so without a bound a slow redis-queues stalls every PUT — the shape of a real
+    prod incident, where a 1.29M-entry list on this same instance surfaced as GET IncompleteRead.
+    """
+    import asyncio as _asyncio
+
+    class HangingPipe:
+        def lpush(self, *_a: object) -> None:
+            return None
+
+        def ltrim(self, *_a: object) -> None:
+            return None
+
+        async def execute(self) -> None:
+            await _asyncio.sleep(30)
+
+    class HangingRedis:
+        def pipeline(self) -> HangingPipe:
+            return HangingPipe()
+
+    publisher = landed.LandedPartPublisher(HangingRedis(), "node-a")
+
+    started = _asyncio.get_running_loop().time()
+    await _asyncio.wait_for(publisher.publish(OBJ, 1, 1), timeout=5)
+    elapsed = _asyncio.get_running_loop().time() - started
+
+    assert elapsed < 3, f"publish waited {elapsed:.1f}s on a hanging redis; it must give up quickly"
+
+
+@pytest.mark.asyncio
+async def test_a_timed_out_announcement_still_never_reaches_the_caller() -> None:
+    """Timing out is the same contract as erroring: the bytes are durable, the walk still finds it."""
+    import asyncio as _asyncio
+
+    class HangingPipe:
+        def lpush(self, *_a: object) -> None:
+            return None
+
+        def ltrim(self, *_a: object) -> None:
+            return None
+
+        async def execute(self) -> None:
+            await _asyncio.sleep(30)
+
+    class HangingRedis:
+        def pipeline(self) -> HangingPipe:
+            return HangingPipe()
+
+    await landed.LandedPartPublisher(HangingRedis(), "node-a").publish(OBJ, 1, 1)


### PR DESCRIPTION
Four defects found by reviewing the assembled `staging → main` diff (#413) line by line. **None appears in any of the fifteen constituent PR descriptions** — each was individually reviewed and merged; these only became visible in the whole.

## 1. `reclaim_failed` aborted the whole pass on one unlink failure

`ssd_reclaim.rs` propagated the unlink error with `?`, returning **before** `mark_failed_reclaimed` — which is the only thing that advances this cursor. The worklist is `ORDER BY updated_at WHERE reclaimed_at IS NULL` with no offset, so one part refusing to be unlinked (`EIO`, `EACCES`, `EROFS`, or `ENOTEMPTY` from the api publishing into a directory being removed) pinned the head of every later page **forever**.

Worse than the evictor's version of this bug: parts unlinked *earlier in the same page* were left unmarked and re-unlinked every poll — the exact "productive metrics over a cursor that never moves" that migration 0018 exists to end. And since #407's residency guard, an unreclaimed row is also un-GC-able.

This is the same bug already fixed in `evict_to_target` **in this release**, whose rationale is written out at `ssd_evict.rs:296-306`. The sibling worker was missed. Same shape applied — count, skip, continue, and rank the errno by what needs a human so a transient `DirectoryNotEmpty` can't mask an `EROFS`.

Five tests. **All five fail against the old `?`.** The existing fake remover could only return `Ok`, which is why nothing caught it.

## 2. Prod still walked the full shard every 5 minutes

`CEPHOR_RECLAIM_POLL_SECS` stayed at **300** in `k8s/production` while staging moved to **3600** — citing *prod's own* 2.28M-part measurement as the justification. `reclaim_ssd` and `reconcile` share one tree walk, so prod would run it 12×/hour on top of reconcile's 6×, on the NVMe serving ingest, immediately after this release demoted that same walk 40× for being too expensive.

Nothing is delayed: every disposition this worker owns is grace-gated at ≥1h, so a 300s poll could only ask the same question twelve times.

## 3. The drain-agent's schema gate guarded nothing

`wait-for-cephor-schema` checked `to_regclass('cephor_replication_status')` — a table that has existed since migration **0005**, so it passed instantly. Against a pre-migration schema the new binary cannot commit or record *any* part (`record_landed_part` is the only record path, so the landed queue **and** the reconciler backstop fail together) while the api keeps accepting PUTs onto the same SSD.

Now gates on the columns this binary actually needs. Verified against a live Postgres across all four states:

| schema state | gate |
|---|---|
| nothing applied | `f` |
| fully migrated | `t` |
| 0019 applied, 0016 missing | `f` |
| 0016 back, 0019 half-applied | `f` |

## 4. `publish_part` could leave a stale-meta, holed part

The un-publish `try` wrapped only the rename loop — but `meta.json` is the readiness gate, so the window doesn't end at the last rename, it ends when the **new** meta lands. An `OSError` from the trim or the meta write left the *previous* attempt's `meta.json` standing over a chunk set that is now this attempt's and a different length: still published, wrong declared size, holes, and stranded by the drain's completeness gate as `IncompleteSource`.

ENOSPC is the way in — and a disk that retention deliberately runs at 15–20% free is where it happens. Two tests, both red against the old scope.

## Also: the landed announcement's LPUSH is now bounded

It's awaited on the **client PUT path**, and the api's queues client is built with no `socket_timeout` — so the existing `except` caught a redis-queues that *errors* and did nothing for one that merely went *slow*. That's the shape of the recorded incident where a 1.29M-entry list on this same instance surfaced as prod GET `IncompleteRead`. `promote_floor` already bounds its own queues read and says why; the write path is the one that needed it more. 1s, after which the part is already durable and the reconcile walk still finds it.

## Deliberately NOT changed: migration 0018

Its `ACCESS EXCLUSIVE` really is held through the index build on 11.4M rows — sqlx wraps the file in one transaction, so the `ALTER TABLE` lock survives to COMMIT, blocking readers including `CompleteMultipartUpload` on a client path.

**But editing the file would have been worse than the bug.** sqlx checksums the entire migration with SHA-384 — comments included — and `Migrator::DEFAULT` validates applied migrations. Changing so much as a comment gives `MigrateError::VersionMismatch(18)` and CrashLoops the allocator on **every environment that already ran it, staging included**. I started to make that change and caught it before pushing.

The prod treatment is operational instead: apply the column and a `CREATE INDEX CONCURRENTLY` by hand first so the migration runs as a pure no-op, and **check `indisvalid`**, because CONCURRENTLY can leave an INVALID index that the file's own `IF NOT EXISTS` then silently declines to rebuild. Written up with the full deploy order in `docs/runbooks/2026-08-10-release-prod-migration-presteps.md`.

## Verification

2845 unit tests · `cargo clippy --all-targets --all-features -D warnings` clean · `cargo fmt` · ruff · ty · both `kubectl kustomize` builds.

**Every fix mutation-checked** — reverted, observed the specific tests go red, restored.

## Not in scope

Two **pre-existing production vulnerabilities** the review surfaced (already live on `main`, so not release blockers, but they need their own fix urgently): `%3F` query smuggling that bypasses the ACL CreateBucket check entirely, and `GET /public/{bucket}/{key}` serving any private object unauthenticated. Both verified live. Details in #413.