### PR TITLE
fix(cache): gate the local read tier on this node's residency

### DIFF
--- a/hippius_s3/cache/__init__.py
+++ b/hippius_s3/cache/__init__.py
@@ -9,6 +9,7 @@ from .dual_fs_store import PromotionRecorder
 from .dual_fs_store import PromotionReleaser
 from .dual_fs_store import ReplicationSuspectFn
 from .fs_store import FileSystemPartsStore
+from .local_residency import LocalResidencyGate
 from .notifier import ChunkNotifier
 from .object_parts import RedisObjectPartsCache
 
@@ -22,6 +23,7 @@ def create_fs_store(
     on_local_read: LocalReadRecorder | None = None,
     published_floor: PublishedFloorSource | None = None,
     replication_suspect: ReplicationSuspectFn | None = None,
+    local_residency: LocalResidencyGate | None = None,
 ) -> FileSystemPartsStore:
     """Build the parts store: dual-tier when a fallback pool is configured, else single.
 
@@ -71,6 +73,7 @@ def create_fs_store(
             space_gate=space_gate,
             on_local_read=on_local_read,
             replication_suspect=replication_suspect,
+            local_residency=local_residency,
         )
     return FileSystemPartsStore(cache_dir)
 

--- a/hippius_s3/cache/dual_fs_store.py
+++ b/hippius_s3/cache/dual_fs_store.py
@@ -8,6 +8,7 @@ from typing import Callable
 from typing import Optional
 
 from hippius_s3.cache.fs_store import FileSystemPartsStore
+from hippius_s3.cache.local_residency import LocalResidencyGate
 from hippius_s3.fs_pressure import FreeSpaceGate
 from hippius_s3.monitoring import ChunkReadTier
 from hippius_s3.monitoring import PromotionSkipReason
@@ -95,6 +96,7 @@ class DualFileSystemPartsStore(FileSystemPartsStore):
         space_gate: Optional[FreeSpaceGate] = None,
         on_local_read: Optional[LocalReadRecorder] = None,
         replication_suspect: Optional[ReplicationSuspectFn] = None,
+        local_residency: Optional[LocalResidencyGate] = None,
     ) -> None:
         super().__init__(primary_dir)
         self.fallback = FileSystemPartsStore(fallback_dir)
@@ -106,6 +108,9 @@ class DualFileSystemPartsStore(FileSystemPartsStore):
         # it. `None` (workers, tests, deployments without a drain) keeps the pool-presence gate
         # as the only condition, which is exactly the pre-probe behaviour.
         self._replication_suspect = replication_suspect
+        # Decides whether this node's own flash is an authoritative source for a part, or a
+        # copy it has no record of holding. `None` leaves the pre-gate behaviour (serve it).
+        self._local_residency = local_residency
         # Promotion yields to ingest: this is the only writer here that is pure optimisation,
         # and it shares the mount with the PUTs that `fs_cache_pressure` refuses when the disk
         # runs out. `None` means no gate (tests, and any deployment without a fallback tier).
@@ -120,10 +125,22 @@ class DualFileSystemPartsStore(FileSystemPartsStore):
         # could invalidate underneath us.
         self._promoting: set[tuple[str, int, int, int]] = set()
 
+    async def _may_serve_local(self, object_id: str, object_version: int, part_number: int) -> bool:
+        """Whether this node's own copy of the part is one it is recorded as holding."""
+        if self._local_residency is None:
+            return True
+        return await self._local_residency.may_serve_local(object_id, int(object_version), int(part_number))
+
     async def get_chunk(
         self, object_id: str, object_version: int, part_number: int, chunk_index: int
     ) -> Optional[bytes]:
         result = await super().get_chunk(object_id, object_version, part_number, chunk_index)
+        if result is not None and not await self._may_serve_local(object_id, object_version, part_number):
+            # On disk here, but this node is not recorded as holding a part the pool already has
+            # — so these bytes are an unowned copy, and the AAD cannot tell them from the real
+            # ones. Fall through to peer/pool, which ARE recorded. Costs latency, never bytes.
+            _record_tier("local_unowned")
+            result = None
         if result is not None:
             _record_tier("local")
             # Tell the evictor this part is still in use. Without it eviction orders on when a

