### PR TITLE
k8s(staging): mirror the prod AIMD retune so the soak exercises it

### DIFF
--- a/k8s/staging/drain-allocator-deployment.yaml
+++ b/k8s/staging/drain-allocator-deployment.yaml
@@ -84,10 +84,39 @@ spec:
             # above the stability threshold and the p99 target above the real per-part copy
             # time lets the AIMD ramp back up (validated live: budget 0.5 -> 100 MB/s, drain
             # resumed). See drainer-optimisations.md.
+            # Mirrors the prod retune (#399) so the soak actually exercises it. Prod-only tuning
+            # meant these four values would have reached production having never run anywhere —
+            # and #399 exists because the fleet fell into a self-sustaining low-throughput state
+            # in prod, which is not a thing you want to first observe there.
+            #
+            # SCALED BY NODE COUNT, NOT COPIED. The threshold #399 is written against is
+            # per-STREAM: its comment reasons "250 MB/s -> 50 MB/s/node -> 3.1 MB/s/stream", i.e.
+            # prod's 5 ingest nodes at CEPHOR_DRAIN_CONCURRENCY=16. Staging has 2 ingest nodes at
+            # the same concurrency, so copying 250 verbatim would give 125 MB/s/node and
+            # 7.8 MB/s/stream — a different operating point, and one that pushes staging's smaller
+            # pool 2.5x harder than prod pushes its own. Halving the fleet floor to 100 restores
+            # 50 MB/s/node and 3.1 MB/s/stream exactly, which is the number the collapse argument
+            # is about. Same for the additive step: 20 MB/s over 2 nodes is prod's 10 MB/s/node.
+            #
+            # If staging gains or loses an ingest node, rescale these. The invariant to hold is
+            # MB/s per stream, not the fleet total.
             - name: CEPHOR_ALLOC_MIN_TOTAL_BPS
-              value: "50000000"    # 50 MB/s floor (was 1 MB/s) — above the collapse threshold
+              value: "100000000"   # 100 MB/s floor = 50 MB/s/node = 3.1 MB/s/stream, as prod
             - name: CEPHOR_ALLOC_TARGET_P99_MS
               value: "8000"        # 8s (was 2s) — headroom over per-part copy under load
+            # Start at the top rather than the floor, so a restart does not re-enter the latched
+            # low state it is being restarted to clear. 2x the floor, the same ratio as prod.
+            # Bounded by CEPHOR_ALLOC_MAX_TOTAL_BPS (unset -> 1 GB/s default): the allocator
+            # rejects an initial above the max at startup, so this must stay under it.
+            - name: CEPHOR_ALLOC_INITIAL_TOTAL_BPS
+              value: "200000000"   # 200 MB/s
+            # Dimensionless, so copied verbatim: a gentler multiplicative decrease (x0.95 per
+            # backing-off tick instead of the x0.8 default) keeps one latency spike from
+            # collapsing the budget several ticks deep.
+            - name: CEPHOR_ALLOC_DECREASE_PERMILLE
+              value: "950"
+            - name: CEPHOR_ALLOC_ADDITIVE_INCREASE_BPS
+              value: "20000000"    # 20 MB/s/tick fleet-wide = 10 MB/s/node, as prod
             # Live ceph-mgr ceiling probe — ENABLED. The allocator reads the real Ceph
             # pool capacity ceiling from the rook-ceph mgr Prometheus endpoint instead of
             # its static fallback ceiling. Cross-namespace reach to rook-ceph confirmed.


### PR DESCRIPTION
#399 tuned the allocator in `k8s/production` **only**, so those four values would reach production having never run anywhere. Staging carries the same binary but the old values, which means today's soak would validate the read tier and skip the control loop entirely.

That matters because #399 exists in response to a real incident: on 2026-08-06 the drain fleet fell into a self-sustaining low-throughput state in prod — replication lag p99 **3.0s → 390s**, throughput **11,082 → 1,399 parts/10min**, `pending` 65 → 7,666 in ~70 minutes. Not a behaviour to first observe in production.

## Scaled by node count, not copied

The threshold #399 argues against is **per-stream**. Its own comment reasons *"250 MB/s → 50 MB/s/node → 3.1 MB/s/stream"* — that is prod's 5 ingest nodes at `CEPHOR_DRAIN_CONCURRENCY=16`. Verified live: prod runs 5 drain-agent nodes, staging runs 2, both at concurrency 16.

| | fleet floor | per node | per stream |
|---|---|---|---|
| prod (#399) | 250 MB/s | 50.0 MB/s | **3.12 MB/s** |
| staging, copied verbatim | 250 MB/s | 125 MB/s | 7.81 MB/s |
| **staging, scaled (this PR)** | 100 MB/s | 50.0 MB/s | **3.12 MB/s** |

A verbatim copy would put staging at a different operating point *and* push its smaller pool 2.5× harder than prod pushes its own — a rehearsal of something other than the thing being rehearsed. Halving the fleet floor restores the exact per-stream rate the collapse argument is written about. Same reasoning for the additive step: 20 MB/s over 2 nodes is prod's 10 MB/s/node.

`DECREASE_PERMILLE` is dimensionless (×0.95 per backing-off tick) and is copied verbatim. `INITIAL_TOTAL` keeps prod's 2×-the-floor ratio, which is what makes a restart start high rather than re-entering the latched low state it is being restarted to clear.

**If staging gains or loses an ingest node, rescale these.** The invariant to hold is MB/s per stream, not the fleet total — that's recorded in the manifest comment.

## Checked rather than assumed

- `min <= max` and `0 < initial <= max` against the 1 GB/s `CEPHOR_ALLOC_MAX_TOTAL_BPS` default. #410 now **rejects an initial above max at startup**, so a wrong value here would crash-loop the allocator rather than degrade.
- `min_total > nearfull_rate` is fine: `allocate()` applies the ceiling *after* the floor, so a NearFull pool still clamps the fleet to 50 MB/s regardless of how high the floor is.
- #410's `the_blind_probe_floor_is_never_looser_than_the_nearfull_rate` is already on staging, so raising the floor does not loosen the blind-probe fail-safe. That was the #410-before-#399 deploy-order constraint, and it is satisfied here.

40 allocator tests pass with these values in the environment; `kubectl kustomize k8s/staging` renders clean.

## What to watch during the soak

`drain_fleet_estimate_bps` should start at 200 MB/s after an allocator restart rather than at the floor — that is the restart-into-latch fix. Then the AIMD should ramp toward the ceiling on healthy ticks and back off by ×0.95 rather than ×0.8 on a latency spike. The floor holding at 100 MB/s under sustained saturation is the absorbing state #399 is about; if p99 sits above the 8s target on every tick with the estimate pinned at the floor, that is the collapse recurring and the floor is still too low.