### PR TITLE
Revert the temporary evictor arming threshold (#417)

### DIFF
--- a/k8s/staging/drain-allocator-deployment.yaml
+++ b/k8s/staging/drain-allocator-deployment.yaml
@@ -100,37 +100,6 @@ spec:
             #
             # If staging gains or loses an ingest node, rescale these. The invariant to hold is
             # MB/s per stream, not the fleet total.
-            # TEMPORARY — TEST INSTRUMENT, REVERT AFTER OBSERVING. See the revert PR.
-            #
-            # Arms the SSD evictor at the CURRENT occupancy so its code path executes at all.
-            # It never has: drain_ssd_evicted_total is 0 on both nodes since deploy, which means
-            # drain_ssd_evict_blocked_unreplicated_total = 0 is an UNMEASURED counter on dead
-            # code, not a passing durability invariant. This makes it a measured one.
-            #
-            # WHY THIS KNOB AND NOT THE DAEMONSET. CEPHOR_EVICT_RESERVE_PERMILLE on drain-agent is
-            # only a FALLBACK: resolved_reserve_permille() prefers the allocator's published
-            # value, and cephor:alloc:{node} currently carries "reserve":"150". Editing the
-            # DaemonSet is a no-op. reserve_permille() interpolates base -> max on severity, and
-            # severity is 0 today (no shortfall, ceph healthy), so the base is published verbatim.
-            #
-            # 220, not 300. Both nodes sit at 208.6 and 210.6 permille free, so 220 arms both;
-            # 300 changes nothing about the outcome and pushes the promote floor further past
-            # reality. This is the smallest value that does the job.
-            #
-            # EXPECT `starved`, AND THAT IS THE CORRECT RESULT. A pass frees back to
-            # reserve + headroom, and headroom alone is 50 permille of a 941.7 GB disk = 47.1 GB,
-            # against the ~1.2 GB/node the drain actually owns (the rest of the disk is
-            # co-tenants — drain_ssd_shared_filesystem = 1 on both nodes). No reserve value makes
-            # deficit-met reachable; that needs the fill test, not a threshold.
-            #
-            # ACCEPTED SIDE EFFECTS, for the minutes this is live:
-            #   - the local read tier is fully evicted (~2.4 GB). Recoverable: those parts are
-            #     `replicated`, so reads fall to the pool and promotion repopulates them.
-            #   - the `starved` ERROR and its alert fire. This is us, not an incident.
-            #   - read-through promotion stops cluster-wide, because the published
-            #     promote_floor = reserve + headroom/2 = 245 permille lands above actual free space.
-            - name: CEPHOR_ALLOC_BASE_RESERVE_PERMILLE
-              value: "220"
             - name: CEPHOR_ALLOC_MIN_TOTAL_BPS
               value: "100000000"   # 100 MB/s floor = 50 MB/s/node = 3.1 MB/s/stream, as prod
             - name: CEPHOR_ALLOC_TARGET_P99_MS


### PR DESCRIPTION
Pure revert of #417 — byte-identical to the pre-#417 manifest, 31 deletions, nothing else touched.

## #417 got what it was raised for

The evictor executed for the first time since the retention work deployed:

| metric | node2 | node3 |
|---|---|---|
| `drain_ssd_evicted_total` | 389 | 397 parts |
| `drain_ssd_evicted_bytes_total` | 2.37 G | 2.40 G |
| **`drain_ssd_evict_blocked_unreplicated_total`** | **0** | **0** |
| `drain_ssd_cache_bytes` | 0 | 0 |

**786 parts / 4.77 GB evicted with `blocked_unreplicated` staying 0 while the code actually ran.** That counter was previously 0 on a path that had never executed — an unmeasured value, not a passing invariant. It is now measured, and it is the most important claim in the retention work.

Also newly exercised: the evictor **arms** at its configured threshold; `mark_evicted` **advances the cursor** (`cephor_ssd_residency` drained to empty); the **`starved` exit** fires and is distinguishable from `budget_exhausted`. `remove_failed=0` with `remove_failed_kind=None` on every pass, so the skip-and-continue path from #414 saw no refusals.

Steady state once the tier emptied, exactly as predicted:

```
ERROR eviction ran out of resident parts before restoring the free-space floor
      free_bytes=193247092736 deficit=61018348625 evicted=0 remove_failed=0
```

## Why revert BEFORE the fill test, not after

The two are mutually exclusive, which I only worked out after #417 was merged.

```
flood   0G -> free 196.5G  evictable   1.3G  deficit  57.8G   starved
flood  50G -> free 146.5G  evictable  51.3G  deficit 107.8G   starved
flood 200G -> free  -3.5G  evictable 201.3G  deficit 257.8G   starved
```

At reserve=220 the target is fixed at 270‰ while free starts at 209‰, and **every flooded GB raises the deficit by exactly what it adds to evictable** — so the ~57 GB gap is constant and `deficit met` is unreachable at any flood size. Only the original 150 threshold makes it reachable, at ~57 GB/node: free drops below 15%, evictable becomes ~58 G against a ~47 G deficit, and the pass exits **deficit met**.

Flooding while #417 is live would waste the upload *and* hold the read tier empty with promotion paused throughout.

## What reverting restores

The read tier repopulates via promotion on read; the promote floor returns to 175‰ so read-through warming resumes; and the `starved` ERROR stops firing on both nodes.

## Still unproven after this

`deficit met` and hysteresis (stopping at target rather than overshooting), plus eviction keeping up under sustained ingest. Those need the fill, which is next.