--- a/hippius_s3/cache/local_residency.py
+++ b/hippius_s3/cache/local_residency.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import asyncpg
+
+from hippius_s3.cache.part_memo import PartMemo
+
+
+logger = logging.getLogger(__name__)
+
+# A part's ownership changes only when the drain commits it or the evictor drops it, so a short
+# memo is safe and keeps this off the hot path for all but the first read of a part per window.
+# Same shape and TTL as the peer resolver's memo, deliberately: both answer "where does this part
+# live", and two different staleness windows for one question would be a trap.
+_MEMO_TTL_SECONDS = 30.0
+_MEMO_MAX_ENTRIES = 100_000
+
+
+class LocalResidencyGate:
+    """Answers whether THIS node may serve a part from its own flash.
+
+    The node-local SSD is a CACHE of the pool, but `get_chunk` treated it as authoritative: it
+    read the file and returned it without ever asking whether this node is recorded as holding
+    that part. Nothing else notices, because the AAD binds (bucket, object, part, chunk) and NOT
+    the upload attempt, so another attempt's bytes decrypt and authenticate perfectly in place.
+
+    That gap is reachable. Two concurrent `UploadPart`s for the same part routed to different
+    api pods each publish their own attempt to their own node's flash — correctly and atomically,
+    per-node. Only one wins the `parts` row and gets residency and replication rows. The loser's
+    bytes remain on the other node with NO record anywhere, and that node serves them for as long
+    as the file exists. Promotion never corrects it: promotion fills a MISSING local copy and
+    never overwrites one that is already there. Observed live on staging at 4 of 8 attempts.
+
+    THE PREDICATE, and why it is not simply "is there a residency row".
+
+    A freshly ingested part has no residency row yet — the drain writes one when it commits — and
+    the pool does not have it either, because that is the same event. Gating on residency alone
+    would refuse to serve the only copy that exists and break read-after-write on every upload.
+    So the question is narrower:
+
+        serve locally  unless  the part is REPLICATED and this node is not recorded as holding it
+
+    Replicated means the pool has a durable, byte-verified copy, so falling through costs latency
+    and nothing else. Not-replicated means this node's copy may be the only one and must be
+    served. The orphan sits in the first case: replicated by its winning node, unrecorded here.
+
+    FAILURE DIRECTION, deliberately split.
+
+    A definitive "this node does not hold a replicated part" refuses the local read — that is the
+    whole point. But an ERROR (DB unreachable, pool exhausted, tables absent) serves locally, as
+    today. Failing closed on an outage would take every local read on the fleet to the pool at
+    once, converting a database blip into a latency and load incident on the tier the drain is
+    also writing to. An orphan is rare and bounded; that is not.
+    """
+
+    def __init__(self, pool: asyncpg.Pool, node_id: str) -> None:
+        self._pool = pool
+        self._node_id = node_id
+        self._memo: PartMemo[tuple[str, int, int], bool] = PartMemo(_MEMO_TTL_SECONDS, _MEMO_MAX_ENTRIES)
+        # Set once a query proves the drain's tables are absent, so a pre-drain deployment pays
+        # one failed query rather than one per read forever.
+        self._tables_absent = False
+
+    async def may_serve_local(self, object_id: str, object_version: int, part_number: int) -> bool:
+        if self._tables_absent:
+            return True
+
+        key = (str(object_id), int(object_version), int(part_number))
+        cached = self._memo.get(key)
+        if cached is not None:
+            return cached
+
+        allowed = await self._probe(key)
+        # Only a definitive answer is memoised. Caching an error would extend one blip into a
+        # 30s window of decisions taken on no information.
+        if allowed is not None:
+            self._memo.put(key, allowed)
+            return allowed
+        return True
+
+    async def _probe(self, key: tuple[str, int, int]) -> Optional[bool]:
+        object_id, object_version, part_number = key
+        try:
+            async with self._pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    """
+                    SELECT
+                        EXISTS (
+                            SELECT 1 FROM cephor_ssd_residency r
+                            WHERE r.node_id = $1 AND r.object_id = $2
+                              AND r.version = $3 AND r.part_number = $4
+                        ) AS resident,
+                        (
+                            SELECT c.status FROM cephor_replication_status c
+                            WHERE c.object_id = $2 AND c.version = $3 AND c.part_number = $4
+                        ) AS status
+                    """,
+                    self._node_id,
+                    object_id,
+                    int(object_version),
+                    int(part_number),
+                )
+        except asyncpg.UndefinedTableError:
+            # Pre-drain deployment: there is no ownership record to consult, and the local store
+            # is simply the cache it has always been.
+            self._tables_absent = True
+            logger.info("drain tables absent; local-tier residency gate disabled")
+            return None
+        except (asyncpg.PostgresError, asyncpg.InterfaceError, OSError) as exc:
+            logger.debug("local residency probe failed for %s: %s", key, exc)
+            return None
+
+        if row is None:
+            return True
+        # A missing status row means the drain has never seen this part — it cannot be replicated,
+        # so this node's copy is the only one there is.
+        if row["status"] != "replicated":
+            return True
+        return bool(row["resident"])
+
+
+def create_local_residency_gate(pool: Optional[asyncpg.Pool], node_id: str) -> Optional[LocalResidencyGate]:
+    """The gate, or `None` where there is nothing to gate against.
+
+    No pool (workers, scripts, tests) or no node identity means this process cannot know which
+    node it is, and a gate that cannot identify itself would refuse every local read.
+    """
+    if pool is None or not node_id:
+        return None
+    return LocalResidencyGate(pool, node_id)

