### PR TITLE
test(staging): TEMPORARY — arm the SSD evictor so its code path executes once

### DIFF
--- a/k8s/staging/drain-allocator-deployment.yaml
+++ b/k8s/staging/drain-allocator-deployment.yaml
@@ -100,6 +100,37 @@ spec:
             #
             # If staging gains or loses an ingest node, rescale these. The invariant to hold is
             # MB/s per stream, not the fleet total.
+            # TEMPORARY — TEST INSTRUMENT, REVERT AFTER OBSERVING. See the revert PR.
+            #
+            # Arms the SSD evictor at the CURRENT occupancy so its code path executes at all.
+            # It never has: drain_ssd_evicted_total is 0 on both nodes since deploy, which means
+            # drain_ssd_evict_blocked_unreplicated_total = 0 is an UNMEASURED counter on dead
+            # code, not a passing durability invariant. This makes it a measured one.
+            #
+            # WHY THIS KNOB AND NOT THE DAEMONSET. CEPHOR_EVICT_RESERVE_PERMILLE on drain-agent is
+            # only a FALLBACK: resolved_reserve_permille() prefers the allocator's published
+            # value, and cephor:alloc:{node} currently carries "reserve":"150". Editing the
+            # DaemonSet is a no-op. reserve_permille() interpolates base -> max on severity, and
+            # severity is 0 today (no shortfall, ceph healthy), so the base is published verbatim.
+            #
+            # 220, not 300. Both nodes sit at 208.6 and 210.6 permille free, so 220 arms both;
+            # 300 changes nothing about the outcome and pushes the promote floor further past
+            # reality. This is the smallest value that does the job.
+            #
+            # EXPECT `starved`, AND THAT IS THE CORRECT RESULT. A pass frees back to
+            # reserve + headroom, and headroom alone is 50 permille of a 941.7 GB disk = 47.1 GB,
+            # against the ~1.2 GB/node the drain actually owns (the rest of the disk is
+            # co-tenants — drain_ssd_shared_filesystem = 1 on both nodes). No reserve value makes
+            # deficit-met reachable; that needs the fill test, not a threshold.
+            #
+            # ACCEPTED SIDE EFFECTS, for the minutes this is live:
+            #   - the local read tier is fully evicted (~2.4 GB). Recoverable: those parts are
+            #     `replicated`, so reads fall to the pool and promotion repopulates them.
+            #   - the `starved` ERROR and its alert fire. This is us, not an incident.
+            #   - read-through promotion stops cluster-wide, because the published
+            #     promote_floor = reserve + headroom/2 = 245 permille lands above actual free space.
+            - name: CEPHOR_ALLOC_BASE_RESERVE_PERMILLE
+              value: "220"
             - name: CEPHOR_ALLOC_MIN_TOTAL_BPS
               value: "100000000"   # 100 MB/s floor = 50 MB/s/node = 3.1 MB/s/stream, as prod
             - name: CEPHOR_ALLOC_TARGET_P99_MS


### PR DESCRIPTION
**Temporary test instrument. Revert immediately after observing** — revert PR accompanies this one.

## Why

The evictor has **never run** on staging: `drain_ssd_evicted_total` is 0 on both nodes since deploy. That means `drain_ssd_evict_blocked_unreplicated_total = 0` is an **unmeasured counter on code that has not executed**, not a passing durability invariant.

That invariant — the evictor never removes a part that isn't yet replicated — is the most important claim in the retention work, and nothing has tested it. This makes it measurable.

## Why the allocator, not the DaemonSet

`CEPHOR_EVICT_RESERVE_PERMILLE` on drain-agent is only a **fallback**. `resolved_reserve_permille()` prefers the allocator's published value, and the live key confirms it:

```
cephor:alloc:k8s-v3-node2 = {"budget":"0","epoch":162,"reserve":"150"}
```

Editing the DaemonSet would have been a no-op. `reserve_permille()` interpolates base→max on severity, and severity is 0 today, so the base publishes verbatim.

## 220, not 300

Both nodes sit at **208.6‰** and **210.6‰** free, so 220 arms both. 300 gives an identical outcome and pushes the promote floor further past reality — strictly worse. This is the smallest value that does the job.

## Expect `starved` — that is the correct result

A pass frees back to `reserve + headroom`, and headroom alone is 50‰ × 941.7 GB = **47.1 GB**, against the **~1.2 GB per node** the drain actually owns. The rest of that disk is co-tenants (`drain_ssd_shared_filesystem = 1` on both nodes).

```
deficit-met needs:  reserve + headroom ≤ 209.8‰   (node2)
arming needs:       reserve            > 208.6‰   (node2)
=> reserve ∈ (208.6, 159.8]  —  empty
```

No reserve value makes deficit-met reachable; it needs a window of ~0.2‰, thinner than co-tenant free-space drift. **Proving deficit-met and hysteresis requires the ~112 GB fill test**, not a threshold change.

## What this does prove — all currently unproven

- the evictor arms at its configured threshold
- the replication gate holds against real candidates: `drain_ssd_evict_blocked_unreplicated_total` stays 0 **while the code runs**
- `mark_evicted` advances the cursor (residency rows drain)
- the `starved` exit fires and is distinguishable from `budget_exhausted`
- `remove_failed` behaves if any unlink fails

## Accepted side effects while live

- **The local read tier is fully evicted** (~2.4 GB). Recoverable — the parts are `replicated`, so reads fall to the pool and promotion repopulates them.
- **The `starved` ERROR and its alert fire.** This is us, not an incident — tell whoever is on call.
- **Read-through promotion stops cluster-wide**, because `promote_floor = reserve + headroom/2 = 245‰` lands above actual free space.

## After merge

Watch `drain_ssd_evicted_bytes_total` climbing, `drain_ssd_evict_blocked_unreplicated_total` staying 0, `cephor_ssd_residency` rows draining, and the pass exit in the drain-agent logs. One or two 30 s poll cycles is enough, then merge the revert.