--- a/hippius_s3/main.py
+++ b/hippius_s3/main.py
@@ -35,6 +35,7 @@ from hippius_s3.api.sub_token_scopes import router as sub_token_scopes_router
 from hippius_s3.api.user import router as user_router
 from hippius_s3.cache import RedisObjectPartsCache
 from hippius_s3.cache import create_fs_store
+from hippius_s3.cache.local_residency import create_local_residency_gate
 from hippius_s3.cache.peers import PEER_PORT
 from hippius_s3.cache.peers import PeerChunkFetcher
 from hippius_s3.cache.peers import PeerRegistry
@@ -235,6 +236,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             # AEAD-retry guard: a redrive marks a part's pool copy stale while `chunk_exists`
             # still passes, so the invalidation path re-checks the status freshly per failure.
             replication_suspect=create_replication_suspect_probe(app.state.postgres_pool),
+            # Refuses this node's own flash for a part the pool already has and this node
+            # is not recorded as holding — the unowned copy two racing UploadParts leave
+            # behind on the losing node, which nothing else can distinguish.
+            local_residency=create_local_residency_gate(app.state.postgres_pool, node_name),
         )
         app.state.obj_cache = RedisObjectPartsCache(
             app.state.redis_client,

--- a/hippius_s3/monitoring.py
+++ b/hippius_s3/monitoring.py
@@ -23,7 +23,11 @@ tracer = trace.get_tracer(__name__)
 
 # The storage tiers a chunk read can be served from, closed by construction so the `tier`
 # label cannot drift into unbounded cardinality.
-ChunkReadTier = Literal["local", "peer", "pool"]
+# `local_unowned` is a REFUSAL, not a tier that served bytes: the part was on this node's
+# flash but the node is not recorded as holding a part the pool already has, so the read
+# fell through to peer/pool instead. A sustained rate means concurrent same-part uploads
+# are leaving unowned copies behind — the read is correct, the write path is not.
+ChunkReadTier = Literal["local", "peer", "pool", "local_unowned"]
 
 # Why a peer fetch did not happen, or its answer was not used. Closed by construction, like
 # ChunkReadTier. The reasons demand different responses and must stay distinguishable:

--- a/tests/unit/cache/test_local_residency_gate.py
+++ b/tests/unit/cache/test_local_residency_gate.py
@@ -1,0 +1,184 @@
+"""The node-local tier is a CACHE, so it may only serve parts this node is recorded as holding.
+
+`get_chunk` used to read the local file and return it with no ownership check at all. Two
+concurrent `UploadPart`s for the same part, routed to different api pods, each publish their own
+attempt to their own node's flash — correctly and atomically per node. Only one wins the `parts`
+row and gets residency and replication rows; the loser's bytes stay on the other node with no
+record anywhere, and that node serves them for as long as the file exists. Promotion never
+corrects it, because promotion fills a MISSING local copy and never overwrites one already
+present. Reproduced live on staging at 4 of 8 attempts.
+
+Nothing downstream can catch it: the AAD binds (bucket, object, part, chunk) and NOT the attempt,
+so the unowned bytes decrypt and authenticate perfectly in place, and `meta.json` is byte-identical
+across the divergent copies.
+
+The predicate is deliberately NOT "is there a residency row". A freshly ingested part has no row
+yet — the drain writes one when it commits — and the pool does not have it either, because that is
+the same event. Gating on residency alone would refuse the only copy that exists and break
+read-after-write on every upload. Hence: refuse only when the part is REPLICATED and this node is
+not recorded as holding it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Optional
+
+import asyncpg
+import pytest
+
+from hippius_s3.cache.local_residency import LocalResidencyGate
+from hippius_s3.cache.local_residency import create_local_residency_gate
+
+
+OBJ = "466916c0-d61b-4518-b81b-9576b574270a"
+NODE = "k8s-v3-node2"
+
+
+class _Pool:
+    """Answers the ownership probe with a canned row, or raises a canned error."""
+
+    def __init__(self, row: Optional[dict[str, Any]] = None, raises: Optional[BaseException] = None) -> None:
+        self._row = row
+        self._raises = raises
+        self.calls = 0
+
+    def acquire(self) -> Any:
+        pool = self
+
+        class _Ctx:
+            async def __aenter__(self) -> Any:
+                return _Conn(pool)
+
+            async def __aexit__(self, *_: object) -> None:
+                return None
+
+        return _Ctx()
+
+
+class _Conn:
+    def __init__(self, pool: _Pool) -> None:
+        self._pool = pool
+
+    async def fetchrow(self, _sql: str, *_args: Any) -> Optional[dict[str, Any]]:
+        self._pool.calls += 1
+        if self._pool._raises is not None:
+            raise self._pool._raises
+        return self._pool._row
+
+
+@pytest.mark.asyncio
+async def test_an_unowned_copy_of_a_replicated_part_is_refused() -> None:
+    """The bug. Replicated elsewhere, no residency row here — these bytes are the race's loser."""
+    gate = LocalResidencyGate(_Pool({"resident": False, "status": "replicated"}), NODE)
+
+    assert await gate.may_serve_local(OBJ, 1, 1) is False
+
+
+@pytest.mark.asyncio
+async def test_a_part_this_node_holds_is_served() -> None:
+    """The ordinary case: ingested or promoted here, so there is a residency row."""
+    gate = LocalResidencyGate(_Pool({"resident": True, "status": "replicated"}), NODE)
+
+    assert await gate.may_serve_local(OBJ, 1, 1) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["pending", "draining", "failed", "corrupt"])
+async def test_a_not_yet_replicated_part_is_served_even_without_a_residency_row(status: str) -> None:
+    """READ-AFTER-WRITE. This is the case that would make the fix worse than the bug.
+
+    The drain writes the residency row when it COMMITS, so between the upload and that commit a
+    part has no row — and the pool does not have it either, because they are the same event.
+    Refusing here would fall through to a pool that cannot answer, turning every fresh upload
+    into a failed read.
+    """
+    gate = LocalResidencyGate(_Pool({"resident": False, "status": status}), NODE)
+
+    assert await gate.may_serve_local(OBJ, 1, 1) is True
+
+
+@pytest.mark.asyncio
+async def test_a_part_the_drain_has_never_seen_is_served() -> None:
+    """No status row at all: it cannot be replicated, so this copy is the only one there is."""
+    gate = LocalResidencyGate(_Pool({"resident": False, "status": None}), NODE)
+
+    assert await gate.may_serve_local(OBJ, 1, 1) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "err",
+    [
+        asyncpg.PostgresError("db down"),
+        asyncpg.InterfaceError("pool exhausted"),
+        OSError("connection refused"),
+    ],
+)
+async def test_a_probe_failure_serves_locally_rather_than_stampeding_the_pool(err: BaseException) -> None:
+    """Fails OPEN on an error, deliberately, and only on an error.
+
+    Failing closed on a DB outage would take every local read on the fleet to the pool at once,
+    converting a database blip into a latency and load incident on the tier the drain is also
+    writing to. An unowned copy is rare and bounded; that is not.
+    """
+    gate = LocalResidencyGate(_Pool(raises=err), NODE)
+
+    assert await gate.may_serve_local(OBJ, 1, 1) is True
+
+
+@pytest.mark.asyncio
+async def test_a_probe_failure_is_not_memoised() -> None:
+    """Caching an error would extend one blip into a 30s window of decisions taken on nothing."""
+    pool = _Pool(raises=asyncpg.PostgresError("blip"))
+    gate = LocalResidencyGate(pool, NODE)
+
+    await gate.may_serve_local(OBJ, 1, 1)
+    await gate.may_serve_local(OBJ, 1, 1)
+
+    assert pool.calls == 2, "an error must be retried, not cached"
+
+
+@pytest.mark.asyncio
+async def test_a_definitive_answer_is_memoised() -> None:
+    """Ownership changes only on a drain commit or an eviction, so a short memo is safe — and it
+    is what keeps this off the hot read path for all but the first read of a part per window."""
+    pool = _Pool({"resident": False, "status": "replicated"})
+    gate = LocalResidencyGate(pool, NODE)
+
+    for _ in range(5):
+        assert await gate.may_serve_local(OBJ, 1, 1) is False
+
+    assert pool.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_the_memo_is_per_part_not_per_object() -> None:
+    """Two parts of one object can legitimately have different owners — resolution is per PART."""
+    pool = _Pool({"resident": False, "status": "replicated"})
+    gate = LocalResidencyGate(pool, NODE)
+
+    await gate.may_serve_local(OBJ, 1, 1)
+    await gate.may_serve_local(OBJ, 1, 2)
+
+    assert pool.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_a_pre_drain_deployment_disables_the_gate_after_one_probe() -> None:
+    """Prod today has no cephor tables. One failed query, then never again."""
+    pool = _Pool(raises=asyncpg.UndefinedTableError("relation does not exist"))
+    gate = LocalResidencyGate(pool, NODE)
+
+    for _ in range(4):
+        assert await gate.may_serve_local(OBJ, 1, 1) is True
+
+    assert pool.calls == 1, "the absence of the tables must be learned once, not per read"
+
+
+def test_no_pool_or_no_node_identity_means_no_gate() -> None:
+    """Workers, scripts and tests have neither. A gate that cannot identify itself would refuse
+    every local read, so it must not exist at all rather than exist and deny."""
+    assert create_local_residency_gate(None, NODE) is None
+    assert create_local_residency_gate(_Pool(), "") is None
+    assert create_local_residency_gate(_Pool(), NODE) is not None

--- a/tests/unit/cache/test_local_residency_store.py
+++ b/tests/unit/cache/test_local_residency_store.py
@@ -1,0 +1,119 @@
+"""The gate, exercised through the real DualFileSystemPartsStore rather than in isolation.
+
+The unit tests above pin the predicate. These pin that `get_chunk` actually HONOURS it — that a
+file present on this node's flash is not returned when the node has no claim to it, and that the
+read falls through to the lower tier instead of failing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hippius_s3.cache.dual_fs_store import DualFileSystemPartsStore
+
+
+OBJ = "466916c0-d61b-4518-b81b-9576b574270a"
+LOCAL = b"local-attempt-bytes"
+POOL = b"pool-attempt-bytes!"
+
+
+class _Gate:
+    def __init__(self, allow: bool) -> None:
+        self.allow = allow
+        self.calls = 0
+
+    async def may_serve_local(self, *_a: object) -> bool:
+        self.calls += 1
+        return self.allow
+
+
+async def _seed(store: DualFileSystemPartsStore, primary: bytes | None, fallback: bytes | None) -> None:
+    if primary is not None:
+        await store.set_chunk(OBJ, 1, 1, 0, primary)
+        await store.set_meta(OBJ, 1, 1, chunk_size=len(primary), num_chunks=1, size_bytes=len(primary))
+    if fallback is not None:
+        await store.fallback.set_chunk(OBJ, 1, 1, 0, fallback)
+        await store.fallback.set_meta(OBJ, 1, 1, chunk_size=len(fallback), num_chunks=1, size_bytes=len(fallback))
+
+
+@pytest.mark.asyncio
+async def test_an_unowned_local_copy_is_not_returned_and_the_pool_answers(tmp_path):
+    gate = _Gate(allow=False)
+    store = DualFileSystemPartsStore(str(tmp_path / "local"), str(tmp_path / "pool"), local_residency=gate)
+    await _seed(store, LOCAL, POOL)
+
+    got = await store.get_chunk(OBJ, 1, 1, 0)
+
+    assert got == POOL, "the unowned local copy was served instead of the pool's"
+    assert gate.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_an_owned_local_copy_is_returned(tmp_path):
+    gate = _Gate(allow=True)
+    store = DualFileSystemPartsStore(str(tmp_path / "local"), str(tmp_path / "pool"), local_residency=gate)
+    await _seed(store, LOCAL, POOL)
+
+    assert await store.get_chunk(OBJ, 1, 1, 0) == LOCAL
+
+
+@pytest.mark.asyncio
+async def test_no_gate_configured_keeps_the_previous_behaviour(tmp_path):
+    """Workers and pre-drain deployments pass None; they must be unaffected."""
+    store = DualFileSystemPartsStore(str(tmp_path / "local"), str(tmp_path / "pool"))
+    await _seed(store, LOCAL, POOL)
+
+    assert await store.get_chunk(OBJ, 1, 1, 0) == LOCAL
+
+
+@pytest.mark.asyncio
+async def test_the_gate_is_not_consulted_when_there_is_no_local_copy(tmp_path):
+    """It answers 'may I serve THIS file'. With no file there is nothing to ask about, and asking
+    would put a DB round-trip on every pool read."""
+    gate = _Gate(allow=True)
+    store = DualFileSystemPartsStore(str(tmp_path / "local"), str(tmp_path / "pool"), local_residency=gate)
+    await _seed(store, None, POOL)
+
+    assert await store.get_chunk(OBJ, 1, 1, 0) == POOL
+    assert gate.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_a_refused_read_self_heals_the_unowned_copy(tmp_path):
+    """Refusing the read also REPAIRS it, which is why no separate reconciler is needed.
+
+    Falling through to the pool reaches `_promote_chunk`, and promotion writes the chunk
+    unconditionally — only *meta* is skipped when already present. So the pool's bytes overwrite
+    the unowned ones and the promotion claims residency for them. The next read is served
+    locally, correctly, from the copy this node now genuinely owns.
+
+    Before the gate this could never happen: `get_chunk` returned the local bytes and the promote
+    path was never reached, so the loser's copy was served for as long as the file existed.
+
+    The repair rides on promotion, so it applies where `HIPPIUS_OBJECT_CACHE_PROMOTE_ON_READ` is
+    set — staging today, not prod. Without it the gate still refuses correctly; the unowned bytes
+    simply stay on the disk unread, and every read of that part costs a pool round-trip until the
+    evictor reclaims it. Correct either way; self-repairing only where promotion is on.
+    """
+    promoted: list[tuple[str, int, int, int]] = []
+
+    async def on_promote(object_id: str, version: int, part: int, size: int) -> bool:
+        promoted.append((object_id, version, part, size))
+        return True
+
+    gate = _Gate(allow=False)
+    store = DualFileSystemPartsStore(
+        str(tmp_path / "local"),
+        str(tmp_path / "pool"),
+        promote=True,
+        local_residency=gate,
+        on_promote=on_promote,
+    )
+    await _seed(store, LOCAL, POOL)
+
+    assert await store.get_chunk(OBJ, 1, 1, 0) == POOL
+    assert promoted, "the pool read did not promote, so the unowned copy was left in place"
+
+    # The bytes on this node's own flash are now the pool's, not the losing attempt's.
+    gate.allow = True
+    assert await store.get_chunk(OBJ, 1, 1, 0) == POOL

--- a/tests/unit/cache/test_publish_cross_process_lock.py
+++ b/tests/unit/cache/test_publish_cross_process_lock.py
@@ -55,8 +55,9 @@ async def test_publish_waits_for_a_lock_another_process_holds(tmp_path) -> None:
     fcntl.flock(other, fcntl.LOCK_EX)
     try:
         task = asyncio.create_task(
-            store.publish_part(OBJ, 1, 1, chunk_size=len(CHUNK), num_chunks=1,
-                               size_bytes=len(CHUNK), attempt_id="attemptaa")
+            store.publish_part(
+                OBJ, 1, 1, chunk_size=len(CHUNK), num_chunks=1, size_bytes=len(CHUNK), attempt_id="attemptaa"
+            )
         )
         # Long enough that a publish which ignored the lock would have finished: the whole swap is
         # a handful of local renames.
@@ -76,8 +77,9 @@ async def test_the_lock_is_released_after_publishing(tmp_path) -> None:
     """A held-forever lock would wedge every later attempt at that part on that node."""
     store = FileSystemPartsStore(str(tmp_path))
     await _stage_one_chunk(store, "attemptaa")
-    await store.publish_part(OBJ, 1, 1, chunk_size=len(CHUNK), num_chunks=1,
-                             size_bytes=len(CHUNK), attempt_id="attemptaa")
+    await store.publish_part(
+        OBJ, 1, 1, chunk_size=len(CHUNK), num_chunks=1, size_bytes=len(CHUNK), attempt_id="attemptaa"
+    )
 
     probe = os.open(_part_dir(store), os.O_RDONLY)
     try:
@@ -101,8 +103,9 @@ async def test_a_failed_publish_still_releases_the_lock(tmp_path) -> None:
         staged.unlink()
 
     with pytest.raises(FileNotFoundError):
-        await store.publish_part(OBJ, 1, 1, chunk_size=len(CHUNK), num_chunks=1,
-                                 size_bytes=len(CHUNK), attempt_id="attemptaa")
+        await store.publish_part(
+            OBJ, 1, 1, chunk_size=len(CHUNK), num_chunks=1, size_bytes=len(CHUNK), attempt_id="attemptaa"
+        )
 
     probe = os.open(part_dir, os.O_RDONLY)
     try:
@@ -123,8 +126,7 @@ async def test_different_parts_do_not_block_each_other(tmp_path) -> None:
     fcntl.flock(held, fcntl.LOCK_EX)
     try:
         await asyncio.wait_for(
-            store.publish_part(OBJ, 1, 2, chunk_size=len(CHUNK), num_chunks=1,
-                               size_bytes=len(CHUNK), attempt_id="aa"),
+            store.publish_part(OBJ, 1, 2, chunk_size=len(CHUNK), num_chunks=1, size_bytes=len(CHUNK), attempt_id="aa"),
             timeout=5,
         )
     finally:


### PR DESCRIPTION
## What

The node-local SSD is a **cache** of the pool, but `get_chunk` treated it as authoritative: it read the file and returned it without ever asking whether this node is recorded as holding that part.

The peer tier already resolves by `cephor_ssd_residency` ([peers.py:332](../blob/staging/hippius_s3/cache/peers.py#L332)) — it only asks nodes recorded as holding the part. Only the local tier trusted the disk. This makes the two consistent.

## Why it matters

Two concurrent `UploadPart`s for the same part, routed to different api pods, each publish their own attempt to their own node's flash — correctly and atomically, *per node*. One wins the `parts` row and gets the residency and replication rows. The loser's bytes stay on the other node with **no record anywhere**, and that node serves them for as long as the file exists.

Nothing downstream can catch it:
- the AAD binds `(bucket, object, part, chunk)` and **not** the attempt, so the unowned bytes decrypt and authenticate perfectly in place;
- `meta.json` is byte-identical across the divergent copies;
- promotion never corrected it, because it fills a *missing* local copy and the local copy was never missing.

Reproduced live on staging at **4 of 8** attempts. Which bytes a client gets depended on which api pod its GET landed on.

## The predicate, and why it is not "is there a residency row"

A freshly ingested part has no residency row yet — the drain writes one when it **commits** — and the pool does not have it either, because that is the same event. Gating on residency alone would refuse the only copy that exists and break read-after-write on **every** upload. So:

> serve locally **unless** the part is `replicated` **and** this node is not recorded as holding it

`replicated` means the pool has a durable, byte-verified copy, so falling through costs latency and nothing else. Not-replicated means this node's copy may be the only one and must be served. The orphan sits squarely in the first case.

## Failure direction, deliberately split

A definitive "this node does not hold a replicated part" **refuses** the local read — that is the point. But an error (DB unreachable, pool exhausted, tables absent) **serves locally**, as today. Failing closed on an outage would take every local read on the fleet to the pool at once, converting a database blip into a latency and load incident on the tier the drain is also writing to. An unowned copy is rare and bounded; that is not.

Pre-drain deployments (prod today has no `cephor_*` tables) latch the gate off after **one** failed probe rather than paying one per read forever.

## Cost

One DB round-trip per part per 30s, memoised in the same `PartMemo` shape and TTL the peer resolver uses — deliberately, since both answer "where does this part live" and two staleness windows for one question would be a trap. Ownership only changes on a drain commit or an eviction. The gate is not consulted at all when there is no local copy, so pool reads are unaffected.

## Self-repair

Where `HIPPIUS_OBJECT_CACHE_PROMOTE_ON_READ` is set (staging today, **not** prod), the refusal also repairs: falling through reaches `_promote_chunk`, which writes the chunk unconditionally and claims residency, so the next read is served locally from a copy this node genuinely owns. Without promotion the gate still refuses correctly — the unowned bytes just sit unread until the evictor reclaims them, at the cost of a pool round-trip per read of that part.

## Observability

Refused reads count as `chunk_reads_by_tier_total{tier="local_unowned"}` — a **refusal**, not a serving tier. A sustained rate means concurrent same-part uploads are leaving unowned copies behind: the read is correct, the write path is not.

## Tests

20 tests across two files.

`test_local_residency_gate.py` pins the predicate: the unowned replicated part is refused; the owned one is served; a part in `pending`/`draining`/`failed`/`corrupt` **and** one the drain has never seen are served without a residency row (the read-after-write case); all three error classes fail open; errors are not memoised, definitive answers are; the memo is per-part not per-object; a pre-drain deployment latches after one probe.

`test_local_residency_store.py` pins that `get_chunk` **honours** it end-to-end, plus the self-repair.

Both mutation-checked:
- removing the gate from `get_chunk` → the unowned-copy test goes red, nothing else;
- dropping the `replicated` condition (gating on residency alone) → **5** tests go red, all of them read-after-write. That mutation is the plausible-looking wrong fix, so it is worth it being loud.

Full unit suite green (2895), `ruff` and `ty` clean.